### PR TITLE
chore: update Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Whisper Money is a privacy-first personal finance application that helps you tra
 
 > 🎮 **Try the Demo:** Experience Whisper Money with our [demo account](https://whisper.money/login?demo=1) - no registration required!
 
-> 💬 **Join our Community:** Whether you're a user looking for help or a developer wanting to contribute, we'd love to have you in our [Discord server](https://discord.gg/2WZmDW9QZ8)! Share feedback, ask questions, discuss new features, or just hang out with fellow privacy enthusiasts.
+> 💬 **Join our Community:** Whether you're a user looking for help or a developer wanting to contribute, we'd love to have you in our [Discord server](https://discord.gg/m8hUhx6D9D)! Share feedback, ask questions, discuss new features, or just hang out with fellow privacy enthusiasts.
 
 ## Features
 

--- a/resources/js/components/partials/header.tsx
+++ b/resources/js/components/partials/header.tsx
@@ -78,7 +78,7 @@ export default function Header({
                                 </Button>
                             </a>
                             <a
-                                href="https://discord.gg/2WZmDW9QZ8"
+                                href="https://discord.gg/m8hUhx6D9D"
                                 target="_blank"
                                 rel="noopener noreferrer"
                             >
@@ -182,7 +182,7 @@ export default function Header({
                                     </Button>
                                 </a>
                                 <a
-                                    href="https://discord.gg/2WZmDW9QZ8"
+                                    href="https://discord.gg/m8hUhx6D9D"
                                     target="_blank"
                                     rel="noopener noreferrer"
                                 >

--- a/resources/js/components/user-menu-content.test.tsx
+++ b/resources/js/components/user-menu-content.test.tsx
@@ -86,7 +86,7 @@ describe('UserMenuContent', () => {
         const feedback = screen.getByRole('link', { name: /feedback/i });
 
         expect(community.getAttribute('href')).toBe(
-            'https://discord.gg/2WZmDW9QZ8',
+            'https://discord.gg/m8hUhx6D9D',
         );
         expect(community.compareDocumentPosition(feedback)).toBe(
             Node.DOCUMENT_POSITION_FOLLOWING,

--- a/resources/js/components/user-menu-content.tsx
+++ b/resources/js/components/user-menu-content.tsx
@@ -96,7 +96,7 @@ export function UserMenuContent({ user }: UserMenuContentProps) {
                 <DropdownMenuItem asChild>
                     <a
                         className="block w-full cursor-pointer"
-                        href="https://discord.gg/2WZmDW9QZ8"
+                        href="https://discord.gg/m8hUhx6D9D"
                         target="_blank"
                         rel="noopener noreferrer"
                         onClick={cleanup}

--- a/resources/js/pages/settings/connections.tsx
+++ b/resources/js/pages/settings/connections.tsx
@@ -466,7 +466,7 @@ export default function ConnectionsPage({ connections }: Props) {
                                                                 </Button>
                                                             )}
                                                             <a
-                                                                href="https://discord.gg/2WZmDW9QZ8"
+                                                                href="https://discord.gg/m8hUhx6D9D"
                                                                 target="_blank"
                                                                 rel="noopener noreferrer"
                                                                 className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"

--- a/resources/views/mail/updates/first-update-jan-2026.blade.php
+++ b/resources/views/mail/updates/first-update-jan-2026.blade.php
@@ -16,7 +16,7 @@ Even more meaningful: we now have our first paying users. This means I need to k
 Whisper Money is a small project built by one person (me!), but it can become something amazing with your input. Here's how you can help shape the future:
 
 <x-mail::panel>
-**Join our Discord community** – Share ideas, report bugs, or just chat about privacy-first finance. [Join our comminity](https://discord.gg/2WZmDW9QZ8).
+**Join our Discord community** – Share ideas, report bugs, or just chat about privacy-first finance. [Join our comminity](https://discord.gg/m8hUhx6D9D).
 
 **Check our Roadmap** – See what's coming next and vote on features you care about:
 [whisper-money.canny.io](https://whisper-money.canny.io/)
@@ -33,7 +33,7 @@ Building a privacy-first alternative to mainstream finance apps is a big challen
 
 Thank you for trusting Whisper Money with your financial data. Your privacy is my priority, always.
 
-<x-mail::button :url="'https://discord.gg/2WZmDW9QZ8'">
+<x-mail::button :url="'https://discord.gg/m8hUhx6D9D'">
 Join the Discord Comminity
 </x-mail::button>
 


### PR DESCRIPTION
Swap Discord invite link `discord.gg/2WZmDW9QZ8` → `discord.gg/m8hUhx6D9D` across all files (README, header, user menu, connections page, welcome email, test).