### PR TITLE
Filter injected webview layout errors

### DIFF
--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -23,6 +23,7 @@ import { installChunkLoadRecovery } from './lib/chunk-load-recovery';
 import { initializePostHog } from './lib/posthog';
 import {
     isChunkLoadErrorEvent,
+    isInjectedWebViewLayoutScriptNoise,
     isPostMessageDataCloneNoise,
 } from './lib/sentry';
 import type { SharedData } from './types';
@@ -39,7 +40,8 @@ Sentry.init({
     beforeSend(event) {
         if (
             isChunkLoadErrorEvent(event) ||
-            isPostMessageDataCloneNoise(event)
+            isPostMessageDataCloneNoise(event) ||
+            isInjectedWebViewLayoutScriptNoise(event)
         ) {
             return null;
         }

--- a/resources/js/lib/sentry.test.ts
+++ b/resources/js/lib/sentry.test.ts
@@ -1,6 +1,10 @@
 import type { Event } from '@sentry/react';
 import { describe, expect, it } from 'vitest';
-import { isChunkLoadErrorEvent, isPostMessageDataCloneNoise } from './sentry';
+import {
+    isChunkLoadErrorEvent,
+    isInjectedWebViewLayoutScriptNoise,
+    isPostMessageDataCloneNoise,
+} from './sentry';
 
 describe('isChunkLoadErrorEvent', () => {
     it('drops recoverable Vite dynamic import failures', () => {
@@ -31,6 +35,81 @@ describe('isChunkLoadErrorEvent', () => {
         };
 
         expect(isChunkLoadErrorEvent(event)).toBe(false);
+    });
+});
+
+describe('isInjectedWebViewLayoutScriptNoise', () => {
+    it('drops injected safe-area layout script globals', () => {
+        const event: Event = {
+            exception: {
+                values: [
+                    {
+                        type: 'ReferenceError',
+                        value: "Can't find variable: currentInset",
+                        stacktrace: {
+                            frames: [
+                                {
+                                    filename: '/login',
+                                    function: 'init',
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
+        };
+
+        expect(isInjectedWebViewLayoutScriptNoise(event)).toBe(true);
+    });
+
+    it('drops injected gap filler CONFIG references', () => {
+        const event: Event = {
+            exception: {
+                values: [
+                    {
+                        type: 'ReferenceError',
+                        value: "Can't find variable: CONFIG",
+                        stacktrace: {
+                            frames: [
+                                {
+                                    filename: '/login',
+                                    function: 'updateFooterPositions',
+                                },
+                                {
+                                    filename: '/login',
+                                    function: 'updateGapFiller',
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
+        };
+
+        expect(isInjectedWebViewLayoutScriptNoise(event)).toBe(true);
+    });
+
+    it('keeps app ReferenceError events', () => {
+        const event: Event = {
+            exception: {
+                values: [
+                    {
+                        type: 'ReferenceError',
+                        value: "Can't find variable: account",
+                        stacktrace: {
+                            frames: [
+                                {
+                                    filename: '/build/assets/app.js',
+                                    function: 'renderAccount',
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
+        };
+
+        expect(isInjectedWebViewLayoutScriptNoise(event)).toBe(false);
     });
 });
 

--- a/resources/js/lib/sentry.ts
+++ b/resources/js/lib/sentry.ts
@@ -3,6 +3,12 @@ import { isChunkLoadError } from './chunk-load-recovery';
 
 const CLONE_ERROR_MESSAGE_PATTERN =
     /object (can not|could not|couldn't|can't) be cloned/i;
+const WEBVIEW_LAYOUT_SCRIPT_GLOBALS = ['currentInset', 'CONFIG'];
+const WEBVIEW_LAYOUT_SCRIPT_FUNCTIONS = [
+    'init',
+    'updateGapFiller',
+    'updateFooterPositions',
+];
 
 export function isChunkLoadErrorEvent(event: Event): boolean {
     return (
@@ -29,6 +35,40 @@ export function isPostMessageDataCloneNoise(event: Event): boolean {
                         (value) => value?.includes('postMessage'),
                     ),
                 )
+            );
+        }) ?? false
+    );
+}
+
+export function isInjectedWebViewLayoutScriptNoise(event: Event): boolean {
+    return (
+        event.exception?.values?.some((exception) => {
+            const exceptionType = exception.type ?? '';
+            const exceptionValue = exception.value ?? '';
+            const frames = exception.stacktrace?.frames ?? [];
+
+            if (exceptionType !== 'ReferenceError') {
+                return false;
+            }
+
+            if (
+                !WEBVIEW_LAYOUT_SCRIPT_GLOBALS.some((globalName) =>
+                    exceptionValue.includes(globalName),
+                )
+            ) {
+                return false;
+            }
+
+            return frames.some((frame) =>
+                [frame.function, frame.filename].some((value) => {
+                    if (!value) {
+                        return false;
+                    }
+
+                    return WEBVIEW_LAYOUT_SCRIPT_FUNCTIONS.some(
+                        (functionName) => value.includes(functionName),
+                    );
+                }),
             );
         }) ?? false
     );


### PR DESCRIPTION
## Summary
- drop injected webview safe-area layout ReferenceErrors from Sentry
- keep unrelated app ReferenceErrors reporting

Fixes PHP-LARAVEL-25
Fixes PHP-LARAVEL-26

## Tests
- npm run test -- resources/js/lib/sentry.test.ts
- npm run lint -- resources/js/app.tsx resources/js/lib/sentry.ts resources/js/lib/sentry.test.ts *(passes with existing chart hook warning)*