### PR TITLE
ci: add manual release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      increment:
+        description: "Version increment"
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create release branch
+        id: branch
+        run: |
+          BRANCH="release/run-${{ github.run_id }}"
+          git checkout -b "$BRANCH"
+          echo "name=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Run release-it
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx release-it ${{ inputs.increment }} --ci
+
+      - name: Read new version
+        id: version
+        run: echo "value=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Open pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --base main \
+            --head "${{ steps.branch.outputs.name }}" \
+            --title "chore: release v${{ steps.version.outputs.value }}" \
+            --body "Automated release PR for **v${{ steps.version.outputs.value }}**.\n\nTag \`v${{ steps.version.outputs.value }}\` and the GitHub release have already been published. Merge this PR to land the version bump and CHANGELOG on \`main\`."

--- a/.release-it.json
+++ b/.release-it.json
@@ -1,7 +1,10 @@
 {
     "git": {
         "commitMessage": "chore: release v${version}",
-        "tagName": "v${version}"
+        "tagName": "v${version}",
+        "requireBranch": false,
+        "requireCleanWorkingDir": true,
+        "push": true
     },
     "github": {
         "release": true,


### PR DESCRIPTION
Adds a manually-triggered release workflow using `release-it`.

## How it works

1. Go to **Actions → Release → Run workflow**
2. Pick `patch` / `minor` / `major`
3. Workflow:
   - checks out `main`, creates `release/run-<id>` branch
   - runs `release-it --ci <increment>`: bumps `package.json`, updates `CHANGELOG.md`, commits, tags `vX.Y.Z`, pushes branch + tag, creates the GitHub release
   - opens a PR back to `main` with the version bump + changelog

No direct push to `main` required. Tag and release are published immediately; the PR just lands the version bump.

## Changes

- `.github/workflows/release.yml` — new workflow
- `.release-it.json` — allow non-main branches, ensure branch push

## Caveats

- Squash-merging the release PR leaves the tag on a dangling commit (tag still valid). Use merge or rebase to keep the tag reachable from `main`.