### PR TITLE
fix(docker): ensure www-data owns storage after artisan commands

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -84,6 +84,11 @@ php artisan event:cache
 echo "Creating storage link..."
 php artisan storage:link 2>/dev/null || true
 
+# Re-apply storage ownership after artisan commands (may have created root-owned files)
+echo "Re-applying storage ownership..."
+chown -R www-data:www-data /app/storage /app/bootstrap/cache
+chmod -R 775 /app/storage /app/bootstrap/cache
+
 echo "=== Startup complete, launching services ==="
 
 # Start supervisor

--- a/docker/supervisor/supervisord.conf
+++ b/docker/supervisor/supervisord.conf
@@ -49,6 +49,7 @@ stderr_logfile=/var/log/redis.log
 [program:inertia-ssr]
 process_name=%(program_name)s_%(process_num)02d
 command=bash -c 'exec php /app/artisan inertia:start-ssr --runtime=bun'
+user=www-data
 autostart=true
 autorestart=true
 stderr_logfile=/var/log/worker-inertia-ssr.log
@@ -57,6 +58,7 @@ stdout_logfile=/var/log/worker-inertia-ssr.log
 [program:queue-worker-emails]
 process_name=%(program_name)s
 command=php /app/artisan queue:work database --queue=emails --sleep=1 --tries=5 --max-time=3600
+user=www-data
 autostart=true
 autorestart=true
 redirect_stderr=true
@@ -67,6 +69,7 @@ numprocs=1
 [program:queue-worker]
 process_name=%(program_name)s_%(process_num)02d
 command=php /app/artisan queue:work database --queue=default --sleep=3 --tries=3 --max-time=3600
+user=www-data
 autostart=true
 autorestart=true
 redirect_stderr=true


### PR DESCRIPTION
## Problem

Sentry reporting permission-denied errors on `/open-banking/callback`:

> UnexpectedValueException: The stream or file "/app/storage/logs/laravel.log" could not be opened in append mode: Failed to open stream: Permission denied

4 issues, 14 events (PHP-LARAVEL-Z, 10, 11, 12).

## Root cause

Entrypoint runs as root. After the initial `chown www-data`, artisan commands (`config:cache`, `route:cache`, `view:cache`, `event:cache`, `migrate`) execute and can create/touch `storage/logs/laravel.log` as root. Later, php-fpm (www-data) tries to append and fails.

Queue workers + inertia-ssr also run as root via supervisor — same failure mode from worker side.

## Fix

- `docker/entrypoint.sh`: re-chown `/app/storage` and `/app/bootstrap/cache` to www-data **after** artisan cache warm-up, just before `exec supervisord`.
- `docker/supervisor/supervisord.conf`: add `user=www-data` to `queue-worker`, `queue-worker-emails`, `inertia-ssr`. Nginx and php-fpm master keep root (need port 80 / pool forking).

## Verification

Deploy and confirm Sentry issues stop firing on next `/open-banking/callback` hits.