### PR TITLE
fix: expose pi mcp extension as mcps.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.phpunit.cache
 /bootstrap/ssr
 /node_modules
+node_modules/
 /public/build
 /public/hot
 /public/storage

--- a/.pi/extensions/mcps.ts
+++ b/.pi/extensions/mcps.ts
@@ -1,0 +1,1 @@
+export { default } from './mcps/main.ts';

--- a/.pi/extensions/mcps/main.ts
+++ b/.pi/extensions/mcps/main.ts
@@ -1,0 +1,1136 @@
+import { Client } from '@modelcontextprotocol/sdk/client';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { Type } from '@sinclair/typebox';
+import { existsSync } from 'node:fs';
+import { readFile, writeFile } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
+import path from 'node:path';
+
+type JsonObject = Record<string, unknown>;
+
+type PiToolInfo = {
+    name: string;
+};
+
+type PiUiContext = {
+    notify(message: string, level: 'info' | 'warning' | 'error'): void;
+};
+
+type PiReloadContext = {
+    hasUI: boolean;
+    ui: PiUiContext;
+    reload(): Promise<void>;
+};
+
+type PiSessionContext = {
+    cwd: string;
+    hasUI: boolean;
+    ui: PiUiContext;
+};
+
+type PiToolRegistration = {
+    name: string;
+    label: string;
+    description: string;
+    promptSnippet: string;
+    parameters: unknown;
+    execute(
+        toolCallId: string,
+        params: JsonObject,
+        signal: AbortSignal | undefined,
+        onUpdate: ((update: JsonObject) => void) | undefined,
+    ): Promise<{
+        content: Array<{ type: 'text'; text: string }>;
+        details: JsonObject;
+    }>;
+};
+
+type PiExtensionApi = {
+    getAllTools(): PiToolInfo[];
+    registerTool(tool: PiToolRegistration): void;
+    registerCommand(
+        name: string,
+        command: {
+            description: string;
+            handler(args: string, ctx: PiReloadContext): Promise<void>;
+        },
+    ): void;
+    on(
+        event: 'session_start',
+        handler: (event: JsonObject, ctx: PiSessionContext) => Promise<void>,
+    ): void;
+    on(event: 'session_shutdown', handler: () => Promise<void>): void;
+};
+
+type McpTool = {
+    name: string;
+    title?: string;
+    description?: string;
+    inputSchema?: JsonObject;
+};
+
+type StdioServerConfig = {
+    kind: 'stdio';
+    name: string;
+    command: string;
+    args: string[];
+    env?: Record<string, string>;
+    cwd?: string;
+};
+
+type HttpServerConfig = {
+    kind: 'http';
+    name: string;
+    url: string;
+    headers?: Record<string, string>;
+};
+
+type ResolvedServerConfig = StdioServerConfig | HttpServerConfig;
+
+type ServerState = {
+    config: ResolvedServerConfig;
+    client?: Client;
+    transport?: StdioClientTransport | StreamableHTTPClientTransport;
+    tools: McpTool[];
+    error?: string;
+};
+
+type RegisteredToolState = {
+    serverName: string;
+    sourceToolName: string;
+    registeredToolName: string;
+    description?: string;
+};
+
+const DEFAULT_MAX_BYTES = 50 * 1024;
+const DEFAULT_MAX_LINES = 2000;
+const OPENCODE_MCP_AUTH_PATH = path.join(
+    homedir(),
+    '.local',
+    'share',
+    'opencode',
+    'mcp-auth.json',
+);
+
+function safeToolName(value: string): string {
+    return (
+        value
+            .replace(/[^a-zA-Z0-9_-]/g, '_')
+            .replace(/_+/g, '_')
+            .replace(/^_+|_+$/g, '') || 'tool'
+    );
+}
+
+function safeServerSlug(value: string): string {
+    return safeToolName(value).toLowerCase();
+}
+
+function titleCase(value: string): string {
+    return value
+        .split(/[-_\s]+/)
+        .filter(Boolean)
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' ');
+}
+
+function joinDescription(
+    ...parts: Array<string | undefined>
+): string | undefined {
+    const text = parts
+        .filter(
+            (part): part is string =>
+                typeof part === 'string' && part.trim().length > 0,
+        )
+        .join(' ')
+        .trim();
+    return text.length > 0 ? text : undefined;
+}
+
+function schemaDescription(schema: JsonObject): string | undefined {
+    const enumValues = Array.isArray(schema.enum)
+        ? schema.enum.filter((item) =>
+              ['string', 'number', 'boolean'].includes(typeof item),
+          )
+        : [];
+    const enumDescription =
+        enumValues.length > 0
+            ? `Allowed values: ${enumValues.join(', ')}.`
+            : undefined;
+
+    return joinDescription(
+        typeof schema.title === 'string' ? schema.title : undefined,
+        typeof schema.description === 'string' ? schema.description : undefined,
+        enumDescription,
+    );
+}
+
+function toTypeBoxSchema(schema: unknown): unknown {
+    if (!schema || typeof schema !== 'object' || Array.isArray(schema)) {
+        return Type.Any();
+    }
+
+    const jsonSchema = schema as JsonObject;
+    const description = schemaDescription(jsonSchema);
+
+    if (jsonSchema.const !== undefined) {
+        if (typeof jsonSchema.const === 'string') {
+            return Type.Literal(
+                jsonSchema.const,
+                description ? { description } : {},
+            );
+        }
+
+        if (typeof jsonSchema.const === 'number') {
+            return Type.Literal(
+                jsonSchema.const,
+                description ? { description } : {},
+            );
+        }
+
+        if (typeof jsonSchema.const === 'boolean') {
+            return Type.Literal(
+                jsonSchema.const,
+                description ? { description } : {},
+            );
+        }
+    }
+
+    if (Array.isArray(jsonSchema.type)) {
+        const nonNullTypes = jsonSchema.type.filter(
+            (item): item is string =>
+                typeof item === 'string' && item !== 'null',
+        );
+        if (nonNullTypes.length > 0) {
+            return toTypeBoxSchema({ ...jsonSchema, type: nonNullTypes[0] });
+        }
+    }
+
+    if (Array.isArray(jsonSchema.oneOf) && jsonSchema.oneOf.length > 0) {
+        return toTypeBoxSchema(jsonSchema.oneOf[0]);
+    }
+
+    if (Array.isArray(jsonSchema.anyOf) && jsonSchema.anyOf.length > 0) {
+        return toTypeBoxSchema(jsonSchema.anyOf[0]);
+    }
+
+    if (jsonSchema.type === 'object' || jsonSchema.properties) {
+        const rawProperties = jsonSchema.properties;
+        const required = new Set(
+            Array.isArray(jsonSchema.required)
+                ? jsonSchema.required.filter(
+                      (item): item is string => typeof item === 'string',
+                  )
+                : [],
+        );
+        const properties: Record<string, unknown> = {};
+
+        if (
+            rawProperties &&
+            typeof rawProperties === 'object' &&
+            !Array.isArray(rawProperties)
+        ) {
+            for (const [key, value] of Object.entries(rawProperties)) {
+                const propertySchema = toTypeBoxSchema(value);
+                properties[key] = required.has(key)
+                    ? propertySchema
+                    : Type.Optional(propertySchema as never);
+            }
+        }
+
+        return Type.Object(properties, {
+            additionalProperties: jsonSchema.additionalProperties === true,
+            ...(description ? { description } : {}),
+        });
+    }
+
+    if (jsonSchema.type === 'array') {
+        return Type.Array(
+            toTypeBoxSchema(jsonSchema.items),
+            description ? { description } : {},
+        );
+    }
+
+    if (jsonSchema.type === 'string') {
+        return Type.String(description ? { description } : {});
+    }
+
+    if (jsonSchema.type === 'integer') {
+        return Type.Integer(description ? { description } : {});
+    }
+
+    if (jsonSchema.type === 'number') {
+        return Type.Number(description ? { description } : {});
+    }
+
+    if (jsonSchema.type === 'boolean') {
+        return Type.Boolean(description ? { description } : {});
+    }
+
+    return Type.Any(description ? { description } : {});
+}
+
+async function readJsonFile(filePath: string): Promise<JsonObject | undefined> {
+    if (!existsSync(filePath)) {
+        return undefined;
+    }
+
+    const content = await readFile(filePath, 'utf8');
+    return JSON.parse(content) as JsonObject;
+}
+
+async function findUp(
+    startDir: string,
+    fileName: string,
+): Promise<string | undefined> {
+    let currentDir = path.resolve(startDir);
+
+    while (true) {
+        const candidate = path.join(currentDir, fileName);
+        if (existsSync(candidate)) {
+            return candidate;
+        }
+
+        const parentDir = path.dirname(currentDir);
+        if (parentDir === currentDir) {
+            return undefined;
+        }
+
+        currentDir = parentDir;
+    }
+}
+
+function normalizeStringRecord(
+    value: unknown,
+): Record<string, string> | undefined {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return undefined;
+    }
+
+    const output: Record<string, string> = {};
+
+    for (const [key, item] of Object.entries(value)) {
+        if (typeof item === 'string') {
+            output[key] = item;
+        }
+    }
+
+    return Object.keys(output).length > 0 ? output : undefined;
+}
+
+function isEnabled(server: JsonObject): boolean {
+    if (typeof server.enabled === 'boolean') {
+        return server.enabled;
+    }
+
+    return true;
+}
+
+function normalizeMcpServers(
+    raw: JsonObject,
+    cwd: string,
+): ResolvedServerConfig[] {
+    const servers = raw.mcpServers;
+    if (!servers || typeof servers !== 'object' || Array.isArray(servers)) {
+        return [];
+    }
+
+    const output: ResolvedServerConfig[] = [];
+
+    for (const [name, value] of Object.entries(servers)) {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+            continue;
+        }
+
+        const server = value as JsonObject;
+        if (!isEnabled(server)) {
+            continue;
+        }
+
+        if (typeof server.command === 'string') {
+            output.push({
+                kind: 'stdio',
+                name,
+                command: server.command,
+                args: Array.isArray(server.args)
+                    ? server.args.filter(
+                          (item): item is string => typeof item === 'string',
+                      )
+                    : [],
+                env: normalizeStringRecord(server.env),
+                cwd,
+            });
+            continue;
+        }
+
+        if (typeof server.url === 'string') {
+            output.push({
+                kind: 'http',
+                name,
+                url: server.url,
+                headers: normalizeStringRecord(server.headers),
+            });
+        }
+    }
+
+    return output;
+}
+
+function normalizeOpencodeServers(
+    raw: JsonObject,
+    cwd: string,
+): ResolvedServerConfig[] {
+    const servers = raw.mcp;
+    if (!servers || typeof servers !== 'object' || Array.isArray(servers)) {
+        return [];
+    }
+
+    const output: ResolvedServerConfig[] = [];
+
+    for (const [name, value] of Object.entries(servers)) {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+            continue;
+        }
+
+        const server = value as JsonObject;
+        if (!isEnabled(server)) {
+            continue;
+        }
+
+        if (
+            server.type === 'local' &&
+            Array.isArray(server.command) &&
+            server.command.length > 0
+        ) {
+            const commandParts = server.command.filter(
+                (item): item is string => typeof item === 'string',
+            );
+            if (commandParts.length === 0) {
+                continue;
+            }
+
+            output.push({
+                kind: 'stdio',
+                name,
+                command: commandParts[0],
+                args: commandParts.slice(1),
+                env: normalizeStringRecord(server.env),
+                cwd,
+            });
+            continue;
+        }
+
+        if (
+            (server.type === 'remote' || server.type === 'http') &&
+            typeof server.url === 'string'
+        ) {
+            output.push({
+                kind: 'http',
+                name,
+                url: server.url,
+                headers: normalizeStringRecord(server.headers),
+            });
+        }
+    }
+
+    return output;
+}
+
+async function discoverMcpServers(
+    startDir: string,
+): Promise<{ configPath?: string; servers: ResolvedServerConfig[] }> {
+    const mcpConfigPath = await findUp(startDir, '.mcp.json');
+    if (mcpConfigPath) {
+        const raw = await readJsonFile(mcpConfigPath);
+        if (raw) {
+            return {
+                configPath: mcpConfigPath,
+                servers: normalizeMcpServers(raw, path.dirname(mcpConfigPath)),
+            };
+        }
+    }
+
+    const opencodeConfigPath = await findUp(startDir, 'opencode.json');
+    if (opencodeConfigPath) {
+        const raw = await readJsonFile(opencodeConfigPath);
+        if (raw) {
+            return {
+                configPath: opencodeConfigPath,
+                servers: normalizeOpencodeServers(
+                    raw,
+                    path.dirname(opencodeConfigPath),
+                ),
+            };
+        }
+    }
+
+    return { servers: [] };
+}
+
+async function readOpencodeMcpAuth(): Promise<JsonObject | undefined> {
+    try {
+        return await readJsonFile(OPENCODE_MCP_AUTH_PATH);
+    } catch {
+        return undefined;
+    }
+}
+
+function extractOpencodeAccessToken(
+    auth: JsonObject | undefined,
+    serverName: string,
+    serverUrl: string,
+): string | undefined {
+    if (!auth) {
+        return undefined;
+    }
+
+    const directMatch = auth[serverName];
+    if (
+        directMatch &&
+        typeof directMatch === 'object' &&
+        !Array.isArray(directMatch)
+    ) {
+        const directConfig = directMatch as JsonObject;
+        const tokens = directConfig.tokens;
+        if (
+            typeof directConfig.serverUrl === 'string' &&
+            directConfig.serverUrl === serverUrl &&
+            tokens &&
+            typeof tokens === 'object' &&
+            !Array.isArray(tokens)
+        ) {
+            const accessToken = (tokens as JsonObject).accessToken;
+            if (typeof accessToken === 'string' && accessToken.length > 0) {
+                return accessToken;
+            }
+        }
+    }
+
+    for (const value of Object.values(auth)) {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+            continue;
+        }
+
+        const candidate = value as JsonObject;
+        if (candidate.serverUrl !== serverUrl) {
+            continue;
+        }
+
+        const tokens = candidate.tokens;
+        if (!tokens || typeof tokens !== 'object' || Array.isArray(tokens)) {
+            continue;
+        }
+
+        const accessToken = (tokens as JsonObject).accessToken;
+        if (typeof accessToken === 'string' && accessToken.length > 0) {
+            return accessToken;
+        }
+    }
+
+    return undefined;
+}
+
+function resolveAccessTokenFromEnv(serverName: string): string | undefined {
+    const upperSnake = safeToolName(serverName)
+        .replace(/-/g, '_')
+        .toUpperCase();
+    const candidates = [
+        `MCP_${upperSnake}_ACCESS_TOKEN`,
+        `MCP_${upperSnake}_TOKEN`,
+        `${upperSnake}_MCP_ACCESS_TOKEN`,
+        `${upperSnake}_ACCESS_TOKEN`,
+    ];
+
+    if (upperSnake === 'SENTRY') {
+        candidates.push('SENTRY_MCP_ACCESS_TOKEN', 'SENTRY_ACCESS_TOKEN');
+    }
+
+    for (const key of candidates) {
+        const value = process.env[key];
+        if (typeof value === 'string' && value.length > 0) {
+            return value;
+        }
+    }
+
+    return undefined;
+}
+
+async function buildHttpHeaders(
+    config: HttpServerConfig,
+): Promise<Record<string, string> | undefined> {
+    const headers: Record<string, string> = { ...(config.headers ?? {}) };
+    const hasAuthorizationHeader = Object.keys(headers).some(
+        (key) => key.toLowerCase() === 'authorization',
+    );
+
+    if (!hasAuthorizationHeader) {
+        const envToken = resolveAccessTokenFromEnv(config.name);
+        const opencodeAuth = envToken ? undefined : await readOpencodeMcpAuth();
+        const token =
+            envToken ??
+            extractOpencodeAccessToken(opencodeAuth, config.name, config.url);
+
+        if (token) {
+            headers.Authorization = `Bearer ${token}`;
+        }
+    }
+
+    return Object.keys(headers).length > 0 ? headers : undefined;
+}
+
+async function createServerState(
+    config: ResolvedServerConfig,
+): Promise<ServerState> {
+    const client = new Client(
+        { name: 'pi-mcp-bridge', version: '0.1.0' },
+        { capabilities: {} },
+    );
+
+    if (config.kind === 'stdio') {
+        const transport = new StdioClientTransport({
+            command: config.command,
+            args: config.args,
+            env: config.env,
+            cwd: config.cwd,
+            stderr: 'inherit',
+        });
+
+        await client.connect(transport);
+        const toolsResponse = await client.listTools();
+
+        return {
+            config,
+            client,
+            transport,
+            tools: toolsResponse.tools,
+        };
+    }
+
+    const headers = await buildHttpHeaders(config);
+    const transport = new StreamableHTTPClientTransport(new URL(config.url), {
+        requestInit: headers ? { headers } : undefined,
+    });
+
+    await client.connect(transport);
+    const toolsResponse = await client.listTools();
+
+    return {
+        config,
+        client,
+        transport,
+        tools: toolsResponse.tools,
+    };
+}
+
+async function closeServerState(server: ServerState): Promise<void> {
+    try {
+        await server.transport?.close();
+    } catch {
+        // Ignore close failures.
+    }
+}
+
+function renderContentBlock(block: JsonObject): string {
+    const type = typeof block.type === 'string' ? block.type : 'unknown';
+
+    if (type === 'text' && typeof block.text === 'string') {
+        return block.text;
+    }
+
+    if (type === 'image') {
+        const mimeType =
+            typeof block.mimeType === 'string'
+                ? block.mimeType
+                : 'application/octet-stream';
+        return `[image omitted: ${mimeType}]`;
+    }
+
+    if (type === 'audio') {
+        const mimeType =
+            typeof block.mimeType === 'string'
+                ? block.mimeType
+                : 'application/octet-stream';
+        return `[audio omitted: ${mimeType}]`;
+    }
+
+    if (
+        type === 'resource' &&
+        block.resource &&
+        typeof block.resource === 'object' &&
+        !Array.isArray(block.resource)
+    ) {
+        const resource = block.resource as JsonObject;
+        if (typeof resource.text === 'string') {
+            return resource.text;
+        }
+
+        const uri =
+            typeof resource.uri === 'string'
+                ? resource.uri
+                : 'unknown-resource';
+        return `[resource omitted: ${uri}]`;
+    }
+
+    if (type === 'resource_link') {
+        const name = typeof block.name === 'string' ? block.name : 'resource';
+        const uri =
+            typeof block.uri === 'string' ? block.uri : 'unknown-resource';
+        return `[resource link: ${name} -> ${uri}]`;
+    }
+
+    return `[unsupported MCP content block: ${type}]`;
+}
+
+function renderStructuredContent(value: unknown): string | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+
+    try {
+        return JSON.stringify(value, null, 2);
+    } catch {
+        return undefined;
+    }
+}
+
+function formatSize(bytes: number): string {
+    if (bytes < 1024) {
+        return `${bytes}B`;
+    }
+
+    if (bytes < 1024 * 1024) {
+        return `${(bytes / 1024).toFixed(1).replace(/\.0$/, '')}KB`;
+    }
+
+    return `${(bytes / (1024 * 1024)).toFixed(1).replace(/\.0$/, '')}MB`;
+}
+
+function truncateText(content: string): {
+    content: string;
+    truncated: boolean;
+    totalBytes: number;
+    totalLines: number;
+    outputBytes: number;
+    outputLines: number;
+} {
+    const lines = content.split('\n');
+    const totalLines = lines.length;
+    const totalBytes = Buffer.byteLength(content, 'utf8');
+
+    let outputLines = totalLines;
+    let selectedLines = lines;
+
+    if (selectedLines.length > DEFAULT_MAX_LINES) {
+        selectedLines = selectedLines.slice(0, DEFAULT_MAX_LINES);
+        outputLines = selectedLines.length;
+    }
+
+    let output = selectedLines.join('\n');
+    let outputBytes = Buffer.byteLength(output, 'utf8');
+
+    if (outputBytes > DEFAULT_MAX_BYTES) {
+        let currentBytes = 0;
+        const trimmedLines: string[] = [];
+
+        for (const line of selectedLines) {
+            const candidate = trimmedLines.length === 0 ? line : `\n${line}`;
+            const candidateBytes = Buffer.byteLength(candidate, 'utf8');
+            if (currentBytes + candidateBytes > DEFAULT_MAX_BYTES) {
+                break;
+            }
+
+            trimmedLines.push(line);
+            currentBytes += candidateBytes;
+        }
+
+        selectedLines = trimmedLines;
+        outputLines = selectedLines.length;
+        output = selectedLines.join('\n');
+        outputBytes = Buffer.byteLength(output, 'utf8');
+    }
+
+    return {
+        content: output,
+        truncated: outputLines < totalLines || outputBytes < totalBytes,
+        totalBytes,
+        totalLines,
+        outputBytes,
+        outputLines,
+    };
+}
+
+async function writeTruncatedOutput(
+    content: string,
+    serverName: string,
+    toolName: string,
+): Promise<string> {
+    const filePath = path.join(
+        tmpdir(),
+        `pi-mcp-${safeServerSlug(serverName)}-${safeToolName(toolName)}-${Date.now()}.log`,
+    );
+    await writeFile(filePath, content, 'utf8');
+    return filePath;
+}
+
+function summarizeProgress(progress: JsonObject): string {
+    const message =
+        typeof progress.message === 'string' ? progress.message : undefined;
+    const amount =
+        typeof progress.progress === 'number' ? progress.progress : undefined;
+    const total =
+        typeof progress.total === 'number' ? progress.total : undefined;
+
+    if (message && amount !== undefined && total !== undefined) {
+        return `${message} (${amount}/${total})`;
+    }
+
+    if (message && amount !== undefined) {
+        return `${message} (${amount})`;
+    }
+
+    if (message) {
+        return message;
+    }
+
+    if (amount !== undefined && total !== undefined) {
+        return `Progress: ${amount}/${total}`;
+    }
+
+    if (amount !== undefined) {
+        return `Progress: ${amount}`;
+    }
+
+    return 'Working...';
+}
+
+async function formatToolResult(
+    result: JsonObject,
+    serverName: string,
+    toolName: string,
+): Promise<{ text: string; details: JsonObject }> {
+    const rawContent = Array.isArray(result.content) ? result.content : [];
+    const renderedBlocks = rawContent
+        .filter(
+            (item): item is JsonObject =>
+                Boolean(item) &&
+                typeof item === 'object' &&
+                !Array.isArray(item),
+        )
+        .map((item) => renderContentBlock(item));
+
+    const structuredContent = renderStructuredContent(result.structuredContent);
+    const sections = renderedBlocks.filter(Boolean);
+
+    if (
+        structuredContent &&
+        (sections.length === 0 || !sections.includes(structuredContent))
+    ) {
+        sections.push(structuredContent);
+    }
+
+    const fullText = sections.join('\n\n').trim() || `${toolName} completed.`;
+    const truncation = truncateText(fullText);
+    let text = truncation.content;
+    let fullOutputPath: string | undefined;
+
+    if (truncation.truncated) {
+        fullOutputPath = await writeTruncatedOutput(
+            fullText,
+            serverName,
+            toolName,
+        );
+        text += `\n\n[Output truncated: ${truncation.outputLines} of ${truncation.totalLines} lines (${formatSize(truncation.outputBytes)} of ${formatSize(truncation.totalBytes)}). Full output saved to: ${fullOutputPath}]`;
+    }
+
+    return {
+        text,
+        details: {
+            server: serverName,
+            tool: toolName,
+            fullOutputPath,
+            isError: result.isError === true,
+            structuredContent: result.structuredContent,
+        },
+    };
+}
+
+export default function mcpBridgeExtension(pi: PiExtensionApi): void {
+    const serverStates = new Map<string, ServerState>();
+    const toolStates = new Map<string, RegisteredToolState>();
+    const registrationState = {
+        configPath: undefined as string | undefined,
+        loadErrors: [] as string[],
+    };
+
+    async function cleanupServers(): Promise<void> {
+        await Promise.all(
+            Array.from(serverStates.values()).map((server) =>
+                closeServerState(server),
+            ),
+        );
+        serverStates.clear();
+    }
+
+    async function loadServers(cwd: string): Promise<void> {
+        registrationState.loadErrors = [];
+        registrationState.configPath = undefined;
+
+        await cleanupServers();
+
+        const discovery = await discoverMcpServers(cwd);
+        registrationState.configPath = discovery.configPath;
+
+        for (const config of discovery.servers) {
+            try {
+                const serverState = await createServerState(config);
+                serverStates.set(config.name, serverState);
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error);
+                registrationState.loadErrors.push(`${config.name}: ${message}`);
+                serverStates.set(config.name, {
+                    config,
+                    tools: [],
+                    error: message,
+                });
+            }
+        }
+    }
+
+    async function ensureConnected(serverName: string): Promise<ServerState> {
+        const existing = serverStates.get(serverName);
+        if (!existing) {
+            throw new Error(`Unknown MCP server: ${serverName}`);
+        }
+
+        if (existing.client && existing.transport) {
+            return existing;
+        }
+
+        const refreshed = await createServerState(existing.config);
+        serverStates.set(serverName, refreshed);
+        return refreshed;
+    }
+
+    function buildRegisteredToolName(
+        tool: RegisteredToolState,
+        nameCounts: Map<string, number>,
+        reservedNames: Set<string>,
+    ): string {
+        const requested = safeToolName(tool.sourceToolName);
+        if (
+            requested === tool.sourceToolName &&
+            !reservedNames.has(requested) &&
+            (nameCounts.get(tool.sourceToolName) ?? 0) === 1
+        ) {
+            reservedNames.add(requested);
+            return requested;
+        }
+
+        const base = `mcp_${safeServerSlug(tool.serverName)}_${requested}`;
+        let candidate = base;
+        let suffix = 2;
+
+        while (reservedNames.has(candidate)) {
+            candidate = `${base}_${suffix}`;
+            suffix += 1;
+        }
+
+        reservedNames.add(candidate);
+        return candidate;
+    }
+
+    function registerTools(): void {
+        const allKnownTools = Array.from(serverStates.values()).flatMap(
+            (server) =>
+                server.tools.map((tool) => ({
+                    serverName: server.config.name,
+                    sourceToolName: tool.name,
+                    description: tool.description,
+                    title: tool.title,
+                    inputSchema: tool.inputSchema,
+                })),
+        );
+
+        const nameCounts = new Map<string, number>();
+        for (const tool of allKnownTools) {
+            nameCounts.set(
+                tool.sourceToolName,
+                (nameCounts.get(tool.sourceToolName) ?? 0) + 1,
+            );
+        }
+
+        const reservedNames = new Set(
+            pi.getAllTools().map((tool) => tool.name),
+        );
+
+        for (const tool of allKnownTools) {
+            const state: RegisteredToolState = {
+                serverName: tool.serverName,
+                sourceToolName: tool.sourceToolName,
+                registeredToolName: '',
+                description: tool.description,
+            };
+
+            state.registeredToolName = buildRegisteredToolName(
+                state,
+                nameCounts,
+                reservedNames,
+            );
+            toolStates.set(state.registeredToolName, state);
+
+            const labelTitle = tool.title ?? titleCase(tool.sourceToolName);
+            const description = tool.description
+                ? `${tool.description} (MCP server: ${tool.serverName})`
+                : `Call MCP tool ${tool.sourceToolName} on server ${tool.serverName}.`;
+
+            pi.registerTool({
+                name: state.registeredToolName,
+                label: `${labelTitle}`,
+                description,
+                promptSnippet: `${labelTitle} via MCP server ${tool.serverName}`,
+                parameters: toTypeBoxSchema(
+                    tool.inputSchema ?? { type: 'object', properties: {} },
+                ),
+                async execute(
+                    _toolCallId: string,
+                    params: JsonObject,
+                    signal: AbortSignal | undefined,
+                    onUpdate: ((update: JsonObject) => void) | undefined,
+                ) {
+                    const server = await ensureConnected(state.serverName);
+
+                    onUpdate?.({
+                        content: [
+                            {
+                                type: 'text',
+                                text: `Calling ${state.sourceToolName} on MCP server ${state.serverName}...`,
+                            },
+                        ],
+                    });
+
+                    const result = (await server.client?.callTool(
+                        {
+                            name: state.sourceToolName,
+                            arguments: params,
+                        },
+                        undefined,
+                        {
+                            signal,
+                            resetTimeoutOnProgress: true,
+                            onprogress: (progress: JsonObject) => {
+                                onUpdate?.({
+                                    content: [
+                                        {
+                                            type: 'text',
+                                            text: summarizeProgress(progress),
+                                        },
+                                    ],
+                                    details: { progress },
+                                });
+                            },
+                        },
+                    )) as JsonObject | undefined;
+
+                    if (!result) {
+                        throw new Error(
+                            `MCP tool ${state.sourceToolName} returned no result.`,
+                        );
+                    }
+
+                    const formatted = await formatToolResult(
+                        result,
+                        state.serverName,
+                        state.sourceToolName,
+                    );
+                    if (result.isError === true) {
+                        throw new Error(formatted.text);
+                    }
+
+                    return {
+                        content: [{ type: 'text', text: formatted.text }],
+                        details: formatted.details,
+                    };
+                },
+            });
+        }
+    }
+
+    function statusLines(): string[] {
+        const lines: string[] = [];
+
+        if (registrationState.configPath) {
+            lines.push(`config: ${registrationState.configPath}`);
+        } else {
+            lines.push('config: not found (.mcp.json or opencode.json)');
+        }
+
+        for (const [serverName, server] of serverStates.entries()) {
+            if (server.error) {
+                lines.push(`${serverName}: error - ${server.error}`);
+                continue;
+            }
+
+            lines.push(`${serverName}: ${server.tools.length} tools loaded`);
+        }
+
+        for (const error of registrationState.loadErrors) {
+            if (!lines.includes(error)) {
+                lines.push(`load error: ${error}`);
+            }
+        }
+
+        if (toolStates.size > 0) {
+            lines.push(`registered tools: ${toolStates.size}`);
+        }
+
+        return lines;
+    }
+
+    pi.registerCommand('mcp-status', {
+        description: 'Show MCP bridge status',
+        handler: async (_args: string, ctx: PiReloadContext) => {
+            const message = statusLines().join('\n');
+            if (ctx.hasUI) {
+                ctx.ui.notify(
+                    `MCP bridge loaded. See terminal for details.`,
+                    'info',
+                );
+            }
+            console.log(message);
+        },
+    });
+
+    pi.registerCommand('mcp-reload', {
+        description: 'Reload pi resources and MCP bridge',
+        handler: async (_args: string, ctx: PiReloadContext) => {
+            await ctx.reload();
+            return;
+        },
+    });
+
+    pi.on(
+        'session_start',
+        async (_event: JsonObject, ctx: PiSessionContext) => {
+            await loadServers(ctx.cwd);
+            registerTools();
+
+            if (ctx.hasUI) {
+                const successCount = Array.from(serverStates.values()).filter(
+                    (server) => !server.error,
+                ).length;
+                const toolCount = toolStates.size;
+                ctx.ui.notify(
+                    `MCP bridge ready: ${successCount} servers, ${toolCount} tools.`,
+                    registrationState.loadErrors.length > 0
+                        ? 'warning'
+                        : 'info',
+                );
+            }
+        },
+    );
+
+    pi.on('session_shutdown', async () => {
+        await cleanupServers();
+    });
+}

--- a/.pi/extensions/mcps/package-lock.json
+++ b/.pi/extensions/mcps/package-lock.json
@@ -1,0 +1,1145 @@
+{
+  "name": "pi-mcp-bridge",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pi-mcp-bridge",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@sinclair/typebox": "^0.34.49",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "license": "MIT"
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/.pi/extensions/mcps/package.json
+++ b/.pi/extensions/mcps/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "pi-mcp-bridge",
+    "private": true,
+    "description": "Project-local Pi extension that loads MCP servers from .mcp.json or opencode.json",
+    "type": "module",
+    "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@sinclair/typebox": "^0.34.49",
+        "zod": "^4.3.6"
+    }
+}


### PR DESCRIPTION
## Summary
- add project-local `mcps.ts` extension entry for Pi auto-discovery
- move MCP bridge implementation into `.pi/extensions/mcps/main.ts`
- ignore nested `node_modules/` directories so extension package installs do not dirty repo

## Testing
- `node -e "const createJiti=require('/opt/homebrew/lib/node_modules/@mariozechner/pi-coding-agent/node_modules/@mariozechner/jiti/lib/jiti.cjs'); const jiti=createJiti(process.cwd()); const mod=jiti('./.pi/extensions/mcps.ts'); if (typeof mod.default !== "function") process.exit(1); console.log("ok");"`