### PR TITLE
Fix PHP-LARAVEL-1S browser translation crash

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" @class(['dark' => ($appearance ?? 'system') == 'dark'])>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" translate="no" @class(['notranslate', 'dark' => ($appearance ?? 'system') == 'dark'])>
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
         <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
         <meta name="theme-color" content="#383838" media="(prefers-color-scheme: dark)">
+        <meta name="google" content="notranslate">
 
         {{-- Inline script to detect system dark mode preference and apply it immediately --}}
         <script>

--- a/tests/Feature/PwaTest.php
+++ b/tests/Feature/PwaTest.php
@@ -23,12 +23,3 @@ test('app template includes pwa meta tags and service worker registration', func
         ->assertSee("navigator.serviceWorker.register('/sw.js', { scope: '/' }).catch", false)
         ->assertSee('viewport-fit=cover', false);
 });
-
-test('app template disables browser translation to protect react managed dom', function () {
-    $response = $this->get('/');
-
-    $response->assertSuccessful()
-        ->assertSee('translate="no"', false)
-        ->assertSee('notranslate', false)
-        ->assertSee('name="google" content="notranslate"', false);
-});

--- a/tests/Feature/PwaTest.php
+++ b/tests/Feature/PwaTest.php
@@ -23,3 +23,12 @@ test('app template includes pwa meta tags and service worker registration', func
         ->assertSee("navigator.serviceWorker.register('/sw.js', { scope: '/' }).catch", false)
         ->assertSee('viewport-fit=cover', false);
 });
+
+test('app template disables browser translation to protect react managed dom', function () {
+    $response = $this->get('/');
+
+    $response->assertSuccessful()
+        ->assertSee('translate="no"', false)
+        ->assertSee('notranslate', false)
+        ->assertSee('name="google" content="notranslate"', false);
+});


### PR DESCRIPTION
## Sentry issue
- https://whisper-money.sentry.io/issues/PHP-LARAVEL-1S

## Root cause
- Browser/page translation mutated React-managed DOM on /onboarding by injecting font wrappers. React later attempted to unmount a node that translation had moved, causing NotFoundError removeChild.

## Fix
- Mark the Inertia root document as not translatable with translate="no", notranslate class, and google notranslate meta tag.
- Add regression coverage for the root template markers.

## Verification
- vendor/bin/pint --dirty --format agent
- php artisan test --compact tests/Feature/PwaTest.php