### PR TITLE
fix: default account charts to user currency

### DIFF
--- a/resources/js/components/accounts/account-balance-chart.tsx
+++ b/resources/js/components/accounts/account-balance-chart.tsx
@@ -359,8 +359,7 @@ export function AccountBalanceChart({
     const isLoan = account.type === 'loan';
     const isRealEstate = isRealEstateAccount(account);
     const [granularity, setGranularity] = useState<ChartGranularity>('monthly');
-    const [currencyMode, setCurrencyMode] =
-        useState<ChartCurrencyMode>('account');
+    const [currencyMode, setCurrencyMode] = useState<ChartCurrencyMode>('user');
     const [balanceData, setBalanceData] = useState<AccountBalanceData | null>(
         null,
     );

--- a/resources/js/components/charts/chart-currency-toggle.test.tsx
+++ b/resources/js/components/charts/chart-currency-toggle.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ChartCurrencyToggle } from './chart-currency-toggle';
+
+describe('ChartCurrencyToggle', () => {
+    it('renders user currency before account currency', () => {
+        render(
+            <ChartCurrencyToggle
+                value="user"
+                onValueChange={vi.fn()}
+                userCurrencyCode="USD"
+                accountCurrencyCode="EUR"
+                showTooltip={false}
+            />,
+        );
+
+        const buttons = screen.getAllByRole('radio');
+
+        expect(buttons).toHaveLength(2);
+        expect(buttons[0]).toHaveTextContent('USD');
+        expect(buttons[1]).toHaveTextContent('EUR');
+        expect(buttons[0]).toHaveAttribute('data-state', 'on');
+    });
+});

--- a/resources/js/components/charts/chart-currency-toggle.tsx
+++ b/resources/js/components/charts/chart-currency-toggle.tsx
@@ -32,17 +32,17 @@ export function ChartCurrencyToggle({
         tooltip: string;
     }> = [
         {
-            mode: 'account',
-            label: accountCurrencyCode,
-            tooltip: __('Show in account currency (:currency)', {
-                currency: accountCurrencyCode,
-            }),
-        },
-        {
             mode: 'user',
             label: userCurrencyCode,
             tooltip: __('Show in your currency (:currency)', {
                 currency: userCurrencyCode,
+            }),
+        },
+        {
+            mode: 'account',
+            label: accountCurrencyCode,
+            tooltip: __('Show in account currency (:currency)', {
+                currency: accountCurrencyCode,
             }),
         },
     ];


### PR DESCRIPTION
## Summary
- default account charts to the user's currency when a currency toggle is available
- reverse the account chart currency toggle order so the user currency appears first
- add a focused frontend test covering the toggle order and selected state

## Testing
- npm test -- chart-currency-toggle