### PR TITLE
feat(accounts): show projection on real estate chart

### DIFF
--- a/app/Http/Controllers/Api/DashboardAnalyticsController.php
+++ b/app/Http/Controllers/Api/DashboardAnalyticsController.php
@@ -214,6 +214,77 @@ class DashboardAnalyticsController extends Controller
             }
         }
 
+        // Append projected future months for real estate accounts with revaluation
+        // and/or a linked loan, so the chart shows both market value and mortgage
+        // forward together.
+        if ($account->type === AccountType::RealEstate) {
+            $realEstateDetail = $account->realEstateDetail;
+            $revaluationPercentage = $realEstateDetail?->revaluation_percentage;
+            $hasRevaluation = $revaluationPercentage !== null && (float) $revaluationPercentage !== 0.0;
+
+            $linkedLoanDetail = null;
+            if ($linkedLoanAccount) {
+                $linkedLoanAccount->loadMissing('loanDetail');
+                $linkedLoanDetail = $linkedLoanAccount->loanDetail;
+            }
+
+            if ($hasRevaluation || $linkedLoanDetail) {
+                $monthsAhead = 12;
+                $now = Carbon::now();
+                $lastPoint = end($points);
+                $baseValue = is_array($lastPoint) ? ($lastPoint['value'] ?? 0) : 0;
+                $monthlyRate = $hasRevaluation ? ((float) $revaluationPercentage / 12 / 100) : 0.0;
+
+                $loanProjection = $linkedLoanDetail
+                    ? $this->loanAmortizationService->generateProjection($linkedLoanDetail, $monthsAhead)
+                    : [];
+
+                for ($i = 1; $i <= $monthsAhead; $i++) {
+                    $projectedDate = $now->copy()->addMonths($i)->endOfMonth();
+                    $yearMonth = $projectedDate->format('Y-m');
+
+                    $projectedValue = (int) round($baseValue * pow(1 + $monthlyRate, $i));
+
+                    $projectedPoint = [
+                        'month' => $yearMonth,
+                        'timestamp' => $projectedDate->timestamp,
+                        'value' => $projectedValue,
+                        'projected' => true,
+                    ];
+
+                    if ($displayCurrencyCode !== null) {
+                        $projectedPoint['display_value'] = $this->convertBalanceForDate(
+                            $account->currency_code,
+                            $displayCurrencyCode,
+                            $projectedValue,
+                            Carbon::today(),
+                        );
+                    }
+
+                    if ($linkedLoanDetail && array_key_exists($yearMonth, $loanProjection)) {
+                        $mortgageProj = $loanProjection[$yearMonth];
+                        $projectedPoint['mortgage_balance'] = $this->convertBalanceForDate(
+                            $linkedLoanAccount->currency_code,
+                            $account->currency_code,
+                            $mortgageProj,
+                            $projectedDate,
+                        );
+
+                        if ($displayCurrencyCode !== null) {
+                            $projectedPoint['display_mortgage_balance'] = $this->convertBalanceForDate(
+                                $linkedLoanAccount->currency_code,
+                                $displayCurrencyCode,
+                                $mortgageProj,
+                                $projectedDate,
+                            );
+                        }
+                    }
+
+                    $points[] = $projectedPoint;
+                }
+            }
+        }
+
         $response = [
             'data' => $points,
             'account' => [

--- a/app/Http/Controllers/Api/DashboardAnalyticsController.php
+++ b/app/Http/Controllers/Api/DashboardAnalyticsController.php
@@ -232,7 +232,7 @@ class DashboardAnalyticsController extends Controller
                 $monthsAhead = 12;
                 $now = Carbon::now();
                 $lastPoint = end($points);
-                $baseValue = is_array($lastPoint) ? ($lastPoint['value'] ?? 0) : 0;
+                $baseValue = is_array($lastPoint) ? $lastPoint['value'] : 0;
                 $monthlyRate = $hasRevaluation ? ((float) $revaluationPercentage / 12 / 100) : 0.0;
 
                 $loanProjection = $linkedLoanDetail

--- a/lang/es.json
+++ b/lang/es.json
@@ -997,6 +997,7 @@
   "Property Type": "Tipo de Propiedad",
   "Property address": "Dirección de la propiedad",
   "Projected": "Proyectado",
+  "Projected mortgage": "Hipoteca proyectada",
   "Protect your privacy with no tracking or third-party analytics.": "Protege tu privacidad sin rastreo ni análisis de terceros.",
   "Purchase Date": "Fecha de Compra",
   "Purchase Price": "Precio de Compra",

--- a/resources/js/components/accounts/account-balance-chart.tsx
+++ b/resources/js/components/accounts/account-balance-chart.tsx
@@ -230,6 +230,8 @@ export interface BalanceDataPoint {
     invested_amount?: number | null;
     mortgage_balance?: number | null;
     projected?: boolean;
+    projected_value?: number;
+    projected_mortgage_balance?: number;
     display_value?: number;
     display_invested_amount?: number | null;
     display_mortgage_balance?: number;
@@ -474,10 +476,11 @@ export function AccountBalanceChart({
 
         const hasProjection = data.some((d) => d.projected);
 
-        // Add projected_value field for chart rendering:
-        // - Historical points: value only, no projected_value
-        // - Last historical point: also gets projected_value to connect the lines
-        // - Projected points: both value and projected_value
+        // Add projected_value / projected_mortgage_balance fields for chart
+        // rendering:
+        // - Historical points: value/mortgage_balance only
+        // - Last historical point: also gets projected_* to connect the lines
+        // - Projected points: both value/mortgage_balance and projected_*
         let augmentedData = data;
         if (hasProjection) {
             const lastHistoricalIndex = data.findIndex((d) => d.projected) - 1;
@@ -486,6 +489,12 @@ export function AccountBalanceChart({
                 projected_value:
                     d.projected || i === lastHistoricalIndex
                         ? d.value
+                        : undefined,
+                projected_mortgage_balance:
+                    (d.projected || i === lastHistoricalIndex) &&
+                    d.mortgage_balance !== null &&
+                    d.mortgage_balance !== undefined
+                        ? d.mortgage_balance
                         : undefined,
             }));
         }
@@ -530,8 +539,12 @@ export function AccountBalanceChart({
                     'projected_value' in point &&
                     point.display_value !== undefined
                         ? point.display_value
-                        : ((point as unknown as Record<string, unknown>)
-                              .projected_value as number | undefined),
+                        : point.projected_value,
+                projected_mortgage_balance:
+                    'projected_mortgage_balance' in point &&
+                    point.display_mortgage_balance !== undefined
+                        ? point.display_mortgage_balance
+                        : point.projected_mortgage_balance,
             }));
         }
 
@@ -670,8 +683,18 @@ export function AccountBalanceChart({
             ? {
                   projected_value: {
                       label: __('Projected'),
-                      color: 'var(--color-chart-2)',
+                      color: hasMortgageData
+                          ? accountMainLineColor
+                          : 'var(--color-chart-2)',
                   },
+                  ...(hasMortgageData
+                      ? {
+                            projected_mortgage_balance: {
+                                label: __('Projected mortgage'),
+                                color: mortgageLineColor,
+                            },
+                        }
+                      : {}),
               }
             : {}),
     };
@@ -923,6 +946,42 @@ export function AccountBalanceChart({
                                         activeDot={{ r: 4 }}
                                         connectNulls
                                     />
+                                    {hasProjectedData && (
+                                        <>
+                                            <Line
+                                                dataKey="projected_value"
+                                                type="monotone"
+                                                stroke={accountMainLineColor}
+                                                strokeWidth={2}
+                                                strokeDasharray="6 4"
+                                                dot={false}
+                                                activeDot={{ r: 4 }}
+                                                connectNulls
+                                            />
+                                            <Line
+                                                dataKey="projected_mortgage_balance"
+                                                type="monotone"
+                                                stroke={mortgageLineColor}
+                                                strokeWidth={1.5}
+                                                strokeDasharray="6 4"
+                                                dot={false}
+                                                activeDot={{ r: 4 }}
+                                                connectNulls
+                                            />
+                                            <ReferenceLine
+                                                x={todayMarker}
+                                                stroke="var(--color-foreground)"
+                                                strokeWidth={1}
+                                                strokeDasharray="4 4"
+                                                label={{
+                                                    value: __('Today'),
+                                                    position: 'top',
+                                                    fontSize: 12,
+                                                    fill: 'var(--color-muted-foreground)',
+                                                }}
+                                            />
+                                        </>
+                                    )}
                                 </ComposedChart>
                             ) : granularity === 'daily' ? (
                                 <AreaChart

--- a/tests/Feature/AccountControllerTest.php
+++ b/tests/Feature/AccountControllerTest.php
@@ -465,6 +465,7 @@ test('real estate balance evolution includes mortgage balance data', function ()
     RealEstateDetail::factory()->create([
         'account_id' => $realEstateAccount->id,
         'linked_loan_account_id' => $loanAccount->id,
+        'revaluation_percentage' => null,
     ]);
 
     $response = $this->getJson('/api/dashboard/account/'.$realEstateAccount->id.'/balance-evolution?'.http_build_query([

--- a/tests/Feature/DashboardAnalyticsTest.php
+++ b/tests/Feature/DashboardAnalyticsTest.php
@@ -6,6 +6,7 @@ use App\Models\Account;
 use App\Models\AccountBalance;
 use App\Models\Category;
 use App\Models\ExchangeRate;
+use App\Models\LoanDetail;
 use App\Models\RealEstateDetail;
 use App\Models\Transaction;
 use App\Models\User;
@@ -1281,4 +1282,103 @@ test('account balance evolution exposes alternate user-currency mortgage values 
     expect($data['data'][0]['mortgage_balance'])->toBe((int) round(18000000 / 0.80));
     expect($data['data'][0]['display_mortgage_balance'])->toBe((int) round(18000000 / 0.72));
     expect($data['display_currency_code'])->toBe('USD');
+});
+
+test('real estate balance evolution appends projected market value when revaluation percentage is set', function () {
+    $property = Account::factory()->create([
+        'user_id' => $this->user->id,
+        'type' => AccountType::RealEstate,
+        'currency_code' => 'USD',
+    ]);
+
+    RealEstateDetail::factory()->create([
+        'account_id' => $property->id,
+        'revaluation_percentage' => '6.00',
+    ]);
+
+    $endOfLastMonth = now()->subMonthNoOverflow()->endOfMonth();
+
+    AccountBalance::factory()->create([
+        'account_id' => $property->id,
+        'balance_date' => $endOfLastMonth,
+        'balance' => 50000000,
+    ]);
+
+    $response = $this->getJson('/api/dashboard/account/'.$property->id.'/balance-evolution?'.http_build_query([
+        'from' => $endOfLastMonth->copy()->startOfMonth()->toDateString(),
+        'to' => now()->toDateString(),
+    ]));
+
+    $response->assertOk();
+    $data = $response->json();
+
+    $projected = collect($data['data'])->where('projected', true)->values();
+    expect($projected)->toHaveCount(12);
+
+    // Each future point should be greater than the prior (6% APR compounded monthly)
+    $values = $projected->pluck('value')->all();
+    for ($i = 1; $i < count($values); $i++) {
+        expect($values[$i])->toBeGreaterThan($values[$i - 1]);
+    }
+});
+
+test('real estate balance evolution appends projected mortgage balance from linked loan', function () {
+    $property = Account::factory()->create([
+        'user_id' => $this->user->id,
+        'type' => AccountType::RealEstate,
+        'currency_code' => 'USD',
+    ]);
+    $loan = Account::factory()->create([
+        'user_id' => $this->user->id,
+        'type' => AccountType::Loan,
+        'currency_code' => 'USD',
+    ]);
+
+    RealEstateDetail::factory()->create([
+        'account_id' => $property->id,
+        'linked_loan_account_id' => $loan->id,
+        'revaluation_percentage' => null,
+    ]);
+
+    LoanDetail::factory()->create([
+        'account_id' => $loan->id,
+        'original_amount' => 20000000,
+        'annual_interest_rate' => '3.50',
+        'loan_term_months' => 240,
+        'start_date' => now()->subYear()->startOfMonth(),
+    ]);
+
+    $endOfLastMonth = now()->subMonthNoOverflow()->endOfMonth();
+
+    AccountBalance::factory()->create([
+        'account_id' => $property->id,
+        'balance_date' => $endOfLastMonth,
+        'balance' => 50000000,
+    ]);
+    AccountBalance::factory()->create([
+        'account_id' => $loan->id,
+        'balance_date' => $endOfLastMonth,
+        'balance' => 18000000,
+    ]);
+
+    $response = $this->getJson('/api/dashboard/account/'.$property->id.'/balance-evolution?'.http_build_query([
+        'from' => $endOfLastMonth->copy()->startOfMonth()->toDateString(),
+        'to' => now()->toDateString(),
+    ]));
+
+    $response->assertOk();
+    $data = $response->json();
+
+    $projected = collect($data['data'])->where('projected', true)->values();
+    expect($projected)->toHaveCount(12);
+
+    // No revaluation -> projected market value should equal last historical value
+    expect($projected->first()['value'])->toBe(50000000);
+
+    // Mortgage balance should decrease over time
+    $mortgages = $projected->pluck('mortgage_balance')->filter()->values()->all();
+    expect($mortgages)->not->toBeEmpty();
+    for ($i = 1; $i < count($mortgages); $i++) {
+        expect($mortgages[$i])->toBeLessThan($mortgages[$i - 1]);
+    }
 });


### PR DESCRIPTION
Real estate account chart now appends 12 months of projected data when
the property has a revaluation percentage and/or a linked loan:

- Market value projected forward via the configured revaluation rate
  (compounded monthly).
- Mortgage balance projected via LoanAmortizationService on the linked
  loan, so the mortgage decline is visible alongside the property
  revaluation in the same chart.

Backend: DashboardAnalyticsController appends projected points with
display-currency variants. Frontend: chart adds dashed projection lines
for value and mortgage_balance plus a Today reference line. Tooltip and
currency-mode swap propagate the new projected_mortgage_balance field.
