### PR TITLE
fix: keep lead invite command aliases

### DIFF
--- a/app/Console/Commands/SendUserLeadInvitations.php
+++ b/app/Console/Commands/SendUserLeadInvitations.php
@@ -22,6 +22,11 @@ class SendUserLeadInvitations extends Command
 
     protected $description = 'Send launch invitation emails to the next batch of waitlist leads';
 
+    protected $aliases = [
+        'leads:send-invite',
+        'leads:send-invites',
+    ];
+
     public function handle(LeadCohortResolver $resolver, LeadPromoCodeAllocator $allocator): int
     {
         $limit = (int) $this->option('limit');

--- a/tests/Feature/Commands/SendUserLeadInvitationsTest.php
+++ b/tests/Feature/Commands/SendUserLeadInvitationsTest.php
@@ -22,6 +22,15 @@ beforeEach(function (): void {
     });
 });
 
+it('keeps the previous invite command aliases available', function (string $command): void {
+    $this->artisan($command, ['--dry-run' => true])
+        ->expectsOutput('No pending leads found.')
+        ->assertSuccessful();
+})->with([
+    'singular alias' => 'leads:send-invite',
+    'plural alias' => 'leads:send-invites',
+]);
+
 it('sends invitations to the next batch ordered by position', function (): void {
     UserLead::factory()->count(15)->state(new Sequence(
         ...array_map(fn (int $i) => ['position' => $i, 'email_verified_at' => now()], range(1, 15)),


### PR DESCRIPTION
## Sentry issue
- https://whisper-money.sentry.io/issues/PHP-LARAVEL-1H

## Root cause
Production invoked old/typoed Artisan command names (`leads:send-invite` / `leads:send-invites`) after the command was named `leads:send-invitations`, causing Symfony CommandNotFoundException before command logic ran.

## Fix
- Add compatibility aliases for previous invite command names.
- Add regression coverage that both aliases execute successfully.

## Verification
- `vendor/bin/pint --dirty --format agent`
- `php artisan test --compact tests/Feature/Commands/SendUserLeadInvitationsTest.php`
