### PR TITLE
feat(accounts): show 50 transactions per page and link to full list

### DIFF
--- a/lang/es.json
+++ b/lang/es.json
@@ -1564,6 +1564,7 @@
     "View and manage your transactions": "Ver y gestionar tus transacciones",
     "View balance evolution over time": "Ver evolución del balance a lo largo del tiempo",
     "View details": "Ver detalles",
+    "View in Transactions": "Ver en Transacciones",
     "Visual Reports": "Reportes Visuales",
     "Visual insights": "Análisis visuales",
     "Visual insights & reports": "Análisis visuales e informes",

--- a/resources/js/components/transactions/transaction-list.tsx
+++ b/resources/js/components/transactions/transaction-list.tsx
@@ -1,5 +1,6 @@
 import { useLocale } from '@/hooks/use-locale';
 import { __ } from '@/utils/i18n';
+import { Link } from '@inertiajs/react';
 import {
     Cell,
     ColumnFiltersState,
@@ -15,6 +16,7 @@ import {
 import { VirtualItem, Virtualizer } from '@tanstack/react-virtual';
 import axios from 'axios';
 import { format, getYear, isWithinInterval, parseISO } from 'date-fns';
+import { ExternalLink } from 'lucide-react';
 import {
     createElement,
     useCallback,
@@ -26,6 +28,7 @@ import {
 import { toast } from 'sonner';
 
 import { single as reEvaluateSingle } from '@/actions/App/Http/Controllers/ReEvaluateTransactionRulesController';
+import { index as transactionsIndex } from '@/actions/App/Http/Controllers/TransactionController';
 import {
     AutomateCategorizationDialog,
     type AutomateCategorizationCandidate,
@@ -1385,6 +1388,22 @@ export function TransactionList({
                                     ) : (
                                         <>{__('Load more')}</>
                                     )}
+                                </Button>
+                            )}
+                            {accountId && (
+                                <Button asChild variant="outline">
+                                    <Link
+                                        href={
+                                            transactionsIndex({
+                                                query: {
+                                                    account_ids: accountId,
+                                                },
+                                            }).url
+                                        }
+                                    >
+                                        <ExternalLink />
+                                        {__('View in Transactions')}
+                                    </Link>
                                 </Button>
                             )}
                         </DataTablePagination>

--- a/resources/js/pages/Accounts/Show.tsx
+++ b/resources/js/pages/Accounts/Show.tsx
@@ -398,7 +398,7 @@ export default function AccountShow({
                         labels={labels}
                         automationRules={automationRules}
                         accountId={account.id}
-                        pageSize={10}
+                        pageSize={50}
                         hideAccountFilter={true}
                         showActionsMenu={false}
                         maxHeight={600}


### PR DESCRIPTION
## What

- Bump the account page transaction list page size from **10 → 50** (`Accounts/Show.tsx`).
- Add a **View in Transactions** button next to *Load more* (only on the account page) that opens the Transactions page pre-filtered to the current account via `account_ids`.
- Add Spanish translation `View in Transactions` → `Ver en Transacciones`.

## Notes

- The account list is synced client-side (IndexedDB); `pageSize` controls how many rows render before *Load more*, so no backend change needed.
- The Transactions index already defaults to `per_page = 50` and reads `account_ids` from the query string.

## Testing

- `vitest` Accounts/Show tests pass.
- `bun run format`, `bun run lint`, `bun run build` pass.