### PR TITLE
Fix Vite asset preload recovery

### DIFF
--- a/resources/js/lib/chunk-load-recovery.test.ts
+++ b/resources/js/lib/chunk-load-recovery.test.ts
@@ -15,6 +15,16 @@ describe('isChunkLoadError', () => {
         ).toBe(true);
     });
 
+    it('detects Vite CSS preload failures', () => {
+        expect(
+            isChunkLoadError(
+                new Error(
+                    'Unable to preload CSS for /build/assets/app-BpqbLMXP.css',
+                ),
+            ),
+        ).toBe(true);
+    });
+
     it('ignores unrelated errors', () => {
         expect(isChunkLoadError(new Error('Validation failed'))).toBe(false);
     });

--- a/resources/js/lib/chunk-load-recovery.ts
+++ b/resources/js/lib/chunk-load-recovery.ts
@@ -6,6 +6,7 @@ const CHUNK_LOAD_ERROR_PATTERNS = [
     /error loading dynamically imported module/i,
     /Importing a module script failed/i,
     /Load failed for module script/i,
+    /Unable to preload CSS/i,
     /ChunkLoadError/i,
     /Loading chunk \d+ failed/i,
 ];


### PR DESCRIPTION
## Summary
- detect Vite CSS preload failures as chunk load errors
- reuse existing one-shot reload recovery for stale asset failures

Fixes PHP-LARAVEL-29
Fixes PHP-LARAVEL-27

## Tests
- npm run test -- resources/js/lib/chunk-load-recovery.test.ts
- npm run types *(fails: existing unrelated TypeScript errors in accounts, charts, transactions, crypto, etc.)*