### PR TITLE
fix(sentry): only report errors in production

### DIFF
--- a/config/sentry.php
+++ b/config/sentry.php
@@ -8,7 +8,11 @@
 return [
 
     // @see https://docs.sentry.io/product/sentry-basics/dsn-explainer/
-    'dsn' => env('SENTRY_LARAVEL_DSN', env('SENTRY_DSN')),
+    // Only report to Sentry from the production environment. A null DSN disables
+    // the SDK entirely, so nothing is sent from local, staging, or testing.
+    'dsn' => env('APP_ENV') === 'production'
+        ? env('SENTRY_LARAVEL_DSN', env('SENTRY_DSN'))
+        : null,
 
     // @see https://spotlightjs.com/
     // 'spotlight' => env('SENTRY_SPOTLIGHT', false),

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -52,7 +52,8 @@ Sentry.init({
         return event;
     },
     enabled:
-        import.meta.env.PROD && Boolean(import.meta.env.SENTRY_LARAVEL_DSN),
+        import.meta.env.MODE === 'production' &&
+        Boolean(import.meta.env.SENTRY_LARAVEL_DSN),
 });
 
 initializePostHog();

--- a/tests/Feature/SentryConfigTest.php
+++ b/tests/Feature/SentryConfigTest.php
@@ -4,6 +4,11 @@ it('binds the sentry release from the environment', function () {
     expect(config('sentry.release'))->toBe(env('SENTRY_RELEASE'));
 });
 
+it('disables the sentry dsn outside the production environment', function () {
+    expect(app()->environment())->not->toBe('production')
+        ->and(config('sentry.dsn'))->toBeNull();
+});
+
 it('does not wait for registry image publishing before marking a sentry deploy', function () {
     $workflow = file_get_contents(base_path('.github/workflows/ci.yml'));
 


### PR DESCRIPTION
## What

Gate Sentry error reporting on the production environment so nothing is sent from local, staging, or testing.

- **Backend** (`config/sentry.php`): DSN resolves to `null` unless `APP_ENV=production`. A null DSN disables the Laravel SDK entirely.
- **Frontend** (`resources/js/app.tsx`): `enabled` now requires `import.meta.env.MODE === 'production'` (plus a DSN).