### PR TITLE
Fix default category creation N+1

### DIFF
--- a/app/Actions/CreateDefaultCategories.php
+++ b/app/Actions/CreateDefaultCategories.php
@@ -3,7 +3,9 @@
 namespace App\Actions;
 
 use App\Enums\CategoryCashflowDirection;
+use App\Models\Category;
 use App\Models\User;
+use Illuminate\Support\Str;
 
 class CreateDefaultCategories
 {
@@ -15,12 +17,29 @@ class CreateDefaultCategories
         $locale = $user->locale ?? app()->getLocale();
         $defaultCategories = self::getDefaultCategories($locale);
 
-        foreach ($defaultCategories as $category) {
-            $user->categories()->firstOrCreate(
-                ['name' => $category['name']],
-                $category
-            );
+        $existingCategoryNames = $user->categories()
+            ->whereIn('name', array_column($defaultCategories, 'name'))
+            ->pluck('name')
+            ->all();
+
+        $now = now();
+        $categories = collect($defaultCategories)
+            ->reject(fn (array $category): bool => in_array($category['name'], $existingCategoryNames, true))
+            ->map(fn (array $category): array => [
+                ...$category,
+                'cashflow_direction' => $category['cashflow_direction'] ?? CategoryCashflowDirection::Hidden->value,
+                'id' => (string) Str::uuid(),
+                'user_id' => $user->id,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ])
+            ->all();
+
+        if ($categories === []) {
+            return;
         }
+
+        Category::query()->insert($categories);
     }
 
     /**

--- a/tests/Feature/Settings/CategoryTest.php
+++ b/tests/Feature/Settings/CategoryTest.php
@@ -6,6 +6,7 @@ use App\Enums\CategoryType;
 use App\Models\Category;
 use App\Models\User;
 use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Support\Facades\DB;
 
 beforeEach(function () {
     config(['landing.hide_auth_buttons' => false]);
@@ -304,6 +305,23 @@ test('default categories are not created twice for the same user', function () {
     $service->handle($user);
 
     expect($user->categories()->count())->toBe(64);
+});
+
+test('default categories are created without repeated category lookups', function () {
+    $user = User::factory()->create();
+    $service = new CreateDefaultCategories;
+    $categorySelects = 0;
+
+    DB::listen(function ($query) use (&$categorySelects) {
+        if (str_starts_with($query->sql, 'select `name` from `categories`')) {
+            $categorySelects++;
+        }
+    });
+
+    $service->handle($user);
+
+    expect($user->categories()->count())->toBe(64)
+        ->and($categorySelects)->toBe(1);
 });
 
 test('category names are unique per user', function () {


### PR DESCRIPTION
## Summary
- replace default category firstOrCreate loop with one lookup plus bulk insert
- add regression coverage for repeated category lookups

Fixes PHP-LARAVEL-19

## Tests
- vendor/bin/pint --dirty --format agent
- php artisan test --compact tests/Feature/Settings/CategoryTest.php --filter='default categories'