### PR TITLE
fix(cashflow): stack mobile header controls

### DIFF
--- a/resources/js/components/cashflow/period-navigation.tsx
+++ b/resources/js/components/cashflow/period-navigation.tsx
@@ -61,8 +61,8 @@ export function PeriodNavigation({
     };
 
     return (
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-            <ButtonGroup>
+        <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
+            <ButtonGroup className="w-full sm:w-fit">
                 {periodTypeOptions.map((option) => (
                     <Button
                         key={option.value}
@@ -72,6 +72,7 @@ export function PeriodNavigation({
                         }
                         onClick={() => onPeriodTypeChange(option.value)}
                         className={cn(
+                            'flex-1 sm:flex-none',
                             periodType === option.value &&
                                 'border-primary bg-primary text-primary-foreground',
                         )}
@@ -81,7 +82,7 @@ export function PeriodNavigation({
                 ))}
             </ButtonGroup>
 
-            <ButtonGroup>
+            <ButtonGroup className="w-full sm:w-fit">
                 <Button
                     variant="outline"
                     size="icon"
@@ -91,7 +92,11 @@ export function PeriodNavigation({
                     <ChevronLeft className="size-4" />
                 </Button>
 
-                <Button onClick={handleCurrentPeriod} variant="outline">
+                <Button
+                    onClick={handleCurrentPeriod}
+                    variant="outline"
+                    className="flex-1 sm:flex-none"
+                >
                     {formatPeriodLabel(currentDate, periodType, locale)}
                 </Button>
 

--- a/resources/js/pages/cashflow/index.tsx
+++ b/resources/js/pages/cashflow/index.tsx
@@ -158,7 +158,7 @@ export default function CashflowPage() {
             <Head title={__('Cashflow')} />
 
             <div className="space-y-6 p-6">
-                <div className="flex items-center justify-between">
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                     <HeadingSmall
                         title={__('Cashflow')}
                         description={__(


### PR DESCRIPTION
## Summary
- stack cashflow header on mobile
- make period type and period selector rows full width on mobile

## Tests
- npx eslint resources/js/pages/cashflow/index.tsx resources/js/components/cashflow/period-navigation.tsx