### PR TITLE
feat(posthog): route analytics through reverse proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,7 +82,8 @@ VITE_APP_NAME="${APP_NAME}"
 # PostHog Analytics
 VITE_POSTHOG_ENABLED=false
 VITE_POSTHOG_API_KEY=
-VITE_POSTHOG_HOST=https://eu.i.posthog.com
+VITE_POSTHOG_HOST=https://t.whisper.money
+VITE_POSTHOG_UI_HOST=https://eu.posthog.com
 
 # Stripe Configuration
 STRIPE_KEY=

--- a/resources/js/lib/posthog.ts
+++ b/resources/js/lib/posthog.ts
@@ -13,7 +13,11 @@ const getPostHogApiKey = (): string | undefined => {
 };
 
 const getPostHogHost = (): string => {
-    return import.meta.env.VITE_POSTHOG_HOST || 'https://eu.i.posthog.com';
+    return import.meta.env.VITE_POSTHOG_HOST || 'https://t.whisper.money';
+};
+
+const getPostHogUiHost = (): string => {
+    return import.meta.env.VITE_POSTHOG_UI_HOST || 'https://eu.posthog.com';
 };
 
 export const isPostHogSessionRecordingEnabled = (): boolean => {
@@ -42,6 +46,7 @@ export function initializePostHog(): void {
 
     posthog.init(apiKey, {
         api_host: host,
+        ui_host: getPostHogUiHost(),
         person_profiles: 'always',
         disable_session_recording: !isPostHogSessionRecordingEnabled(),
         loaded: () => {


### PR DESCRIPTION
## What

Route PostHog through the managed reverse proxy at `t.whisper.money` to dodge ad blockers and keep analytics first-party.

We use the **JS library method** (`posthog-js` in `resources/js/lib/posthog.ts`), so only that init needed changes — no snippet.

## Changes
- `api_host` default → `https://t.whisper.money` (proxy domain)
- Add `ui_host` (default `https://eu.posthog.com`) so dashboard links resolve back to PostHog correctly
- Both stay env-overridable: `VITE_POSTHOG_HOST`, new `VITE_POSTHOG_UI_HOST`
- Update `.env.example`

## Test
- `posthog.test.ts` passes
- format + lint clean (one pre-existing unrelated warning)