### PR TITLE
Disable SSR for dashboard routes and extract API routes

### DIFF
--- a/app/Http/Middleware/WithoutSsr.php
+++ b/app/Http/Middleware/WithoutSsr.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class WithoutSsr
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        config(['inertia.ssr.enabled' => false]);
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -13,6 +13,7 @@ use Illuminate\Http\Request;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,50 @@
+<?php
+
+use App\Http\Controllers\AccountBalanceController;
+use App\Http\Controllers\Api\DashboardAnalyticsController;
+use App\Http\Controllers\EncryptionController;
+use App\Http\Controllers\Sync\AccountBalanceSyncController;
+use App\Http\Controllers\Sync\AccountSyncController;
+use App\Http\Controllers\Sync\AutomationRuleSyncController;
+use App\Http\Controllers\Sync\BankSyncController;
+use App\Http\Controllers\Sync\CategorySyncController;
+use App\Http\Controllers\Sync\TransactionSyncController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['web', 'auth'])->group(function () {
+    // Encryption
+    Route::post('encryption/setup', [EncryptionController::class, 'setup']);
+    Route::get('encryption/message', [EncryptionController::class, 'getMessage']);
+
+    // Sync
+    Route::prefix('sync')->group(function () {
+        Route::get('categories', [CategorySyncController::class, 'index']);
+        Route::get('accounts', [AccountSyncController::class, 'index']);
+        Route::get('banks', [BankSyncController::class, 'index']);
+        Route::get('automation-rules', [AutomationRuleSyncController::class, 'index']);
+
+        Route::get('transactions', [TransactionSyncController::class, 'index']);
+        Route::post('transactions', [TransactionSyncController::class, 'store']);
+        Route::patch('transactions/{transaction}', [TransactionSyncController::class, 'update']);
+        Route::delete('transactions/{transaction}', [TransactionSyncController::class, 'destroy']);
+
+        Route::get('account-balances', [AccountBalanceSyncController::class, 'index']);
+        Route::post('account-balances', [AccountBalanceSyncController::class, 'store']);
+        Route::patch('account-balances/{accountBalance}', [AccountBalanceSyncController::class, 'update']);
+    });
+
+    // Account Balances
+    Route::put('accounts/{account}/balance/current', [AccountBalanceController::class, 'updateCurrent'])->name('api.accounts.balance.update-current');
+    Route::get('accounts/{account}/balances', [AccountBalanceController::class, 'index'])->name('api.accounts.balances.index');
+    Route::delete('accounts/{account}/balances/{accountBalance}', [AccountBalanceController::class, 'destroy'])->name('api.accounts.balances.destroy');
+
+    // Dashboard Analytics
+    Route::prefix('dashboard')->group(function () {
+        Route::get('net-worth', [DashboardAnalyticsController::class, 'netWorth']);
+        Route::get('monthly-spending', [DashboardAnalyticsController::class, 'monthlySpending']);
+        Route::get('cash-flow', [DashboardAnalyticsController::class, 'cashFlow']);
+        Route::get('net-worth-evolution', [DashboardAnalyticsController::class, 'netWorthEvolution']);
+        Route::get('top-categories', [DashboardAnalyticsController::class, 'topCategories']);
+        Route::get('account/{account}/balance-evolution', [DashboardAnalyticsController::class, 'accountBalanceEvolution']);
+    });
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,18 +1,13 @@
 <?php
 
-use App\Http\Controllers\AccountBalanceController;
 use App\Http\Controllers\AccountController;
 use App\Http\Controllers\DashboardController;
-use App\Http\Controllers\EncryptionController;
 use App\Http\Controllers\RobotsController;
 use App\Http\Controllers\SitemapController;
 use App\Http\Controllers\SubscriptionController;
-use App\Http\Controllers\Sync\AccountBalanceSyncController;
-use App\Http\Controllers\Sync\AccountSyncController;
-use App\Http\Controllers\Sync\BankSyncController;
-use App\Http\Controllers\Sync\CategorySyncController;
 use App\Http\Controllers\TransactionController;
 use App\Http\Controllers\UserLeadController;
+use App\Http\Middleware\WithoutSsr;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 use Laravel\Fortify\Features;
@@ -42,34 +37,6 @@ Route::middleware(['auth'])->group(function () {
     Route::get('setup-encryption', function () {
         return Inertia::render('auth/setup-encryption');
     })->name('setup-encryption');
-
-    Route::post('api/encryption/setup', [EncryptionController::class, 'setup']);
-    Route::get('api/encryption/message', [EncryptionController::class, 'getMessage']);
-
-    Route::get('api/sync/categories', [CategorySyncController::class, 'index']);
-    Route::get('api/sync/accounts', [AccountSyncController::class, 'index']);
-    Route::get('api/sync/banks', [BankSyncController::class, 'index']);
-    Route::get('api/sync/automation-rules', [\App\Http\Controllers\Sync\AutomationRuleSyncController::class, 'index']);
-    Route::get('api/sync/transactions', [\App\Http\Controllers\Sync\TransactionSyncController::class, 'index']);
-    Route::post('api/sync/transactions', [\App\Http\Controllers\Sync\TransactionSyncController::class, 'store']);
-    Route::patch('api/sync/transactions/{transaction}', [\App\Http\Controllers\Sync\TransactionSyncController::class, 'update']);
-    Route::delete('api/sync/transactions/{transaction}', [\App\Http\Controllers\Sync\TransactionSyncController::class, 'destroy']);
-    Route::get('api/sync/account-balances', [AccountBalanceSyncController::class, 'index']);
-    Route::post('api/sync/account-balances', [AccountBalanceSyncController::class, 'store']);
-    Route::patch('api/sync/account-balances/{accountBalance}', [AccountBalanceSyncController::class, 'update']);
-    Route::put('api/accounts/{account}/balance/current', [AccountBalanceController::class, 'updateCurrent'])->name('accounts.balance.update-current');
-    Route::get('api/accounts/{account}/balances', [AccountBalanceController::class, 'index'])->name('accounts.balances.index');
-    Route::delete('api/accounts/{account}/balances/{accountBalance}', [AccountBalanceController::class, 'destroy'])->name('accounts.balances.destroy');
-
-    // Dashboard Analytics
-    Route::prefix('api/dashboard')->group(function () {
-        Route::get('net-worth', [\App\Http\Controllers\Api\DashboardAnalyticsController::class, 'netWorth']);
-        Route::get('monthly-spending', [\App\Http\Controllers\Api\DashboardAnalyticsController::class, 'monthlySpending']);
-        Route::get('cash-flow', [\App\Http\Controllers\Api\DashboardAnalyticsController::class, 'cashFlow']);
-        Route::get('net-worth-evolution', [\App\Http\Controllers\Api\DashboardAnalyticsController::class, 'netWorthEvolution']);
-        Route::get('top-categories', [\App\Http\Controllers\Api\DashboardAnalyticsController::class, 'topCategories']);
-        Route::get('account/{account}/balance-evolution', [\App\Http\Controllers\Api\DashboardAnalyticsController::class, 'accountBalanceEvolution']);
-    });
 });
 
 Route::middleware(['auth', 'verified'])->group(function () {
@@ -79,7 +46,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('subscribe/cancel', [SubscriptionController::class, 'cancel'])->name('subscribe.cancel');
 });
 
-Route::middleware(['auth', 'verified', 'redirect.encryption', 'subscribed'])->group(function () {
+Route::middleware(['auth', 'verified', 'redirect.encryption', 'subscribed', WithoutSsr::class])->group(function () {
     Route::get('dashboard', DashboardController::class)->name('dashboard');
 
     Route::get('accounts', [AccountController::class, 'index'])->name('accounts.list');


### PR DESCRIPTION
## Summary

- Add `WithoutSsr` middleware to disable SSR per route
- Extract API endpoints to `routes/api.php` for better organization
- Apply `WithoutSsr` to dashboard, accounts, and transactions routes

## Changes

### New Files
- `app/Http/Middleware/WithoutSsr.php` - Middleware that disables SSR for specific routes
- `routes/api.php` - Dedicated file for API endpoints

### Modified Files
- `bootstrap/app.php` - Register API routes
- `routes/web.php` - Remove API routes, apply WithoutSsr middleware

## Route Structure

- **routes/web.php** - Page routes only (Inertia pages)
- **routes/api.php** - All `/api/*` endpoints
- **routes/settings.php** - Settings routes (existing)