### PR TITLE
fix(accounts): translate update button in edit account modal

### DIFF
--- a/resources/js/components/accounts/edit-account-dialog.tsx
+++ b/resources/js/components/accounts/edit-account-dialog.tsx
@@ -361,7 +361,9 @@ export function EditAccountDialog({
                                 type="submit"
                                 disabled={isSubmitting || !initialValues}
                             >
-                                {isSubmitting ? 'Updating...' : 'Update'}
+                                {isSubmitting
+                                    ? __('Updating...')
+                                    : __('Update')}
                             </Button>
                         </div>
                     </div>

--- a/resources/js/components/delete-user.tsx
+++ b/resources/js/components/delete-user.tsx
@@ -49,7 +49,9 @@ export default function DeleteUser() {
         <div className="space-y-6">
             <HeadingSmall
                 title={__('Delete account')}
-                description={__('Mark your account as deleted and disable access')}
+                description={__(
+                    'Mark your account as deleted and disable access',
+                )}
             />
 
             <div className="space-y-4 rounded-lg border border-red-100 bg-red-50 p-4 dark:border-red-200/10 dark:bg-red-700/10">

--- a/resources/js/lib/sync-manager.ts
+++ b/resources/js/lib/sync-manager.ts
@@ -1,6 +1,6 @@
-import { __ } from '@/utils/i18n';
 import type { Transaction } from '@/types/transaction';
 import type { UUID } from '@/types/uuid';
+import { __ } from '@/utils/i18n';
 import axios from 'axios';
 import { db } from './dexie-db';
 

--- a/resources/js/utils/date.ts
+++ b/resources/js/utils/date.ts
@@ -1,10 +1,10 @@
+import { __ } from '@/utils/i18n';
 import {
     format as dateFnsFormat,
     isToday as dateFnsIsToday,
     isYesterday as dateFnsIsYesterday,
 } from 'date-fns';
 import { es } from 'date-fns/locale';
-import { __ } from '@/utils/i18n';
 
 /**
  * Get the date-fns locale object based on locale code


### PR DESCRIPTION
## Problem
Update button in edit account modal showed hardcoded English (`Update` / `Updating...`) instead of translated text.

## Fix
Wrap button label in `__()` so it resolves the existing `es.json` keys (`Actualizar` / `Actualizando...`).

## Test
`edit-account-dialog.test.tsx` passes.