### PR TITLE
feat: add PKR currency support

### DIFF
--- a/config/currencies.php
+++ b/config/currencies.php
@@ -57,6 +57,12 @@ return [
             'allows_account' => true,
         ],
         [
+            'code' => 'PKR',
+            'name' => 'Pakistani Rupee',
+            'allows_primary' => true,
+            'allows_account' => true,
+        ],
+        [
             'code' => 'MXN',
             'name' => 'Mexican Peso',
             'allows_primary' => true,

--- a/tests/Feature/Settings/AccountTest.php
+++ b/tests/Feature/Settings/AccountTest.php
@@ -132,6 +132,25 @@ it('accepts new latam currency when creating account', function () {
     ]);
 });
 
+it('accepts Pakistani rupee when creating account', function () {
+    actingAs($this->user);
+
+    $response = $this->post(route('accounts.store'), [
+        'name' => 'Pakistan Account',
+        'bank_id' => $this->bank->id,
+        'currency_code' => 'PKR',
+        'type' => AccountType::Checking->value,
+    ]);
+
+    $response->assertRedirect();
+
+    assertDatabaseHas('accounts', [
+        'user_id' => $this->user->id,
+        'bank_id' => $this->bank->id,
+        'currency_code' => 'PKR',
+    ]);
+});
+
 it('accepts bitcoin when creating account', function () {
     actingAs($this->user);
 

--- a/tests/Feature/Settings/ProfileUpdateTest.php
+++ b/tests/Feature/Settings/ProfileUpdateTest.php
@@ -53,6 +53,25 @@ test('profile accepts new latam primary currency', function () {
     expect($user->refresh()->currency_code)->toBe('ARS');
 });
 
+test('profile accepts Pakistani rupee as primary currency', function () {
+    $user = User::factory()->create();
+
+    $response = $this
+        ->actingAs($user)
+        ->patch(route('profile.update'), [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'currency_code' => 'PKR',
+            'month_start_day' => 1,
+        ]);
+
+    $response
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(route('account.edit'));
+
+    expect($user->refresh()->currency_code)->toBe('PKR');
+});
+
 test('profile rejects bitcoin as primary currency', function () {
     $user = User::factory()->create();
 


### PR DESCRIPTION
## Summary
- Add Pakistani Rupee (PKR) to supported primary and account currencies
- Cover PKR account creation and profile currency selection

## Tests
- vendor/bin/pint --dirty --format agent
- php artisan test --compact tests/Feature/Settings/AccountTest.php tests/Feature/Settings/ProfileUpdateTest.php