### PR TITLE
feat: Add public feature activation endpoint

### DIFF
--- a/app/Http/Controllers/FeatureActivationController.php
+++ b/app/Http/Controllers/FeatureActivationController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Console\Commands\Concerns\ResolvesFeatures;
+use App\Http\Requests\FeatureActivationRequest;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Laravel\Pennant\Feature;
+
+class FeatureActivationController extends Controller
+{
+    use ResolvesFeatures;
+
+    public function __invoke(FeatureActivationRequest $request, string $feature): RedirectResponse
+    {
+        $featureClass = $this->resolveFeatureClass($feature);
+
+        if (! $featureClass) {
+            abort(404);
+        }
+
+        $user = User::where('email', $request->validated('email'))->first();
+
+        if ($user) {
+            Feature::for($user)->activate($featureClass);
+        }
+
+        return redirect()->route('dashboard');
+    }
+}

--- a/app/Http/Requests/FeatureActivationRequest.php
+++ b/app/Http/Requests/FeatureActivationRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class FeatureActivationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'string', 'email'],
+        ];
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\AccountController;
 use App\Http\Controllers\BudgetController;
 use App\Http\Controllers\CashflowController;
 use App\Http\Controllers\DashboardController;
+use App\Http\Controllers\FeatureActivationController;
 use App\Http\Controllers\OnboardingController;
 use App\Http\Controllers\RobotsController;
 use App\Http\Controllers\SitemapController;
@@ -33,6 +34,8 @@ Route::get('privacy', function () {
 Route::get('terms', function () {
     return Inertia::render('terms');
 })->name('terms');
+
+Route::get('enable/{feature}', FeatureActivationController::class)->name('features.activate');
 
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('subscribe', [SubscriptionController::class, 'index'])->name('subscribe');

--- a/tests/Feature/FeatureActivationTest.php
+++ b/tests/Feature/FeatureActivationTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Models\User;
+use Laravel\Pennant\Feature;
+
+test('activating a valid feature for an existing user redirects to dashboard', function () {
+    $user = User::factory()->create();
+
+    $response = $this->get(route('features.activate', [
+        'feature' => 'budgets',
+        'email' => $user->email,
+    ]));
+
+    $response->assertRedirect(route('dashboard'));
+
+    expect(Feature::for($user)->active('budgets'))->toBeTrue();
+});
+
+test('activating a feature for a non-existent user still redirects to dashboard', function () {
+    $response = $this->get(route('features.activate', [
+        'feature' => 'budgets',
+        'email' => 'nonexistent@example.com',
+    ]));
+
+    $response->assertRedirect(route('dashboard'));
+});
+
+test('activating a non-existent feature returns 404', function () {
+    $response = $this->get(route('features.activate', [
+        'feature' => 'nonexistent',
+        'email' => 'test@example.com',
+    ]));
+
+    $response->assertNotFound();
+});
+
+test('missing email query param returns validation error', function () {
+    $response = $this->get(route('features.activate', [
+        'feature' => 'budgets',
+    ]));
+
+    $response->assertSessionHasErrors('email');
+});
+
+test('invalid email query param returns validation error', function () {
+    $response = $this->get(route('features.activate', [
+        'feature' => 'budgets',
+        'email' => 'not-an-email',
+    ]));
+
+    $response->assertSessionHasErrors('email');
+});


### PR DESCRIPTION
## Summary

- Adds a public `GET /enable/{feature}?email=...` route that activates a Pennant feature flag for the given user
- Returns 404 only for non-existent features; always redirects to dashboard otherwise (prevents user enumeration)
- Includes form request validation for the email query param

## Test plan

- [x] Valid feature + existing user activates the flag and redirects to dashboard
- [x] Valid feature + non-existent user still redirects to dashboard (no 404)
- [x] Non-existent feature returns 404
- [x] Missing or invalid email returns validation errors
- [x] All 5 tests pass (`php artisan test --compact --filter=FeatureActivation`)
- [x] Pint formatting passes