### PR TITLE
feat(leads): schedule invitation emails

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -9,3 +9,5 @@ Schedule::command('banking:cancel-free-enablebanking')->lastDayOfMonth('18:00');
 Schedule::command('real-estate:apply-revaluation')->monthlyOn(1, '00:00');
 Schedule::command('loans:generate-balances')->monthlyOn(1, '00:00');
 Schedule::command('resend:sync-leads')->dailyAt('03:00');
+Schedule::command('leads:send-invitations --force --limit=100')->dailyAt('09:00');
+Schedule::command('leads:send-re-invitations --force')->dailyAt('09:00');


### PR DESCRIPTION
## Summary
- run lead invitation emails daily at 9:00 AM
- run lead re-invitation emails daily at 9:00 AM
- use --force so scheduler runs non-interactively

## Verification
- php artisan schedule:list --no-interaction | rg "leads:send-(re-)?invitations"