### PR TITLE
Init browser Sentry from env DSN

### DIFF
--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -24,11 +24,13 @@ import type { SharedData } from './types';
 import { setTranslations } from './utils/i18n';
 
 Sentry.init({
-    dsn: 'https://47f7a823afae4c2f93ab3159ca7c0a3a@bugsink.whisper.money:8000/2',
+    dsn: import.meta.env.SENTRY_LARAVEL_DSN,
     environment: import.meta.env.MODE,
     integrations: [],
     tracesSampleRate: 0,
-    enabled: import.meta.env.PROD,
+    sendDefaultPii: true,
+    enabled:
+        import.meta.env.PROD && Boolean(import.meta.env.SENTRY_LARAVEL_DSN),
 });
 
 initializePostHog();

--- a/resources/js/types/vite-env.d.ts
+++ b/resources/js/types/vite-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+    readonly SENTRY_LARAVEL_DSN?: string;
     readonly VITE_APP_NAME?: string;
     readonly VITE_POSTHOG_ENABLED?: string;
     readonly VITE_POSTHOG_API_KEY?: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import laravel from 'laravel-vite-plugin';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+    envPrefix: ['VITE_', 'SENTRY_LARAVEL_DSN'],
     build: {
         sourcemap: true,
     },


### PR DESCRIPTION
## Summary
- read browser Sentry DSN from `SENTRY_LARAVEL_DSN`
- expose `SENTRY_LARAVEL_DSN` through Vite env
- enable default PII and disable client Sentry when DSN missing
- removed temporary welcome test button

## Tests
- `npx eslint resources/js/pages/welcome.tsx resources/js/app.tsx resources/js/types/vite-env.d.ts vite.config.ts`
- `php artisan test --compact tests/Feature/SentryConfigTest.php`
- `npm run build` (build completed; existing Sentry sourcemap upload reports SSL error against Bugsink)
