### PR TITLE
chore: remove hardcoded resend segment ID

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,7 +59,7 @@ ADMIN_EMAIL=
 
 # Resend Email Service (set MAIL_MAILER=resend to use in production)
 RESEND_API_KEY=
-RESEND_LEADS_SEGMENT_ID=a4c14fa2-84a7-484a-9699-3de716f1b3ef
+RESEND_LEADS_SEGMENT_ID=
 
 # Drip Emails (welcome, onboarding, promo codes, etc.)
 DRIP_EMAILS_ENABLED=true

--- a/.env.production.example
+++ b/.env.production.example
@@ -43,7 +43,7 @@ REDIS_PORT=6379
 # Email - Resend (Recommended for production)
 MAIL_MAILER=resend
 RESEND_API_KEY=your-resend-api-key
-RESEND_LEADS_SEGMENT_ID=a4c14fa2-84a7-484a-9699-3de716f1b3ef
+RESEND_LEADS_SEGMENT_ID=your-segment-id
 MAIL_FROM_ADDRESS=no-reply@your-domain.com
 MAIL_FROM_NAME="Whisper Money"
 MAIL_DRIP_FROM_ADDRESS=hi@your-domain.com

--- a/config/services.php
+++ b/config/services.php
@@ -20,7 +20,7 @@ return [
 
     'resend' => [
         'key' => env('RESEND_API_KEY'),
-        'leads_segment_id' => env('RESEND_LEADS_SEGMENT_ID', 'a4c14fa2-84a7-484a-9699-3de716f1b3ef'),
+        'leads_segment_id' => env('RESEND_LEADS_SEGMENT_ID'),
     ],
 
     'ses' => [

--- a/tests/Feature/ResendSyncLeadsCommandTest.php
+++ b/tests/Feature/ResendSyncLeadsCommandTest.php
@@ -7,10 +7,12 @@ use Resend\Exceptions\ErrorException;
 use function Pest\Laravel\artisan;
 use function Pest\Laravel\mock;
 
+const TEST_RESEND_LEADS_SEGMENT_ID = 'test-segment-id';
+
 test('resend:sync-leads syncs all user leads to resend', function () {
     config([
         'services.resend.key' => 'test-api-key',
-        'services.resend.leads_segment_id' => 'a4c14fa2-84a7-484a-9699-3de716f1b3ef',
+        'services.resend.leads_segment_id' => TEST_RESEND_LEADS_SEGMENT_ID,
     ]);
 
     UserLead::factory()->count(3)->create();
@@ -27,7 +29,7 @@ test('resend:sync-leads syncs all user leads to resend', function () {
 test('resend:sync-leads fails when api key is not configured', function () {
     config([
         'services.resend.key' => null,
-        'services.resend.leads_segment_id' => 'a4c14fa2-84a7-484a-9699-3de716f1b3ef',
+        'services.resend.leads_segment_id' => TEST_RESEND_LEADS_SEGMENT_ID,
     ]);
 
     artisan('resend:sync-leads')
@@ -49,7 +51,7 @@ test('resend:sync-leads fails when leads segment id is not configured', function
 test('resend:sync-leads handles empty user leads', function () {
     config([
         'services.resend.key' => 'test-api-key',
-        'services.resend.leads_segment_id' => 'a4c14fa2-84a7-484a-9699-3de716f1b3ef',
+        'services.resend.leads_segment_id' => TEST_RESEND_LEADS_SEGMENT_ID,
     ]);
 
     artisan('resend:sync-leads')
@@ -60,7 +62,7 @@ test('resend:sync-leads handles empty user leads', function () {
 test('resend:sync-leads reports failures and continues syncing', function () {
     config([
         'services.resend.key' => 'test-api-key',
-        'services.resend.leads_segment_id' => 'a4c14fa2-84a7-484a-9699-3de716f1b3ef',
+        'services.resend.leads_segment_id' => TEST_RESEND_LEADS_SEGMENT_ID,
     ]);
 
     $firstLead = UserLead::factory()->create(['email' => 'first@example.com']);
@@ -83,7 +85,7 @@ test('resend:sync-leads reports failures and continues syncing', function () {
 test('syncLead adds an existing resend contact to the leads segment', function () {
     config([
         'services.resend.key' => 'test-api-key',
-        'services.resend.leads_segment_id' => 'a4c14fa2-84a7-484a-9699-3de716f1b3ef',
+        'services.resend.leads_segment_id' => TEST_RESEND_LEADS_SEGMENT_ID,
     ]);
 
     $lead = UserLead::factory()->create(['email' => 'lead@example.com']);
@@ -91,7 +93,7 @@ test('syncLead adds an existing resend contact to the leads segment', function (
     $segmentsService = Mockery::mock();
     $segmentsService->shouldReceive('add')
         ->once()
-        ->with('lead@example.com', 'a4c14fa2-84a7-484a-9699-3de716f1b3ef');
+        ->with('lead@example.com', TEST_RESEND_LEADS_SEGMENT_ID);
 
     $contactsService = new class($segmentsService)
     {


### PR DESCRIPTION
## Summary
- remove the hardcoded Resend leads segment ID from tracked config
- keep `RESEND_LEADS_SEGMENT_ID` environment-driven for production use
- replace leaked test UUID references with a test-only placeholder

## Testing
- php artisan test --compact tests/Feature/ResendSyncLeadsCommandTest.php
- vendor/bin/pint --dirty --format agent