### PR TITLE
feat: add BRL currency support

### DIFF
--- a/config/currencies.php
+++ b/config/currencies.php
@@ -117,6 +117,12 @@ return [
             'allows_account' => true,
         ],
         [
+            'code' => 'BRL',
+            'name' => 'Brazilian Real',
+            'allows_primary' => true,
+            'allows_account' => true,
+        ],
+        [
             'code' => 'BTC',
             'name' => 'Bitcoin',
             'allows_primary' => false,

--- a/tests/Feature/Settings/AccountTest.php
+++ b/tests/Feature/Settings/AccountTest.php
@@ -151,6 +151,25 @@ it('accepts Pakistani rupee when creating account', function () {
     ]);
 });
 
+it('accepts Brazilian real when creating account', function () {
+    actingAs($this->user);
+
+    $response = $this->post(route('accounts.store'), [
+        'name' => 'Brazil Account',
+        'bank_id' => $this->bank->id,
+        'currency_code' => 'BRL',
+        'type' => AccountType::Checking->value,
+    ]);
+
+    $response->assertRedirect();
+
+    assertDatabaseHas('accounts', [
+        'user_id' => $this->user->id,
+        'bank_id' => $this->bank->id,
+        'currency_code' => 'BRL',
+    ]);
+});
+
 it('accepts bitcoin when creating account', function () {
     actingAs($this->user);
 

--- a/tests/Feature/Settings/ProfileUpdateTest.php
+++ b/tests/Feature/Settings/ProfileUpdateTest.php
@@ -72,6 +72,25 @@ test('profile accepts Pakistani rupee as primary currency', function () {
     expect($user->refresh()->currency_code)->toBe('PKR');
 });
 
+test('profile accepts Brazilian real as primary currency', function () {
+    $user = User::factory()->create();
+
+    $response = $this
+        ->actingAs($user)
+        ->patch(route('profile.update'), [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'currency_code' => 'BRL',
+            'month_start_day' => 1,
+        ]);
+
+    $response
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(route('account.edit'));
+
+    expect($user->refresh()->currency_code)->toBe('BRL');
+});
+
 test('profile rejects bitcoin as primary currency', function () {
     $user = User::factory()->create();
 


### PR DESCRIPTION
## Summary
- Add BRL (Brazilian Real) to supported currency list (`config/currencies.php`), allowed as both primary and account currency.

## API compatibility
- Verified `@fawazahmed0/currency-api` supports BRL in both directions (e.g. USD→BRL ≈ 5.05). No conversion changes needed.

## Tests
- Added BRL account-creation test (`AccountTest.php`).
- Added BRL primary-currency test (`ProfileUpdateTest.php`).
- Both pass.