### PR TITLE
fix: reorder signed names in mail templates

### DIFF
--- a/resources/views/mail/bank-transactions-synced.blade.php
+++ b/resources/views/mail/bank-transactions-synced.blade.php
@@ -12,6 +12,6 @@
 </x-mail::button>
 
 {{ __('Best,') }}<br>
-{{ __('Víctor & Álvaro') }}<br>
+{{ __('Álvaro & Víctor') }}<br>
 {{ __('Founders of Whisper Money') }}
 </x-mail::message>

--- a/resources/views/mail/banking-connection-auth-failed.blade.php
+++ b/resources/views/mail/banking-connection-auth-failed.blade.php
@@ -12,6 +12,6 @@
 </x-mail::button>
 
 {{ __('Best,') }}<br>
-{{ __('Víctor & Álvaro') }}<br>
+{{ __('Álvaro & Víctor') }}<br>
 {{ __('Founders of Whisper Money') }}
 </x-mail::message>

--- a/resources/views/mail/drip/feedback.blade.php
+++ b/resources/views/mail/drip/feedback.blade.php
@@ -20,6 +20,6 @@
 {{ __('Thanks for being part of Whisper Money. It really means a lot.') }}
 
 {{ __('Best,') }}<br>
-{{ __('Víctor & Álvaro') }}<br>
+{{ __('Álvaro & Víctor') }}<br>
 {{ __('Founders of Whisper Money') }}
 </x-mail::message>

--- a/resources/views/mail/drip/import-help.blade.php
+++ b/resources/views/mail/drip/import-help.blade.php
@@ -31,6 +31,6 @@
 {{ __('Thanks for giving Whisper Money a try!') }}
 
 {{ __('Best,') }}<br>
-{{ __('Víctor & Álvaro') }}<br>
+{{ __('Álvaro & Víctor') }}<br>
 {{ __('Founders of Whisper Money') }}
 </x-mail::message>

--- a/resources/views/mail/drip/onboarding-reminder.blade.php
+++ b/resources/views/mail/drip/onboarding-reminder.blade.php
@@ -23,6 +23,6 @@
 {{ __("Looking forward to hearing from you! And if you decide Whisper Money isn't for you, that's totally fine - but we'd love to know why so we can improve.") }}
 
 {{ __('Best,') }}<br>
-{{ __('Víctor & Álvaro') }}<br>
+{{ __('Álvaro & Víctor') }}<br>
 {{ __('Founders of Whisper Money') }}
 </x-mail::message>

--- a/resources/views/mail/drip/promo-code.blade.php
+++ b/resources/views/mail/drip/promo-code.blade.php
@@ -27,6 +27,6 @@
 {{ __('Thanks for being part of this journey with us!') }}
 
 {{ __('Best,') }}<br>
-{{ __('Víctor & Álvaro') }}<br>
+{{ __('Álvaro & Víctor') }}<br>
 {{ __('Founders of Whisper Money') }}
 </x-mail::message>

--- a/resources/views/mail/drip/subscription-cancelled.blade.php
+++ b/resources/views/mail/drip/subscription-cancelled.blade.php
@@ -26,6 +26,6 @@
 {{ __('Thanks again for being part of this journey!') }}
 
 {{ __('Best,') }}<br>
-{{ __('Víctor & Álvaro') }}<br>
+{{ __('Álvaro & Víctor') }}<br>
 {{ __('Founders of Whisper Money') }}
 </x-mail::message>

--- a/resources/views/mail/drip/welcome.blade.php
+++ b/resources/views/mail/drip/welcome.blade.php
@@ -33,6 +33,6 @@
 {{ __('Thanks for giving Whisper Money a try. It means a lot to us.') }}
 
 {{ __('Best,') }}<br>
-{{ __('Víctor & Álvaro') }}<br>
+{{ __('Álvaro & Víctor') }}<br>
 {{ __('Founders of Whisper Money') }}
 </x-mail::message>

--- a/resources/views/mail/user-lead-invitation.blade.php
+++ b/resources/views/mail/user-lead-invitation.blade.php
@@ -32,6 +32,6 @@
 {{ __("Thanks for being interested in what we're building!") }}
 
 {{ __('Best,') }}<br>
-{{ __('Víctor & Álvaro') }}<br>
+{{ __('Álvaro & Víctor') }}<br>
 {{ __('Founders of Whisper Money') }}
 </x-mail::message>

--- a/resources/views/mail/verify-email.blade.php
+++ b/resources/views/mail/verify-email.blade.php
@@ -12,7 +12,7 @@
 {{ __("If you didn't create a Whisper Money account, you can safely ignore this email.") }}
 
 {{ __('Best,') }}<br>
-{{ __('Víctor & Álvaro') }}<br>
+{{ __('Álvaro & Víctor') }}<br>
 {{ __('Founders of Whisper Money') }}
 
 <x-mail::subcopy>

--- a/resources/views/mail/waitlist-overtaken.blade.php
+++ b/resources/views/mail/waitlist-overtaken.blade.php
@@ -34,6 +34,6 @@
 {{ __("Share it with friends, family, or anyone who cares about their financial privacy. Every sign-up moves you 10 spots closer to the front.") }}
 
 {{ __("Best,") }}<br>
-{{ __('Víctor & Álvaro') }}<br>
+{{ __('Álvaro & Víctor') }}<br>
 {{ __("Founders of Whisper Money") }}
 </x-mail::message>

--- a/resources/views/mail/waitlist-referral-notification.blade.php
+++ b/resources/views/mail/waitlist-referral-notification.blade.php
@@ -34,6 +34,6 @@
 {{ __("Thanks for spreading the word. It means everything to us.") }}
 
 {{ __("Best,") }}<br>
-{{ __('Víctor & Álvaro') }}<br>
+{{ __('Álvaro & Víctor') }}<br>
 {{ __("Founders of Whisper Money") }}
 </x-mail::message>

--- a/resources/views/mail/waitlist-welcome.blade.php
+++ b/resources/views/mail/waitlist-welcome.blade.php
@@ -55,6 +55,6 @@
 {{ __("We're working hard to open things up, and we can't wait to share Whisper Money with you.") }}
 
 {{ __("Best,") }}<br>
-{{ __('Víctor & Álvaro') }}<br>
+{{ __('Álvaro & Víctor') }}<br>
 {{ __("Founders of Whisper Money") }}
 </x-mail::message>

--- a/tests/Feature/MailSenderTest.php
+++ b/tests/Feature/MailSenderTest.php
@@ -147,3 +147,29 @@ test('verification notification uses the default sender', function () {
     expect($from->getAddress())->toBe('no-reply@whisper.money')
         ->and($from->getName())->toBe('Whisper Money');
 });
+
+test('mail blade signatures use alvaro before victor', function () {
+    $mailViews = [
+        'mail/verify-email.blade.php',
+        'mail/waitlist-welcome.blade.php',
+        'mail/waitlist-referral-notification.blade.php',
+        'mail/user-lead-invitation.blade.php',
+        'mail/waitlist-overtaken.blade.php',
+        'mail/drip/import-help.blade.php',
+        'mail/drip/onboarding-reminder.blade.php',
+        'mail/drip/promo-code.blade.php',
+        'mail/drip/subscription-cancelled.blade.php',
+        'mail/drip/welcome.blade.php',
+        'mail/bank-transactions-synced.blade.php',
+        'mail/drip/feedback.blade.php',
+        'mail/banking-connection-auth-failed.blade.php',
+    ];
+
+    foreach ($mailViews as $mailView) {
+        $contents = File::get(resource_path("views/{$mailView}"));
+
+        expect($contents)
+            ->toContain("{{ __('Álvaro & Víctor') }}<br>")
+            ->not->toContain("{{ __('Víctor & Álvaro') }}<br>");
+    }
+});


### PR DESCRIPTION
## Summary
- update mail signatures to show Álvaro before Víctor across the Blade mail templates
- add a focused mail test that guards the signature order so the old ordering does not reappear
- verified with `php artisan test --compact tests/Feature/MailSenderTest.php`