### PR TITLE
chore: add PR check watch note to AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,8 @@ Pattern: [thing] [action] [reason]. [next step].
 ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift.
 Code/commits/PRs: normal. Off: "stop caveman" / "normal mode".
 
+- After creating a PR use `gh pr checks 123 --watch --fail-fast` to check CI every 10 sec, if something fails, fix it, and update the pr.
+
 <laravel-boost-guidelines>
 === foundation rules ===
 


### PR DESCRIPTION
## Summary
- add instruction to watch PR checks after PR creation
- include fail-fast command example for CI monitoring

## Testing
- not run (AGENTS.md change only)