### PR TITLE
feat: store invested_amount in user currency instead of account currency

### DIFF
--- a/app/Http/Controllers/Api/DashboardAnalyticsController.php
+++ b/app/Http/Controllers/Api/DashboardAnalyticsController.php
@@ -140,10 +140,8 @@ class DashboardAnalyticsController extends Controller
                 $investedAmount = $lookup->getInvestedAmountAt($account->id, $date);
                 $point['invested_amount'] = $investedAmount;
 
-                if ($displayCurrencyCode !== null) {
-                    $point['display_invested_amount'] = $investedAmount !== null
-                        ? $this->convertBalanceForDate($account->currency_code, $displayCurrencyCode, $investedAmount, $date)
-                        : null;
+                if ($displayCurrencyCode !== null && $investedAmount !== null) {
+                    $point['display_invested_amount'] = $this->convertBalanceForDate($userCurrency, $account->currency_code, $investedAmount, $date);
                 }
             }
 
@@ -276,10 +274,8 @@ class DashboardAnalyticsController extends Controller
                 $investedAmount = $lookup->getInvestedAmountAt($account->id, $date);
                 $point['invested_amount'] = $investedAmount;
 
-                if ($displayCurrencyCode !== null) {
-                    $point['display_invested_amount'] = $investedAmount !== null
-                        ? $this->convertBalanceForDate($account->currency_code, $displayCurrencyCode, $investedAmount, $date)
-                        : null;
+                if ($displayCurrencyCode !== null && $investedAmount !== null) {
+                    $point['display_invested_amount'] = $this->convertBalanceForDate($userCurrency, $account->currency_code, $investedAmount, $date);
                 }
             }
 

--- a/app/Jobs/SyncBankingConnectionJob.php
+++ b/app/Jobs/SyncBankingConnectionJob.php
@@ -194,7 +194,7 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
     private function syncIndexaCapital(BankingConnection $connection, bool $isFirstSync): void
     {
         $client = new IndexaCapitalClient($connection->api_token);
-        $syncService = new IndexaCapitalBalanceSyncService;
+        $syncService = app(IndexaCapitalBalanceSyncService::class);
 
         $connection->load('accounts');
 

--- a/app/Services/AccountMetricsService.php
+++ b/app/Services/AccountMetricsService.php
@@ -47,9 +47,7 @@ class AccountMetricsService
 
                 if ($account->type->supportsInvestedAmount()) {
                     $investedAmount = $lookup->getInvestedAmountAt($account->id, $date);
-                    $point['investedAmount'] = $investedAmount !== null
-                        ? $this->convertBalance($investedAmount, $account->currency_code, $userCurrency, $date->toDateString())
-                        : null;
+                    $point['investedAmount'] = $investedAmount;
                 }
 
                 $history[] = $point;
@@ -61,10 +59,7 @@ class AccountMetricsService
 
             $investedAmount = null;
             if ($account->type->supportsInvestedAmount()) {
-                $rawInvested = $lookup->getInvestedAmountAt($account->id, $now);
-                $investedAmount = $rawInvested !== null
-                    ? $this->convertBalance($rawInvested, $account->currency_code, $userCurrency, $now->toDateString())
-                    : null;
+                $investedAmount = $lookup->getInvestedAmountAt($account->id, $now);
             }
 
             $metrics[$account->id] = [
@@ -126,10 +121,7 @@ class AccountMetricsService
                 }
 
                 if ($account->type->supportsInvestedAmount()) {
-                    $investedAmount = $lookup->getInvestedAmountAt($account->id, $date);
-                    $point[$account->id.'_invested'] = $investedAmount !== null
-                        ? $this->convertBalance($investedAmount, $account->currency_code, $userCurrency, $date->toDateString())
-                        : null;
+                    $point[$account->id.'_invested'] = $lookup->getInvestedAmountAt($account->id, $date);
                 }
             }
 
@@ -138,7 +130,7 @@ class AccountMetricsService
         }
 
         $now = Carbon::now();
-        $accountsConfig = $accounts->mapWithKeys(function ($account) use ($userCurrency, $lookup, $now) {
+        $accountsConfig = $accounts->mapWithKeys(function ($account) use ($lookup, $now) {
             $config = [
                 'id' => $account->id,
                 'name' => $account->name,
@@ -155,10 +147,7 @@ class AccountMetricsService
             }
 
             if ($account->type->supportsInvestedAmount()) {
-                $investedAmount = $lookup->getInvestedAmountAt($account->id, $now);
-                $config['invested_amount'] = $investedAmount !== null
-                    ? $this->convertBalance($investedAmount, $account->currency_code, $userCurrency, $now->toDateString())
-                    : null;
+                $config['invested_amount'] = $lookup->getInvestedAmountAt($account->id, $now);
             }
 
             return [$account->id => $config];

--- a/app/Services/Banking/BinanceBalanceSyncService.php
+++ b/app/Services/Banking/BinanceBalanceSyncService.php
@@ -380,12 +380,12 @@ class BinanceBalanceSyncService
 
     /**
      * Calculate the net invested amount by fetching all deposit and withdrawal history.
-     * Net invested = sum of completed deposits - sum of completed withdrawals, converted to fiat.
+     * Net invested = sum of completed deposits - sum of completed withdrawals, converted to the user's currency.
      * Fetches history in 90-day windows going as far back as possible.
      */
     private function calculateInvestedAmount(Account $account, BinanceClient $client): ?int
     {
-        $targetCurrency = strtoupper($account->currency_code);
+        $targetCurrency = strtoupper($account->user->currency_code);
 
         $deposits = $this->fetchAllDepositHistory($client);
         Sleep::for(self::THROTTLE_SECONDS)->seconds();

--- a/app/Services/Banking/BitpandaBalanceSyncService.php
+++ b/app/Services/Banking/BitpandaBalanceSyncService.php
@@ -21,7 +21,7 @@ class BitpandaBalanceSyncService
             return;
         }
 
-        $investedAmountCents = $this->calculateInvestedAmount($client, strtoupper($account->currency_code));
+        $investedAmountCents = $this->calculateInvestedAmount($client, strtoupper($account->user->currency_code));
         $this->syncCurrentBalance($account, $client, $investedAmountCents);
     }
 

--- a/app/Services/Banking/IndexaCapitalBalanceSyncService.php
+++ b/app/Services/Banking/IndexaCapitalBalanceSyncService.php
@@ -3,10 +3,13 @@
 namespace App\Services\Banking;
 
 use App\Models\Account;
+use App\Services\CurrencyConversionService;
 use Illuminate\Support\Facades\Log;
 
 class IndexaCapitalBalanceSyncService
 {
+    public function __construct(private CurrencyConversionService $currencyConverter) {}
+
     /**
      * Sync portfolio balances for an Indexa Capital account.
      * On first sync, stores all available daily historical balances.
@@ -41,6 +44,9 @@ class IndexaCapitalBalanceSyncService
             }
         }
 
+        $accountCurrency = strtoupper($account->currency_code);
+        $userCurrency = strtoupper($account->user->currency_code);
+
         $count = 0;
 
         foreach ($portfolios as $entry) {
@@ -56,7 +62,7 @@ class IndexaCapitalBalanceSyncService
             }
 
             $balanceCents = (int) round(floatval($value) * 100);
-            $investedAmountCents = $this->calculateInvestedAmount($entry, $netAmounts);
+            $investedAmountCents = $this->calculateInvestedAmount($entry, $netAmounts, $accountCurrency, $userCurrency, $date);
 
             $account->balances()->updateOrCreate(
                 ['balance_date' => $date],
@@ -77,7 +83,7 @@ class IndexaCapitalBalanceSyncService
     }
 
     /**
-     * Calculate invested amount from the net_amounts data.
+     * Calculate invested amount from the net_amounts data, converted to the user's currency.
      *
      * Uses net_amounts (cumulative net inflows keyed by YYYYMMDD) which represents
      * the actual money invested (inflows - outflows - tax_outflows), matching
@@ -88,25 +94,36 @@ class IndexaCapitalBalanceSyncService
      * @param  array<string, mixed>  $entry
      * @param  array<string, float>  $netAmounts
      */
-    private function calculateInvestedAmount(array $entry, array $netAmounts): ?int
+    private function calculateInvestedAmount(array $entry, array $netAmounts, string $accountCurrency, string $userCurrency, string $date): ?int
     {
-        $date = $entry['date'] ?? null;
+        $entryDate = $entry['date'] ?? null;
+        $amount = null;
 
-        if ($date !== null && ! empty($netAmounts)) {
-            $dateKey = str_replace('-', '', $date);
+        if ($entryDate !== null && ! empty($netAmounts)) {
+            $dateKey = str_replace('-', '', $entryDate);
 
             if (isset($netAmounts[$dateKey])) {
-                return (int) round(floatval($netAmounts[$dateKey]) * 100);
+                $amount = floatval($netAmounts[$dateKey]);
             }
         }
 
-        $totalAmount = $entry['total_amount'] ?? null;
-        $returnValue = $entry['return'] ?? null;
+        if ($amount === null) {
+            $totalAmount = $entry['total_amount'] ?? null;
+            $returnValue = $entry['return'] ?? null;
 
-        if ($totalAmount !== null && $returnValue !== null) {
-            return (int) round((floatval($totalAmount) - floatval($returnValue)) * 100);
+            if ($totalAmount !== null && $returnValue !== null) {
+                $amount = floatval($totalAmount) - floatval($returnValue);
+            }
         }
 
-        return null;
+        if ($amount === null) {
+            return null;
+        }
+
+        if (strcasecmp($accountCurrency, $userCurrency) !== 0) {
+            $amount = $this->currencyConverter->convert($accountCurrency, $userCurrency, $amount, $date);
+        }
+
+        return (int) round($amount * 100);
     }
 }

--- a/resources/js/components/accounts/account-balance-chart.tsx
+++ b/resources/js/components/accounts/account-balance-chart.tsx
@@ -516,27 +516,38 @@ export function AccountBalanceChart({
             : account.currency_code;
 
     const activeChartData = useMemo(() => {
-        if (currencyMode !== 'user' || !hasCurrencyToggle) {
-            return chartData;
+        if (currencyMode === 'user' && hasCurrencyToggle) {
+            // User currency mode: swap balance to display_value (account→user),
+            // but invested_amount is already in user currency — keep as-is
+            return chartData.map((point) => ({
+                ...point,
+                value: point.display_value ?? point.value,
+                mortgage_balance:
+                    point.display_mortgage_balance !== undefined
+                        ? point.display_mortgage_balance
+                        : point.mortgage_balance,
+                projected_value:
+                    'projected_value' in point &&
+                    point.display_value !== undefined
+                        ? point.display_value
+                        : ((point as unknown as Record<string, unknown>)
+                              .projected_value as number | undefined),
+            }));
         }
 
-        return chartData.map((point) => ({
-            ...point,
-            value: point.display_value ?? point.value,
-            invested_amount:
-                point.display_invested_amount !== undefined
-                    ? point.display_invested_amount
-                    : point.invested_amount,
-            mortgage_balance:
-                point.display_mortgage_balance !== undefined
-                    ? point.display_mortgage_balance
-                    : point.mortgage_balance,
-            projected_value:
-                'projected_value' in point && point.display_value !== undefined
-                    ? point.display_value
-                    : ((point as unknown as Record<string, unknown>)
-                          .projected_value as number | undefined),
-        }));
+        if (currencyMode === 'account' && hasCurrencyToggle) {
+            // Account currency mode: balance is already in account currency,
+            // but invested_amount is in user currency — swap to display_invested_amount (user→account)
+            return chartData.map((point) => ({
+                ...point,
+                invested_amount:
+                    point.display_invested_amount !== undefined
+                        ? point.display_invested_amount
+                        : point.invested_amount,
+            }));
+        }
+
+        return chartData;
     }, [chartData, currencyMode, hasCurrencyToggle]);
 
     const activeCurrentBalance = useMemo(() => {
@@ -566,20 +577,16 @@ export function AccountBalanceChart({
     ]);
 
     const activeCurrentInvestedAmount = useMemo(() => {
-        if (currencyMode !== 'user' || !hasCurrencyToggle) {
+        if (!hasCurrencyToggle) {
             return currentInvestedAmount;
         }
+        // In both currency modes, activeChartData has the correctly-swapped invested_amount
         for (let i = activeChartData.length - 1; i >= 0; i--) {
             const ia = activeChartData[i].invested_amount;
             if (ia !== null && ia !== undefined) return ia;
         }
         return null;
-    }, [
-        activeChartData,
-        currentInvestedAmount,
-        currencyMode,
-        hasCurrencyToggle,
-    ]);
+    }, [activeChartData, currentInvestedAmount, hasCurrencyToggle]);
 
     const activeShortTrend = useMemo(() => {
         if (currencyMode !== 'user' || !hasCurrencyToggle) return shortTrend;

--- a/resources/js/components/accounts/balances-modal.tsx
+++ b/resources/js/components/accounts/balances-modal.tsx
@@ -34,6 +34,7 @@ import {
     TableRow,
 } from '@/components/ui/table';
 import { useLocale } from '@/hooks/use-locale';
+import type { SharedData } from '@/types';
 import type { Account, AccountBalance } from '@/types/account';
 import {
     balanceTermCapitalized,
@@ -41,6 +42,7 @@ import {
 } from '@/types/account';
 import { formatCurrency } from '@/utils/currency';
 import { __ } from '@/utils/i18n';
+import { usePage } from '@inertiajs/react';
 import { Pencil, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 
@@ -88,6 +90,11 @@ export function BalancesModal({
 
     const formatBalance = (valueInCents: number) =>
         formatCurrency(valueInCents, account.currency_code, locale);
+
+    const userCurrencyCode =
+        usePage<SharedData>().props.auth.user.currency_code;
+    const formatInvestedAmount = (valueInCents: number) =>
+        formatCurrency(valueInCents, userCurrencyCode, locale);
 
     const showInvestedAmount = supportsInvestedAmount(account);
     const isLoan = account.type === 'loan';
@@ -329,7 +336,7 @@ export function BalancesModal({
                                                     <TableCell className="text-right font-mono text-muted-foreground">
                                                         {balance.invested_amount !==
                                                         null
-                                                            ? formatBalance(
+                                                            ? formatInvestedAmount(
                                                                   balance.invested_amount,
                                                               )
                                                             : '—'}
@@ -471,7 +478,7 @@ export function BalancesModal({
                                     onChange={(value) =>
                                         setEditInvestedAmount(value || null)
                                     }
-                                    currencyCode={account.currency_code}
+                                    currencyCode={userCurrencyCode}
                                 />
                             </div>
                         )}

--- a/resources/js/components/accounts/import-balances-drawer.tsx
+++ b/resources/js/components/accounts/import-balances-drawer.tsx
@@ -64,7 +64,8 @@ export function ImportBalancesDrawer({
     accountId,
     onSuccess,
 }: ImportBalancesDrawerProps) {
-    const { locale } = usePage<SharedData>().props;
+    const { locale, auth } = usePage<SharedData>().props;
+    const userCurrencyCode = auth.user.currency_code;
     const [isImporting, setIsImporting] = useState(false);
     const [importProgress, setImportProgress] = useState(0);
     const [importTotal, setImportTotal] = useState(0);
@@ -646,6 +647,7 @@ export function ImportBalancesDrawer({
                         dateFormatDetected={state.dateFormatDetected}
                         parsedData={state.parsedData}
                         currencyCode={selectedAccount?.currency_code || 'USD'}
+                        investedAmountCurrencyCode={userCurrencyCode}
                         showInvestedAmount={showInvestedAmount}
                         isLoan={selectedAccount?.type === 'loan'}
                         onMappingChange={handleMappingChange}
@@ -660,6 +662,7 @@ export function ImportBalancesDrawer({
                     <ImportBalanceStepPreview
                         balances={state.balances}
                         currencyCode={selectedAccount?.currency_code || 'USD'}
+                        investedAmountCurrencyCode={userCurrencyCode}
                         showInvestedAmount={showInvestedAmount}
                         isLoan={selectedAccount?.type === 'loan'}
                         onConfirm={handleConfirmImport}

--- a/resources/js/components/accounts/import-balances/import-balance-step-mapping.tsx
+++ b/resources/js/components/accounts/import-balances/import-balance-step-mapping.tsx
@@ -26,6 +26,7 @@ interface ImportBalanceStepMappingProps {
     dateFormatDetected: boolean;
     parsedData: ParsedRow[];
     currencyCode: string;
+    investedAmountCurrencyCode: string;
     showInvestedAmount: boolean;
     isLoan?: boolean;
     onMappingChange: (field: keyof BalanceColumnMapping, value: string) => void;
@@ -41,6 +42,7 @@ export function ImportBalanceStepMapping({
     dateFormatDetected,
     parsedData,
     currencyCode,
+    investedAmountCurrencyCode,
     showInvestedAmount,
     isLoan = false,
     onMappingChange,
@@ -55,6 +57,14 @@ export function ImportBalanceStepMapping({
         new Intl.NumberFormat(locale, {
             style: 'currency',
             currency: currencyCode,
+        })
+            .format(value)
+            .replace(/\s/g, '\u202F');
+
+    const formatRawInvestedAmount = (value: number) =>
+        new Intl.NumberFormat(locale, {
+            style: 'currency',
+            currency: investedAmountCurrencyCode,
         })
             .format(value)
             .replace(/\s/g, '\u202F');
@@ -77,7 +87,7 @@ export function ImportBalanceStepMapping({
             );
             investedAmount =
                 invested !== null
-                    ? formatRawAmount(invested)
+                    ? formatRawInvestedAmount(invested)
                     : 'Invalid amount';
         }
 

--- a/resources/js/components/accounts/import-balances/import-balance-step-preview.tsx
+++ b/resources/js/components/accounts/import-balances/import-balance-step-preview.tsx
@@ -17,6 +17,7 @@ import { __ } from '@/utils/i18n';
 interface ImportBalanceStepPreviewProps {
     balances: ParsedBalance[];
     currencyCode: string;
+    investedAmountCurrencyCode: string;
     showInvestedAmount: boolean;
     isLoan?: boolean;
     onConfirm: () => void;
@@ -27,6 +28,7 @@ interface ImportBalanceStepPreviewProps {
 export function ImportBalanceStepPreview({
     balances,
     currencyCode,
+    investedAmountCurrencyCode,
     showInvestedAmount,
     isLoan = false,
     onConfirm,
@@ -38,6 +40,9 @@ export function ImportBalanceStepPreview({
 
     const formatBalance = (valueInCents: number): string =>
         formatCurrency(valueInCents, currencyCode, locale);
+
+    const formatInvestedAmount = (valueInCents: number): string =>
+        formatCurrency(valueInCents, investedAmountCurrencyCode, locale);
 
     const hasInvestedData =
         showInvestedAmount && balances.some((b) => b.invested_amount !== null);
@@ -100,7 +105,7 @@ export function ImportBalanceStepPreview({
                                     {hasInvestedData && (
                                         <TableCell className="text-right font-mono text-muted-foreground">
                                             {balance.invested_amount !== null
-                                                ? formatBalance(
+                                                ? formatInvestedAmount(
                                                       balance.invested_amount,
                                                   )
                                                 : '—'}

--- a/resources/js/components/accounts/update-balance-dialog.tsx
+++ b/resources/js/components/accounts/update-balance-dialog.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import type { SharedData } from '@/types';
 import {
     type Account,
     type AccountBalance,
@@ -21,6 +22,7 @@ import {
     supportsInvestedAmount,
 } from '@/types/account';
 import { __ } from '@/utils/i18n';
+import { usePage } from '@inertiajs/react';
 import { useEffect, useRef, useState } from 'react';
 
 interface UpdateBalanceDialogProps {
@@ -54,6 +56,8 @@ export function UpdateBalanceDialog({
     const inputRef = useRef<HTMLInputElement>(null);
     const showInvestedAmount = supportsInvestedAmount(account);
     const isLoan = account.type === 'loan';
+    const userCurrencyCode =
+        usePage<SharedData>().props.auth.user.currency_code;
 
     useEffect(() => {
         async function fetchLastBalance() {
@@ -228,7 +232,7 @@ export function UpdateBalanceDialog({
                                             value === 0 ? null : value,
                                         )
                                     }
-                                    currencyCode={account.currency_code}
+                                    currencyCode={userCurrencyCode}
                                 />
                             )}
                         </div>

--- a/tests/Feature/DashboardAnalyticsTest.php
+++ b/tests/Feature/DashboardAnalyticsTest.php
@@ -1094,6 +1094,12 @@ test('account balance evolution includes display_invested_amount for foreign cur
         'rates' => ['eur' => 0.90],
     ]);
 
+    ExchangeRate::factory()->create([
+        'base_currency' => 'eur',
+        'date' => $endOfMonth->toDateString(),
+        'rates' => ['usd' => 1 / 0.90],
+    ]);
+
     $response = $this->getJson('/api/dashboard/account/'.$account->id.'/balance-evolution?'.http_build_query([
         'from' => $lastMonth->copy()->startOfMonth()->toDateString(),
         'to' => $endOfMonth->toDateString(),
@@ -1102,12 +1108,12 @@ test('account balance evolution includes display_invested_amount for foreign cur
     $response->assertOk();
     $data = $response->json();
 
-    // Original invested_amount in EUR
+    // invested_amount is now stored in user currency (USD)
     expect($data['data'][0]['invested_amount'])->toBe(400000);
-    // Converted display values
+    // Converted display values (invested_amount converted from user currency USD → account currency EUR)
     expect($data['data'][0])->toHaveKey('display_value');
     expect($data['data'][0])->toHaveKey('display_invested_amount');
-    expect($data['data'][0]['display_invested_amount'])->toBe((int) round(400000 / 0.90));
+    expect($data['data'][0]['display_invested_amount'])->toBe((int) round(400000 * 0.90));
     expect($data['display_currency_code'])->toBe('USD');
 });
 

--- a/tests/Feature/OpenBanking/IndexaCapitalBalanceSyncTest.php
+++ b/tests/Feature/OpenBanking/IndexaCapitalBalanceSyncTest.php
@@ -29,7 +29,7 @@ test('syncs historical balances from indexa capital portfolios', function () {
     ]);
 
     $client = new IndexaCapitalClient('test-token');
-    $service = new IndexaCapitalBalanceSyncService;
+    $service = app(IndexaCapitalBalanceSyncService::class);
     $service->sync($account, $client);
 
     expect($account->balances()->count())->toBe(3);
@@ -62,7 +62,7 @@ test('syncs all available historical data', function () {
     ]);
 
     $client = new IndexaCapitalClient('test-token');
-    $service = new IndexaCapitalBalanceSyncService;
+    $service = app(IndexaCapitalBalanceSyncService::class);
     $service->sync($account, $client);
 
     expect($account->balances()->count())->toBe(4);
@@ -93,7 +93,7 @@ test('updates existing balance for same date', function () {
     ]);
 
     $client = new IndexaCapitalClient('test-token');
-    $service = new IndexaCapitalBalanceSyncService;
+    $service = app(IndexaCapitalBalanceSyncService::class);
     $service->sync($account, $client);
 
     expect($account->balances()->count())->toBe(1);
@@ -110,7 +110,7 @@ test('skips account without external_account_id', function () {
     $client = Mockery::mock(IndexaCapitalClient::class);
     $client->shouldNotReceive('getPerformance');
 
-    $service = new IndexaCapitalBalanceSyncService;
+    $service = app(IndexaCapitalBalanceSyncService::class);
     $service->sync($account, $client);
 
     expect($account->balances()->count())->toBe(0);
@@ -134,7 +134,7 @@ test('handles missing portfolios gracefully', function () {
     ]);
 
     $client = new IndexaCapitalClient('test-token');
-    $service = new IndexaCapitalBalanceSyncService;
+    $service = app(IndexaCapitalBalanceSyncService::class);
     $service->sync($account, $client);
 
     expect($account->balances()->count())->toBe(0);
@@ -158,7 +158,7 @@ test('handles empty portfolios array gracefully', function () {
     ]);
 
     $client = new IndexaCapitalClient('test-token');
-    $service = new IndexaCapitalBalanceSyncService;
+    $service = app(IndexaCapitalBalanceSyncService::class);
     $service->sync($account, $client);
 
     expect($account->balances()->count())->toBe(0);
@@ -173,6 +173,7 @@ test('stores invested_amount from net_amounts data', function () {
         'user_id' => $user->id,
         'banking_connection_id' => $connection->id,
         'external_account_id' => 'IC-001',
+        'currency_code' => 'USD',
     ]);
 
     $today = now()->toDateString();
@@ -206,7 +207,7 @@ test('stores invested_amount from net_amounts data', function () {
     ]);
 
     $client = new IndexaCapitalClient('test-token');
-    $service = new IndexaCapitalBalanceSyncService;
+    $service = app(IndexaCapitalBalanceSyncService::class);
     $service->sync($account, $client);
 
     expect($account->balances()->count())->toBe(2);
@@ -229,6 +230,7 @@ test('stores null invested_amount when net_amounts is missing', function () {
         'user_id' => $user->id,
         'banking_connection_id' => $connection->id,
         'external_account_id' => 'IC-001',
+        'currency_code' => 'USD',
     ]);
 
     Http::fake([
@@ -240,7 +242,7 @@ test('stores null invested_amount when net_amounts is missing', function () {
     ]);
 
     $client = new IndexaCapitalClient('test-token');
-    $service = new IndexaCapitalBalanceSyncService;
+    $service = app(IndexaCapitalBalanceSyncService::class);
     $service->sync($account, $client);
 
     expect($account->balances()->count())->toBe(1);
@@ -259,6 +261,7 @@ test('falls back to total_amount minus return when net_amounts is missing', func
         'user_id' => $user->id,
         'banking_connection_id' => $connection->id,
         'external_account_id' => 'IC-001',
+        'currency_code' => 'USD',
     ]);
 
     Http::fake([
@@ -271,7 +274,7 @@ test('falls back to total_amount minus return when net_amounts is missing', func
     ]);
 
     $client = new IndexaCapitalClient('test-token');
-    $service = new IndexaCapitalBalanceSyncService;
+    $service = app(IndexaCapitalBalanceSyncService::class);
     $service->sync($account, $client);
 
     $balance = $account->balances()->first();
@@ -318,7 +321,7 @@ test('subsequent sync only processes entries since last balance date', function 
     ]);
 
     $client = new IndexaCapitalClient('test-token');
-    $service = new IndexaCapitalBalanceSyncService;
+    $service = app(IndexaCapitalBalanceSyncService::class);
     $service->sync($account, $client, isFirstSync: false);
 
     // 2 pre-existing + 3 new entries = 5 total (the one on the boundary date gets updated, not duplicated)
@@ -365,7 +368,7 @@ test('full sync processes all entries regardless of existing balances', function
     ]);
 
     $client = new IndexaCapitalClient('test-token');
-    $service = new IndexaCapitalBalanceSyncService;
+    $service = app(IndexaCapitalBalanceSyncService::class);
     $service->sync($account, $client, isFirstSync: true);
 
     // All 3 entries processed (1 existing updated + 2 new)


### PR DESCRIPTION
## Summary

- **Store `invested_amount` in user's currency** (e.g. EUR) instead of the account's currency (e.g. BTC), since it represents "how much of my money did I put in" — a concept tied to the user's home currency.
- **Flip `display_invested_amount`** in API responses: now converts from user currency → account currency (previously account → user), for the chart's account-currency toggle mode.
- **Remove redundant conversions** in `AccountMetricsService` since invested amounts are already in user currency after sync.

## Changes

### Backend (5 files)
- **BinanceBalanceSyncService** — convert to `$account->user->currency_code` instead of `$account->currency_code`
- **BitpandaBalanceSyncService** — same currency target change
- **IndexaCapitalBalanceSyncService** — inject `CurrencyConversionService`, convert invested amount float to user currency before storing as cents
- **DashboardAnalyticsController** — flip `display_invested_amount` conversion direction (user→account) in both monthly and daily endpoints
- **AccountMetricsService** — remove 4 now-redundant invested_amount conversion spots (values already in user currency)

### Frontend (6 files)
- **update-balance-dialog.tsx** — invested amount input uses user currency
- **balances-modal.tsx** — invested amount display and edit uses user currency
- **account-balance-chart.tsx** — currency toggle: user-currency mode keeps invested_amount as-is; account-currency mode swaps to `display_invested_amount`
- **import-balances-drawer.tsx** — passes `investedAmountCurrencyCode` (user currency) to sub-components
- **import-balance-step-mapping.tsx** / **import-balance-step-preview.tsx** — format invested amounts in user currency

### Tests (2 files)
- **IndexaCapitalBalanceSyncTest** — use `app()` instead of `new` (constructor now has DI), pin account currency to USD for deterministic assertions
- **DashboardAnalyticsTest** — add EUR-based exchange rate, flip assertion from `/ 0.90` to `* 0.90`