### PR TITLE
Fix Sentry release commit detection in image build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,7 +367,7 @@ jobs:
             sentry-cli releases new "$SENTRY_RELEASE"
           fi
 
-          sentry-cli releases set-commits "$SENTRY_RELEASE" --auto
+          sentry-cli releases set-commits "$SENTRY_RELEASE" --auto --ignore-missing
           sentry-cli releases finalize "$SENTRY_RELEASE"
 
       - name: Set up QEMU


### PR DESCRIPTION
## Summary
- add --ignore-missing to Sentry set-commits so build-image does not fail when previous release SHA is unavailable
- cover the workflow command in Sentry config test

## Tests
- vendor/bin/pint --dirty --format agent
- php artisan test --compact tests/Feature/SentryConfigTest.php