### PR TITLE
fix: include production Dockerfile in deploy filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,7 @@ jobs:
               - 'phpunit.xml*'
               - 'pint.json'
               - 'Dockerfile'
+              - 'Dockerfile.*'
               - 'docker/**'
               - '.dockerignore'
               - '.env.example'


### PR DESCRIPTION
## Summary
- include Dockerfile.* in CI changes filter
- ensure Dockerfile.production-only commits build and deploy

## Verification
- python3 assertion confirms Dockerfile.* filter exists and matches Dockerfile.production