### PR TITLE
feat: centralize pricing config with multiple plans support

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -50,6 +50,12 @@ class HandleInertiaRequests extends Middleware
                 'hasProPlan' => $user?->hasProPlan() ?? false,
             ],
             'subscriptionsEnabled' => config('subscriptions.enabled', false),
+            'pricing' => [
+                'plans' => config('subscriptions.plans', []),
+                'defaultPlan' => config('subscriptions.default_plan', 'monthly'),
+                'bestValuePlan' => config('subscriptions.best_value', null),
+                'promo' => config('subscriptions.promo', []),
+            ],
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
         ];
     }

--- a/config/subscriptions.php
+++ b/config/subscriptions.php
@@ -17,20 +17,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Stripe Price IDs
-    |--------------------------------------------------------------------------
-    |
-    | These are the Stripe Price IDs for the different subscription plans.
-    | You can find these in your Stripe Dashboard under Products.
-    |
-    */
-
-    'prices' => [
-        'pro_monthly' => env('STRIPE_PRO_PRICE_ID', 'price_1SbJYkLNIsVExnyvAJhUoSeB'),
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
     | Stripe Product IDs
     |--------------------------------------------------------------------------
     |
@@ -40,6 +26,110 @@ return [
 
     'products' => [
         'pro' => env('STRIPE_PRO_PRODUCT_ID', 'prod_TYQPg0s9rpxNsU'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Subscription Plans
+    |--------------------------------------------------------------------------
+    |
+    | Define all available subscription plans here. Each plan includes display
+    | information (name, price, features) and Stripe configuration. The key
+    | is used as the plan identifier.
+    |
+    | Supported billing_period values: 'month', 'year', null (for lifetime)
+    |
+    */
+
+    'plans' => [
+        'monthly' => [
+            'name' => 'Pro Monthly',
+            'price' => 9,
+            'original_price' => null,
+            'stripe_price_id' => env('STRIPE_PRO_MONTHLY_PRICE_ID', 'price_1SbJYkLNIsVExnyvAJhUoSeB'),
+            'billing_period' => 'month',
+            'features' => [
+                'Unlimited accounts',
+                'Unlimited transactions',
+                'End-to-end encryption',
+                'Smart categorization',
+                'Automation rules',
+                'Visual insights & reports',
+                'Priority support',
+            ],
+        ],
+        // 'yearly' => [
+        //     'name' => 'Pro Yearly',
+        //     'price' => 69,
+        //     'original_price' => 144,
+        //     'stripe_price_id' => env('STRIPE_PRO_YEARLY_PRICE_ID'),
+        //     'billing_period' => 'year',
+        //     'features' => [
+        //         'Unlimited accounts',
+        //         'Unlimited transactions',
+        //         'End-to-end encryption',
+        //         'Smart categorization',
+        //         'Automation rules',
+        //         'Visual insights & reports',
+        //         'Priority support',
+        //     ],
+        // ],
+        // 'lifetime' => [
+        //     'name' => 'Lifetime License',
+        //     'price' => 129,
+        //     'original_price' => 299,
+        //     'stripe_price_id' => env('STRIPE_LIFETIME_PRICE_ID'),
+        //     'billing_period' => null,
+        //     'features' => [
+        //         'Unlimited accounts',
+        //         'Unlimited transactions',
+        //         'End-to-end encryption',
+        //         'Smart categorization',
+        //         'Automation rules',
+        //         'Visual insights & reports',
+        //         'Priority support',
+        //         'Lifetime updates',
+        //     ],
+        // ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Plan
+    |--------------------------------------------------------------------------
+    |
+    | The default plan key to display prominently or use for checkout.
+    |
+    */
+
+    'default_plan' => 'yearly',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Best Value Plan
+    |--------------------------------------------------------------------------
+    |
+    | The plan key that is considered the "best value" and should be.
+    |
+    */
+
+    'best_value_plan' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Promotional Code Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Configure promotional codes to display on pricing pages. Set enabled
+    | to false to hide all promo code mentions from the UI.
+    |
+    */
+
+    'promo' => [
+        'enabled' => env('PROMO_ENABLED', true),
+        'code' => 'FOUNDER',
+        'description' => '$8 off your first month',
+        'badge' => 'Founder Promotion',
     ],
 
 ];

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -1,6 +1,7 @@
 import { InertiaLinkProps } from '@inertiajs/react';
 import { LucideIcon } from 'lucide-react';
 import { ReactNode } from 'react';
+import { PricingConfig } from './pricing';
 import { UUID } from './uuid';
 
 export interface Auth {
@@ -41,6 +42,7 @@ export interface SharedData {
     quote: { message: string; author: string };
     auth: Auth;
     subscriptionsEnabled: boolean;
+    pricing: PricingConfig;
     sidebarOpen: boolean;
     [key: string]: unknown;
 }

--- a/resources/js/types/pricing.ts
+++ b/resources/js/types/pricing.ts
@@ -1,0 +1,22 @@
+export interface Plan {
+    name: string;
+    price: number;
+    original_price: number | null;
+    stripe_price_id: string | null;
+    billing_period: 'month' | 'year' | null;
+    features: string[];
+}
+
+export interface PromoConfig {
+    enabled: boolean;
+    code: string;
+    description: string;
+    badge: string;
+}
+
+export interface PricingConfig {
+    plans: Record<string, Plan>;
+    defaultPlan: string;
+    bestValuePlan: string | null;
+    promo: PromoConfig;
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,7 +15,6 @@ Route::get('/', function () {
     return Inertia::render('welcome', [
         'canRegister' => Features::enabled(Features::registration()),
         'hideAuthButtons' => config('landing.hide_auth_buttons', false),
-        'subscriptionsEnabled' => config('subscriptions.enabled', false),
     ]);
 })->name('home');
 

--- a/tests/Feature/SubscriptionTest.php
+++ b/tests/Feature/SubscriptionTest.php
@@ -140,6 +140,10 @@ test('landing page passes subscriptions enabled prop when enabled', function () 
             ->component('welcome')
             ->has('subscriptionsEnabled')
             ->where('subscriptionsEnabled', true)
+            ->has('pricing')
+            ->has('pricing.plans')
+            ->has('pricing.defaultPlan')
+            ->has('pricing.promo')
         );
 });
 
@@ -152,5 +156,30 @@ test('landing page passes subscriptions enabled prop when disabled', function ()
             ->component('welcome')
             ->has('subscriptionsEnabled')
             ->where('subscriptionsEnabled', false)
+            ->has('pricing')
+        );
+});
+
+test('pricing config includes all plan details', function () {
+    config(['subscriptions.enabled' => true]);
+
+    $this->get(route('home'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('welcome')
+            ->has('pricing.plans.monthly', fn ($plan) => $plan
+                ->has('name')
+                ->has('price')
+                ->has('original_price')
+                ->has('stripe_price_id')
+                ->has('billing_period')
+                ->has('features')
+            )
+            ->has('pricing.promo', fn ($promo) => $promo
+                ->has('enabled')
+                ->has('code')
+                ->has('description')
+                ->has('badge')
+            )
         );
 });


### PR DESCRIPTION
## Summary

Centralizes all pricing/subscription plan configuration in a single PHP config file, making it easy to modify prices, features, and promotional codes from one place.

## Changes

### Config (`config/subscriptions.php`)
- Added `plans` array with support for multiple billing cycles (monthly, yearly, lifetime)
- Each plan includes: name, price, original_price (for discounts), stripe_price_id, billing_period, and features
- Added `default_plan` setting to control which plan is highlighted
- Added `promo` config with enabled flag, code, description, and badge

### Frontend
- Created TypeScript types for `Plan`, `PromoConfig`, and `PricingConfig`
- Updated `welcome.tsx` to display all plans in a responsive grid layout
- Updated `paywall.tsx` to show all plans with "Most Popular" and "Best Value" badges
- Promo code section is now conditionally rendered based on `promo.enabled`

### Backend
- Updated `HandleInertiaRequests.php` to share pricing config globally
- Removed redundant props from routes

### Tests
- Added test to verify pricing config structure is passed correctly

## How to Use

To modify pricing, edit `config/subscriptions.php`:
- Change `default_plan` to highlight a different plan
- Set `promo.enabled` to `false` (or `PROMO_ENABLED=false` in `.env`) to hide promo codes
- Add/remove/modify plans as needed