### PR TITLE
fix: preserve cents in chart amounts

### DIFF
--- a/resources/js/components/accounts/account-balance-chart.tsx
+++ b/resources/js/components/accounts/account-balance-chart.tsx
@@ -303,7 +303,7 @@ function formatChartCurrency(
     currencyCode: string,
     locale: string,
 ): string {
-    return formatCurrency(value, currencyCode, locale, 0, 0);
+    return formatCurrency(value, currencyCode, locale);
 }
 
 function calculateTrend(
@@ -763,8 +763,6 @@ export function AccountBalanceChart({
                             <AmountDisplay
                                 amountInCents={activeCurrentBalance}
                                 currencyCode={activeCurrencyCode}
-                                minimumFractionDigits={0}
-                                maximumFractionDigits={0}
                             />
                         </button>
                         {currentEquity !== null && (
@@ -778,8 +776,6 @@ export function AccountBalanceChart({
                                     <AmountDisplay
                                         amountInCents={currentEquity}
                                         currencyCode={activeCurrencyCode}
-                                        minimumFractionDigits={0}
-                                        maximumFractionDigits={0}
                                     />
                                 </span>
                             </div>

--- a/resources/js/components/charts/mom-chart.tsx
+++ b/resources/js/components/charts/mom-chart.tsx
@@ -67,8 +67,6 @@ function CustomTooltip({ active, payload, currencyCode }: CustomTooltipProps) {
                     <AmountDisplay
                         amountInCents={change ?? 0}
                         currencyCode={currencyCode}
-                        minimumFractionDigits={0}
-                        maximumFractionDigits={0}
                     />
                 </span>
             </div>

--- a/resources/js/components/dashboard/net-worth-chart.tsx
+++ b/resources/js/components/dashboard/net-worth-chart.tsx
@@ -470,8 +470,6 @@ export function NetWorthChart({
                 <AmountDisplay
                     amountInCents={value}
                     currencyCode={userCurrency}
-                    minimumFractionDigits={0}
-                    maximumFractionDigits={0}
                 />
             );
         };
@@ -530,8 +528,6 @@ export function NetWorthChart({
                                     amountInCents={totalAmount}
                                     currencyCode={userCurrency}
                                     variant="large"
-                                    minimumFractionDigits={0}
-                                    maximumFractionDigits={0}
                                 />
                             </div>
                             <PercentageTrendIndicator

--- a/resources/js/components/dashboard/percentage-trend-indicator.tsx
+++ b/resources/js/components/dashboard/percentage-trend-indicator.tsx
@@ -74,8 +74,6 @@ export function PercentageTrendIndicator({
                         currencyCode={currencyCode}
                         variant="trend"
                         highlightPositive={amountDiff >= 0}
-                        minimumFractionDigits={0}
-                        maximumFractionDigits={0}
                     />{' '}
                     {label}
                 </TooltipContent>

--- a/resources/js/components/ui/chart.tsx
+++ b/resources/js/components/ui/chart.tsx
@@ -141,8 +141,12 @@ interface ChartTooltipContentProps {
     };
 }
 
-function formatCurrencyWithCode(value: number, currencyCode: string, locale: string): string {
-    return formatCurrency(value, currencyCode, locale, 0, 0);
+function formatCurrencyWithCode(
+    value: number,
+    currencyCode: string,
+    locale: string,
+): string {
+    return formatCurrency(value, currencyCode, locale);
 }
 
 const ChartTooltipContent = React.forwardRef<

--- a/resources/js/utils/currency.test.ts
+++ b/resources/js/utils/currency.test.ts
@@ -64,6 +64,11 @@ describe('formatCurrency', () => {
         expect(formatCurrency(100000, 'USD', 'en-US', 0, 0)).toBe('$1,000');
     });
 
+    it('preserves two decimals for chart-style balance amounts', () => {
+        expect(formatCurrency(164545, 'EUR', 'de-DE')).toBe('1.645,45\u202F€');
+        expect(formatCurrency(164545, 'USD', 'en-US')).toBe('$1,645.45');
+    });
+
     it('formats es-ES EUR 4-digit amounts with thousands separator', () => {
         // In some ICU/CLDR versions, es-ES uses useGrouping:'auto' which omits the thousands
         // separator for 4-digit numbers (1,000–9,999). We force useGrouping:'always' so that


### PR DESCRIPTION
## Summary
- keep two decimal places in net worth and account chart amounts instead of rounding to whole units
- update shared chart tooltip, trend tooltip, and MoM tooltip currency formatting so related chart values stay consistent
- add targeted formatter coverage for chart-style balances with decimals

## Testing
- npm test -- resources/js/utils/currency.test.ts