### PR TITLE
refactor: use shared trend indicator components with hover tooltips

### DIFF
--- a/resources/js/components/accounts/account-balance-chart.tsx
+++ b/resources/js/components/accounts/account-balance-chart.tsx
@@ -1,3 +1,4 @@
+import { PercentageTrendIndicator } from '@/components/dashboard/percentage-trend-indicator';
 import { EncryptedText } from '@/components/encrypted-text';
 import {
     Card,
@@ -14,7 +15,6 @@ import {
 } from '@/components/ui/chart';
 import { Account } from '@/types/account';
 import { format, subMonths } from 'date-fns';
-import { TrendingDown, TrendingUp } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { Bar, BarChart, XAxis } from 'recharts';
 
@@ -67,7 +67,7 @@ function formatCurrency(value: number, currencyCode: string): string {
 function calculateTrend(
     data: BalanceDataPoint[],
     monthsBack: number,
-): number | null {
+): { percentage: number; previousValue: number; currentValue: number } | null {
     if (data.length < 2) return null;
 
     const currentIndex = data.length - 1;
@@ -80,38 +80,12 @@ function calculateTrend(
 
     if (previousValue === 0) return null;
 
-    return ((currentValue - previousValue) / Math.abs(previousValue)) * 100;
-}
-
-function TrendIndicator({
-    trend,
-    label,
-}: {
-    trend: number | null;
-    label: string;
-}) {
-    if (trend === null) return null;
-
-    const isPositive = trend >= 0;
-    const Icon = isPositive ? TrendingUp : TrendingDown;
-    const iconColorClass = isPositive
-        ? 'text-green-600/70 dark:text-green-400/70'
-        : 'text-red-600/70 dark:text-red-400/70';
-
-    return (
-        <div className="flex items-center gap-1">
-            <span
-                className={
-                    isPositive ? 'bg-green-100/25 dark:bg-green-900/25' : ''
-                }
-            >
-                {isPositive ? '+' : ''}
-                {trend.toFixed(1)}%
-            </span>
-            <span className="text-muted-foreground">{label}</span>
-            <Icon className={`h-4 w-4 ${iconColorClass}`} />
-        </div>
-    );
+    return {
+        percentage:
+            ((currentValue - previousValue) / Math.abs(previousValue)) * 100,
+        previousValue,
+        currentValue,
+    };
 }
 
 export function AccountBalanceChart({
@@ -226,13 +200,19 @@ export function AccountBalanceChart({
                     <div className="flex flex-col gap-2">
                         <CardTitle>Balance evolution</CardTitle>
                         <CardDescription className="flex flex-col gap-1 text-sm">
-                            <TrendIndicator
-                                trend={monthlyTrend}
+                            <PercentageTrendIndicator
+                                trend={monthlyTrend?.percentage ?? null}
                                 label="this month"
+                                previousAmount={monthlyTrend?.previousValue}
+                                currentAmount={monthlyTrend?.currentValue}
+                                currencyCode={account.currency_code}
                             />
-                            <TrendIndicator
-                                trend={yearlyTrend}
+                            <PercentageTrendIndicator
+                                trend={yearlyTrend?.percentage ?? null}
                                 label="for the last 12 months"
+                                previousAmount={yearlyTrend?.previousValue}
+                                currentAmount={yearlyTrend?.currentValue}
+                                currencyCode={account.currency_code}
                             />
                         </CardDescription>
                     </div>

--- a/resources/js/components/accounts/account-list-card.tsx
+++ b/resources/js/components/accounts/account-list-card.tsx
@@ -1,9 +1,9 @@
 import { show } from '@/actions/App/Http/Controllers/AccountController';
+import { AmountTrendIndicator } from '@/components/dashboard/amount-trend-indicator';
 import { EncryptedText } from '@/components/encrypted-text';
 import { Card, CardContent } from '@/components/ui/card';
 import { AccountWithMetrics } from '@/hooks/use-dashboard-data';
 import { Link } from '@inertiajs/react';
-import { TrendingDown, TrendingUp } from 'lucide-react';
 import { useState } from 'react';
 import { Line, LineChart, ResponsiveContainer, Tooltip } from 'recharts';
 import { Button } from '../ui/button';
@@ -53,10 +53,6 @@ export function AccountListCard({
     });
 
     const isPositive = account.diff >= 0;
-    const TrendIcon = isPositive ? TrendingUp : TrendingDown;
-    const trendColorClass = isPositive
-        ? 'text-green-600 dark:text-green-400'
-        : 'text-red-600 dark:text-red-400';
 
     return (
         <Card className="w-full py-0">
@@ -108,19 +104,16 @@ export function AccountListCard({
                             >
                                 {formatter.format(account.currentBalance / 100)}
                             </button>
-                            <div
-                                className={`flex items-center gap-1 text-sm ${trendColorClass}`}
-                            >
-                                <TrendIcon className="h-4 w-4" />
-                                <span className="tabular-nums">
-                                    {formatter.format(
-                                        Math.abs(account.diff) / 100,
-                                    )}
-                                </span>
-                                <span className="text-muted-foreground">
-                                    vs last month
-                                </span>
-                            </div>
+                            <AmountTrendIndicator
+                                isPositive={isPositive}
+                                trend={formatter.format(
+                                    Math.abs(account.diff) / 100,
+                                )}
+                                label="vs last month"
+                                className="text-sm"
+                                previousAmount={account.previousBalance}
+                                currentAmount={account.currentBalance}
+                            />
                         </div>
                     </div>
                     <div className="h-[100px] w-full">

--- a/resources/js/components/dashboard/account-balance-card.tsx
+++ b/resources/js/components/dashboard/account-balance-card.tsx
@@ -90,6 +90,8 @@ export function AccountBalanceCard({
                             )}
                             label="vs last month"
                             className="text-sm"
+                            previousAmount={account.previousBalance}
+                            currentAmount={account.currentBalance}
                         />
                     </div>
                     <div className="h-[70px] w-full max-w-[250px] flex-1">

--- a/resources/js/components/dashboard/amount-trend-indicator.tsx
+++ b/resources/js/components/dashboard/amount-trend-indicator.tsx
@@ -1,17 +1,36 @@
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import { TrendingDown, TrendingUp } from 'lucide-react';
+
+interface AmountTrendIndicatorProps {
+    trend: string | null;
+    isPositive: boolean;
+    label: string;
+    className?: string;
+    previousAmount?: number;
+    currentAmount?: number;
+}
+
+function calculatePercentageChange(
+    previousAmount: number,
+    currentAmount: number,
+): number | null {
+    if (previousAmount === 0) return null;
+    return ((currentAmount - previousAmount) / Math.abs(previousAmount)) * 100;
+}
 
 export function AmountTrendIndicator({
     trend,
     isPositive,
     label,
     className = '',
-}: {
-    trend: string | null;
-    isPositive: boolean;
-    label: string;
-    className?: string;
-}) {
+    previousAmount,
+    currentAmount,
+}: AmountTrendIndicatorProps) {
     if (trend === null) return null;
 
     const Icon = isPositive ? TrendingUp : TrendingDown;
@@ -19,7 +38,12 @@ export function AmountTrendIndicator({
         ? 'text-green-600/70 dark:text-green-400/70'
         : 'text-red-600/70 dark:text-red-400/70';
 
-    return (
+    const percentageChange =
+        previousAmount !== undefined && currentAmount !== undefined
+            ? calculatePercentageChange(previousAmount, currentAmount)
+            : null;
+
+    const content = (
         <div className={cn(['flex items-center gap-1', className])}>
             <span
                 className={
@@ -32,4 +56,20 @@ export function AmountTrendIndicator({
             <Icon className={`h-4 w-4 ${iconColorClass}`} />
         </div>
     );
+
+    if (percentageChange !== null) {
+        return (
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <div className="cursor-default">{content}</div>
+                </TooltipTrigger>
+                <TooltipContent>
+                    {percentageChange >= 0 ? '+' : ''}
+                    {percentageChange.toFixed(1)}% {label}
+                </TooltipContent>
+            </Tooltip>
+        );
+    }
+
+    return content;
 }

--- a/resources/js/components/dashboard/percentage-trend-indicator.tsx
+++ b/resources/js/components/dashboard/percentage-trend-indicator.tsx
@@ -1,32 +1,83 @@
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
 import { TrendingDown, TrendingUp } from 'lucide-react';
+
+interface PercentageTrendIndicatorProps {
+    trend: number | null;
+    label: string;
+    previousAmount?: number;
+    currentAmount?: number;
+    currencyCode?: string;
+    invertColors?: boolean;
+    className?: string;
+}
+
+function formatCurrency(amount: number, currencyCode: string): string {
+    return new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: currencyCode,
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+    }).format(amount / 100);
+}
 
 export function PercentageTrendIndicator({
     trend,
     label,
-}: {
-    trend: number | null;
-    label: string;
-}) {
+    previousAmount,
+    currentAmount,
+    currencyCode = 'USD',
+    invertColors = false,
+    className,
+}: PercentageTrendIndicatorProps) {
     if (trend === null) return null;
 
     const isPositive = trend >= 0;
+    const isGood = invertColors ? !isPositive : isPositive;
     const Icon = isPositive ? TrendingUp : TrendingDown;
-    const iconColorClass = isPositive
+    const iconColorClass = isGood
         ? 'text-green-600/70 dark:text-green-400/70'
         : 'text-red-600/70 dark:text-red-400/70';
 
-    return (
-        <div className="flex items-center gap-1">
+    const amountDiff =
+        previousAmount !== undefined && currentAmount !== undefined
+            ? currentAmount - previousAmount
+            : null;
+
+    const content = (
+        <div className={cn(['flex items-center gap-1', className])}>
             <span
-                className={
-                    isPositive ? 'bg-green-100/25 dark:bg-green-900/25' : ''
-                }
+                className={isGood ? 'bg-green-100/25 dark:bg-green-900/25' : ''}
             >
                 {isPositive ? '+' : ''}
                 {trend.toFixed(1)}%
             </span>
-            <span className="text-muted-foreground">{label}</span>
+            {label && <span className="text-muted-foreground">{label}</span>}
             <Icon className={`h-4 w-4 ${iconColorClass}`} />
         </div>
     );
+
+    if (amountDiff !== null) {
+        const formattedDiff = formatCurrency(
+            Math.abs(amountDiff),
+            currencyCode,
+        );
+        return (
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <div className="cursor-default">{content}</div>
+                </TooltipTrigger>
+                <TooltipContent>
+                    {amountDiff >= 0 ? '+' : '-'}
+                    {formattedDiff} {label}
+                </TooltipContent>
+            </Tooltip>
+        );
+    }
+
+    return content;
 }

--- a/resources/js/components/dashboard/top-categories-card.tsx
+++ b/resources/js/components/dashboard/top-categories-card.tsx
@@ -9,7 +9,8 @@ import { Progress } from '@/components/ui/progress';
 import { cn } from '@/lib/utils';
 import { Category, getCategoryColorClasses } from '@/types/category';
 import * as Icons from 'lucide-react';
-import { LucideIcon, TrendingDown, TrendingUp } from 'lucide-react';
+import { LucideIcon } from 'lucide-react';
+import { PercentageTrendIndicator } from './percentage-trend-indicator';
 
 interface CategoryData {
     category: Category;
@@ -90,8 +91,6 @@ export function TopCategoriesCard({
                                       item.previous_amount) *
                                   100
                                 : null;
-                        const isSpendingLess =
-                            percentageChange !== null && percentageChange < 0;
                         const percentage =
                             item.total_amount > 0
                                 ? (item.amount / item.total_amount) * 100
@@ -101,13 +100,6 @@ export function TopCategoriesCard({
                         );
                         const chartColor =
                             CHART_COLORS[index % CHART_COLORS.length];
-
-                        const TrendIcon = isSpendingLess
-                            ? TrendingDown
-                            : TrendingUp;
-                        const trendColorClass = isSpendingLess
-                            ? 'text-green-600/70 dark:text-green-400/70'
-                            : 'text-red-600/70 dark:text-red-400/70';
 
                         return (
                             <div key={item.category.id} className="space-y-2">
@@ -124,23 +116,17 @@ export function TopCategoriesCard({
                                         {item.category.name}
                                     </span>
                                     {percentageChange !== null && (
-                                        <div className="flex shrink-0 items-center gap-0.5 text-xs">
-                                            <span
-                                                className={
-                                                    isSpendingLess
-                                                        ? 'bg-green-100/25 dark:bg-green-900/25'
-                                                        : ''
-                                                }
-                                            >
-                                                {percentageChange >= 0
-                                                    ? '+'
-                                                    : ''}
-                                                {percentageChange.toFixed(0)}%
-                                            </span>
-                                            <TrendIcon
-                                                className={`size-3.5 ${trendColorClass}`}
-                                            />
-                                        </div>
+                                        <PercentageTrendIndicator
+                                            trend={percentageChange}
+                                            label=""
+                                            previousAmount={
+                                                item.previous_amount
+                                            }
+                                            currentAmount={item.amount}
+                                            currencyCode="USD"
+                                            invertColors
+                                            className="shrink-0 text-xs"
+                                        />
                                     )}
                                     <span className="shrink-0 text-sm font-semibold tabular-nums">
                                         {formatter.format(item.amount / 100)}


### PR DESCRIPTION
## Summary

Refactored all places using TrendingUp/TrendingDown icons directly to use the shared `AmountTrendIndicator` and `PercentageTrendIndicator` components.

<img width="1113" height="799" alt="image" src="https://github.com/user-attachments/assets/8a635d23-3c14-48b6-80d0-b5641af93024" />

## Changes

- **AmountTrendIndicator**: Now shows percentage diff on hover via tooltip
- **PercentageTrendIndicator**: Now shows amount diff on hover via tooltip
- Added `invertColors` prop to `PercentageTrendIndicator` for spending categories (where spending less is good)
- Added `className` prop to both components for flexibility

## Files refactored

- `account-list-card.tsx` - Now uses `AmountTrendIndicator`
- `top-categories-card.tsx` - Now uses `PercentageTrendIndicator`
- `account-balance-chart.tsx` - Removed local `TrendIndicator` function, now uses shared `PercentageTrendIndicator`
- `account-balance-card.tsx` - Updated to pass new props
- `net-worth-chart.tsx` - Updated to pass new props

## Testing

- All existing tests pass
- Hover over any trend indicator to see the alternate metric (percentage or amount)