### PR TITLE
feat: Add automerge workflow for labeled PRs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,19 @@
+name: Automerge
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  automerge:
+    if: github.event.label.name == 'Automerge'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow that enables auto-merge when the "Automerge" label is added to a PR
- Uses `gh pr merge --auto --squash` to squash-merge once all required CI checks pass

## Test plan
- [ ] Add the "Automerge" label to this PR to verify the workflow triggers
- [ ] Confirm the PR is auto-merged after CI passes