### PR TITLE
chore: Sync users to Resend after email verification

### DIFF
--- a/app/Listeners/SyncUserToResendListener.php
+++ b/app/Listeners/SyncUserToResendListener.php
@@ -3,7 +3,7 @@
 namespace App\Listeners;
 
 use App\Services\ResendService;
-use Illuminate\Auth\Events\Registered;
+use Illuminate\Auth\Events\Verified;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Facades\Log;
 
@@ -11,7 +11,7 @@ class SyncUserToResendListener implements ShouldQueue
 {
     public function __construct(public ResendService $resendService) {}
 
-    public function handle(Registered $event): void
+    public function handle(Verified $event): void
     {
         if (! config('services.resend.key')) {
             Log::warning('Resend API key not configured, skipping contact sync');

--- a/tests/Feature/Listeners/SyncUserToResendListenerTest.php
+++ b/tests/Feature/Listeners/SyncUserToResendListenerTest.php
@@ -3,7 +3,7 @@
 use App\Listeners\SyncUserToResendListener;
 use App\Models\User;
 use App\Services\ResendService;
-use Illuminate\Auth\Events\Registered;
+use Illuminate\Auth\Events\Verified;
 use Illuminate\Support\Facades\Log;
 
 use function Pest\Laravel\mock;
@@ -21,7 +21,7 @@ test('user is synced to resend contacts', function () {
         ->once()
         ->with(Mockery::on(fn ($u) => $u->id === $user->id));
 
-    (new SyncUserToResendListener($resendService))->handle(new Registered($user));
+    (new SyncUserToResendListener($resendService))->handle(new Verified($user));
 });
 
 test('listener skips sync when api key is not configured', function () {
@@ -36,5 +36,5 @@ test('listener skips sync when api key is not configured', function () {
 
     $user = User::factory()->create();
 
-    (new SyncUserToResendListener($resendService))->handle(new Registered($user));
+    (new SyncUserToResendListener($resendService))->handle(new Verified($user));
 });


### PR DESCRIPTION
## Summary
- Changed `SyncUserToResendListener` to listen to the `Verified` event instead of `Registered`, so contacts are only created in Resend after the user verifies their email address
- Updated corresponding tests to use the `Verified` event

## Test plan
- [x] `SyncUserToResendListenerTest` passes with `Verified` event
- [x] All auth and listener tests pass