### PR TITLE
fix(demo-reset): use renamed 'ING Direct' bank

### DIFF
--- a/app/Console/Commands/ResetDemoAccountCommand.php
+++ b/app/Console/Commands/ResetDemoAccountCommand.php
@@ -148,7 +148,7 @@ class ResetDemoAccountCommand extends Command
     {
         $bbvaBank = Bank::query()->whereNull('user_id')->where('name', 'BBVA')->first()
             ?? Bank::factory()->create(['user_id' => null]);
-        $ingBank = Bank::query()->whereNull('user_id')->where('name', 'ING')->first()
+        $ingBank = Bank::query()->whereNull('user_id')->where('name', 'ING Direct')->first()
             ?? Bank::factory()->create(['user_id' => null]);
         $indexaCapitalBank = Bank::query()->whereNull('user_id')->where('name', 'Indexa Capital')->first()
             ?? Bank::factory()->create(['user_id' => null]);


### PR DESCRIPTION
## Summary
- `demo:reset` was looking up the `ING` bank, but it was renamed to `ING Direct` in production.
- The miss fell through to `Bank::factory()->create(...)`, which fails in prod because Faker's `fake()` helper isn't available (dev-only autoload).

## Fix
Update the name lookup in `ResetDemoAccountCommand` to `ING Direct`.

## Sentry
- Fixes PHP-LARAVEL-7 (root cause)
- Fixes PHP-LARAVEL-4 (scheduler wrapper)