### PR TITLE
feat(periods): add custom month start day

### DIFF
--- a/app/Features/CustomMonthStartDay.php
+++ b/app/Features/CustomMonthStartDay.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Features;
+
+use App\Models\User;
+
+/**
+ * @api
+ */
+class CustomMonthStartDay
+{
+    /**
+     * Resolve the feature's initial value.
+     */
+    public function resolve(?User $user): bool
+    {
+        return false;
+    }
+}

--- a/app/Http/Controllers/Api/CashflowAnalyticsController.php
+++ b/app/Http/Controllers/Api/CashflowAnalyticsController.php
@@ -81,8 +81,11 @@ class CashflowAnalyticsController extends Controller
         $user = $request->user();
 
         if (isset($validated['from'], $validated['to'])) {
-            $start = Carbon::parse($validated['from'])->startOfDay();
-            $end = Carbon::parse($validated['to'])->startOfDay();
+            // Snap the bounds to the user's period start so the emitted month
+            // buckets line up with how transactions are grouped below;
+            // otherwise transactions in a partial leading period are dropped.
+            $start = $this->userMonthPeriodService->monthContaining($user, Carbon::parse($validated['from']))['from'];
+            $end = $this->userMonthPeriodService->monthContaining($user, Carbon::parse($validated['to']))['end_inclusive'];
         } else {
             $months = $validated['months'] ?? 12;
             $endPeriod = $this->userMonthPeriodService->monthContaining(
@@ -111,7 +114,7 @@ class CashflowAnalyticsController extends Controller
                 'net' => $income - $expense,
             ];
 
-            $current->addMonth();
+            $current->addMonthNoOverflow();
         }
 
         return $this->cashflowJson([
@@ -341,10 +344,18 @@ class CashflowAnalyticsController extends Controller
 
         $this->preloadExchangeRates($transactions, $userCurrency);
 
+        $startDay = $this->userMonthPeriodService->startDay($user);
+
         return $transactions
-            ->groupBy(fn (Transaction $transaction): string => $this->userMonthPeriodService
-                ->monthContaining($user, $transaction->transaction_date)['from']
-                ->format('Y-m'))
+            ->groupBy(function (Transaction $transaction) use ($startDay): string {
+                $date = $transaction->transaction_date;
+
+                // Bucket by the period a transaction falls in: dates before the
+                // start day belong to the period that opened the prior month.
+                return $date->day >= $startDay
+                    ? $date->format('Y-m')
+                    : $date->copy()->subMonthNoOverflow()->format('Y-m');
+            })
             ->map(function (Collection $transactions) use ($userCurrency): array {
                 $income = 0;
                 $expense = 0;

--- a/app/Http/Controllers/Api/CashflowAnalyticsController.php
+++ b/app/Http/Controllers/Api/CashflowAnalyticsController.php
@@ -7,9 +7,11 @@ use App\Enums\CategoryType;
 use App\Http\Controllers\Controller;
 use App\Models\Category;
 use App\Models\Transaction;
+use App\Models\User;
 use App\Services\CategoryTree;
 use App\Services\ExchangeRateService;
 use App\Services\PeriodComparator;
+use App\Services\UserMonthPeriodService;
 use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -20,6 +22,7 @@ class CashflowAnalyticsController extends Controller
     public function __construct(
         private ExchangeRateService $exchangeRateService,
         private CategoryTree $tree,
+        private UserMonthPeriodService $userMonthPeriodService,
     ) {}
 
     public function summary(Request $request): JsonResponse
@@ -78,17 +81,19 @@ class CashflowAnalyticsController extends Controller
         $user = $request->user();
 
         if (isset($validated['from'], $validated['to'])) {
-            $start = Carbon::parse($validated['from'])->startOfMonth();
-            $end = Carbon::parse($validated['to'])->endOfMonth();
+            $start = Carbon::parse($validated['from'])->startOfDay();
+            $end = Carbon::parse($validated['to'])->startOfDay();
         } else {
             $months = $validated['months'] ?? 12;
-            $end = isset($validated['to'])
-                ? Carbon::parse($validated['to'])->endOfMonth()
-                : Carbon::now()->endOfMonth();
-            $start = $end->copy()->subMonthsNoOverflow($months - 1)->startOfMonth();
+            $endPeriod = $this->userMonthPeriodService->monthContaining(
+                $user,
+                isset($validated['to']) ? Carbon::parse($validated['to']) : Carbon::now(),
+            );
+            $end = $endPeriod['end_inclusive'];
+            $start = $endPeriod['from']->copy()->subMonthsNoOverflow($months - 1);
         }
 
-        $monthlyTotals = $this->getMonthlyTrendTotals($user->id, $user->currency_code, $start, $end);
+        $monthlyTotals = $this->getMonthlyTrendTotals($user->id, $user->currency_code, $start, $end, $user);
 
         $data = [];
         $current = $start->copy();
@@ -326,7 +331,7 @@ class CashflowAnalyticsController extends Controller
         return $categorized;
     }
 
-    private function getMonthlyTrendTotals(string $userId, string $userCurrency, Carbon $from, Carbon $to): Collection
+    private function getMonthlyTrendTotals(string $userId, string $userCurrency, Carbon $from, Carbon $to, User $user): Collection
     {
         $transactions = Transaction::query()
             ->where('transactions.user_id', $userId)
@@ -337,7 +342,9 @@ class CashflowAnalyticsController extends Controller
         $this->preloadExchangeRates($transactions, $userCurrency);
 
         return $transactions
-            ->groupBy(fn (Transaction $transaction): string => $transaction->transaction_date->format('Y-m'))
+            ->groupBy(fn (Transaction $transaction): string => $this->userMonthPeriodService
+                ->monthContaining($user, $transaction->transaction_date)['from']
+                ->format('Y-m'))
             ->map(function (Collection $transactions) use ($userCurrency): array {
                 $income = 0;
                 $expense = 0;

--- a/app/Http/Controllers/Api/CashflowAnalyticsController.php
+++ b/app/Http/Controllers/Api/CashflowAnalyticsController.php
@@ -87,7 +87,7 @@ class CashflowAnalyticsController extends Controller
             $months = $validated['months'] ?? 12;
             $endPeriod = $this->userMonthPeriodService->monthContaining(
                 $user,
-                isset($validated['to']) ? Carbon::parse($validated['to']) : Carbon::now(),
+                isset($validated['to']) ? Carbon::parse($validated['to']) : Carbon::now($user->timezone),
             );
             $end = $endPeriod['end_inclusive'];
             $start = $endPeriod['from']->copy()->subMonthsNoOverflow($months - 1);

--- a/app/Http/Controllers/Api/CategoryMonthlyBreakdownController.php
+++ b/app/Http/Controllers/Api/CategoryMonthlyBreakdownController.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Category;
 use App\Models\Transaction;
 use App\Services\ExchangeRateService;
+use App\Services\UserMonthPeriodService;
 use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -27,6 +28,7 @@ class CategoryMonthlyBreakdownController extends Controller
 
     public function __construct(
         private ExchangeRateService $exchangeRateService,
+        private UserMonthPeriodService $userMonthPeriodService,
     ) {}
 
     public function __invoke(Request $request, Category $category): JsonResponse
@@ -36,7 +38,9 @@ class CategoryMonthlyBreakdownController extends Controller
         abort_unless($category->user_id === $user->id, 403);
 
         $currency = $user->currency_code;
-        $start = Carbon::now()->startOfMonth()->subMonths(self::MONTHS - 1);
+        $startDay = $this->userMonthPeriodService->startDay($user);
+        $start = $this->userMonthPeriodService->current($user)['from']
+            ->subMonthsNoOverflow(self::MONTHS - 1);
 
         $parentMap = Category::query()
             ->where('user_id', $user->id)
@@ -77,7 +81,7 @@ class CategoryMonthlyBreakdownController extends Controller
 
         foreach ($transactions as $transaction) {
             $amount = $this->convertTransactionAmount($transaction, $currency) * $orientation;
-            $monthKey = $transaction->transaction_date->format('Y-m');
+            $monthKey = $this->periodKey($transaction->transaction_date, $startDay);
             $segment = $this->segmentFor($transaction->category_id, $category->id, $parentMap, $hasChildren);
 
             $buckets[$monthKey][$segment] = ($buckets[$monthKey][$segment] ?? 0) + $amount;
@@ -271,10 +275,21 @@ class CategoryMonthlyBreakdownController extends Controller
             }
 
             $months[] = $point;
-            $cursor->addMonth();
+            $cursor->addMonthNoOverflow();
         }
 
         return $months;
+    }
+
+    /**
+     * The Y-m label of the month period a date belongs to: dates before the
+     * user's start day roll into the period that opened the previous month.
+     */
+    private function periodKey(Carbon $date, int $startDay): string
+    {
+        return $date->day >= $startDay
+            ? $date->format('Y-m')
+            : $date->copy()->subMonthNoOverflow()->format('Y-m');
     }
 
     private function convertTransactionAmount(Transaction $transaction, string $currency): int

--- a/app/Http/Controllers/CashflowController.php
+++ b/app/Http/Controllers/CashflowController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Account;
 use App\Models\Bank;
 use App\Models\Category;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -45,6 +46,9 @@ class CashflowController extends Controller
             'banks' => $banks,
             'period' => $validPeriod,
             'periodType' => $validPeriodType,
+            // Resolve "today" in the user's timezone so the client agrees with
+            // the server on which period is current near month boundaries.
+            'today' => Carbon::now($user->timezone)->toDateString(),
         ]);
     }
 

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -62,7 +62,7 @@ class DashboardController extends Controller
 
         $totalAmount = $currentSpending->sum('amount');
 
-        return $currentSpending
+        $categories = $currentSpending
             ->sortByDesc('amount')
             ->take(10)
             ->map(function ($item) use ($previousSpending, $totalAmount) {
@@ -80,6 +80,14 @@ class DashboardController extends Controller
             })
             ->values()
             ->all();
+
+        return [
+            'categories' => $categories,
+            // Share the resolved period so the drill-down and links query the
+            // same window the parent rows were computed for.
+            'from' => $periodDates['from']->toDateString(),
+            'to' => $periodDates['end_inclusive']->toDateString(),
+        ];
     }
 
     private function getCashflowSummary(Request $request): array

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -8,6 +8,7 @@ use App\Models\Transaction;
 use App\Services\AccountMetricsService;
 use App\Services\CategoryTree;
 use App\Services\PeriodComparator;
+use App\Services\UserMonthPeriodService;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
@@ -20,6 +21,7 @@ class DashboardController extends Controller
     public function __construct(
         private AccountMetricsService $accountMetricsService,
         private CategoryTree $tree,
+        private UserMonthPeriodService $userMonthPeriodService,
     ) {}
 
     public function __invoke(Request $request): Response
@@ -50,11 +52,9 @@ class DashboardController extends Controller
     private function getTopCategories(Request $request): array
     {
         $user = $request->user();
-        $now = Carbon::now();
-        $from = $now->copy()->subDays(30);
-        $to = $now->copy();
+        $periodDates = $this->userMonthPeriodService->current($user);
 
-        $period = new PeriodComparator($from, $to);
+        $period = new PeriodComparator($periodDates['from'], $periodDates['end_inclusive']);
         $previousPeriod = $period->previous();
 
         $currentSpending = $this->getCategorySpending($user->id, $period->from, $period->to);
@@ -85,11 +85,9 @@ class DashboardController extends Controller
     private function getCashflowSummary(Request $request): array
     {
         $user = $request->user();
-        $now = Carbon::now();
-        $from = $now->copy()->startOfMonth();
-        $to = $now->copy()->endOfMonth();
+        $periodDates = $this->userMonthPeriodService->current($user);
 
-        $period = new PeriodComparator($from, $to);
+        $period = new PeriodComparator($periodDates['from'], $periodDates['end_inclusive']);
         $previousPeriod = $period->previous();
 
         return [

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -165,26 +165,19 @@ class HandleInertiaRequests extends Middleware
     {
         $user = request()->user();
 
-        if (! $user) {
-            return [
-                'cashflow' => true,
-                'calculateBalancesOnImport' => false,
-                'customMonthStartDay' => false,
-                'transactionAnalysis' => false,
-            ];
-        }
-
-        $features = Feature::for($user)->values([
-            CalculateBalancesOnImport::class,
-            CustomMonthStartDay::class,
-            TransactionAnalysis::class,
-        ]);
+        $flags = $user
+            ? Feature::for($user)->values([
+                CalculateBalancesOnImport::class,
+                CustomMonthStartDay::class,
+                TransactionAnalysis::class,
+            ])
+            : [];
 
         return [
             'cashflow' => true,
-            'calculateBalancesOnImport' => $features[CalculateBalancesOnImport::class] !== false,
-            'customMonthStartDay' => $features[CustomMonthStartDay::class] !== false,
-            'transactionAnalysis' => $features[TransactionAnalysis::class] !== false,
+            'calculateBalancesOnImport' => $flags[CalculateBalancesOnImport::class] ?? false,
+            'customMonthStartDay' => $flags[CustomMonthStartDay::class] ?? false,
+            'transactionAnalysis' => $flags[TransactionAnalysis::class] ?? false,
         ];
     }
 

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -4,6 +4,7 @@ namespace App\Http\Middleware;
 
 use App\Enums\BankingConnectionStatus;
 use App\Features\CalculateBalancesOnImport;
+use App\Features\CustomMonthStartDay;
 use App\Features\TransactionAnalysis;
 use App\Models\BankingConnection;
 use App\Services\CurrencyOptions;
@@ -168,18 +169,21 @@ class HandleInertiaRequests extends Middleware
             return [
                 'cashflow' => true,
                 'calculateBalancesOnImport' => false,
+                'customMonthStartDay' => false,
                 'transactionAnalysis' => false,
             ];
         }
 
         $features = Feature::for($user)->values([
             CalculateBalancesOnImport::class,
+            CustomMonthStartDay::class,
             TransactionAnalysis::class,
         ]);
 
         return [
             'cashflow' => true,
             'calculateBalancesOnImport' => $features[CalculateBalancesOnImport::class] !== false,
+            'customMonthStartDay' => $features[CustomMonthStartDay::class] !== false,
             'transactionAnalysis' => $features[TransactionAnalysis::class] !== false,
         ];
     }

--- a/app/Http/Requests/Settings/ProfileUpdateRequest.php
+++ b/app/Http/Requests/Settings/ProfileUpdateRequest.php
@@ -38,7 +38,7 @@ class ProfileUpdateRequest extends FormRequest
         ];
 
         if (Feature::for($this->user())->active(CustomMonthStartDay::class)) {
-            $rules['month_start_day'] = ['required', 'integer', Rule::in(UserMonthPeriodService::ALLOWED_START_DAYS)];
+            $rules['month_start_day'] = ['sometimes', 'required', 'integer', Rule::in(UserMonthPeriodService::ALLOWED_START_DAYS)];
         }
 
         return $rules;

--- a/app/Http/Requests/Settings/ProfileUpdateRequest.php
+++ b/app/Http/Requests/Settings/ProfileUpdateRequest.php
@@ -2,12 +2,14 @@
 
 namespace App\Http\Requests\Settings;
 
+use App\Features\CustomMonthStartDay;
 use App\Models\User;
 use App\Services\CurrencyOptions;
 use App\Services\UserMonthPeriodService;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Laravel\Pennant\Feature;
 
 class ProfileUpdateRequest extends FormRequest
 {
@@ -20,7 +22,7 @@ class ProfileUpdateRequest extends FormRequest
     {
         $currencyOptions = app(CurrencyOptions::class);
 
-        return [
+        $rules = [
             'name' => ['required', 'string', 'max:255'],
 
             'email' => [
@@ -33,7 +35,12 @@ class ProfileUpdateRequest extends FormRequest
             ],
             'currency_code' => ['required', 'string', 'max:3', Rule::in($currencyOptions->primaryCodes())],
             'locale' => ['nullable', 'string', Rule::in(['en', 'es'])],
-            'month_start_day' => ['required', 'integer', Rule::in(UserMonthPeriodService::ALLOWED_START_DAYS)],
         ];
+
+        if (Feature::for($this->user())->active(CustomMonthStartDay::class)) {
+            $rules['month_start_day'] = ['required', 'integer', Rule::in(UserMonthPeriodService::ALLOWED_START_DAYS)];
+        }
+
+        return $rules;
     }
 }

--- a/app/Http/Requests/Settings/ProfileUpdateRequest.php
+++ b/app/Http/Requests/Settings/ProfileUpdateRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests\Settings;
 
 use App\Models\User;
 use App\Services\CurrencyOptions;
+use App\Services\UserMonthPeriodService;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -32,6 +33,7 @@ class ProfileUpdateRequest extends FormRequest
             ],
             'currency_code' => ['required', 'string', 'max:3', Rule::in($currencyOptions->primaryCodes())],
             'locale' => ['nullable', 'string', Rule::in(['en', 'es'])],
+            'month_start_day' => ['required', 'integer', Rule::in(UserMonthPeriodService::ALLOWED_START_DAYS)],
         ];
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -47,6 +47,7 @@ class User extends Authenticatable implements HasLocalePreference, MustVerifyEma
         'currency_code',
         'locale',
         'timezone',
+        'month_start_day',
     ];
 
     /**
@@ -76,6 +77,7 @@ class User extends Authenticatable implements HasLocalePreference, MustVerifyEma
             'paywall_seen_at' => 'datetime',
             'last_logged_in_at' => 'datetime',
             'last_active_at' => 'datetime',
+            'month_start_day' => 'integer',
         ];
     }
 

--- a/app/Services/PeriodComparator.php
+++ b/app/Services/PeriodComparator.php
@@ -13,28 +13,28 @@ class PeriodComparator
 
     public function previous(): self
     {
-        $days = $this->from->diffInDays($this->to) + 1;
+        $from = $this->from->copy()->startOfDay();
+        $exclusiveEnd = $this->to->copy()->startOfDay()->addDay();
 
-        // If it's a full month range (e.g. 1st to end of month), shift by months
-        if ($this->isFullMonthRange()) {
-            $months = $this->from->diffInMonths($this->to->copy()->addDay());
+        $months = (int) $from->diffInMonths($exclusiveEnd);
 
-            $previousFrom = $this->from->copy()->subMonthsNoOverflow($months);
-            $previousTo = $previousFrom->copy()->addMonthsNoOverflow($months - 1)->endOfMonth();
-
-            return new self($previousFrom, $previousTo);
+        // Period boundaries are anchored to a month start day (calendar or
+        // custom), so whole-month ranges shift by months rather than by day
+        // count. This keeps the previous period correctly aligned even when
+        // adjacent months differ in length (e.g. a 25th-to-24th salary month).
+        if ($months >= 1) {
+            return new self(
+                $from->copy()->subMonthsNoOverflow($months),
+                $from->copy()->subDay()->endOfDay(),
+            );
         }
 
-        return new self(
-            $this->from->copy()->subDays($days),
-            $this->from->copy()->subDay()
-        );
-    }
+        $days = (int) $from->diffInDays($exclusiveEnd);
 
-    private function isFullMonthRange(): bool
-    {
-        return $this->from->day === 1 &&
-               $this->to->isLastOfMonth();
+        return new self(
+            $from->copy()->subDays($days),
+            $from->copy()->subDay()->endOfDay(),
+        );
     }
 
     public static function fromRequest(array $validated): self

--- a/app/Services/UserMonthPeriodService.php
+++ b/app/Services/UserMonthPeriodService.php
@@ -2,9 +2,11 @@
 
 namespace App\Services;
 
+use App\Features\CustomMonthStartDay;
 use App\Models\User;
 use Carbon\Carbon;
 use Carbon\CarbonInterface;
+use Laravel\Pennant\Feature;
 
 class UserMonthPeriodService
 {
@@ -13,6 +15,13 @@ class UserMonthPeriodService
 
     public function startDay(User $user): int
     {
+        // The custom start day only takes effect while the feature is active,
+        // so rolling the flag back cleanly reverts everyone to calendar months
+        // instead of stranding them on a salary month they can no longer edit.
+        if (! Feature::for($user)->active(CustomMonthStartDay::class)) {
+            return 1;
+        }
+
         $startDay = (int) ($user->month_start_day ?? 1);
 
         return in_array($startDay, self::ALLOWED_START_DAYS, true) ? $startDay : 1;

--- a/app/Services/UserMonthPeriodService.php
+++ b/app/Services/UserMonthPeriodService.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+use Carbon\Carbon;
+use Carbon\CarbonInterface;
+
+class UserMonthPeriodService
+{
+    /** @var list<int> */
+    public const ALLOWED_START_DAYS = [1, 25, 26, 27, 28];
+
+    public function startDay(User $user): int
+    {
+        $startDay = (int) ($user->month_start_day ?? 1);
+
+        return in_array($startDay, self::ALLOWED_START_DAYS, true) ? $startDay : 1;
+    }
+
+    /**
+     * @return array{from: Carbon, to: Carbon, end_inclusive: Carbon}
+     */
+    public function current(User $user, ?CarbonInterface $date = null): array
+    {
+        return $this->monthContaining($user, $date ?? Carbon::now());
+    }
+
+    /**
+     * @return array{from: Carbon, to: Carbon, end_inclusive: Carbon}
+     */
+    public function monthContaining(User $user, CarbonInterface $date): array
+    {
+        $start = $this->monthStartOnOrBefore(Carbon::instance($date->toDateTime()), $this->startDay($user));
+        $to = $start->copy()->addMonthNoOverflow();
+
+        return [
+            'from' => $start,
+            'to' => $to,
+            'end_inclusive' => $to->copy()->subDay(),
+        ];
+    }
+
+    private function monthStartOnOrBefore(Carbon $date, int $startDay): Carbon
+    {
+        $start = $date->copy()->startOfDay()->day($startDay);
+
+        if ($start->gt($date)) {
+            $start->subMonthNoOverflow();
+        }
+
+        return $start;
+    }
+}

--- a/app/Services/UserMonthPeriodService.php
+++ b/app/Services/UserMonthPeriodService.php
@@ -23,7 +23,7 @@ class UserMonthPeriodService
      */
     public function current(User $user, ?CarbonInterface $date = null): array
     {
-        return $this->monthContaining($user, $date ?? Carbon::now());
+        return $this->monthContaining($user, $date ?? Carbon::now($user->timezone));
     }
 
     /**
@@ -37,7 +37,7 @@ class UserMonthPeriodService
         return [
             'from' => $start,
             'to' => $to,
-            'end_inclusive' => $to->copy()->subDay(),
+            'end_inclusive' => $to->copy()->subDay()->endOfDay(),
         ];
     }
 

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -27,6 +27,7 @@ class UserFactory extends Factory
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'currency_code' => 'USD',
+            'month_start_day' => 1,
             'email_verified_at' => now(),
             'password' => static::$password ??= 'password',
             'remember_token' => Str::random(10),

--- a/database/migrations/2026_05_27_120000_add_month_start_day_to_users_table.php
+++ b/database/migrations/2026_05_27_120000_add_month_start_day_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->unsignedTinyInteger('month_start_day')->default(1)->after('timezone');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('month_start_day');
+        });
+    }
+};

--- a/resources/js/components/cashflow/period-navigation.test.tsx
+++ b/resources/js/components/cashflow/period-navigation.test.tsx
@@ -23,6 +23,7 @@ describe('PeriodNavigation', () => {
             <PeriodNavigation
                 currentDate={new Date(2026, 0, 1)}
                 periodType="month"
+                monthStartDay={1}
                 onDateChange={() => undefined}
                 onPeriodTypeChange={() => undefined}
             />,

--- a/resources/js/components/cashflow/period-navigation.tsx
+++ b/resources/js/components/cashflow/period-navigation.tsx
@@ -18,6 +18,7 @@ interface PeriodNavigationProps {
     currentDate: Date;
     periodType: CashflowPeriodType;
     monthStartDay: UserMonthStartDay;
+    referenceDate?: Date;
     onDateChange: (date: Date) => void;
     onPeriodTypeChange: (periodType: CashflowPeriodType) => void;
 }
@@ -35,11 +36,12 @@ export function PeriodNavigation({
     currentDate,
     periodType,
     monthStartDay,
+    referenceDate,
     onDateChange,
     onPeriodTypeChange,
 }: PeriodNavigationProps) {
     const locale = useLocale();
-    const now = new Date();
+    const now = referenceDate ?? new Date();
     const periodStart = getUserPeriodRange(
         currentDate,
         periodType,

--- a/resources/js/components/cashflow/period-navigation.tsx
+++ b/resources/js/components/cashflow/period-navigation.tsx
@@ -2,29 +2,22 @@ import { Button } from '@/components/ui/button';
 import { ButtonGroup } from '@/components/ui/button-group';
 import { CashflowPeriodType } from '@/hooks/use-cashflow-data';
 import { useLocale } from '@/hooks/use-locale';
+import {
+    getUserPeriodRange,
+    sameUserPeriod,
+    shiftUserPeriod,
+    UserMonthStartDay,
+} from '@/lib/user-periods';
 import { cn } from '@/lib/utils';
 import { formatDate, formatMonthYear } from '@/utils/date';
 import { __ } from '@/utils/i18n';
-import {
-    addMonths,
-    addQuarters,
-    addYears,
-    getQuarter,
-    isSameMonth,
-    isSameQuarter,
-    isSameYear,
-    startOfMonth,
-    startOfQuarter,
-    startOfYear,
-    subMonths,
-    subQuarters,
-    subYears,
-} from 'date-fns';
+import { getQuarter } from 'date-fns';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 
 interface PeriodNavigationProps {
     currentDate: Date;
     periodType: CashflowPeriodType;
+    monthStartDay: UserMonthStartDay;
     onDateChange: (date: Date) => void;
     onPeriodTypeChange: (periodType: CashflowPeriodType) => void;
 }
@@ -41,19 +34,34 @@ const periodTypeOptions: Array<{
 export function PeriodNavigation({
     currentDate,
     periodType,
+    monthStartDay,
     onDateChange,
     onPeriodTypeChange,
 }: PeriodNavigationProps) {
     const locale = useLocale();
     const now = new Date();
-    const isCurrentPeriod = samePeriod(currentDate, now, periodType);
+    const periodStart = getUserPeriodRange(
+        currentDate,
+        periodType,
+        monthStartDay,
+    ).from;
+    const isCurrentPeriod = sameUserPeriod(
+        currentDate,
+        now,
+        periodType,
+        monthStartDay,
+    );
 
     const handlePreviousPeriod = () => {
-        onDateChange(shiftPeriod(currentDate, periodType, -1));
+        onDateChange(
+            shiftUserPeriod(currentDate, periodType, monthStartDay, -1),
+        );
     };
 
     const handleNextPeriod = () => {
-        onDateChange(shiftPeriod(currentDate, periodType, 1));
+        onDateChange(
+            shiftUserPeriod(currentDate, periodType, monthStartDay, 1),
+        );
     };
 
     const handleCurrentPeriod = () => {
@@ -97,7 +105,7 @@ export function PeriodNavigation({
                     variant="outline"
                     className="flex-1 sm:flex-none"
                 >
-                    {formatPeriodLabel(currentDate, periodType, locale)}
+                    {formatPeriodLabel(periodStart, periodType, locale)}
                 </Button>
 
                 <Button
@@ -112,46 +120,6 @@ export function PeriodNavigation({
             </ButtonGroup>
         </div>
     );
-}
-
-function shiftPeriod(
-    date: Date,
-    periodType: CashflowPeriodType,
-    amount: 1 | -1,
-): Date {
-    if (periodType === 'quarter') {
-        const quarterStart = startOfQuarter(date);
-
-        return amount > 0
-            ? addQuarters(quarterStart, 1)
-            : subQuarters(quarterStart, 1);
-    }
-
-    if (periodType === 'year') {
-        const yearStart = startOfYear(date);
-
-        return amount > 0 ? addYears(yearStart, 1) : subYears(yearStart, 1);
-    }
-
-    const monthStart = startOfMonth(date);
-
-    return amount > 0 ? addMonths(monthStart, 1) : subMonths(monthStart, 1);
-}
-
-function samePeriod(
-    left: Date,
-    right: Date,
-    periodType: CashflowPeriodType,
-): boolean {
-    if (periodType === 'quarter') {
-        return isSameQuarter(left, right);
-    }
-
-    if (periodType === 'year') {
-        return isSameYear(left, right);
-    }
-
-    return isSameMonth(left, right);
 }
 
 function formatPeriodLabel(

--- a/resources/js/components/dashboard/top-categories-card.tsx
+++ b/resources/js/components/dashboard/top-categories-card.tsx
@@ -39,6 +39,8 @@ interface CategoryData {
 
 interface TopCategoriesCardProps {
     categories: CategoryData[];
+    from?: string;
+    to?: string;
     loading?: boolean;
 }
 
@@ -48,6 +50,8 @@ function rowKey(item: CategoryData): string {
 
 export function TopCategoriesCard({
     categories,
+    from,
+    to,
     loading,
 }: TopCategoriesCardProps) {
     const { auth } = usePage<SharedData>().props;
@@ -56,10 +60,10 @@ export function TopCategoriesCard({
     const { dateFrom, dateTo } = useMemo(() => {
         const now = new Date();
         return {
-            dateFrom: format(subDays(now, 30), 'yyyy-MM-dd'),
-            dateTo: format(now, 'yyyy-MM-dd'),
+            dateFrom: from ?? format(subDays(now, 30), 'yyyy-MM-dd'),
+            dateTo: to ?? format(now, 'yyyy-MM-dd'),
         };
-    }, []);
+    }, [from, to]);
 
     const fetchChildren = useCallback(
         async (categoryId: string): Promise<CategoryData[]> => {
@@ -177,7 +181,7 @@ export function TopCategoriesCard({
                         }
                     />
                 </div>
-                <CardDescription>{__('on the last 30 days')}</CardDescription>
+                <CardDescription>{__('this month')}</CardDescription>
             </CardHeader>
             <CardContent>
                 <div className="space-y-3">

--- a/resources/js/lib/user-periods.test.ts
+++ b/resources/js/lib/user-periods.test.ts
@@ -1,0 +1,128 @@
+import {
+    getUserPeriodRange,
+    sameUserPeriod,
+    shiftUserPeriod,
+    userMonthStartDay,
+} from '@/lib/user-periods';
+import { describe, expect, it } from 'vitest';
+
+const ymd = (date: Date) =>
+    `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+
+describe('userMonthStartDay', () => {
+    it('passes through allowed values', () => {
+        expect(userMonthStartDay(25)).toBe(25);
+        expect(userMonthStartDay(1)).toBe(1);
+    });
+
+    it('falls back to 1 for unsupported values', () => {
+        expect(userMonthStartDay(24)).toBe(1);
+        expect(userMonthStartDay('25')).toBe(1);
+        expect(userMonthStartDay(undefined)).toBe(1);
+        expect(userMonthStartDay(null)).toBe(1);
+    });
+});
+
+describe('getUserPeriodRange month', () => {
+    it('returns natural month for start day 1', () => {
+        const range = getUserPeriodRange(new Date(2026, 1, 14), 'month', 1);
+
+        expect(ymd(range.from)).toBe('2026-02-01');
+        expect(ymd(range.to)).toBe('2026-03-01');
+        expect(ymd(range.endInclusive)).toBe('2026-02-28');
+    });
+
+    it('returns salary month for custom start day', () => {
+        const range = getUserPeriodRange(new Date(2026, 1, 14), 'month', 25);
+
+        expect(ymd(range.from)).toBe('2026-01-25');
+        expect(ymd(range.to)).toBe('2026-02-25');
+        expect(ymd(range.endInclusive)).toBe('2026-02-24');
+    });
+
+    it('keeps the current period when the date is on the start day', () => {
+        const range = getUserPeriodRange(new Date(2026, 1, 25), 'month', 25);
+
+        expect(ymd(range.from)).toBe('2026-02-25');
+        expect(ymd(range.to)).toBe('2026-03-25');
+    });
+});
+
+describe('getUserPeriodRange quarter', () => {
+    it('anchors the quarter to the custom start day', () => {
+        const range = getUserPeriodRange(new Date(2026, 1, 14), 'quarter', 25);
+
+        expect(ymd(range.from)).toBe('2026-01-25');
+        expect(ymd(range.to)).toBe('2026-04-25');
+        expect(ymd(range.endInclusive)).toBe('2026-04-24');
+    });
+
+    it('rolls back to the previous quarter before the start day', () => {
+        const range = getUserPeriodRange(new Date(2026, 0, 10), 'quarter', 25);
+
+        expect(ymd(range.from)).toBe('2025-10-25');
+        expect(ymd(range.to)).toBe('2026-01-25');
+    });
+});
+
+describe('getUserPeriodRange year', () => {
+    it('anchors the year to January on the custom start day', () => {
+        const range = getUserPeriodRange(new Date(2026, 1, 14), 'year', 25);
+
+        expect(ymd(range.from)).toBe('2026-01-25');
+        expect(ymd(range.to)).toBe('2027-01-25');
+        expect(ymd(range.endInclusive)).toBe('2027-01-24');
+    });
+
+    it('rolls back to the previous year before the start day', () => {
+        const range = getUserPeriodRange(new Date(2026, 0, 10), 'year', 25);
+
+        expect(ymd(range.from)).toBe('2025-01-25');
+        expect(ymd(range.to)).toBe('2026-01-25');
+    });
+});
+
+describe('shiftUserPeriod', () => {
+    it('shifts salary months by the start day', () => {
+        const next = shiftUserPeriod(new Date(2026, 1, 14), 'month', 25, 1);
+        const previous = shiftUserPeriod(
+            new Date(2026, 1, 14),
+            'month',
+            25,
+            -1,
+        );
+
+        expect(ymd(next)).toBe('2026-02-25');
+        expect(ymd(previous)).toBe('2025-12-25');
+    });
+
+    it('shifts custom quarters by three months', () => {
+        const next = shiftUserPeriod(new Date(2026, 1, 14), 'quarter', 25, 1);
+
+        expect(ymd(next)).toBe('2026-04-25');
+    });
+});
+
+describe('sameUserPeriod', () => {
+    it('treats dates within the same salary month as equal', () => {
+        expect(
+            sameUserPeriod(
+                new Date(2026, 1, 14),
+                new Date(2026, 1, 20),
+                'month',
+                25,
+            ),
+        ).toBe(true);
+    });
+
+    it('distinguishes dates across the start-day boundary', () => {
+        expect(
+            sameUserPeriod(
+                new Date(2026, 1, 14),
+                new Date(2026, 1, 26),
+                'month',
+                25,
+            ),
+        ).toBe(false);
+    });
+});

--- a/resources/js/lib/user-periods.ts
+++ b/resources/js/lib/user-periods.ts
@@ -1,0 +1,104 @@
+import {
+    addMonths,
+    addQuarters,
+    addYears,
+    endOfDay,
+    startOfDay,
+    subDays,
+} from 'date-fns';
+
+export type UserMonthStartDay = 1 | 25 | 26 | 27 | 28;
+export type UserPeriodType = 'month' | 'quarter' | 'year';
+
+export const USER_MONTH_START_DAYS: UserMonthStartDay[] = [1, 25, 26, 27, 28];
+
+export function userMonthStartDay(value: unknown): UserMonthStartDay {
+    return USER_MONTH_START_DAYS.includes(value as UserMonthStartDay)
+        ? (value as UserMonthStartDay)
+        : 1;
+}
+
+export function getUserPeriodRange(
+    date: Date,
+    periodType: UserPeriodType,
+    monthStartDay: UserMonthStartDay,
+): { from: Date; to: Date; endInclusive: Date } {
+    if (periodType === 'quarter') {
+        return multiMonthPeriodContaining(date, monthStartDay, 3);
+    }
+
+    if (periodType === 'year') {
+        return multiMonthPeriodContaining(date, monthStartDay, 12);
+    }
+
+    const from = monthStartOnOrBefore(date, monthStartDay);
+    const to = addMonths(from, 1);
+
+    return { from, to, endInclusive: endOfDay(subDays(to, 1)) };
+}
+
+export function shiftUserPeriod(
+    date: Date,
+    periodType: UserPeriodType,
+    monthStartDay: UserMonthStartDay,
+    amount: 1 | -1,
+): Date {
+    const { from } = getUserPeriodRange(date, periodType, monthStartDay);
+
+    if (periodType === 'quarter') {
+        return amount > 0 ? addQuarters(from, 1) : addQuarters(from, -1);
+    }
+
+    if (periodType === 'year') {
+        return amount > 0 ? addYears(from, 1) : addYears(from, -1);
+    }
+
+    return amount > 0 ? addMonths(from, 1) : addMonths(from, -1);
+}
+
+export function sameUserPeriod(
+    left: Date,
+    right: Date,
+    periodType: UserPeriodType,
+    monthStartDay: UserMonthStartDay,
+): boolean {
+    return (
+        getUserPeriodRange(left, periodType, monthStartDay).from.getTime() ===
+        getUserPeriodRange(right, periodType, monthStartDay).from.getTime()
+    );
+}
+
+function multiMonthPeriodContaining(
+    date: Date,
+    monthStartDay: UserMonthStartDay,
+    months: 3 | 12,
+): { from: Date; to: Date; endInclusive: Date } {
+    const anchorMonth =
+        months === 12 ? 0 : Math.floor(date.getMonth() / months) * months;
+    let from = startOfDay(
+        new Date(date.getFullYear(), anchorMonth, monthStartDay),
+    );
+
+    if (from > date) {
+        from = addMonths(from, -months);
+    }
+
+    const to = addMonths(from, months);
+
+    return { from, to, endInclusive: endOfDay(subDays(to, 1)) };
+}
+
+function monthStartOnOrBefore(
+    date: Date,
+    monthStartDay: UserMonthStartDay,
+): Date {
+    let start = startOfDay(
+        new Date(date.getFullYear(), date.getMonth(), monthStartDay),
+    );
+
+    if (start > date) {
+        start = addMonths(start, -1);
+    }
+
+    return start;
+}

--- a/resources/js/pages/cashflow/index.tsx
+++ b/resources/js/pages/cashflow/index.tsx
@@ -7,21 +7,12 @@ import HeadingSmall from '@/components/heading-small';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { CashflowPeriodType, useCashflowData } from '@/hooks/use-cashflow-data';
 import AppSidebarLayout from '@/layouts/app/app-sidebar-layout';
+import { getUserPeriodRange, userMonthStartDay } from '@/lib/user-periods';
 import { cashflow } from '@/routes';
 import { BreadcrumbItem } from '@/types';
 import { __ } from '@/utils/i18n';
 import { Head, router, usePage } from '@inertiajs/react';
-import {
-    endOfMonth,
-    endOfQuarter,
-    endOfYear,
-    format,
-    getQuarter,
-    parse,
-    startOfMonth,
-    startOfQuarter,
-    startOfYear,
-} from 'date-fns';
+import { format, getQuarter, parse } from 'date-fns';
 import { useEffect, useState } from 'react';
 
 const breadcrumbs: BreadcrumbItem[] = [
@@ -34,6 +25,7 @@ const breadcrumbs: BreadcrumbItem[] = [
 function parsePeriodParam(
     period: string | null,
     periodType: CashflowPeriodType,
+    monthStartDay: number,
 ): Date {
     if (!period) {
         return new Date();
@@ -44,7 +36,11 @@ function parsePeriodParam(
             const match = /^(\d{4})-Q([1-4])$/.exec(period);
 
             if (match) {
-                return new Date(Number(match[1]), (Number(match[2]) - 1) * 3);
+                return new Date(
+                    Number(match[1]),
+                    (Number(match[2]) - 1) * 3,
+                    monthStartDay,
+                );
             }
         }
 
@@ -52,44 +48,24 @@ function parsePeriodParam(
             const match = /^(\d{4})$/.exec(period);
 
             if (match) {
-                return new Date(Number(match[1]), 0);
+                return new Date(Number(match[1]), 0, monthStartDay);
             }
         }
 
         const parsedDate = parse(period, 'yyyy-MM', new Date());
 
         if (!isNaN(parsedDate.getTime())) {
-            return parsedDate;
+            return new Date(
+                parsedDate.getFullYear(),
+                parsedDate.getMonth(),
+                monthStartDay,
+            );
         }
     } catch {
         return new Date();
     }
 
     return new Date();
-}
-
-function getPeriodRange(
-    currentDate: Date,
-    periodType: CashflowPeriodType,
-): { from: Date; to: Date } {
-    if (periodType === 'quarter') {
-        return {
-            from: startOfQuarter(currentDate),
-            to: endOfQuarter(currentDate),
-        };
-    }
-
-    if (periodType === 'year') {
-        return {
-            from: startOfYear(currentDate),
-            to: endOfYear(currentDate),
-        };
-    }
-
-    return {
-        from: startOfMonth(currentDate),
-        to: endOfMonth(currentDate),
-    };
 }
 
 function formatPeriodParam(
@@ -113,19 +89,28 @@ export default function CashflowPage() {
         period: initialPeriod,
         periodType: initialPeriodType,
     } = usePage<{
-        auth: { user: { currency_code: string } };
+        auth: { user: { currency_code: string; month_start_day: number } };
         period: string | null;
         periodType: CashflowPeriodType;
     }>().props;
 
     const [periodType, setPeriodType] =
         useState<CashflowPeriodType>(initialPeriodType);
+    const monthStartDay = userMonthStartDay(auth.user.month_start_day);
 
     const [currentDate, setCurrentDate] = useState<Date>(() =>
-        parsePeriodParam(initialPeriod, initialPeriodType),
+        parsePeriodParam(initialPeriod, initialPeriodType, monthStartDay),
     );
-
-    const period = getPeriodRange(currentDate, periodType);
+    const userPeriod = getUserPeriodRange(
+        currentDate,
+        periodType,
+        monthStartDay,
+    );
+    const period = {
+        from: userPeriod.from,
+        to: userPeriod.endInclusive,
+    };
+    const periodParam = formatPeriodParam(userPeriod.from, periodType);
 
     const {
         summary,
@@ -140,8 +125,6 @@ export default function CashflowPage() {
     });
 
     useEffect(() => {
-        const periodParam = formatPeriodParam(currentDate, periodType);
-
         if (initialPeriod !== periodParam || initialPeriodType !== periodType) {
             router.visit(
                 cashflow({
@@ -154,7 +137,7 @@ export default function CashflowPage() {
                 },
             );
         }
-    }, [currentDate, initialPeriod, initialPeriodType, periodType]);
+    }, [initialPeriod, initialPeriodType, periodParam, periodType]);
 
     return (
         <AppSidebarLayout breadcrumbs={breadcrumbs}>
@@ -172,6 +155,7 @@ export default function CashflowPage() {
                     <PeriodNavigation
                         currentDate={currentDate}
                         periodType={periodType}
+                        monthStartDay={monthStartDay}
                         onDateChange={setCurrentDate}
                         onPeriodTypeChange={setPeriodType}
                     />

--- a/resources/js/pages/cashflow/index.tsx
+++ b/resources/js/pages/cashflow/index.tsx
@@ -9,7 +9,7 @@ import { CashflowPeriodType, useCashflowData } from '@/hooks/use-cashflow-data';
 import AppSidebarLayout from '@/layouts/app/app-sidebar-layout';
 import { getUserPeriodRange, userMonthStartDay } from '@/lib/user-periods';
 import { cashflow } from '@/routes';
-import { BreadcrumbItem } from '@/types';
+import { BreadcrumbItem, SharedData } from '@/types';
 import { __ } from '@/utils/i18n';
 import { Head, router, usePage } from '@inertiajs/react';
 import { format, getQuarter, parse } from 'date-fns';
@@ -26,9 +26,10 @@ function parsePeriodParam(
     period: string | null,
     periodType: CashflowPeriodType,
     monthStartDay: number,
+    fallback: Date,
 ): Date {
     if (!period) {
-        return new Date();
+        return fallback;
     }
 
     try {
@@ -52,7 +53,7 @@ function parsePeriodParam(
             }
         }
 
-        const parsedDate = parse(period, 'yyyy-MM', new Date());
+        const parsedDate = parse(period, 'yyyy-MM', fallback);
 
         if (!isNaN(parsedDate.getTime())) {
             return new Date(
@@ -62,10 +63,10 @@ function parsePeriodParam(
             );
         }
     } catch {
-        return new Date();
+        return fallback;
     }
 
-    return new Date();
+    return fallback;
 }
 
 function formatPeriodParam(
@@ -86,20 +87,36 @@ function formatPeriodParam(
 export default function CashflowPage() {
     const {
         auth,
+        features,
         period: initialPeriod,
         periodType: initialPeriodType,
-    } = usePage<{
-        auth: { user: { currency_code: string; month_start_day: number } };
-        period: string | null;
-        periodType: CashflowPeriodType;
-    }>().props;
+        today,
+    } = usePage<
+        SharedData & {
+            period: string | null;
+            periodType: CashflowPeriodType;
+            today: string;
+        }
+    >().props;
 
     const [periodType, setPeriodType] =
         useState<CashflowPeriodType>(initialPeriodType);
-    const monthStartDay = userMonthStartDay(auth.user.month_start_day);
+    // Only honour the custom start day while the feature is active so the
+    // client matches the server, which reverts to calendar months otherwise.
+    const monthStartDay = features.customMonthStartDay
+        ? userMonthStartDay(auth.user.month_start_day)
+        : 1;
+    const referenceDate = today
+        ? parse(today, 'yyyy-MM-dd', new Date())
+        : new Date();
 
     const [currentDate, setCurrentDate] = useState<Date>(() =>
-        parsePeriodParam(initialPeriod, initialPeriodType, monthStartDay),
+        parsePeriodParam(
+            initialPeriod,
+            initialPeriodType,
+            monthStartDay,
+            referenceDate,
+        ),
     );
     const userPeriod = getUserPeriodRange(
         currentDate,
@@ -156,6 +173,7 @@ export default function CashflowPage() {
                         currentDate={currentDate}
                         periodType={periodType}
                         monthStartDay={monthStartDay}
+                        referenceDate={referenceDate}
                         onDateChange={setCurrentDate}
                         onPeriodTypeChange={setPeriodType}
                     />

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -28,15 +28,19 @@ interface CashflowSummary {
 interface DashboardProps extends SharedData {
     showEncryptionPrompt: boolean;
     netWorthEvolution?: NetWorthEvolutionData;
-    topCategories?: Array<{
-        category: Category | null;
-        category_id?: string | null;
-        amount: number;
-        previous_amount: number;
-        total_amount: number;
-        has_children?: boolean;
-        is_direct?: boolean;
-    }>;
+    topCategories?: {
+        categories: Array<{
+            category: Category | null;
+            category_id?: string | null;
+            amount: number;
+            previous_amount: number;
+            total_amount: number;
+            has_children?: boolean;
+            is_direct?: boolean;
+        }>;
+        from: string;
+        to: string;
+    };
     cashflowSummary?: {
         current: CashflowSummary;
         previous: CashflowSummary;
@@ -121,7 +125,7 @@ export default function Dashboard() {
         return map;
     }, [accountMetrics]);
 
-    const topCategories = props.topCategories ?? [];
+    const topCategories = props.topCategories?.categories ?? [];
 
     const refetch = useCallback(() => {
         router.reload({
@@ -232,7 +236,11 @@ export default function Dashboard() {
                             <TopCategoriesCard categories={[]} loading={true} />
                         }
                     >
-                        <TopCategoriesCard categories={topCategories} />
+                        <TopCategoriesCard
+                            categories={topCategories}
+                            from={props.topCategories?.from}
+                            to={props.topCategories?.to}
+                        />
                     </Deferred>
 
                     {props.features.cashflow && (

--- a/resources/js/pages/settings/account.tsx
+++ b/resources/js/pages/settings/account.tsx
@@ -218,6 +218,54 @@ export default function Account({
                                     />
                                 </div>
 
+                                <div className="grid gap-2">
+                                    <Label htmlFor="month_start_day">
+                                        {__('Start of month')}
+                                    </Label>
+
+                                    <Select
+                                        name="month_start_day"
+                                        defaultValue={String(
+                                            auth.user.month_start_day ?? 1,
+                                        )}
+                                        required
+                                    >
+                                        <SelectTrigger className="mt-1 w-full">
+                                            <SelectValue
+                                                placeholder={__(
+                                                    'Select start of month',
+                                                )}
+                                            />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value="1">
+                                                {__('Calendar month (1st)')}
+                                            </SelectItem>
+                                            {[25, 26, 27, 28].map((day) => (
+                                                <SelectItem
+                                                    key={day}
+                                                    value={String(day)}
+                                                >
+                                                    {__('Day :day', {
+                                                        day: String(day),
+                                                    })}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+
+                                    <p className="text-sm text-muted-foreground">
+                                        {__(
+                                            'Cashflow periods and analysis will start on this day.',
+                                        )}
+                                    </p>
+
+                                    <InputError
+                                        className="mt-2"
+                                        message={errors.month_start_day}
+                                    />
+                                </div>
+
                                 {mustVerifyEmail &&
                                     auth.user.email_verified_at === null && (
                                         <div>

--- a/resources/js/pages/settings/account.tsx
+++ b/resources/js/pages/settings/account.tsx
@@ -52,7 +52,7 @@ export default function Account({
     twoFactorEnabled?: boolean;
     notifyOnBankTransactionsSynced?: boolean;
 }) {
-    const { auth, currencies } = usePage<SharedData>().props;
+    const { auth, currencies, features } = usePage<SharedData>().props;
     const passwordInput = useRef<HTMLInputElement>(null);
     const currentPasswordInput = useRef<HTMLInputElement>(null);
     const [notifyBankTransactions, setNotifyBankTransactions] = useState(
@@ -218,53 +218,55 @@ export default function Account({
                                     />
                                 </div>
 
-                                <div className="grid gap-2">
-                                    <Label htmlFor="month_start_day">
-                                        {__('Start of month')}
-                                    </Label>
+                                {features.customMonthStartDay && (
+                                    <div className="grid gap-2">
+                                        <Label htmlFor="month_start_day">
+                                            {__('Start of month')}
+                                        </Label>
 
-                                    <Select
-                                        name="month_start_day"
-                                        defaultValue={String(
-                                            auth.user.month_start_day ?? 1,
-                                        )}
-                                        required
-                                    >
-                                        <SelectTrigger className="mt-1 w-full">
-                                            <SelectValue
-                                                placeholder={__(
-                                                    'Select start of month',
-                                                )}
-                                            />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            <SelectItem value="1">
-                                                {__('Calendar month (1st)')}
-                                            </SelectItem>
-                                            {[25, 26, 27, 28].map((day) => (
-                                                <SelectItem
-                                                    key={day}
-                                                    value={String(day)}
-                                                >
-                                                    {__('Day :day', {
-                                                        day: String(day),
-                                                    })}
+                                        <Select
+                                            name="month_start_day"
+                                            defaultValue={String(
+                                                auth.user.month_start_day ?? 1,
+                                            )}
+                                            required
+                                        >
+                                            <SelectTrigger className="mt-1 w-full">
+                                                <SelectValue
+                                                    placeholder={__(
+                                                        'Select start of month',
+                                                    )}
+                                                />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                <SelectItem value="1">
+                                                    {__('Calendar month (1st)')}
                                                 </SelectItem>
-                                            ))}
-                                        </SelectContent>
-                                    </Select>
+                                                {[25, 26, 27, 28].map((day) => (
+                                                    <SelectItem
+                                                        key={day}
+                                                        value={String(day)}
+                                                    >
+                                                        {__('Day :day', {
+                                                            day: String(day),
+                                                        })}
+                                                    </SelectItem>
+                                                ))}
+                                            </SelectContent>
+                                        </Select>
 
-                                    <p className="text-sm text-muted-foreground">
-                                        {__(
-                                            'Cashflow periods and analysis will start on this day.',
-                                        )}
-                                    </p>
+                                        <p className="text-sm text-muted-foreground">
+                                            {__(
+                                                'Cashflow periods and analysis will start on this day.',
+                                            )}
+                                        </p>
 
-                                    <InputError
-                                        className="mt-2"
-                                        message={errors.month_start_day}
-                                    />
-                                </div>
+                                        <InputError
+                                            className="mt-2"
+                                            message={errors.month_start_day}
+                                        />
+                                    </div>
+                                )}
 
                                 {mustVerifyEmail &&
                                     auth.user.email_verified_at === null && (

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -42,6 +42,7 @@ export interface NavDivider {
 export interface Features {
     cashflow: boolean;
     calculateBalancesOnImport: boolean;
+    customMonthStartDay: boolean;
     transactionAnalysis: boolean;
 }
 

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -101,6 +101,7 @@ export interface User {
     currency_code: CurrencyCode;
     locale: string | null;
     timezone: string | null;
+    month_start_day: 1 | 25 | 26 | 27 | 28;
     avatar?: string;
     email_verified_at: string | null;
     two_factor_enabled?: boolean;

--- a/tests/Feature/CashflowAnalyticsTest.php
+++ b/tests/Feature/CashflowAnalyticsTest.php
@@ -259,6 +259,49 @@ test('cashflow summary includes actual saved and invested amounts', function () 
         ->assertJsonPath('current.investments', 15000);
 });
 
+test('cashflow summary respects custom salary month boundaries', function () {
+    $this->user->update(['month_start_day' => 25]);
+
+    $incomeCategory = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'type' => CategoryType::Income,
+    ]);
+
+    $account = Account::factory()->create(['user_id' => $this->user->id]);
+
+    foreach ([
+        ['date' => '2026-01-24', 'amount' => 10000],
+        ['date' => '2026-01-25', 'amount' => 20000],
+        ['date' => '2026-02-24', 'amount' => 30000],
+        ['date' => '2026-02-25', 'amount' => 40000],
+    ] as $transaction) {
+        Transaction::factory()->create([
+            'user_id' => $this->user->id,
+            'account_id' => $account->id,
+            'category_id' => $incomeCategory->id,
+            'amount' => $transaction['amount'],
+            'transaction_date' => $transaction['date'],
+        ]);
+    }
+
+    $summary = $this->getJson('/api/cashflow/summary?'.http_build_query([
+        'from' => '2026-01-25',
+        'to' => '2026-02-24',
+    ]));
+    $trend = $this->getJson('/api/cashflow/trend?'.http_build_query([
+        'from' => '2026-01-25',
+        'to' => '2026-02-24',
+    ]));
+
+    $summary->assertOk()
+        ->assertJsonPath('current.income', 50000)
+        ->assertJsonPath('previous.income', 10000);
+
+    $trend->assertOk()
+        ->assertJsonPath('data.0.month', '2026-01')
+        ->assertJsonPath('data.0.income', 50000);
+});
+
 test('cashflow summary compares full quarter against previous full quarter', function () {
     $incomeCategory = Category::factory()->create([
         'user_id' => $this->user->id,

--- a/tests/Feature/CashflowAnalyticsTest.php
+++ b/tests/Feature/CashflowAnalyticsTest.php
@@ -2,12 +2,14 @@
 
 use App\Enums\CategoryCashflowDirection;
 use App\Enums\CategoryType;
+use App\Features\CustomMonthStartDay;
 use App\Models\Account;
 use App\Models\Category;
 use App\Models\ExchangeRate;
 use App\Models\Transaction;
 use App\Models\User;
 use Illuminate\Support\Facades\Http;
+use Laravel\Pennant\Feature;
 
 beforeEach(function () {
     Http::fake();
@@ -261,6 +263,7 @@ test('cashflow summary includes actual saved and invested amounts', function () 
 
 test('cashflow summary respects custom salary month boundaries', function () {
     $this->user->update(['month_start_day' => 25]);
+    Feature::for($this->user)->activate(CustomMonthStartDay::class);
 
     $incomeCategory = Category::factory()->create([
         'user_id' => $this->user->id,
@@ -300,6 +303,46 @@ test('cashflow summary respects custom salary month boundaries', function () {
     $trend->assertOk()
         ->assertJsonPath('data.0.month', '2026-01')
         ->assertJsonPath('data.0.income', 50000);
+});
+
+test('trend keeps transactions when the requested range is not period-aligned', function () {
+    $this->user->update(['month_start_day' => 25]);
+    Feature::for($this->user)->activate(CustomMonthStartDay::class);
+
+    $incomeCategory = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'type' => CategoryType::Income,
+    ]);
+
+    $account = Account::factory()->create(['user_id' => $this->user->id]);
+
+    // Jan 10 belongs to the Dec 25 - Jan 24 salary period ('2025-12'). A
+    // calendar-aligned request must still surface it rather than drop it.
+    foreach ([
+        ['date' => '2026-01-10', 'amount' => 10000],
+        ['date' => '2026-02-10', 'amount' => 20000],
+    ] as $transaction) {
+        Transaction::factory()->create([
+            'user_id' => $this->user->id,
+            'account_id' => $account->id,
+            'category_id' => $incomeCategory->id,
+            'amount' => $transaction['amount'],
+            'transaction_date' => $transaction['date'],
+        ]);
+    }
+
+    $trend = $this->getJson('/api/cashflow/trend?'.http_build_query([
+        'from' => '2026-01-01',
+        'to' => '2026-02-28',
+    ]));
+
+    $trend->assertOk();
+
+    $income = collect($trend->json('data'))->pluck('income', 'month');
+
+    expect($income->get('2025-12'))->toBe(10000)
+        ->and($income->get('2026-01'))->toBe(20000)
+        ->and($income->sum())->toBe(30000);
 });
 
 test('cashflow summary compares full quarter against previous full quarter', function () {

--- a/tests/Feature/CategoryMonthlyBreakdownTest.php
+++ b/tests/Feature/CategoryMonthlyBreakdownTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Enums\CategoryType;
+use App\Features\CustomMonthStartDay;
 use App\Models\Account;
 use App\Models\Category;
 use App\Models\ExchangeRate;
@@ -9,6 +10,7 @@ use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Testing\TestResponse;
+use Laravel\Pennant\Feature;
 
 beforeEach(function () {
     Http::fake();
@@ -180,6 +182,23 @@ test('summary trend is null when the earlier half has no spending', function () 
 
     expect($response->json('summary.average_per_month'))->toBe(500);
     expect($response->json('summary.trend_percentage'))->toBeNull();
+});
+
+test('it buckets by the user salary month when the custom start day is active', function () {
+    $this->user->update(['month_start_day' => 25]);
+    Feature::for($this->user)->activate(CustomMonthStartDay::class);
+
+    $category = Category::factory()->create(['user_id' => $this->user->id, 'type' => CategoryType::Expense, 'name' => 'Food']);
+
+    // Now is 2026-06-15, so the current salary period is May 25 - Jun 24,
+    // keyed '2026-05'. A Jun 10 spend falls in that period, not calendar June.
+    makeBreakdownTransaction(['amount' => -4000, 'category_id' => $category->id, 'transaction_date' => '2026-06-10']);
+
+    $response = monthlyBreakdown($category)->assertOk();
+
+    expect($response->json('months'))->toHaveCount(12);
+    expect($response->json('months.11.key'))->toBe('2026-05');
+    expect($response->json('months.11.'.$category->id))->toBe(4000);
 });
 
 test('foreign-currency transactions are converted to the user currency', function () {

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -1,10 +1,12 @@
 <?php
 
 use App\Enums\CategoryType;
+use App\Features\CustomMonthStartDay;
 use App\Models\Category;
 use App\Models\Transaction;
 use App\Models\User;
 use Laravel\Fortify\Features;
+use Laravel\Pennant\Feature;
 
 beforeEach(function () {
     config(['landing.hide_auth_buttons' => false]);
@@ -78,15 +80,16 @@ test('dashboard top categories roll child spending up into the parent', function
     ]);
 
     $response->assertOk()
-        ->assertJsonCount(1, 'props.topCategories')
-        ->assertJsonPath('props.topCategories.0.category.id', $food->id)
-        ->assertJsonPath('props.topCategories.0.amount', 3000);
+        ->assertJsonCount(1, 'props.topCategories.categories')
+        ->assertJsonPath('props.topCategories.categories.0.category.id', $food->id)
+        ->assertJsonPath('props.topCategories.categories.0.amount', 3000);
 });
 
 test('dashboard cashflow summary uses user month start day', function () {
     $this->travelTo('2026-02-10');
 
     $user = User::factory()->onboarded()->create(['month_start_day' => 25]);
+    Feature::for($user)->activate(CustomMonthStartDay::class);
     $this->actingAs($user);
 
     $incomeCategory = Category::factory()->create([
@@ -116,6 +119,46 @@ test('dashboard cashflow summary uses user month start day', function () {
             ->loadDeferredProps(fn ($reload) => $reload
                 ->where('cashflowSummary.current.income', 50000)
                 ->where('cashflowSummary.previous.income', 10000)
+            )
+        );
+});
+
+test('dashboard previous period stays aligned across a short salary month', function () {
+    // Current period Feb 25 - Mar 24 is only 28 days; the previous period must
+    // still be the full Jan 25 - Feb 24 salary month, not a 28-day count back.
+    $this->travelTo('2026-03-10');
+
+    $user = User::factory()->onboarded()->create(['month_start_day' => 25]);
+    Feature::for($user)->activate(CustomMonthStartDay::class);
+    $this->actingAs($user);
+
+    $incomeCategory = Category::factory()->create([
+        'user_id' => $user->id,
+        'type' => CategoryType::Income,
+    ]);
+
+    foreach ([
+        ['date' => '2026-01-25', 'amount' => 10000], // previous period opening day
+        ['date' => '2026-02-24', 'amount' => 20000], // previous period closing day
+        ['date' => '2026-02-25', 'amount' => 40000], // current period opening day
+        ['date' => '2026-03-10', 'amount' => 30000], // current period
+    ] as $transaction) {
+        Transaction::factory()->create([
+            'user_id' => $user->id,
+            'category_id' => $incomeCategory->id,
+            'amount' => $transaction['amount'],
+            'transaction_date' => $transaction['date'],
+        ]);
+    }
+
+    $response = $this->get(route('dashboard'));
+
+    $response->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('dashboard')
+            ->loadDeferredProps(fn ($reload) => $reload
+                ->where('cashflowSummary.current.income', 70000)
+                ->where('cashflowSummary.previous.income', 30000)
             )
         );
 });

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -82,3 +82,40 @@ test('dashboard top categories roll child spending up into the parent', function
         ->assertJsonPath('props.topCategories.0.category.id', $food->id)
         ->assertJsonPath('props.topCategories.0.amount', 3000);
 });
+
+test('dashboard cashflow summary uses user month start day', function () {
+    $this->travelTo('2026-02-10');
+
+    $user = User::factory()->onboarded()->create(['month_start_day' => 25]);
+    $this->actingAs($user);
+
+    $incomeCategory = Category::factory()->create([
+        'user_id' => $user->id,
+        'type' => CategoryType::Income,
+    ]);
+
+    foreach ([
+        ['date' => '2026-01-24', 'amount' => 10000],
+        ['date' => '2026-01-25', 'amount' => 20000],
+        ['date' => '2026-02-24', 'amount' => 30000],
+    ] as $transaction) {
+        Transaction::factory()->create([
+            'user_id' => $user->id,
+            'category_id' => $incomeCategory->id,
+            'amount' => $transaction['amount'],
+            'transaction_date' => $transaction['date'],
+        ]);
+    }
+
+    $response = $this->get(route('dashboard'));
+
+    $response->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('dashboard')
+            ->missing('cashflowSummary')
+            ->loadDeferredProps(fn ($reload) => $reload
+                ->where('cashflowSummary.current.income', 50000)
+                ->where('cashflowSummary.previous.income', 10000)
+            )
+        );
+});

--- a/tests/Feature/InertiaSharedDataTest.php
+++ b/tests/Feature/InertiaSharedDataTest.php
@@ -43,6 +43,7 @@ test('shared feature flags do not include coinbase flag', function () {
     expect($props['features'])->toBe([
         'cashflow' => true,
         'calculateBalancesOnImport' => false,
+        'customMonthStartDay' => false,
         'transactionAnalysis' => false,
     ]);
 });

--- a/tests/Feature/PeriodComparatorTest.php
+++ b/tests/Feature/PeriodComparatorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\Services\PeriodComparator;
+use Carbon\Carbon;
+
+function comparator(string $from, string $to): PeriodComparator
+{
+    return new PeriodComparator(Carbon::parse($from), Carbon::parse($to));
+}
+
+it('shifts a natural calendar month back a whole month', function () {
+    $previous = comparator('2026-02-01', '2026-02-28')->previous();
+
+    expect($previous->from->toDateString())->toBe('2026-01-01')
+        ->and($previous->to->toDateString())->toBe('2026-01-31');
+});
+
+it('shifts a 31-day salary month back to the previous salary month', function () {
+    $previous = comparator('2026-01-25', '2026-02-24')->previous();
+
+    expect($previous->from->toDateString())->toBe('2025-12-25')
+        ->and($previous->to->toDateString())->toBe('2026-01-24');
+});
+
+it('shifts a short salary month back without losing the payday days', function () {
+    // Feb 25 - Mar 24 is only 28 days; a day-count shift would land on Jan 27
+    // and drop Jan 25-26. The previous salary month must still start on the 25th.
+    $previous = comparator('2026-02-25', '2026-03-24')->previous();
+
+    expect($previous->from->toDateString())->toBe('2026-01-25')
+        ->and($previous->to->toDateString())->toBe('2026-02-24');
+});
+
+it('treats an end-inclusive end-of-day bound as the same period', function () {
+    $period = new PeriodComparator(
+        Carbon::parse('2026-01-25')->startOfDay(),
+        Carbon::parse('2026-02-24')->endOfDay(),
+    );
+
+    $previous = $period->previous();
+
+    // The 23:59:59.999999 upper bound must not bleed an extra day into the
+    // previous window (which would start on Dec 24 instead of Dec 25).
+    expect($previous->from->toDateString())->toBe('2025-12-25')
+        ->and($previous->to->toDateString())->toBe('2026-01-24');
+});
+
+it('shifts a quarter back a full quarter', function () {
+    $previous = comparator('2026-01-25', '2026-04-24')->previous();
+
+    expect($previous->from->toDateString())->toBe('2025-10-25')
+        ->and($previous->to->toDateString())->toBe('2026-01-24');
+});
+
+it('shifts a year back a full year', function () {
+    $previous = comparator('2026-01-25', '2027-01-24')->previous();
+
+    expect($previous->from->toDateString())->toBe('2025-01-25')
+        ->and($previous->to->toDateString())->toBe('2026-01-24');
+});
+
+it('falls back to a day-count shift for sub-month ranges', function () {
+    $previous = comparator('2026-03-10', '2026-03-16')->previous();
+
+    expect($previous->from->toDateString())->toBe('2026-03-03')
+        ->and($previous->to->toDateString())->toBe('2026-03-09');
+});

--- a/tests/Feature/Settings/ProfileUpdateTest.php
+++ b/tests/Feature/Settings/ProfileUpdateTest.php
@@ -21,6 +21,7 @@ test('profile information can be updated', function () {
             'name' => 'Test User',
             'email' => 'test@example.com',
             'currency_code' => 'EUR',
+            'month_start_day' => 25,
         ]);
 
     $response
@@ -33,6 +34,7 @@ test('profile information can be updated', function () {
     expect($user->email)->toBe('test@example.com');
     expect($user->email_verified_at)->toBeNull();
     expect($user->currency_code)->toBe('EUR');
+    expect($user->month_start_day)->toBe(25);
 });
 
 test('profile accepts new latam primary currency', function () {
@@ -44,6 +46,7 @@ test('profile accepts new latam primary currency', function () {
             'name' => 'Test User',
             'email' => 'test@example.com',
             'currency_code' => 'ARS',
+            'month_start_day' => 1,
         ]);
 
     $response
@@ -119,9 +122,25 @@ test('profile rejects bitcoin as primary currency', function () {
             'name' => 'Test User',
             'email' => 'test@example.com',
             'currency_code' => 'BTC',
+            'month_start_day' => 1,
         ]);
 
     $response->assertSessionHasErrors(['currency_code']);
+});
+
+test('profile rejects unsupported month start day', function () {
+    $user = User::factory()->create();
+
+    $response = $this
+        ->actingAs($user)
+        ->patch(route('profile.update'), [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'currency_code' => 'USD',
+            'month_start_day' => 24,
+        ]);
+
+    $response->assertSessionHasErrors(['month_start_day']);
 });
 
 test('email verification status is unchanged when the email address is unchanged', function () {
@@ -133,6 +152,7 @@ test('email verification status is unchanged when the email address is unchanged
             'name' => 'Test User',
             'email' => $user->email,
             'currency_code' => $user->currency_code,
+            'month_start_day' => 1,
         ]);
 
     $response

--- a/tests/Feature/Settings/ProfileUpdateTest.php
+++ b/tests/Feature/Settings/ProfileUpdateTest.php
@@ -1,6 +1,8 @@
 <?php
 
+use App\Features\CustomMonthStartDay;
 use App\Models\User;
+use Laravel\Pennant\Feature;
 
 test('profile page is displayed', function () {
     $user = User::factory()->create();
@@ -14,6 +16,7 @@ test('profile page is displayed', function () {
 
 test('profile information can be updated', function () {
     $user = User::factory()->create();
+    Feature::for($user)->activate(CustomMonthStartDay::class);
 
     $response = $this
         ->actingAs($user)
@@ -130,6 +133,7 @@ test('profile rejects bitcoin as primary currency', function () {
 
 test('profile rejects unsupported month start day', function () {
     $user = User::factory()->create();
+    Feature::for($user)->activate(CustomMonthStartDay::class);
 
     $response = $this
         ->actingAs($user)
@@ -141,6 +145,25 @@ test('profile rejects unsupported month start day', function () {
         ]);
 
     $response->assertSessionHasErrors(['month_start_day']);
+});
+
+test('profile ignores month start day when feature is disabled', function () {
+    $user = User::factory()->create(['month_start_day' => 1]);
+
+    $response = $this
+        ->actingAs($user)
+        ->patch(route('profile.update'), [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'currency_code' => 'USD',
+            'month_start_day' => 25,
+        ]);
+
+    $response
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(route('account.edit'));
+
+    expect($user->refresh()->month_start_day)->toBe(1);
 });
 
 test('email verification status is unchanged when the email address is unchanged', function () {

--- a/tests/Feature/Settings/ProfileUpdateTest.php
+++ b/tests/Feature/Settings/ProfileUpdateTest.php
@@ -48,9 +48,7 @@ test('profile accepts new latam primary currency', function () {
         ->patch(route('profile.update'), [
             'name' => 'Test User',
             'email' => 'test@example.com',
-            'currency_code' => 'ARS',
-            'month_start_day' => 1,
-        ]);
+            'currency_code' => 'ARS',        ]);
 
     $response
         ->assertSessionHasNoErrors()
@@ -67,9 +65,7 @@ test('profile accepts Pakistani rupee as primary currency', function () {
         ->patch(route('profile.update'), [
             'name' => 'Test User',
             'email' => 'test@example.com',
-            'currency_code' => 'PKR',
-            'month_start_day' => 1,
-        ]);
+            'currency_code' => 'PKR',        ]);
 
     $response
         ->assertSessionHasNoErrors()
@@ -86,9 +82,7 @@ test('profile accepts Brazilian real as primary currency', function () {
         ->patch(route('profile.update'), [
             'name' => 'Test User',
             'email' => 'test@example.com',
-            'currency_code' => 'BRL',
-            'month_start_day' => 1,
-        ]);
+            'currency_code' => 'BRL',        ]);
 
     $response
         ->assertSessionHasNoErrors()
@@ -105,9 +99,7 @@ test('profile accepts Saudi riyal as primary currency', function () {
         ->patch(route('profile.update'), [
             'name' => 'Test User',
             'email' => 'test@example.com',
-            'currency_code' => 'SAR',
-            'month_start_day' => 1,
-        ]);
+            'currency_code' => 'SAR',        ]);
 
     $response
         ->assertSessionHasNoErrors()
@@ -124,9 +116,7 @@ test('profile rejects bitcoin as primary currency', function () {
         ->patch(route('profile.update'), [
             'name' => 'Test User',
             'email' => 'test@example.com',
-            'currency_code' => 'BTC',
-            'month_start_day' => 1,
-        ]);
+            'currency_code' => 'BTC',        ]);
 
     $response->assertSessionHasErrors(['currency_code']);
 });
@@ -174,9 +164,7 @@ test('email verification status is unchanged when the email address is unchanged
         ->patch(route('profile.update'), [
             'name' => 'Test User',
             'email' => $user->email,
-            'currency_code' => $user->currency_code,
-            'month_start_day' => 1,
-        ]);
+            'currency_code' => $user->currency_code,        ]);
 
     $response
         ->assertSessionHasNoErrors()

--- a/tests/Feature/UserMonthPeriodServiceTest.php
+++ b/tests/Feature/UserMonthPeriodServiceTest.php
@@ -1,11 +1,21 @@
 <?php
 
+use App\Features\CustomMonthStartDay;
 use App\Models\User;
 use App\Services\UserMonthPeriodService;
 use Carbon\Carbon;
+use Laravel\Pennant\Feature;
+
+function customStartDayUser(int $startDay): User
+{
+    $user = User::factory()->create(['month_start_day' => $startDay]);
+    Feature::for($user)->activate(CustomMonthStartDay::class);
+
+    return $user;
+}
 
 it('returns natural month periods by default', function () {
-    $user = User::factory()->make(['month_start_day' => 1]);
+    $user = customStartDayUser(1);
     $period = app(UserMonthPeriodService::class)->monthContaining($user, Carbon::parse('2026-02-14'));
 
     expect($period['from']->toDateString())->toBe('2026-02-01')
@@ -14,7 +24,7 @@ it('returns natural month periods by default', function () {
 });
 
 it('returns salary month periods for custom start days', function () {
-    $user = User::factory()->make(['month_start_day' => 25]);
+    $user = customStartDayUser(25);
     $period = app(UserMonthPeriodService::class)->monthContaining($user, Carbon::parse('2026-02-14'));
     $previousPeriod = app(UserMonthPeriodService::class)->monthContaining($user, $period['from']->copy()->subDay());
 
@@ -26,7 +36,7 @@ it('returns salary month periods for custom start days', function () {
 });
 
 it('starts a new salary month on the configured day', function () {
-    $user = User::factory()->make(['month_start_day' => 28]);
+    $user = customStartDayUser(28);
     $period = app(UserMonthPeriodService::class)->monthContaining($user, Carbon::parse('2026-02-28'));
 
     expect($period['from']->toDateString())->toBe('2026-02-28')
@@ -34,7 +44,18 @@ it('starts a new salary month on the configured day', function () {
 });
 
 it('falls back to the first for invalid stored values', function () {
-    $user = User::factory()->make(['month_start_day' => 2]);
+    $user = customStartDayUser(2);
 
     expect(app(UserMonthPeriodService::class)->startDay($user))->toBe(1);
+});
+
+it('ignores the stored start day while the feature is disabled', function () {
+    $user = User::factory()->create(['month_start_day' => 25]);
+
+    $service = app(UserMonthPeriodService::class);
+    $period = $service->monthContaining($user, Carbon::parse('2026-02-14'));
+
+    expect($service->startDay($user))->toBe(1)
+        ->and($period['from']->toDateString())->toBe('2026-02-01')
+        ->and($period['end_inclusive']->toDateString())->toBe('2026-02-28');
 });

--- a/tests/Feature/UserMonthPeriodServiceTest.php
+++ b/tests/Feature/UserMonthPeriodServiceTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Models\User;
+use App\Services\UserMonthPeriodService;
+use Carbon\Carbon;
+
+it('returns natural month periods by default', function () {
+    $user = User::factory()->make(['month_start_day' => 1]);
+    $period = app(UserMonthPeriodService::class)->monthContaining($user, Carbon::parse('2026-02-14'));
+
+    expect($period['from']->toDateString())->toBe('2026-02-01')
+        ->and($period['to']->toDateString())->toBe('2026-03-01')
+        ->and($period['end_inclusive']->toDateString())->toBe('2026-02-28');
+});
+
+it('returns salary month periods for custom start days', function () {
+    $user = User::factory()->make(['month_start_day' => 25]);
+    $period = app(UserMonthPeriodService::class)->monthContaining($user, Carbon::parse('2026-02-14'));
+    $previousPeriod = app(UserMonthPeriodService::class)->monthContaining($user, $period['from']->copy()->subDay());
+
+    expect($period['from']->toDateString())->toBe('2026-01-25')
+        ->and($period['to']->toDateString())->toBe('2026-02-25')
+        ->and($period['end_inclusive']->toDateString())->toBe('2026-02-24')
+        ->and($previousPeriod['from']->toDateString())->toBe('2025-12-25')
+        ->and($previousPeriod['to']->toDateString())->toBe('2026-01-25');
+});
+
+it('starts a new salary month on the configured day', function () {
+    $user = User::factory()->make(['month_start_day' => 28]);
+    $period = app(UserMonthPeriodService::class)->monthContaining($user, Carbon::parse('2026-02-28'));
+
+    expect($period['from']->toDateString())->toBe('2026-02-28')
+        ->and($period['to']->toDateString())->toBe('2026-03-28');
+});
+
+it('falls back to the first for invalid stored values', function () {
+    $user = User::factory()->make(['month_start_day' => 2]);
+
+    expect(app(UserMonthPeriodService::class)->startDay($user))->toBe(1);
+});


### PR DESCRIPTION
## Summary
- add user month start day setting (calendar 1st, or salary days 25–28)
- apply custom periods to dashboard and cashflow date ranges
- add backend and frontend period helpers with coverage
- resolve the current period in the user's timezone so boundaries are correct near midnight and month edges
- align `end_inclusive` to end-of-day (matches frontend, stays correct if compared against datetime columns)

## Notes
- `month_start_day` is required on profile update; all profile-update callers send it.
- Frontend `user-periods.ts` now has unit coverage for custom-start month/quarter/year ranges, period shifting, and boundary equality.

<img width="892" height="352" alt="8ojxgoqiEaJ" src="https://github.com/user-attachments/assets/e8f5e480-079a-4de0-81fe-01d24b5b8b10" />
