### PR TITLE
Fix: prevent duplicate budget period race condition

### DIFF
--- a/app/Services/BudgetPeriodService.php
+++ b/app/Services/BudgetPeriodService.php
@@ -23,14 +23,18 @@ class BudgetPeriodService
             $allocatedAmount = $lastPeriod !== null ? $lastPeriod->allocated_amount : 0;
         }
 
-        return BudgetPeriod::create([
-            'budget_id' => $budget->id,
-            'start_date' => $periodStart,
-            'end_date' => $periodEnd,
-            'allocated_amount' => $allocatedAmount,
-            'carried_over_amount' => 0,
-            'processing_historical' => $processHistorical,
-        ]);
+        return BudgetPeriod::firstOrCreate(
+            [
+                'budget_id' => $budget->id,
+                'start_date' => $periodStart,
+            ],
+            [
+                'end_date' => $periodEnd,
+                'allocated_amount' => $allocatedAmount,
+                'carried_over_amount' => 0,
+                'processing_historical' => $processHistorical,
+            ],
+        );
     }
 
     public function closePeriod(BudgetPeriod $period): void


### PR DESCRIPTION
## Summary

- Fixes a race condition in `BudgetPeriodService::generatePeriod()` where concurrent requests (e.g. browser test parallelism or rapid navigation) could attempt to create duplicate `BudgetPeriod` records with the same `(budget_id, start_date)`, violating the unique constraint and causing a `UniqueConstraintViolationException`.
- Changes `BudgetPeriod::create()` to `BudgetPeriod::firstOrCreate()`, using the unique key columns as the lookup and the remaining columns as defaults for new records.

## Context

This was surfaced by a flaky browser test (`BudgetCrudTest::user can update budget name`) but affects production as well — any concurrent page loads for the same budget could trigger the error.