### PR TITLE
Fix service worker registration rejection

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -66,7 +66,7 @@
 
         <script>
             if ('serviceWorker' in navigator) {
-                navigator.serviceWorker.register('/sw.js', { scope: '/' });
+                navigator.serviceWorker.register('/sw.js', { scope: '/' }).catch(function () {});
             }
         </script>
     </body>

--- a/tests/Feature/PwaTest.php
+++ b/tests/Feature/PwaTest.php
@@ -20,5 +20,6 @@ test('app template includes pwa meta tags and service worker registration', func
         ->assertSee('content="default"', false)
         ->assertDontSee('black-translucent', false)
         ->assertSee('serviceWorker', false)
+        ->assertSee("navigator.serviceWorker.register('/sw.js', { scope: '/' }).catch", false)
         ->assertSee('viewport-fit=cover', false);
 });


### PR DESCRIPTION
## Sentry
- Fixes PHP-LARAVEL-1Q
- https://whisper-money.sentry.io/issues/PHP-LARAVEL-1Q

## Root cause
- Service worker registration promise rejected in production and had no rejection handler.
- Browser reported unhandled promise rejection: Error: Rejected.

## Fix
- Add a catch handler to service worker registration so unsupported/intercepted registration failures do not become unhandled global errors.
- Add regression coverage asserting registration has rejection handling.

## Verification
- vendor/bin/pint --dirty --format agent
- php artisan test --compact tests/Feature/PwaTest.php