### PR TITLE
fix(schedule): remove stale horizon snapshot

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -3,7 +3,6 @@
 use Illuminate\Support\Facades\Schedule;
 
 Schedule::command('demo:reset')->twiceDaily();
-Schedule::command('horizon:snapshot')->everyFiveMinutes();
 Schedule::command('budgets:generate-periods')->daily();
 Schedule::command('banking:sync')->everySixHours();
 Schedule::command('banks:check-logos')->weekly();

--- a/tests/Feature/ScheduleCommandsTest.php
+++ b/tests/Feature/ScheduleCommandsTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Console\Scheduling\Event;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
+
+test('scheduled commands do not include horizon snapshot', function () {
+    Artisan::call('schedule:list');
+
+    $commands = collect(Schedule::events())
+        ->map(fn (Event $event): string => $event->command)
+        ->filter();
+
+    expect($commands)->each->not->toContain('horizon:snapshot');
+    expect($commands->implode("\n"))->not->toContain('horizon:snapshot');
+});


### PR DESCRIPTION
## Summary
- remove the stale `horizon:snapshot` scheduled command that still runs in production
- add a regression test to ensure scheduled commands do not include Horizon snapshot
- keep production aligned with the current `queue:work` worker setup