### PR TITLE
fix(open-banking): sort bank sync email data

### DIFF
--- a/app/Jobs/SendDailyBankTransactionsSyncedEmailJob.php
+++ b/app/Jobs/SendDailyBankTransactionsSyncedEmailJob.php
@@ -61,6 +61,7 @@ class SendDailyBankTransactionsSyncedEmailJob implements ShouldBeUnique, ShouldQ
         $transactionsPerBank = $pendingTransactions
             ->groupBy(fn (Transaction $transaction) => $transaction->account->bank->name ?? __('Unknown Bank'))
             ->map(fn ($transactions) => $transactions->count())
+            ->sortKeys()
             ->all();
 
         Mail::to($this->user)->send(new BankTransactionsSyncedEmail(


### PR DESCRIPTION
## Summary
- sort bank names before building the daily synced-transactions email payload
- make the queued mailable payload deterministic so the open banking job test stops failing intermittently
- keep the email bank list order stable for users

## Testing
- php artisan test --compact tests/Feature/OpenBanking/SyncBankingConnectionJobTest.php