### PR TITLE
fix: prioritize exact bank search matches

### DIFF
--- a/app/Http/Controllers/Settings/BankController.php
+++ b/app/Http/Controllers/Settings/BankController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Settings;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Settings\StoreBankRequest;
 use App\Models\Bank;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
@@ -14,17 +15,22 @@ class BankController extends Controller
     public function index(Request $request): JsonResponse
     {
         $query = Bank::query()
-            ->where(function ($q) {
+            ->where(function (Builder $q) {
                 $q->whereNull('user_id')
                     ->orWhere('user_id', auth()->id());
             });
 
-        if ($request->has('search')) {
-            $search = $request->input('search');
-            $query->where('name', 'like', "%{$search}%");
-        }
+        $search = trim((string) $request->input('search', ''));
 
-        $banks = $query->orderBy('name')->limit(20)->get();
+        $query->when($search !== '', function (Builder $query) use ($search) {
+            $query->where('name', 'like', "%{$search}%")
+                ->orderByRaw(
+                    'CASE WHEN name = ? THEN 0 WHEN name LIKE ? THEN 1 ELSE 2 END',
+                    [$search, "{$search}%"]
+                );
+        });
+
+        $banks = $query->orderBy('name')->get();
 
         return response()->json(['data' => $banks]);
     }

--- a/tests/Feature/Settings/BankTest.php
+++ b/tests/Feature/Settings/BankTest.php
@@ -122,3 +122,58 @@ it('requires authentication to create a bank', function () {
 
     $response->assertUnauthorized();
 });
+
+it('prioritizes exact and prefix bank matches when searching', function () {
+    actingAs($this->user);
+
+    Bank::factory()->create(['name' => 'Online Banking Demo', 'user_id' => null]);
+    Bank::factory()->create(['name' => 'ING Wholesale Banking', 'user_id' => null]);
+    Bank::factory()->create(['name' => 'ING', 'user_id' => null]);
+    Bank::factory()->create(['name' => 'My Savings Bank', 'user_id' => null]);
+
+    $response = $this->getJson(route('banks.index', ['search' => 'ING']));
+
+    $response->assertSuccessful();
+
+    expect(collect($response->json('data'))->pluck('name')->take(4)->all())
+        ->toBe([
+            'ING',
+            'ING Wholesale Banking',
+            'My Savings Bank',
+            'Online Banking Demo',
+        ]);
+});
+
+it('returns all matching banks without truncating search results', function () {
+    actingAs($this->user);
+
+    foreach (range(1, 25) as $index) {
+        Bank::factory()->create([
+            'name' => sprintf('ING Result %02d', $index),
+            'user_id' => null,
+        ]);
+    }
+
+    $response = $this->getJson(route('banks.index', ['search' => 'ING Result']));
+
+    $response->assertSuccessful();
+
+    expect($response->json('data'))
+        ->toHaveCount(25);
+});
+
+it('includes matching user banks in search results', function () {
+    actingAs($this->user);
+
+    Bank::factory()->create(['name' => 'ING', 'user_id' => null]);
+    Bank::factory()->create(['name' => 'ING Personal Vault', 'user_id' => $this->user->id]);
+    Bank::factory()->create(['name' => 'ING Hidden', 'user_id' => User::factory()->create()->id]);
+
+    $response = $this->getJson(route('banks.index', ['search' => 'ING']));
+
+    $response->assertSuccessful();
+
+    expect(collect($response->json('data'))->pluck('name')->all())
+        ->toContain('ING', 'ING Personal Vault')
+        ->not->toContain('ING Hidden');
+});


### PR DESCRIPTION
## Summary
- remove the bank search result cap so exact matches are no longer pushed out of the response
- rank exact name matches first, then prefix matches, then broader substring matches
- add feature coverage for search ranking, full result sets, and user-specific visibility