### PR TITLE
fix: avoid iOS PWA status bar overlap

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -46,7 +46,7 @@
         <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
         <meta name="apple-mobile-web-app-title" content="Whisper Money" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
-        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="default" />
         <meta name="mobile-web-app-capable" content="yes" />
         <link rel="manifest" href="/favicon/site.webmanifest" />
 

--- a/tests/Feature/PwaTest.php
+++ b/tests/Feature/PwaTest.php
@@ -16,6 +16,9 @@ test('app template includes pwa meta tags and service worker registration', func
 
     $response->assertStatus(200)
         ->assertSee('apple-mobile-web-app-capable', false)
+        ->assertSee('apple-mobile-web-app-status-bar-style', false)
+        ->assertSee('content="default"', false)
+        ->assertDontSee('black-translucent', false)
         ->assertSee('serviceWorker', false)
         ->assertSee('viewport-fit=cover', false);
 });


### PR DESCRIPTION
## Summary
- switch the iOS standalone PWA status bar style from `black-translucent` to `default`
- keep installed iOS app content below the status bar and notch area
- extend the PWA template test to guard against regressing to translucent overlap

## Testing
- vendor/bin/pint --dirty --format agent
- php artisan test --compact tests/Feature/PwaTest.php