### PR TITLE
Hide stale onboarding plan warning

### DIFF
--- a/resources/js/components/onboarding/step-create-account.tsx
+++ b/resources/js/components/onboarding/step-create-account.tsx
@@ -59,7 +59,9 @@ interface StepCreateAccountProps {
     isFirstAccount: boolean;
     existingAccounts?: ExistingAccount[];
     createdAccounts?: CreatedAccountDisplay[];
+    hasSelectedConnectedAccount?: boolean;
     onAccountCreated: (account: CreatedAccount) => void;
+    onConnectedAccountSelected?: () => void;
     onContinue?: () => void;
 }
 
@@ -68,10 +70,13 @@ export function StepCreateAccount({
     isFirstAccount,
     existingAccounts = [],
     createdAccounts = [],
+    hasSelectedConnectedAccount = false,
     onAccountCreated,
+    onConnectedAccountSelected,
     onContinue,
 }: StepCreateAccountProps) {
-    const { pricing, subscriptionsEnabled, locale } = usePage<SharedData>().props;
+    const { pricing, subscriptionsEnabled, locale } =
+        usePage<SharedData>().props;
     const [mode, setMode] = useState<AccountMode>('select');
     const [selectedMode, setSelectedMode] = useState<'manual' | 'connected'>(
         'connected',
@@ -140,6 +145,14 @@ export function StepCreateAccount({
 
         const data = await response.json();
         return data.id;
+    }
+
+    function handleModeContinue() {
+        if (selectedMode === 'connected') {
+            onConnectedAccountSelected?.();
+        }
+
+        setMode(selectedMode);
     }
 
     async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
@@ -640,6 +653,7 @@ export function StepCreateAccount({
                             )}
                         </p>
                         {subscriptionsEnabled &&
+                            !hasSelectedConnectedAccount &&
                             cheapestMonthlyPrice !== null && (
                                 <p className="mt-2 text-xs font-medium text-emerald-600 dark:text-emerald-400">
                                     {__('From')}{' '}
@@ -654,21 +668,23 @@ export function StepCreateAccount({
                     </button>
                 </div>
 
-                {selectedMode === 'connected' && subscriptionsEnabled && (
-                    <div className="rounded-lg border border-emerald-100 bg-emerald-50 p-3 text-sm dark:border-emerald-900/50 dark:bg-emerald-900/20">
-                        <p className="text-center text-sm text-emerald-700 dark:text-emerald-300">
-                            {__(
-                                "Connected accounts are a Standard Plan feature. You'll choose a plan at the end of the onboarding.",
-                            )}
-                        </p>
-                    </div>
-                )}
+                {selectedMode === 'connected' &&
+                    subscriptionsEnabled &&
+                    !hasSelectedConnectedAccount && (
+                        <div className="rounded-lg border border-emerald-100 bg-emerald-50 p-3 text-sm dark:border-emerald-900/50 dark:bg-emerald-900/20">
+                            <p className="text-center text-sm text-emerald-700 dark:text-emerald-300">
+                                {__(
+                                    "Connected accounts are a Standard Plan feature. You'll choose a plan at the end of the onboarding.",
+                                )}
+                            </p>
+                        </div>
+                    )}
 
                 <div className="w-full max-w-md space-y-2">
                     <StepButton
                         className="w-full sm:w-full"
                         text={__('Continue')}
-                        onClick={() => setMode(selectedMode)}
+                        onClick={handleModeContinue}
                     />
 
                     {(hasCreatedAccounts || hasExistingAccounts) && (

--- a/resources/js/hooks/use-onboarding-state.test.tsx
+++ b/resources/js/hooks/use-onboarding-state.test.tsx
@@ -1,0 +1,41 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useOnboardingState } from './use-onboarding-state';
+
+describe('useOnboardingState', () => {
+    it('tracks when connected account setup has been selected', () => {
+        const { result } = renderHook(() => useOnboardingState());
+
+        expect(result.current.hasSelectedConnectedAccount).toBe(false);
+
+        act(() => {
+            result.current.markConnectedAccountSelected();
+        });
+
+        expect(result.current.hasSelectedConnectedAccount).toBe(true);
+    });
+
+    it('starts with connected account setup selected when a connected account already exists', () => {
+        const { result } = renderHook(() =>
+            useOnboardingState({ hasConnectedAccount: true }),
+        );
+
+        expect(result.current.hasSelectedConnectedAccount).toBe(true);
+    });
+
+    it('remembers connected account setup when a connected account appears later', () => {
+        const { result, rerender } = renderHook(
+            ({ hasConnectedAccount }: { hasConnectedAccount: boolean }) =>
+                useOnboardingState({ hasConnectedAccount }),
+            {
+                initialProps: { hasConnectedAccount: false },
+            },
+        );
+
+        expect(result.current.hasSelectedConnectedAccount).toBe(false);
+
+        rerender({ hasConnectedAccount: true });
+
+        expect(result.current.hasSelectedConnectedAccount).toBe(true);
+    });
+});

--- a/resources/js/hooks/use-onboarding-state.ts
+++ b/resources/js/hooks/use-onboarding-state.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 export type OnboardingStep =
     | 'welcome'
@@ -35,6 +35,7 @@ export interface OnboardingState {
     totalSteps: number;
     createdAccounts: CreatedAccount[];
     isFirstAccount: boolean;
+    hasSelectedConnectedAccount: boolean;
 }
 
 export interface CreatedAccount {
@@ -50,10 +51,15 @@ export interface CreatedAccount {
 interface UseOnboardingStateOptions {
     existingAccountsCount?: number;
     initialStep?: OnboardingStep;
+    hasConnectedAccount?: boolean;
 }
 
 export function useOnboardingState(options: UseOnboardingStateOptions = {}) {
-    const { existingAccountsCount = 0, initialStep } = options;
+    const {
+        existingAccountsCount = 0,
+        initialStep,
+        hasConnectedAccount = false,
+    } = options;
 
     const primarySteps = PRIMARY_STEPS;
 
@@ -67,6 +73,14 @@ export function useOnboardingState(options: UseOnboardingStateOptions = {}) {
     const [createdAccounts, setCreatedAccounts] = useState<CreatedAccount[]>(
         [],
     );
+    const [hasSelectedConnectedAccount, setHasSelectedConnectedAccount] =
+        useState(hasConnectedAccount);
+
+    useEffect(() => {
+        if (hasConnectedAccount) {
+            setHasSelectedConnectedAccount(true);
+        }
+    }, [hasConnectedAccount]);
 
     // Calculate step index for progress indicator
     // Sub-steps (import-transactions, import-balances) use the same index as 'create-account'
@@ -108,6 +122,10 @@ export function useOnboardingState(options: UseOnboardingStateOptions = {}) {
         setCreatedAccounts((prev) => [...prev, account]);
     }, []);
 
+    const markConnectedAccountSelected = useCallback(() => {
+        setHasSelectedConnectedAccount(true);
+    }, []);
+
     const isFirstAccount =
         createdAccounts.length === 0 && existingAccountsCount === 0;
 
@@ -117,9 +135,11 @@ export function useOnboardingState(options: UseOnboardingStateOptions = {}) {
         totalSteps,
         createdAccounts,
         isFirstAccount,
+        hasSelectedConnectedAccount,
         goToStep,
         goNext,
         goBack,
         addCreatedAccount,
+        markConnectedAccountSelected,
     };
 }

--- a/resources/js/pages/onboarding/index.tsx
+++ b/resources/js/pages/onboarding/index.tsx
@@ -87,18 +87,27 @@ export default function Onboarding({
         }
     }, [sync]);
 
+    const hasConnectedAccount = useMemo(
+        () =>
+            accounts.some((account) => account.banking_connection_id !== null),
+        [accounts],
+    );
+
     const {
         currentStep,
         stepIndex,
         totalSteps,
         createdAccounts,
         isFirstAccount,
+        hasSelectedConnectedAccount,
         goToStep,
         goNext,
         addCreatedAccount,
+        markConnectedAccountSelected,
     } = useOnboardingState({
         existingAccountsCount: accounts.length,
         initialStep,
+        hasConnectedAccount,
     });
 
     const handleAccountCreated = async (account: CreatedAccount) => {
@@ -157,7 +166,13 @@ export default function Onboarding({
                         isFirstAccount={isFirstAccount}
                         existingAccounts={accounts}
                         createdAccounts={createdAccounts}
+                        hasSelectedConnectedAccount={
+                            hasSelectedConnectedAccount
+                        }
                         onAccountCreated={handleAccountCreated}
+                        onConnectedAccountSelected={
+                            markConnectedAccountSelected
+                        }
                         onContinue={goNext}
                     />
                 );

--- a/tests/Browser/OnboardingFlowTest.php
+++ b/tests/Browser/OnboardingFlowTest.php
@@ -227,6 +227,36 @@ it('shows add another account form without first account restriction', function 
         ->assertNoJavascriptErrors();
 });
 
+it('hides the connected plan warning after connected setup is selected once', function () {
+    config(['subscriptions.enabled' => true]);
+
+    $user = User::factory()->create([
+        'onboarded_at' => null,
+    ]);
+
+    $this->actingAs($user);
+
+    $warning = "Connected accounts are a Standard Plan feature. You'll choose a plan at the end of the onboarding.";
+
+    $page = visit('/onboarding');
+
+    $page->click("Let's Get Started")
+        ->wait(1)
+        ->click('Create Your First Account')
+        ->wait(1)
+        ->assertSee($warning)
+        ->assertSee('/month')
+        ->click('Continue')
+        ->wait(1)
+        ->assertSee('Connect Your Bank')
+        ->click('Back')
+        ->wait(1)
+        ->assertSee('How would you like to set up this account?')
+        ->assertDontSee($warning)
+        ->assertDontSee('/month')
+        ->assertNoJavascriptErrors();
+});
+
 it('creates a real estate account during onboarding by default', function () {
     $user = User::factory()->create([
         'onboarded_at' => null,


### PR DESCRIPTION
## Summary
- hide connected-account plan warning and price after the user chooses connected setup once
- seed onboarding state from existing connected accounts
- add hook unit coverage and browser coverage for warning/price visibility

## Tests
- bun run test -- resources/js/hooks/use-onboarding-state.test.tsx
- php artisan test --compact tests/Browser/OnboardingFlowTest.php --filter="hides the connected plan warning"
- npm run types -- --pretty false 2>&1 | rg "resources/js/(components/onboarding/step-create-account|hooks/use-onboarding-state|pages/onboarding/index)" (no onboarding errors; repo has unrelated existing TS errors)