### PR TITLE
Wait longer for cashflow browser breakdown

### DIFF
--- a/tests/Browser/CashflowCategoryNavigationTest.php
+++ b/tests/Browser/CashflowCategoryNavigationTest.php
@@ -27,7 +27,7 @@ it('clicking an expense category on cashflow page navigates to transactions with
 
     $page = $this->actingAs($user)->visit("/cashflow?period={$period}");
 
-    $page->waitForText('Groceries', 10)
+    $page->waitForText('Groceries', 30)
         ->click('Groceries')
         ->wait(2)
         ->assertPathIs('/transactions')
@@ -56,7 +56,7 @@ it('clicking an income category on cashflow page navigates to transactions with 
 
     $page = $this->actingAs($user)->visit("/cashflow?period={$period}");
 
-    $page->waitForText('Salary', 10)
+    $page->waitForText('Salary', 30)
         ->click('Salary')
         ->wait(2)
         ->assertPathIs('/transactions')


### PR DESCRIPTION
## Summary
- extend cashflow category browser waits from 10s to 30s

## Why
CI shard 3 intermittently loads cashflow breakdown data after the 10s text wait, especially with larger frontend bundles. The test already waits for API-rendered category text; this makes the async wait match CI timing.

## Tests
- vendor/bin/pint --dirty --format agent
- php artisan test --compact tests/Browser/CashflowCategoryNavigationTest.php (timed out locally after pint; CI covers browser suite)