### PR TITLE
chore: track Sentry releases in CI

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -38,6 +38,7 @@ QUEUE_CONNECTION=database
 
 # Sentry Error Tracking
 SENTRY_LARAVEL_DSN=
+# SENTRY_RELEASE is injected by CI as whisper-money@<git-sha> during production builds.
 SENTRY_TRACES_SAMPLE_RATE=1.0
 SENTRY_PROFILES_SAMPLE_RATE=1.0
 SENTRY_ENABLE_LOGS=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,12 +227,32 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tests, linter, static-analysis, performance-tests]
     if: (github.ref == 'refs/heads/main' && github.event_name == 'push') || github.event_name == 'workflow_dispatch'
+    env:
+      SENTRY_RELEASE: whisper-money@${{ github.sha }}
     permissions:
       contents: read
       packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Sentry CLI
+        run: curl -sL https://sentry.io/get-cli/ | bash
+
+      - name: Create Sentry release
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        run: |
+          if ! sentry-cli releases info "$SENTRY_RELEASE" >/dev/null 2>&1; then
+            sentry-cli releases new "$SENTRY_RELEASE"
+          fi
+
+          sentry-cli releases set-commits "$SENTRY_RELEASE" --auto
+          sentry-cli releases finalize "$SENTRY_RELEASE"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -264,6 +284,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            SENTRY_RELEASE=${{ env.SENTRY_RELEASE }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -271,6 +293,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tests, linter, static-analysis, performance-tests]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    env:
+      SENTRY_RELEASE: whisper-money@${{ github.sha }}
     concurrency:
       group: production-deploy-main
       cancel-in-progress: true
@@ -339,6 +363,18 @@ jobs:
 
           echo "All $max_attempts attempts failed. Giving up."
           exit 1
+
+      - name: Install Sentry CLI
+        if: steps.deploy_guard.outputs.should_deploy == 'true'
+        run: curl -sL https://sentry.io/get-cli/ | bash
+
+      - name: Mark Sentry release deployed
+        if: steps.deploy_guard.outputs.should_deploy == 'true'
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        run: sentry-cli releases deploys "$SENTRY_RELEASE" new -e production
 
       - name: Deployment skipped
         if: steps.deploy_guard.outputs.should_deploy == 'false'

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,6 +1,8 @@
 # Use the official PHP 8.4 FPM image
 FROM php:8.4-fpm
 
+ARG SENTRY_RELEASE
+
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     git \
@@ -39,6 +41,8 @@ RUN apt-get update && apt-get install -y memcached redis-server && rm -rf /var/l
 
 # Set working directory
 WORKDIR /app
+
+ENV SENTRY_RELEASE=${SENTRY_RELEASE}
 
 # Copy application files
 COPY . /app/.

--- a/tests/Feature/SentryConfigTest.php
+++ b/tests/Feature/SentryConfigTest.php
@@ -1,0 +1,5 @@
+<?php
+
+it('binds the sentry release from the environment', function () {
+    expect(config('sentry.release'))->toBe(env('SENTRY_RELEASE'));
+});


### PR DESCRIPTION
## Summary
- create and finalize Sentry releases in CI using `whisper-money@<git-sha>`
- bake the release into the production image so Laravel tags backend events with the deployed version
- mark production deploys in Sentry and add a focused test covering the release binding

## Testing
- php artisan test --compact tests/Feature/SentryConfigTest.php
