### PR TITLE
fix(ci): order sentry deploy after build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    needs: [tests, linter, static-analysis, performance-tests]
+    needs: [build-image]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     env:
       SENTRY_RELEASE: whisper-money@${{ github.sha }}

--- a/tests/Feature/SentryConfigTest.php
+++ b/tests/Feature/SentryConfigTest.php
@@ -3,3 +3,11 @@
 it('binds the sentry release from the environment', function () {
     expect(config('sentry.release'))->toBe(env('SENTRY_RELEASE'));
 });
+
+it('waits for the image build before marking a sentry deploy', function () {
+    $workflow = file_get_contents(base_path('.github/workflows/ci.yml'));
+
+    expect($workflow)
+        ->toContain("deploy:\n    runs-on: ubuntu-latest\n    needs: [build-image]")
+        ->toContain('run: sentry-cli releases deploys "$SENTRY_RELEASE" new -e production');
+});


### PR DESCRIPTION
## Summary
- make the `deploy` job wait for `build-image` so Sentry release creation finishes before deploy tracking runs
- keep the Sentry deploy marker on the same release name while removing the race that caused `Release not found`
- add a focused regression test that asserts the workflow keeps this dependency in place

## Testing
- php artisan test --compact tests/Feature/SentryConfigTest.php