### PR TITLE
fix: make transaction sync email use default sender

### DIFF
--- a/app/Mail/BankTransactionsSyncedEmail.php
+++ b/app/Mail/BankTransactionsSyncedEmail.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Address;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\Middleware\RateLimited;
@@ -43,6 +44,10 @@ class BankTransactionsSyncedEmail extends Mailable implements ShouldQueue
     public function envelope(): Envelope
     {
         return new Envelope(
+            from: new Address(
+                config('mail.from.address', 'no-reply@whisper.money'),
+                config('mail.from.name', 'Whisper Money'),
+            ),
             subject: __(':count new transactions synced on Whisper Money', ['count' => $this->totalTransactions]),
         );
     }

--- a/tests/Feature/MailSenderTest.php
+++ b/tests/Feature/MailSenderTest.php
@@ -129,6 +129,14 @@ test('default sender is used for active non-drip mailables', function (string $m
     WaitlistOvertaken::class,
 ]);
 
+test('transaction sync email envelope explicitly uses the default sender', function () {
+    $user = User::factory()->create();
+
+    $mailable = new BankTransactionsSyncedEmail($user, 3, ['Test Bank' => 3]);
+
+    expect($mailable->envelope()->from)->toEqual(new Address('no-reply@whisper.money', 'Whisper Money'));
+});
+
 test('verification notification uses the default sender', function () {
     $user = User::factory()->unverified()->create();
 


### PR DESCRIPTION
## Summary
- explicitly set the transaction sync mailable sender to the configured default transactional address
- add a regression test so the transaction sync email cannot fall back to an unintended sender

## Testing
- php artisan test --compact tests/Feature/MailSenderTest.php