### PR TITLE
ci: add manual release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:
@@ -42,5 +42,5 @@ jobs:
 
       - name: Run release-it
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: npx release-it ${{ inputs.bump }} --ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Run release-it
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx release-it ${{ inputs.bump }} --ci


### PR DESCRIPTION
Adds a manually-triggered workflow to cut releases from the GitHub Actions UI.

## What

New workflow: \`.github/workflows/release.yml\`

- Trigger: \`workflow_dispatch\` with a \`bump\` input (\`patch\` / \`minor\` / \`major\`, default \`patch\`)
- Runs \`npx release-it <bump> --ci\` → reuses existing \`.release-it.json\`:
  - angular conventional-changelog preset
  - updates \`CHANGELOG.md\`
  - commits \`chore: release vX.Y.Z\`
  - tags \`vX.Y.Z\`
  - creates GitHub release with grouped Features / Bug Fixes notes

## Auth

Uses the default \`GITHUB_TOKEN\` (no PAT). Requires:

- \`permissions: contents: write\` (push commit/tag, create release)
- Repo setting: Settings → Actions → General → Workflow permissions → **Read and write permissions**

If \`main\` has branch protection blocking direct pushes, the bot token must be allowed to bypass, otherwise the push step will fail and a PAT will be needed instead.

## How to run

Actions tab → Release → Run workflow → pick bump type.