### PR TITLE
feat: expense/income analysis screen + saved filters

### DIFF
--- a/app/Http/Controllers/AnalysisController.php
+++ b/app/Http/Controllers/AnalysisController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Account;
+use App\Models\Bank;
+use App\Models\Category;
+use App\Models\Label;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class AnalysisController extends Controller
+{
+    public function __invoke(Request $request): Response
+    {
+        $user = $request->user();
+
+        $categories = Category::query()
+            ->where('user_id', $user->id)
+            ->orderBy('name')
+            ->get(['id', 'name', 'icon', 'color', 'type', 'cashflow_direction']);
+
+        $accounts = Account::query()
+            ->where('user_id', $user->id)
+            ->with('bank:id,name,logo')
+            ->orderBy('name')
+            ->get(['id', 'name', 'name_iv', 'encrypted', 'bank_id', 'type', 'currency_code']);
+
+        $banks = Bank::query()
+            ->where(function ($query) use ($user) {
+                $query->whereNull('user_id')
+                    ->orWhere('user_id', $user->id);
+            })
+            ->orderBy('name')
+            ->get(['id', 'name', 'logo']);
+
+        $labels = Label::query()
+            ->where('user_id', $user->id)
+            ->orderBy('name')
+            ->get(['id', 'name', 'color']);
+
+        return Inertia::render('analysis/index', [
+            'categories' => $categories,
+            'accounts' => $accounts,
+            'banks' => $banks,
+            'labels' => $labels,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/AnalysisController.php
+++ b/app/Http/Controllers/Api/AnalysisController.php
@@ -115,7 +115,7 @@ class AnalysisController extends Controller
         return match ($groupBy) {
             'category' => $transaction->category_id,
             'account' => $transaction->account_id,
-            'month' => $transaction->transaction_date->format('Y-m'),
+            'month' => $transaction->transaction_date->format('m'),
             default => null,
         };
     }

--- a/app/Http/Controllers/Api/AnalysisController.php
+++ b/app/Http/Controllers/Api/AnalysisController.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\AnalysisRequest;
+use App\Models\Transaction;
+use App\Services\ExchangeRateService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Collection;
+
+class AnalysisController extends Controller
+{
+    public function __construct(private ExchangeRateService $exchangeRateService) {}
+
+    public function index(AnalysisRequest $request): JsonResponse
+    {
+        $user = $request->user();
+        $userCurrency = $user->currency_code;
+        $groupBy = $request->validated()['group_by'];
+
+        $transactions = Transaction::query()
+            ->where('user_id', $user->id)
+            ->with(['account:id,currency_code', 'category:id,name,icon,color,type', 'labels:id,name,color'])
+            ->applyFilters($request->filters())
+            ->get();
+
+        $this->preloadExchangeRates($transactions, $userCurrency);
+
+        $converted = $transactions->map(fn (Transaction $transaction): array => [
+            'transaction' => $transaction,
+            'amount' => $this->convertTransactionAmount($transaction, $userCurrency),
+        ]);
+
+        return response()
+            ->json([
+                'summary' => $this->summary($converted),
+                'groups' => $this->groups($converted, $groupBy)->values(),
+            ])
+            ->header('Cache-Control', 'no-store, private');
+    }
+
+    /**
+     * @param  Collection<int, array{transaction: Transaction, amount: int}>  $converted
+     * @return array{income: int, expense: int, net: int, count: int}
+     */
+    private function summary(Collection $converted): array
+    {
+        $income = $converted->filter(fn (array $row): bool => $row['amount'] > 0)->sum('amount');
+        $expense = abs($converted->filter(fn (array $row): bool => $row['amount'] < 0)->sum('amount'));
+
+        return [
+            'income' => $income,
+            'expense' => $expense,
+            'net' => $income - $expense,
+            'count' => $converted->count(),
+        ];
+    }
+
+    /**
+     * @param  Collection<int, array{transaction: Transaction, amount: int}>  $converted
+     * @return Collection<int, array{key: ?string, amount: int, count: int}>
+     */
+    private function groups(Collection $converted, string $groupBy): Collection
+    {
+        if ($groupBy === 'label') {
+            return $this->labelGroups($converted);
+        }
+
+        return $converted
+            ->groupBy(fn (array $row): string => $this->groupKey($row['transaction'], $groupBy) ?? '__null__')
+            ->map(fn (Collection $rows, string $key): array => [
+                'key' => $key === '__null__' ? null : $key,
+                'amount' => $rows->sum('amount'),
+                'count' => $rows->count(),
+            ])
+            ->sortByDesc(fn (array $group): int => abs($group['amount']));
+    }
+
+    /**
+     * A transaction with several labels contributes to each label's bucket.
+     * Transactions without labels fall into a single null bucket.
+     *
+     * @param  Collection<int, array{transaction: Transaction, amount: int}>  $converted
+     * @return Collection<int, array{key: ?string, amount: int, count: int}>
+     */
+    private function labelGroups(Collection $converted): Collection
+    {
+        $buckets = [];
+
+        foreach ($converted as $row) {
+            $labels = $row['transaction']->labels;
+
+            if ($labels->isEmpty()) {
+                $buckets['__null__'] ??= ['key' => null, 'amount' => 0, 'count' => 0];
+                $buckets['__null__']['amount'] += $row['amount'];
+                $buckets['__null__']['count']++;
+
+                continue;
+            }
+
+            foreach ($labels as $label) {
+                $buckets[$label->id] ??= ['key' => $label->id, 'amount' => 0, 'count' => 0];
+                $buckets[$label->id]['amount'] += $row['amount'];
+                $buckets[$label->id]['count']++;
+            }
+        }
+
+        return collect(array_values($buckets))
+            ->sortByDesc(fn (array $group): int => abs($group['amount']));
+    }
+
+    private function groupKey(Transaction $transaction, string $groupBy): ?string
+    {
+        return match ($groupBy) {
+            'category' => $transaction->category_id,
+            'account' => $transaction->account_id,
+            'month' => $transaction->transaction_date->format('Y-m'),
+            default => null,
+        };
+    }
+
+    private function convertTransactionAmount(Transaction $transaction, string $userCurrency): int
+    {
+        return $this->exchangeRateService->convert(
+            $transaction->currency_code ?: $transaction->account?->currency_code ?: $userCurrency,
+            $userCurrency,
+            $transaction->amount,
+            $transaction->transaction_date->toDateString(),
+        );
+    }
+
+    /**
+     * @param  Collection<int, Transaction>  $transactions
+     */
+    private function preloadExchangeRates(Collection $transactions, string $userCurrency): void
+    {
+        $dates = $transactions
+            ->filter(fn (Transaction $transaction): bool => strcasecmp($transaction->currency_code ?: $transaction->account?->currency_code ?: $userCurrency, $userCurrency) !== 0)
+            ->map(fn (Transaction $transaction): string => $transaction->transaction_date->toDateString())
+            ->unique()
+            ->values();
+
+        if ($dates->isEmpty()) {
+            return;
+        }
+
+        $this->exchangeRateService->preloadRates($userCurrency, $dates);
+    }
+}

--- a/app/Http/Controllers/Api/SavedFilterController.php
+++ b/app/Http/Controllers/Api/SavedFilterController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\StoreSavedFilterRequest;
+use App\Models\SavedFilter;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class SavedFilterController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $savedFilters = SavedFilter::query()
+            ->where('user_id', $request->user()->id)
+            ->orderBy('name')
+            ->get(['id', 'name', 'filters']);
+
+        return response()->json(['data' => $savedFilters]);
+    }
+
+    public function store(StoreSavedFilterRequest $request): JsonResponse
+    {
+        $savedFilter = SavedFilter::query()->create([
+            'user_id' => $request->user()->id,
+            'name' => $request->validated('name'),
+            'filters' => $request->validated('filters'),
+        ]);
+
+        return response()->json([
+            'data' => $savedFilter->only(['id', 'name', 'filters']),
+        ], 201);
+    }
+
+    public function destroy(Request $request, SavedFilter $savedFilter): JsonResponse
+    {
+        abort_unless($savedFilter->user_id === $request->user()->id, 403);
+
+        $savedFilter->delete();
+
+        return response()->json(['message' => 'Saved filter deleted']);
+    }
+}

--- a/app/Http/Controllers/Api/SavedFilterController.php
+++ b/app/Http/Controllers/Api/SavedFilterController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\StoreSavedFilterRequest;
+use App\Http\Requests\Api\UpdateSavedFilterRequest;
 use App\Models\SavedFilter;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -31,6 +32,17 @@ class SavedFilterController extends Controller
         return response()->json([
             'data' => $savedFilter->only(['id', 'name', 'filters']),
         ], 201);
+    }
+
+    public function update(UpdateSavedFilterRequest $request, SavedFilter $savedFilter): JsonResponse
+    {
+        abort_unless($savedFilter->user_id === $request->user()->id, 403);
+
+        $savedFilter->update(['filters' => $request->validated('filters')]);
+
+        return response()->json([
+            'data' => $savedFilter->only(['id', 'name', 'filters']),
+        ]);
     }
 
     public function destroy(Request $request, SavedFilter $savedFilter): JsonResponse

--- a/app/Http/Requests/Api/AnalysisRequest.php
+++ b/app/Http/Requests/Api/AnalysisRequest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AnalysisRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $fields = ['category_ids', 'account_ids', 'label_ids'];
+
+        foreach ($fields as $field) {
+            $value = $this->input($field);
+            if (is_string($value)) {
+                $this->merge([
+                    $field => array_filter(explode(',', $value)),
+                ]);
+            }
+        }
+    }
+
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'group_by' => ['required', 'string', 'in:category,month,account,label'],
+            'date_from' => ['nullable', 'date'],
+            'date_to' => ['nullable', 'date'],
+            'amount_min' => ['nullable', 'numeric'],
+            'amount_max' => ['nullable', 'numeric'],
+            'category_ids' => ['nullable', 'array'],
+            'category_ids.*' => ['string'],
+            'account_ids' => ['nullable', 'array'],
+            'account_ids.*' => ['string', 'uuid'],
+            'label_ids' => ['nullable', 'array'],
+            'label_ids.*' => ['string', 'uuid'],
+            'creditor_name' => ['nullable', 'string', 'max:255'],
+            'debtor_name' => ['nullable', 'string', 'max:255'],
+            'search' => ['nullable', 'string', 'max:200'],
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    public function filters(): array
+    {
+        $validated = $this->validated();
+
+        return array_filter([
+            'date_from' => $validated['date_from'] ?? null,
+            'date_to' => $validated['date_to'] ?? null,
+            'amount_min' => $validated['amount_min'] ?? null,
+            'amount_max' => $validated['amount_max'] ?? null,
+            'category_ids' => $validated['category_ids'] ?? null,
+            'account_ids' => $validated['account_ids'] ?? null,
+            'label_ids' => $validated['label_ids'] ?? null,
+            'creditor_name' => $validated['creditor_name'] ?? null,
+            'debtor_name' => $validated['debtor_name'] ?? null,
+            'search' => $validated['search'] ?? null,
+        ], fn ($value): bool => $value !== null);
+    }
+}

--- a/app/Http/Requests/Api/StoreSavedFilterRequest.php
+++ b/app/Http/Requests/Api/StoreSavedFilterRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreSavedFilterRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('saved_filters', 'name')->where('user_id', $this->user()->id),
+            ],
+            'filters' => ['required', 'array'],
+            'filters.date_from' => ['nullable', 'date'],
+            'filters.date_to' => ['nullable', 'date'],
+            'filters.amount_min' => ['nullable', 'numeric'],
+            'filters.amount_max' => ['nullable', 'numeric'],
+            'filters.category_ids' => ['nullable', 'array'],
+            'filters.category_ids.*' => ['string'],
+            'filters.account_ids' => ['nullable', 'array'],
+            'filters.account_ids.*' => ['string'],
+            'filters.label_ids' => ['nullable', 'array'],
+            'filters.label_ids.*' => ['string'],
+            'filters.creditor_name' => ['nullable', 'string', 'max:255'],
+            'filters.debtor_name' => ['nullable', 'string', 'max:255'],
+            'filters.search' => ['nullable', 'string', 'max:200'],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/UpdateSavedFilterRequest.php
+++ b/app/Http/Requests/Api/UpdateSavedFilterRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateSavedFilterRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'filters' => ['required', 'array'],
+            'filters.date_from' => ['nullable', 'date'],
+            'filters.date_to' => ['nullable', 'date'],
+            'filters.amount_min' => ['nullable', 'numeric'],
+            'filters.amount_max' => ['nullable', 'numeric'],
+            'filters.category_ids' => ['nullable', 'array'],
+            'filters.category_ids.*' => ['string'],
+            'filters.account_ids' => ['nullable', 'array'],
+            'filters.account_ids.*' => ['string'],
+            'filters.label_ids' => ['nullable', 'array'],
+            'filters.label_ids.*' => ['string'],
+            'filters.creditor_name' => ['nullable', 'string', 'max:255'],
+            'filters.debtor_name' => ['nullable', 'string', 'max:255'],
+            'filters.search' => ['nullable', 'string', 'max:200'],
+        ];
+    }
+}

--- a/app/Models/SavedFilter.php
+++ b/app/Models/SavedFilter.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\SavedFilterFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class SavedFilter extends Model
+{
+    /** @use HasFactory<SavedFilterFactory> */
+    use HasFactory, HasUuids;
+
+    protected $fillable = [
+        'user_id',
+        'name',
+        'filters',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'filters' => 'array',
+        ];
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -117,27 +117,35 @@ class Transaction extends Model
             $query->where('amount', '<=', $filters['amount_max'] * 100);
         }
 
-        if (! empty($filters['category_ids'])) {
-            $ids = collect($filters['category_ids']);
-            $hasUncategorized = $ids->contains('uncategorized');
-            $realIds = $ids->reject(fn ($id) => $id === 'uncategorized')->values()->all();
+        $hasCategoryFilter = ! empty($filters['category_ids']);
+        $hasLabelFilter = ! empty($filters['label_ids']);
 
-            $query->where(function (Builder $q) use ($realIds, $hasUncategorized) {
-                if (! empty($realIds)) {
-                    $q->whereIn('category_id', $realIds);
+        if ($hasCategoryFilter || $hasLabelFilter) {
+            $query->where(function (Builder $q) use ($filters, $hasCategoryFilter, $hasLabelFilter) {
+                if ($hasCategoryFilter) {
+                    $ids = collect($filters['category_ids']);
+                    $hasUncategorized = $ids->contains('uncategorized');
+                    $realIds = $ids->reject(fn ($id) => $id === 'uncategorized')->values()->all();
+
+                    $q->where(function (Builder $categoryQuery) use ($realIds, $hasUncategorized) {
+                        if (! empty($realIds)) {
+                            $categoryQuery->whereIn('category_id', $realIds);
+                        }
+                        if ($hasUncategorized) {
+                            $categoryQuery->orWhereNull('category_id');
+                        }
+                    });
                 }
-                if ($hasUncategorized) {
-                    $q->orWhereNull('category_id');
+
+                if ($hasLabelFilter) {
+                    $method = $hasCategoryFilter ? 'orWhereHas' : 'whereHas';
+                    $q->{$method}('labels', fn (Builder $labelQuery) => $labelQuery->whereIn('labels.id', $filters['label_ids']));
                 }
             });
         }
 
         if (! empty($filters['account_ids'])) {
             $query->whereIn('account_id', $filters['account_ids']);
-        }
-
-        if (! empty($filters['label_ids'])) {
-            $query->whereHas('labels', fn (Builder $q) => $q->whereIn('labels.id', $filters['label_ids']));
         }
 
         if (! empty($filters['creditor_name'])) {

--- a/database/factories/SavedFilterFactory.php
+++ b/database/factories/SavedFilterFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\SavedFilter;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<SavedFilter>
+ */
+class SavedFilterFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'name' => fake()->unique()->words(2, true),
+            'filters' => [
+                'categoryIds' => [],
+                'accountIds' => [],
+                'labelIds' => [],
+                'searchText' => fake()->word(),
+            ],
+        ];
+    }
+}

--- a/database/migrations/2026_06_01_131538_create_saved_filters_table.php
+++ b/database/migrations/2026_06_01_131538_create_saved_filters_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('saved_filters', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('user_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->json('filters');
+            $table->timestamps();
+
+            $table->unique(['user_id', 'name']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('saved_filters');
+    }
+};

--- a/resources/js/components/analysis/analysis-breakdown.tsx
+++ b/resources/js/components/analysis/analysis-breakdown.tsx
@@ -1,0 +1,151 @@
+import { CategoryIcon } from '@/components/shared/category-combobox';
+import { AmountDisplay } from '@/components/ui/amount-display';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { useChartColors } from '@/hooks/use-chart-color-scheme';
+import { cn } from '@/lib/utils';
+import { type Account } from '@/types/account';
+import { type Category } from '@/types/category';
+import { getLabelColorClasses } from '@/types/label';
+import { __ } from '@/utils/i18n';
+import { CreditCard, Tag } from 'lucide-react';
+
+export interface ResolvedRow {
+    key: string | null;
+    label: string;
+    amount: number;
+    count: number;
+    category?: Category;
+    labelColor?: string;
+    account?: Account;
+}
+
+interface AnalysisBreakdownProps {
+    title: string;
+    rows: ResolvedRow[];
+    currency: string;
+    loading?: boolean;
+    onDrill?: (row: ResolvedRow) => void;
+}
+
+export function AnalysisBreakdown({
+    title,
+    rows,
+    currency,
+    loading,
+    onDrill,
+}: AnalysisBreakdownProps) {
+    const { categoryBarColor } = useChartColors();
+    const maxAmount = Math.max(...rows.map((row) => Math.abs(row.amount)), 1);
+
+    return (
+        <Card>
+            <CardHeader className="pb-4">
+                <CardTitle className="text-base">{title}</CardTitle>
+            </CardHeader>
+            <CardContent>
+                {loading ? (
+                    <div className="space-y-4">
+                        {Array.from({ length: 6 }).map((_, i) => (
+                            <div key={i} className="space-y-2">
+                                <div className="flex items-center gap-3">
+                                    <div className="size-6 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700" />
+                                    <div className="h-4 w-24 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+                                    <div className="ml-auto h-4 w-16 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+                                </div>
+                                <div className="h-1.5 w-full animate-pulse rounded-full bg-gray-200 dark:bg-gray-700" />
+                            </div>
+                        ))}
+                    </div>
+                ) : rows.length === 0 ? (
+                    <div className="py-10 text-center text-sm text-muted-foreground">
+                        {__('No transactions match these filters')}
+                    </div>
+                ) : (
+                    <div className="space-y-1">
+                        {rows.map((row, index) => {
+                            const barColor = row.category
+                                ? categoryBarColor(row.category.color, index)
+                                : 'var(--chart-1)';
+                            const widthPercentage =
+                                (Math.abs(row.amount) / maxAmount) * 100;
+
+                            return (
+                                <button
+                                    key={row.key ?? '__null__'}
+                                    type="button"
+                                    onClick={() => onDrill?.(row)}
+                                    disabled={!onDrill}
+                                    className={cn(
+                                        '-mx-1.5 block w-full space-y-1.5 rounded-md px-1.5 py-1.5 text-left transition-colors',
+                                        onDrill &&
+                                            'cursor-pointer hover:bg-muted',
+                                    )}
+                                >
+                                    <div className="flex min-w-0 items-center justify-between gap-2">
+                                        <div className="flex min-w-0 items-center gap-2">
+                                            <RowIcon row={row} />
+                                            <span className="min-w-0 truncate text-sm font-medium">
+                                                {row.label}
+                                            </span>
+                                            <span className="shrink-0 text-xs text-muted-foreground">
+                                                ({row.count})
+                                            </span>
+                                        </div>
+                                        <AmountDisplay
+                                            amountInCents={row.amount}
+                                            currencyCode={currency}
+                                            variant="compact"
+                                            showSign
+                                            minimumFractionDigits={0}
+                                            maximumFractionDigits={0}
+                                        />
+                                    </div>
+                                    <Progress
+                                        value={widthPercentage}
+                                        className="h-1.5"
+                                        indicatorColor={barColor}
+                                    />
+                                </button>
+                            );
+                        })}
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+}
+
+function RowIcon({ row }: { row: ResolvedRow }) {
+    if (row.category) {
+        return (
+            <div className="shrink-0">
+                <CategoryIcon category={row.category} />
+            </div>
+        );
+    }
+
+    if (row.account) {
+        return (
+            <div className="flex size-6 shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-200">
+                <CreditCard className="size-3.5" />
+            </div>
+        );
+    }
+
+    if (row.labelColor) {
+        const colorClasses = getLabelColorClasses(row.labelColor);
+        return (
+            <div
+                className={cn(
+                    'flex size-6 shrink-0 items-center justify-center rounded-full',
+                    colorClasses.bg,
+                )}
+            >
+                <Tag className={cn('size-3.5', colorClasses.text)} />
+            </div>
+        );
+    }
+
+    return null;
+}

--- a/resources/js/components/analysis/analysis-chart.tsx
+++ b/resources/js/components/analysis/analysis-chart.tsx
@@ -1,0 +1,166 @@
+import { AmountDisplay } from '@/components/ui/amount-display';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ChartConfig, ChartContainer } from '@/components/ui/chart';
+import { useChartColors } from '@/hooks/use-chart-color-scheme';
+import { useLocale } from '@/hooks/use-locale';
+import { formatCompactNumber } from '@/utils/date';
+import { __ } from '@/utils/i18n';
+import {
+    Bar,
+    BarChart,
+    CartesianGrid,
+    Cell,
+    ReferenceLine,
+    Tooltip,
+    XAxis,
+    YAxis,
+} from 'recharts';
+
+export interface AnalysisChartPoint {
+    key: string;
+    label: string;
+    amount: number;
+}
+
+interface AnalysisChartProps {
+    title: string;
+    data: AnalysisChartPoint[];
+    currency: string;
+    loading?: boolean;
+    scrollable?: boolean;
+}
+
+interface TooltipPayloadItem {
+    payload?: AnalysisChartPoint;
+}
+
+function CustomTooltip({
+    active,
+    payload,
+    currency,
+}: {
+    active?: boolean;
+    payload?: TooltipPayloadItem[];
+    currency: string;
+}) {
+    if (!active || !payload?.length) {
+        return null;
+    }
+
+    const point = payload[0].payload;
+    if (!point) {
+        return null;
+    }
+
+    return (
+        <div className="rounded-lg border border-border/50 bg-background px-3 py-2 text-xs shadow-xl">
+            <div className="mb-1 font-medium">{point.label}</div>
+            <AmountDisplay
+                amountInCents={point.amount}
+                currencyCode={currency}
+                showSign
+                className="font-mono font-medium tabular-nums"
+            />
+        </div>
+    );
+}
+
+export function AnalysisChart({
+    title,
+    data,
+    currency,
+    loading,
+    scrollable,
+}: AnalysisChartProps) {
+    const locale = useLocale();
+    const { cashflowIncomeColor, cashflowExpenseColor } = useChartColors();
+
+    const chartConfig: ChartConfig = {
+        amount: { label: __('Amount'), color: 'var(--color-chart-1)' },
+    };
+
+    const minChartWidth = scrollable ? data.length * 56 : undefined;
+
+    return (
+        <Card>
+            <CardHeader className="pb-4">
+                <CardTitle className="text-base">{title}</CardTitle>
+            </CardHeader>
+            <CardContent>
+                {loading ? (
+                    <div className="h-[300px] animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+                ) : data.length === 0 ? (
+                    <div className="flex h-[300px] items-center justify-center text-sm text-muted-foreground">
+                        {__('No transactions match these filters')}
+                    </div>
+                ) : (
+                    <div className="overflow-x-auto">
+                        <ChartContainer
+                            config={chartConfig}
+                            className="h-[300px] w-full"
+                            style={
+                                minChartWidth
+                                    ? { minWidth: `${minChartWidth}px` }
+                                    : undefined
+                            }
+                        >
+                            <BarChart accessibilityLayer data={data}>
+                                <CartesianGrid
+                                    strokeDasharray="3 3"
+                                    vertical={false}
+                                    stroke="var(--color-border)"
+                                    opacity={0.3}
+                                />
+                                <XAxis
+                                    dataKey="label"
+                                    tickLine={false}
+                                    tickMargin={10}
+                                    axisLine={false}
+                                    interval="preserveStartEnd"
+                                />
+                                <YAxis
+                                    tickLine={false}
+                                    axisLine={false}
+                                    width={60}
+                                    tickFormatter={(value: number) =>
+                                        formatCompactNumber(
+                                            value / 100,
+                                            locale,
+                                            currency,
+                                        )
+                                    }
+                                />
+                                <ReferenceLine
+                                    y={0}
+                                    stroke="var(--color-border)"
+                                    strokeDasharray="3 3"
+                                />
+                                <Tooltip
+                                    content={
+                                        <CustomTooltip currency={currency} />
+                                    }
+                                    cursor={{
+                                        fill: 'var(--color-muted)',
+                                        opacity: 0.3,
+                                    }}
+                                />
+                                <Bar dataKey="amount" radius={[4, 4, 0, 0]}>
+                                    {data.map((point) => (
+                                        <Cell
+                                            key={point.key}
+                                            fill={
+                                                point.amount >= 0
+                                                    ? cashflowIncomeColor
+                                                    : cashflowExpenseColor
+                                            }
+                                        />
+                                    ))}
+                                </Bar>
+                            </BarChart>
+                        </ChartContainer>
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/resources/js/components/analysis/analysis-summary-cards.tsx
+++ b/resources/js/components/analysis/analysis-summary-cards.tsx
@@ -1,0 +1,85 @@
+import { AmountDisplay } from '@/components/ui/amount-display';
+import { Card, CardContent } from '@/components/ui/card';
+import { type AnalysisSummary } from '@/hooks/use-analysis-data';
+import { cn } from '@/lib/utils';
+import { __ } from '@/utils/i18n';
+
+interface AnalysisSummaryCardsProps {
+    summary: AnalysisSummary;
+    currency: string;
+    loading?: boolean;
+}
+
+export function AnalysisSummaryCards({
+    summary,
+    currency,
+    loading,
+}: AnalysisSummaryCardsProps) {
+    return (
+        <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+            <SummaryCard label={__('Income')} loading={loading}>
+                <AmountDisplay
+                    amountInCents={summary.income}
+                    currencyCode={currency}
+                    weight="semibold"
+                    size="xl"
+                    className="text-emerald-600 dark:text-emerald-400"
+                />
+            </SummaryCard>
+
+            <SummaryCard label={__('Spent')} loading={loading}>
+                <AmountDisplay
+                    amountInCents={summary.expense}
+                    currencyCode={currency}
+                    weight="semibold"
+                    size="xl"
+                    className="text-rose-600 dark:text-rose-400"
+                />
+            </SummaryCard>
+
+            <SummaryCard label={__('Net')} loading={loading}>
+                <AmountDisplay
+                    amountInCents={summary.net}
+                    currencyCode={currency}
+                    weight="semibold"
+                    size="xl"
+                    showSign
+                    className={cn(
+                        summary.net >= 0
+                            ? 'text-emerald-600 dark:text-emerald-400'
+                            : 'text-rose-600 dark:text-rose-400',
+                    )}
+                />
+            </SummaryCard>
+
+            <SummaryCard label={__('Transactions')} loading={loading}>
+                <span className="text-xl font-semibold tabular-nums">
+                    {summary.count.toLocaleString()}
+                </span>
+            </SummaryCard>
+        </div>
+    );
+}
+
+function SummaryCard({
+    label,
+    loading,
+    children,
+}: {
+    label: string;
+    loading?: boolean;
+    children: React.ReactNode;
+}) {
+    return (
+        <Card>
+            <CardContent className="flex flex-col gap-1 p-4">
+                <span className="text-xs text-muted-foreground">{label}</span>
+                {loading ? (
+                    <div className="h-7 w-24 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+                ) : (
+                    children
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/resources/js/components/transactions/saved-filters.tsx
+++ b/resources/js/components/transactions/saved-filters.tsx
@@ -1,0 +1,227 @@
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Input } from '@/components/ui/input';
+import {
+    deserializeFilters,
+    hasActiveFilters,
+    type SerializedFilters,
+    serializeFilters,
+} from '@/lib/transaction-filter-serialization';
+import { type TransactionFilters } from '@/types/transaction';
+import { type UUID } from '@/types/uuid';
+import { __ } from '@/utils/i18n';
+import axios from 'axios';
+import { Bookmark, Plus, Trash2 } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+
+interface SavedFilter {
+    id: UUID;
+    name: string;
+    filters: SerializedFilters;
+}
+
+interface SavedFiltersProps {
+    filters: TransactionFilters;
+    onLoad: (filters: TransactionFilters) => void;
+}
+
+export function SavedFilters({ filters, onLoad }: SavedFiltersProps) {
+    const [savedFilters, setSavedFilters] = useState<SavedFilter[]>([]);
+    const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+    const [name, setName] = useState('');
+    const [isSaving, setIsSaving] = useState(false);
+
+    const canSave = hasActiveFilters(filters);
+
+    useEffect(() => {
+        let active = true;
+
+        axios
+            .get<{ data: SavedFilter[] }>('/api/saved-filters')
+            .then((response) => {
+                if (active) {
+                    setSavedFilters(response.data.data);
+                }
+            })
+            .catch((error) => {
+                console.error('Failed to load saved filters:', error);
+            });
+
+        return () => {
+            active = false;
+        };
+    }, []);
+
+    function handleLoad(savedFilter: SavedFilter) {
+        onLoad(deserializeFilters(savedFilter.filters));
+    }
+
+    async function handleDelete(savedFilter: SavedFilter) {
+        const previous = savedFilters;
+        setSavedFilters((current) =>
+            current.filter((item) => item.id !== savedFilter.id),
+        );
+
+        try {
+            await axios.delete(`/api/saved-filters/${savedFilter.id}`);
+        } catch (error) {
+            console.error('Failed to delete saved filter:', error);
+            setSavedFilters(previous);
+            toast.error(__('Failed to delete the saved filter'));
+        }
+    }
+
+    async function handleSave() {
+        const trimmedName = name.trim();
+        if (!trimmedName || isSaving) {
+            return;
+        }
+
+        setIsSaving(true);
+        try {
+            const response = await axios.post<{ data: SavedFilter }>(
+                '/api/saved-filters',
+                {
+                    name: trimmedName,
+                    filters: serializeFilters(filters),
+                },
+            );
+
+            setSavedFilters((current) =>
+                [...current, response.data.data].sort((a, b) =>
+                    a.name.localeCompare(b.name),
+                ),
+            );
+            setSaveDialogOpen(false);
+            setName('');
+            toast.success(__('Filter saved'));
+        } catch (error) {
+            if (axios.isAxiosError(error) && error.response?.status === 422) {
+                toast.error(__('A filter with that name already exists'));
+            } else {
+                console.error('Failed to save filter:', error);
+                toast.error(__('Failed to save the filter'));
+            }
+        } finally {
+            setIsSaving(false);
+        }
+    }
+
+    return (
+        <>
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                    <Button
+                        variant="outline"
+                        size="icon"
+                        aria-label={__('Saved filters')}
+                    >
+                        <Bookmark className="h-4 w-4" />
+                    </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" className="w-64">
+                    <DropdownMenuLabel>{__('Saved filters')}</DropdownMenuLabel>
+                    <DropdownMenuSeparator />
+
+                    {savedFilters.length === 0 ? (
+                        <div className="px-2 py-2 text-sm text-muted-foreground">
+                            {__('No saved filters yet')}
+                        </div>
+                    ) : (
+                        savedFilters.map((savedFilter) => (
+                            <DropdownMenuItem
+                                key={savedFilter.id}
+                                onSelect={() => handleLoad(savedFilter)}
+                                className="group justify-between gap-2"
+                            >
+                                <span className="truncate">
+                                    {savedFilter.name}
+                                </span>
+                                <button
+                                    type="button"
+                                    aria-label={__('Delete saved filter')}
+                                    className="shrink-0 rounded p-1 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 hover:text-destructive"
+                                    onClick={(event) => {
+                                        event.preventDefault();
+                                        event.stopPropagation();
+                                        handleDelete(savedFilter);
+                                    }}
+                                >
+                                    <Trash2 className="h-3.5 w-3.5" />
+                                </button>
+                            </DropdownMenuItem>
+                        ))
+                    )}
+
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                        disabled={!canSave}
+                        onSelect={(event) => {
+                            event.preventDefault();
+                            setSaveDialogOpen(true);
+                        }}
+                    >
+                        <Plus className="mr-1 h-4 w-4" />
+                        {__('Save current filters…')}
+                    </DropdownMenuItem>
+                </DropdownMenuContent>
+            </DropdownMenu>
+
+            <Dialog open={saveDialogOpen} onOpenChange={setSaveDialogOpen}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>{__('Save filter')}</DialogTitle>
+                        <DialogDescription>
+                            {__(
+                                'Give this set of filters a name so you can reuse it later.',
+                            )}
+                        </DialogDescription>
+                    </DialogHeader>
+                    <Input
+                        value={name}
+                        onChange={(event) => setName(event.target.value)}
+                        placeholder={__('e.g. Japan trip, Utilities')}
+                        autoFocus
+                        onKeyDown={(event) => {
+                            if (event.key === 'Enter') {
+                                event.preventDefault();
+                                handleSave();
+                            }
+                        }}
+                    />
+                    <DialogFooter>
+                        <Button
+                            variant="outline"
+                            onClick={() => setSaveDialogOpen(false)}
+                            disabled={isSaving}
+                        >
+                            {__('Cancel')}
+                        </Button>
+                        <Button
+                            onClick={handleSave}
+                            disabled={isSaving || !name.trim()}
+                        >
+                            {isSaving ? __('Saving…') : __('Save')}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </>
+    );
+}

--- a/resources/js/components/transactions/saved-filters.tsx
+++ b/resources/js/components/transactions/saved-filters.tsx
@@ -18,16 +18,25 @@ import {
 import { Input } from '@/components/ui/input';
 import {
     deserializeFilters,
+    filtersFingerprint,
     hasActiveFilters,
     type SerializedFilters,
     serializeFilters,
 } from '@/lib/transaction-filter-serialization';
+import { cn } from '@/lib/utils';
 import { type TransactionFilters } from '@/types/transaction';
 import { type UUID } from '@/types/uuid';
 import { __ } from '@/utils/i18n';
 import axios from 'axios';
-import { Bookmark, Plus, Trash2 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import {
+    Bookmark,
+    BookmarkCheck,
+    Check,
+    Plus,
+    Save,
+    Trash2,
+} from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
 interface SavedFilter {
@@ -43,11 +52,43 @@ interface SavedFiltersProps {
 
 export function SavedFilters({ filters, onLoad }: SavedFiltersProps) {
     const [savedFilters, setSavedFilters] = useState<SavedFilter[]>([]);
+    const [activeId, setActiveId] = useState<UUID | null>(null);
     const [saveDialogOpen, setSaveDialogOpen] = useState(false);
     const [name, setName] = useState('');
     const [isSaving, setIsSaving] = useState(false);
 
     const canSave = hasActiveFilters(filters);
+
+    const currentFingerprint = useMemo(
+        () => filtersFingerprint(serializeFilters(filters)),
+        [filters],
+    );
+
+    // The saved filter that exactly matches the current filters, if any.
+    const matchingSaved = useMemo(
+        () =>
+            savedFilters.find(
+                (savedFilter) =>
+                    filtersFingerprint(savedFilter.filters) ===
+                    currentFingerprint,
+            ) ?? null,
+        [savedFilters, currentFingerprint],
+    );
+
+    // Keep track of the saved filter we're working from: it follows an exact
+    // match, and otherwise sticks around (so edits can be saved over it) until
+    // the filters are cleared.
+    useEffect(() => {
+        if (matchingSaved) {
+            setActiveId(matchingSaved.id);
+        } else if (!canSave) {
+            setActiveId(null);
+        }
+    }, [matchingSaved, canSave]);
+
+    const activeFilter =
+        savedFilters.find((savedFilter) => savedFilter.id === activeId) ?? null;
+    const isDirty = activeFilter !== null && matchingSaved === null;
 
     useEffect(() => {
         let active = true;
@@ -69,6 +110,7 @@ export function SavedFilters({ filters, onLoad }: SavedFiltersProps) {
     }, []);
 
     function handleLoad(savedFilter: SavedFilter) {
+        setActiveId(savedFilter.id);
         onLoad(deserializeFilters(savedFilter.filters));
     }
 
@@ -77,6 +119,9 @@ export function SavedFilters({ filters, onLoad }: SavedFiltersProps) {
         setSavedFilters((current) =>
             current.filter((item) => item.id !== savedFilter.id),
         );
+        if (activeId === savedFilter.id) {
+            setActiveId(null);
+        }
 
         try {
             await axios.delete(`/api/saved-filters/${savedFilter.id}`);
@@ -84,6 +129,26 @@ export function SavedFilters({ filters, onLoad }: SavedFiltersProps) {
             console.error('Failed to delete saved filter:', error);
             setSavedFilters(previous);
             toast.error(__('Failed to delete the saved filter'));
+        }
+    }
+
+    async function handleUpdate(savedFilter: SavedFilter) {
+        try {
+            const response = await axios.patch<{ data: SavedFilter }>(
+                `/api/saved-filters/${savedFilter.id}`,
+                { filters: serializeFilters(filters) },
+            );
+
+            setSavedFilters((current) =>
+                current.map((item) =>
+                    item.id === savedFilter.id ? response.data.data : item,
+                ),
+            );
+            setActiveId(savedFilter.id);
+            toast.success(__('Filter updated'));
+        } catch (error) {
+            console.error('Failed to update saved filter:', error);
+            toast.error(__('Failed to update the saved filter'));
         }
     }
 
@@ -108,6 +173,7 @@ export function SavedFilters({ filters, onLoad }: SavedFiltersProps) {
                     a.name.localeCompare(b.name),
                 ),
             );
+            setActiveId(response.data.data.id);
             setSaveDialogOpen(false);
             setName('');
             toast.success(__('Filter saved'));
@@ -127,13 +193,34 @@ export function SavedFilters({ filters, onLoad }: SavedFiltersProps) {
         <>
             <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                    <Button
-                        variant="outline"
-                        size="icon"
-                        aria-label={__('Saved filters')}
-                    >
-                        <Bookmark className="h-4 w-4" />
-                    </Button>
+                    {activeFilter ? (
+                        <Button
+                            variant="secondary"
+                            className="max-w-[200px]"
+                            aria-label={__('Saved filters')}
+                        >
+                            <BookmarkCheck className="mr-1 h-4 w-4 shrink-0" />
+                            <span className="truncate">
+                                {activeFilter.name}
+                            </span>
+                            {isDirty && (
+                                <span
+                                    className="ml-1 text-muted-foreground"
+                                    title={__('Unsaved changes')}
+                                >
+                                    •
+                                </span>
+                            )}
+                        </Button>
+                    ) : (
+                        <Button
+                            variant="outline"
+                            size="icon"
+                            aria-label={__('Saved filters')}
+                        >
+                            <Bookmark className="h-4 w-4" />
+                        </Button>
+                    )}
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="start" className="w-64">
                     <DropdownMenuLabel>{__('Saved filters')}</DropdownMenuLabel>
@@ -150,8 +237,18 @@ export function SavedFilters({ filters, onLoad }: SavedFiltersProps) {
                                 onSelect={() => handleLoad(savedFilter)}
                                 className="group justify-between gap-2"
                             >
-                                <span className="truncate">
-                                    {savedFilter.name}
+                                <span className="flex min-w-0 items-center gap-2">
+                                    <Check
+                                        className={cn(
+                                            'h-3.5 w-3.5 shrink-0',
+                                            matchingSaved?.id === savedFilter.id
+                                                ? 'opacity-100'
+                                                : 'opacity-0',
+                                        )}
+                                    />
+                                    <span className="truncate">
+                                        {savedFilter.name}
+                                    </span>
                                 </span>
                                 <button
                                     type="button"
@@ -170,6 +267,19 @@ export function SavedFilters({ filters, onLoad }: SavedFiltersProps) {
                     )}
 
                     <DropdownMenuSeparator />
+
+                    {isDirty && activeFilter && (
+                        <DropdownMenuItem
+                            onSelect={(event) => {
+                                event.preventDefault();
+                                handleUpdate(activeFilter);
+                            }}
+                        >
+                            <Save className="mr-1 h-4 w-4" />
+                            {__('Update “:name”', { name: activeFilter.name })}
+                        </DropdownMenuItem>
+                    )}
+
                     <DropdownMenuItem
                         disabled={!canSave}
                         onSelect={(event) => {
@@ -178,7 +288,7 @@ export function SavedFilters({ filters, onLoad }: SavedFiltersProps) {
                         }}
                     >
                         <Plus className="mr-1 h-4 w-4" />
-                        {__('Save current filters…')}
+                        {__('Save as new filter…')}
                     </DropdownMenuItem>
                 </DropdownMenuContent>
             </DropdownMenu>

--- a/resources/js/components/transactions/transaction-filters.tsx
+++ b/resources/js/components/transactions/transaction-filters.tsx
@@ -420,12 +420,24 @@ function CategoryMultiSelect({
     triggerClassName,
 }: CategoryMultiSelectProps) {
     const [open, setOpen] = useState(false);
+    // Snapshot the selected-first order when the dropdown opens so items don't
+    // reshuffle as the user toggles; it recomputes on the next open.
+    const [orderedCategories, setOrderedCategories] = useState<Category[]>(() =>
+        sortSelectedFirst(categories, selectedIds),
+    );
     const isUncategorizedSelected = selectedIds.includes(
         UNCATEGORIZED_CATEGORY_ID,
     );
 
+    function handleOpenChange(next: boolean) {
+        if (next) {
+            setOrderedCategories(sortSelectedFirst(categories, selectedIds));
+        }
+        setOpen(next);
+    }
+
     return (
-        <Popover open={open} onOpenChange={setOpen}>
+        <Popover open={open} onOpenChange={handleOpenChange}>
             <PopoverTrigger asChild>
                 <Button
                     variant="outline"
@@ -469,7 +481,7 @@ function CategoryMultiSelect({
                                 {__('Uncategorized')}
                             </div>
                         </CommandItem>
-                        {categories.map((category) => {
+                        {orderedCategories.map((category) => {
                             const isSelected = selectedIds.includes(
                                 category.id,
                             );
@@ -526,9 +538,21 @@ function LabelMultiSelect({
     triggerClassName,
 }: LabelMultiSelectProps) {
     const [open, setOpen] = useState(false);
+    // Snapshot the selected-first order when the dropdown opens so items don't
+    // reshuffle as the user toggles; it recomputes on the next open.
+    const [orderedLabels, setOrderedLabels] = useState<Label[]>(() =>
+        sortSelectedFirst(labels, selectedIds),
+    );
+
+    function handleOpenChange(next: boolean) {
+        if (next) {
+            setOrderedLabels(sortSelectedFirst(labels, selectedIds));
+        }
+        setOpen(next);
+    }
 
     return (
-        <Popover open={open} onOpenChange={setOpen}>
+        <Popover open={open} onOpenChange={handleOpenChange}>
             <PopoverTrigger asChild>
                 <Button
                     variant="outline"
@@ -552,7 +576,7 @@ function LabelMultiSelect({
                     <CommandInput placeholder={__('Search labels...')} />
                     <CommandList>
                         <CommandEmpty>{__('No labels found.')}</CommandEmpty>
-                        {labels.map((label) => {
+                        {orderedLabels.map((label) => {
                             const isSelected = selectedIds.includes(label.id);
                             const colorClasses = getLabelColorClasses(
                                 label.color,
@@ -599,3 +623,14 @@ function LabelMultiSelect({
 }
 
 const UNCATEGORIZED_CATEGORY_ID = 'uncategorized';
+
+/** Returns selected items first, preserving the original order within each group. */
+function sortSelectedFirst<T extends { id: string }>(
+    items: T[],
+    selectedIds: string[],
+): T[] {
+    return [
+        ...items.filter((item) => selectedIds.includes(item.id)),
+        ...items.filter((item) => !selectedIds.includes(item.id)),
+    ];
+}

--- a/resources/js/components/transactions/transaction-filters.tsx
+++ b/resources/js/components/transactions/transaction-filters.tsx
@@ -5,6 +5,7 @@ import { Check, ChevronsUpDown, Tag, X } from 'lucide-react';
 import { type ReactNode, useEffect, useState } from 'react';
 
 import { AccountName } from '@/components/accounts/account-name';
+import { SavedFilters } from '@/components/transactions/saved-filters';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -165,239 +166,268 @@ export function TransactionFilters({
                                 categories={categories}
                                 selectedIds={filters.categoryIds}
                                 onToggle={handleCategoryToggle}
-                                triggerClassName="w-[180px]"
+                                triggerClassName="w-[230px]"
                             />
                             <LabelMultiSelect
                                 labels={labels}
                                 selectedIds={filters.labelIds}
                                 onToggle={handleLabelToggle}
-                                triggerClassName="w-[160px]"
+                                triggerClassName="w-[210px]"
                             />
                         </>
                     )}
 
-                    <Popover open={isOpen} onOpenChange={setIsOpen}>
-                        <PopoverTrigger asChild>
-                            <Button variant="outline">
-                                {__('Filters')}
+                    <div className="flex items-center gap-2 lg:ml-auto">
+                        <Popover open={isOpen} onOpenChange={setIsOpen}>
+                            <PopoverTrigger asChild>
+                                <Button variant="outline">
+                                    {__('Filters')}
 
-                                {activeFilterCount > 0 && (
-                                    <Badge
-                                        variant="secondary"
-                                        className="ml-2 rounded-full px-1.5 py-0.5"
-                                    >
-                                        {activeFilterCount}
-                                    </Badge>
-                                )}
-                            </Button>
-                        </PopoverTrigger>
-                        <PopoverContent
-                            className="max-h-[600px] w-96 overflow-y-auto"
-                            align="start"
-                        >
-                            <div className="space-y-4">
-                                <div className="flex items-center justify-between">
-                                    <h4 className="font-medium">
-                                        {__('Filters')}
-                                    </h4>
-                                </div>
-
-                                <div className="space-y-2">
-                                    <FormLabel>{__('Date')}</FormLabel>
-                                    <div className="grid grid-cols-2 gap-2 pt-2">
-                                        <Input
-                                            type="date"
-                                            value={
-                                                filters.dateFrom
-                                                    ? format(
-                                                          filters.dateFrom,
-                                                          'yyyy-MM-dd',
-                                                      )
-                                                    : ''
-                                            }
-                                            onChange={(e) =>
-                                                onFiltersChange({
-                                                    ...filters,
-                                                    dateFrom: e.target.value
-                                                        ? new Date(
-                                                              e.target.value,
-                                                          )
-                                                        : null,
-                                                })
-                                            }
-                                            placeholder={__('From')}
-                                        />
-
-                                        <Input
-                                            type="date"
-                                            value={
-                                                filters.dateTo
-                                                    ? format(
-                                                          filters.dateTo,
-                                                          'yyyy-MM-dd',
-                                                      )
-                                                    : ''
-                                            }
-                                            onChange={(e) =>
-                                                onFiltersChange({
-                                                    ...filters,
-                                                    dateTo: e.target.value
-                                                        ? new Date(
-                                                              e.target.value,
-                                                          )
-                                                        : null,
-                                                })
-                                            }
-                                            placeholder={__('To')}
-                                        />
+                                    {activeFilterCount > 0 && (
+                                        <Badge
+                                            variant="secondary"
+                                            className="ml-2 rounded-full px-1.5 py-0.5"
+                                        >
+                                            {activeFilterCount}
+                                        </Badge>
+                                    )}
+                                </Button>
+                            </PopoverTrigger>
+                            <PopoverContent
+                                className="max-h-[600px] w-96 overflow-y-auto"
+                                align="start"
+                            >
+                                <div className="space-y-4">
+                                    <div className="flex items-center justify-between">
+                                        <h4 className="font-medium">
+                                            {__('Filters')}
+                                        </h4>
                                     </div>
-                                </div>
 
-                                <div className="space-y-2">
-                                    <FormLabel>{__('Amount')}</FormLabel>
-                                    <div className="grid grid-cols-2 gap-2 pt-2">
-                                        <Input
-                                            type="number"
-                                            step="0.01"
-                                            value={filters.amountMin ?? ''}
-                                            onChange={(e) =>
-                                                onFiltersChange({
-                                                    ...filters,
-                                                    amountMin: e.target.value
-                                                        ? parseFloat(
-                                                              e.target.value,
+                                    <div className="space-y-2">
+                                        <FormLabel>{__('Date')}</FormLabel>
+                                        <div className="grid grid-cols-2 gap-2 pt-2">
+                                            <Input
+                                                type="date"
+                                                value={
+                                                    filters.dateFrom
+                                                        ? format(
+                                                              filters.dateFrom,
+                                                              'yyyy-MM-dd',
                                                           )
-                                                        : null,
-                                                })
-                                            }
-                                            placeholder={__('Min')}
-                                        />
+                                                        : ''
+                                                }
+                                                onChange={(e) =>
+                                                    onFiltersChange({
+                                                        ...filters,
+                                                        dateFrom: e.target.value
+                                                            ? new Date(
+                                                                  e.target
+                                                                      .value,
+                                                              )
+                                                            : null,
+                                                    })
+                                                }
+                                                placeholder={__('From')}
+                                            />
 
-                                        <Input
-                                            type="number"
-                                            step="0.01"
-                                            value={filters.amountMax ?? ''}
-                                            onChange={(e) =>
-                                                onFiltersChange({
-                                                    ...filters,
-                                                    amountMax: e.target.value
-                                                        ? parseFloat(
-                                                              e.target.value,
+                                            <Input
+                                                type="date"
+                                                value={
+                                                    filters.dateTo
+                                                        ? format(
+                                                              filters.dateTo,
+                                                              'yyyy-MM-dd',
                                                           )
-                                                        : null,
-                                                })
-                                            }
-                                            placeholder={__('Max')}
-                                        />
+                                                        : ''
+                                                }
+                                                onChange={(e) =>
+                                                    onFiltersChange({
+                                                        ...filters,
+                                                        dateTo: e.target.value
+                                                            ? new Date(
+                                                                  e.target
+                                                                      .value,
+                                                              )
+                                                            : null,
+                                                    })
+                                                }
+                                                placeholder={__('To')}
+                                            />
+                                        </div>
                                     </div>
-                                </div>
 
-                                <div className="space-y-2">
-                                    <FormLabel>
-                                        {__('Counterparties')}
-                                    </FormLabel>
-                                    <div className="grid grid-cols-2 gap-2 pt-2">
-                                        <Input
-                                            value={creditorName}
-                                            onChange={(e) =>
-                                                setCreditorName(e.target.value)
-                                            }
-                                            placeholder={__('Creditor name')}
-                                        />
-                                        <Input
-                                            value={debtorName}
-                                            onChange={(e) =>
-                                                setDebtorName(e.target.value)
-                                            }
-                                            placeholder={__('Debtor name')}
-                                        />
+                                    <div className="space-y-2">
+                                        <FormLabel>{__('Amount')}</FormLabel>
+                                        <div className="grid grid-cols-2 gap-2 pt-2">
+                                            <Input
+                                                type="number"
+                                                step="0.01"
+                                                value={filters.amountMin ?? ''}
+                                                onChange={(e) =>
+                                                    onFiltersChange({
+                                                        ...filters,
+                                                        amountMin: e.target
+                                                            .value
+                                                            ? parseFloat(
+                                                                  e.target
+                                                                      .value,
+                                                              )
+                                                            : null,
+                                                    })
+                                                }
+                                                placeholder={__('Min')}
+                                            />
+
+                                            <Input
+                                                type="number"
+                                                step="0.01"
+                                                value={filters.amountMax ?? ''}
+                                                onChange={(e) =>
+                                                    onFiltersChange({
+                                                        ...filters,
+                                                        amountMax: e.target
+                                                            .value
+                                                            ? parseFloat(
+                                                                  e.target
+                                                                      .value,
+                                                              )
+                                                            : null,
+                                                    })
+                                                }
+                                                placeholder={__('Max')}
+                                            />
+                                        </div>
                                     </div>
-                                </div>
 
-                                {!inlineCategoryLabel && (
                                     <div className="space-y-2">
                                         <FormLabel>
-                                            {__('Categories')}
+                                            {__('Counterparties')}
                                         </FormLabel>
-                                        <div className="pt-2">
-                                            <CategoryMultiSelect
-                                                categories={categories}
-                                                selectedIds={
-                                                    filters.categoryIds
+                                        <div className="grid grid-cols-2 gap-2 pt-2">
+                                            <Input
+                                                value={creditorName}
+                                                onChange={(e) =>
+                                                    setCreditorName(
+                                                        e.target.value,
+                                                    )
                                                 }
-                                                onToggle={handleCategoryToggle}
-                                                triggerClassName="w-full"
+                                                placeholder={__(
+                                                    'Creditor name',
+                                                )}
+                                            />
+                                            <Input
+                                                value={debtorName}
+                                                onChange={(e) =>
+                                                    setDebtorName(
+                                                        e.target.value,
+                                                    )
+                                                }
+                                                placeholder={__('Debtor name')}
                                             />
                                         </div>
                                     </div>
-                                )}
 
-                                {!inlineCategoryLabel && (
-                                    <div className="space-y-2">
-                                        <FormLabel>{__('Labels')}</FormLabel>
-                                        <div className="pt-2">
-                                            <LabelMultiSelect
-                                                labels={labels}
-                                                selectedIds={filters.labelIds}
-                                                onToggle={handleLabelToggle}
-                                                triggerClassName="w-full"
-                                            />
+                                    {!inlineCategoryLabel && (
+                                        <div className="space-y-2">
+                                            <FormLabel>
+                                                {__('Categories')}
+                                            </FormLabel>
+                                            <div className="pt-2">
+                                                <CategoryMultiSelect
+                                                    categories={categories}
+                                                    selectedIds={
+                                                        filters.categoryIds
+                                                    }
+                                                    onToggle={
+                                                        handleCategoryToggle
+                                                    }
+                                                    triggerClassName="w-full"
+                                                />
+                                            </div>
                                         </div>
-                                    </div>
-                                )}
+                                    )}
 
-                                {!hideAccountFilter && (
-                                    <div className="space-y-2">
-                                        <FormLabel>{__('Accounts')}</FormLabel>
-                                        <div className="flex flex-wrap gap-2 pt-2">
-                                            {accounts.map((account) => {
-                                                const isSelected =
-                                                    filters.accountIds.includes(
-                                                        account.id,
+                                    {!inlineCategoryLabel && (
+                                        <div className="space-y-2">
+                                            <FormLabel>
+                                                {__('Labels')}
+                                            </FormLabel>
+                                            <div className="pt-2">
+                                                <LabelMultiSelect
+                                                    labels={labels}
+                                                    selectedIds={
+                                                        filters.labelIds
+                                                    }
+                                                    onToggle={handleLabelToggle}
+                                                    triggerClassName="w-full"
+                                                />
+                                            </div>
+                                        </div>
+                                    )}
+
+                                    {!hideAccountFilter && (
+                                        <div className="space-y-2">
+                                            <FormLabel>
+                                                {__('Accounts')}
+                                            </FormLabel>
+                                            <div className="flex flex-wrap gap-2 pt-2">
+                                                {accounts.map((account) => {
+                                                    const isSelected =
+                                                        filters.accountIds.includes(
+                                                            account.id,
+                                                        );
+                                                    return (
+                                                        <Badge
+                                                            key={account.id}
+                                                            variant={
+                                                                isSelected
+                                                                    ? 'default'
+                                                                    : 'outline'
+                                                            }
+                                                            className="cursor-pointer px-2 py-1"
+                                                            onClick={() =>
+                                                                handleAccountToggle(
+                                                                    account.id,
+                                                                )
+                                                            }
+                                                        >
+                                                            <AccountName
+                                                                account={
+                                                                    account
+                                                                }
+                                                                length={{
+                                                                    min: 6,
+                                                                    max: 28,
+                                                                }}
+                                                            />
+                                                        </Badge>
                                                     );
-                                                return (
-                                                    <Badge
-                                                        key={account.id}
-                                                        variant={
-                                                            isSelected
-                                                                ? 'default'
-                                                                : 'outline'
-                                                        }
-                                                        className="cursor-pointer px-2 py-1"
-                                                        onClick={() =>
-                                                            handleAccountToggle(
-                                                                account.id,
-                                                            )
-                                                        }
-                                                    >
-                                                        <AccountName
-                                                            account={account}
-                                                            length={{
-                                                                min: 6,
-                                                                max: 28,
-                                                            }}
-                                                        />
-                                                    </Badge>
-                                                );
-                                            })}
+                                                })}
+                                            </div>
                                         </div>
-                                    </div>
-                                )}
-                            </div>
-                        </PopoverContent>
-                    </Popover>
+                                    )}
+                                </div>
+                            </PopoverContent>
+                        </Popover>
 
-                    {activeFilterCount > 0 && (
-                        <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={clearFilters}
-                            className="h-9"
-                        >
-                            <X className="mr-1 h-4 w-4" />
-                            {__('Clear')}
-                        </Button>
-                    )}
+                        <SavedFilters
+                            filters={filters}
+                            onLoad={onFiltersChange}
+                        />
+
+                        {activeFilterCount > 0 && (
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={clearFilters}
+                                className="h-9"
+                            >
+                                <X className="mr-1 h-4 w-4" />
+                                {__('Clear')}
+                            </Button>
+                        )}
+                    </div>
                 </div>
 
                 {actions ? <div className="w-full">{actions}</div> : null}
@@ -446,7 +476,11 @@ function CategoryMultiSelect({
                 >
                     {selectedIds.length > 0 ? (
                         <span className="truncate">
-                            {selectedIds.length} {__('selected')}
+                            {selectedIds.length === 1
+                                ? __('1 category selected')
+                                : __(':count categories selected', {
+                                      count: selectedIds.length,
+                                  })}
                         </span>
                     ) : (
                         <span className="text-muted-foreground">
@@ -561,7 +595,11 @@ function LabelMultiSelect({
                 >
                     {selectedIds.length > 0 ? (
                         <span className="truncate">
-                            {selectedIds.length} {__('selected')}
+                            {selectedIds.length === 1
+                                ? __('1 label selected')
+                                : __(':count labels selected', {
+                                      count: selectedIds.length,
+                                  })}
                         </span>
                     ) : (
                         <span className="text-muted-foreground">

--- a/resources/js/components/transactions/transaction-filters.tsx
+++ b/resources/js/components/transactions/transaction-filters.tsx
@@ -37,6 +37,8 @@ interface TransactionFiltersProps {
     isKeySet: boolean;
     actions?: ReactNode;
     hideAccountFilter?: boolean;
+    hideSearch?: boolean;
+    inlineCategoryLabel?: boolean;
 }
 
 export function TransactionFilters({
@@ -47,16 +49,13 @@ export function TransactionFilters({
     accounts,
     actions,
     hideAccountFilter = false,
+    hideSearch = false,
+    inlineCategoryLabel = false,
 }: TransactionFiltersProps) {
     const [isOpen, setIsOpen] = useState(false);
-    const [categoryDropdownOpen, setCategoryDropdownOpen] = useState(false);
-    const [labelDropdownOpen, setLabelDropdownOpen] = useState(false);
     const [searchText, setSearchText] = useState(filters.searchText);
     const [creditorName, setCreditorName] = useState(filters.creditorName);
     const [debtorName, setDebtorName] = useState(filters.debtorName);
-    const isUncategorizedSelected = filters.categoryIds.includes(
-        UNCATEGORIZED_CATEGORY_ID,
-    );
 
     // Debounce text filter updates
     useEffect(() => {
@@ -101,7 +100,7 @@ export function TransactionFilters({
         onFiltersChange({ ...filters, categoryIds: newCategoryIds });
     }
 
-    function handleAccountToggle(accountId: number) {
+    function handleAccountToggle(accountId: string) {
         const newAccountIds = filters.accountIds.includes(accountId)
             ? filters.accountIds.filter((id) => id !== accountId)
             : [...filters.accountIds, accountId];
@@ -140,22 +139,42 @@ export function TransactionFilters({
         (filters.dateTo ? 1 : 0) +
         (filters.amountMin !== null ? 1 : 0) +
         (filters.amountMax !== null ? 1 : 0) +
-        filters.categoryIds.length +
-        filters.labelIds.length +
         (filters.creditorName ? 1 : 0) +
         (filters.debtorName ? 1 : 0) +
+        (inlineCategoryLabel
+            ? 0
+            : filters.categoryIds.length + filters.labelIds.length) +
         (hideAccountFilter ? 0 : filters.accountIds.length);
 
     return (
         <div className="space-y-4">
             <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
-                <div className="flex w-full flex-row items-center gap-2">
-                    <Input
-                        placeholder={__('Search description or notes...')}
-                        value={searchText}
-                        onChange={(e) => setSearchText(e.target.value)}
-                        className="min-w-0 flex-1 md:min-w-[350px]"
-                    />
+                <div className="flex w-full flex-wrap items-center gap-2">
+                    {!hideSearch && (
+                        <Input
+                            placeholder={__('Search description or notes...')}
+                            value={searchText}
+                            onChange={(e) => setSearchText(e.target.value)}
+                            className="min-w-0 flex-1 md:min-w-[350px]"
+                        />
+                    )}
+
+                    {inlineCategoryLabel && (
+                        <>
+                            <CategoryMultiSelect
+                                categories={categories}
+                                selectedIds={filters.categoryIds}
+                                onToggle={handleCategoryToggle}
+                                triggerClassName="w-[180px]"
+                            />
+                            <LabelMultiSelect
+                                labels={labels}
+                                selectedIds={filters.labelIds}
+                                onToggle={handleLabelToggle}
+                                triggerClassName="w-[160px]"
+                            />
+                        </>
+                    )}
 
                     <Popover open={isOpen} onOpenChange={setIsOpen}>
                         <PopoverTrigger asChild>
@@ -295,254 +314,37 @@ export function TransactionFilters({
                                     </div>
                                 </div>
 
-                                <div className="space-y-2">
-                                    <FormLabel>{__('Categories')}</FormLabel>
-                                    <div className="pt-2">
-                                        <Popover
-                                            open={categoryDropdownOpen}
-                                            onOpenChange={
-                                                setCategoryDropdownOpen
-                                            }
-                                        >
-                                            <PopoverTrigger asChild>
-                                                <Button
-                                                    variant="outline"
-                                                    role="combobox"
-                                                    className="w-full justify-between"
-                                                >
-                                                    {filters.categoryIds
-                                                        .length > 0 ? (
-                                                        <span className="truncate">
-                                                            {
-                                                                filters
-                                                                    .categoryIds
-                                                                    .length
-                                                            }{' '}
-                                                            selected
-                                                        </span>
-                                                    ) : (
-                                                        <span className="text-muted-foreground">
-                                                            {__(
-                                                                'Select categories...',
-                                                            )}
-                                                        </span>
-                                                    )}
-                                                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                                                </Button>
-                                            </PopoverTrigger>
-                                            <PopoverContent
-                                                className="w-full p-0"
-                                                align="start"
-                                            >
-                                                <Command>
-                                                    <CommandInput
-                                                        placeholder={__(
-                                                            'Search categories...',
-                                                        )}
-                                                    />
-                                                    <CommandList>
-                                                        <CommandEmpty>
-                                                            {__(
-                                                                'No category found.',
-                                                            )}
-                                                        </CommandEmpty>
-                                                        <CommandItem
-                                                            onSelect={() =>
-                                                                handleCategoryToggle(
-                                                                    UNCATEGORIZED_CATEGORY_ID,
-                                                                )
-                                                            }
-                                                        >
-                                                            <div
-                                                                className={cn(
-                                                                    'mr-1 flex size-4 items-center justify-center rounded-sm border border-primary p-1',
-                                                                    isUncategorizedSelected
-                                                                        ? 'bg-primary/10 text-primary-foreground'
-                                                                        : 'opacity-50 [&_svg]:invisible',
-                                                                )}
-                                                            >
-                                                                <Check className="size-3" />
-                                                            </div>
-                                                            <div className="flex items-center gap-2">
-                                                                <div className="flex h-5 w-5 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800">
-                                                                    <Icons.HelpCircle className="h-3 w-3 text-zinc-500" />
-                                                                </div>
-                                                                {__(
-                                                                    'Uncategorized',
-                                                                )}
-                                                            </div>
-                                                        </CommandItem>
-                                                        {categories.map(
-                                                            (category) => {
-                                                                const isSelected =
-                                                                    filters.categoryIds.includes(
-                                                                        category.id,
-                                                                    );
-                                                                const colorClasses =
-                                                                    getCategoryColorClasses(
-                                                                        category.color,
-                                                                    );
-                                                                return (
-                                                                    <CommandItem
-                                                                        key={
-                                                                            category.id
-                                                                        }
-                                                                        onSelect={() =>
-                                                                            handleCategoryToggle(
-                                                                                category.id,
-                                                                            )
-                                                                        }
-                                                                    >
-                                                                        <div
-                                                                            className={cn(
-                                                                                'mr-1 flex size-4 items-center justify-center rounded-sm border border-primary p-1',
-                                                                                isSelected
-                                                                                    ? 'bg-primary/10 text-primary-foreground'
-                                                                                    : 'opacity-50 [&_svg]:invisible',
-                                                                            )}
-                                                                        >
-                                                                            <Check className="size-3" />
-                                                                        </div>
-                                                                        <div className="flex items-center gap-2">
-                                                                            <div
-                                                                                className={cn(
-                                                                                    'flex h-5 w-5 items-center justify-center rounded-full',
-                                                                                    colorClasses.bg,
-                                                                                )}
-                                                                            >
-                                                                                <CategoryIcon
-                                                                                    category={
-                                                                                        category
-                                                                                    }
-                                                                                    size={
-                                                                                        4
-                                                                                    }
-                                                                                />
-                                                                            </div>
-                                                                            <span>
-                                                                                {
-                                                                                    category.name
-                                                                                }
-                                                                            </span>
-                                                                        </div>
-                                                                    </CommandItem>
-                                                                );
-                                                            },
-                                                        )}
-                                                    </CommandList>
-                                                </Command>
-                                            </PopoverContent>
-                                        </Popover>
+                                {!inlineCategoryLabel && (
+                                    <div className="space-y-2">
+                                        <FormLabel>
+                                            {__('Categories')}
+                                        </FormLabel>
+                                        <div className="pt-2">
+                                            <CategoryMultiSelect
+                                                categories={categories}
+                                                selectedIds={
+                                                    filters.categoryIds
+                                                }
+                                                onToggle={handleCategoryToggle}
+                                                triggerClassName="w-full"
+                                            />
+                                        </div>
                                     </div>
-                                </div>
+                                )}
 
-                                <div className="space-y-2">
-                                    <FormLabel>{__('Labels')}</FormLabel>
-                                    <div className="pt-2">
-                                        <Popover
-                                            open={labelDropdownOpen}
-                                            onOpenChange={setLabelDropdownOpen}
-                                        >
-                                            <PopoverTrigger asChild>
-                                                <Button
-                                                    variant="outline"
-                                                    role="combobox"
-                                                    className="w-full justify-between"
-                                                >
-                                                    {filters.labelIds.length >
-                                                    0 ? (
-                                                        <span className="truncate">
-                                                            {
-                                                                filters.labelIds
-                                                                    .length
-                                                            }{' '}
-                                                            selected
-                                                        </span>
-                                                    ) : (
-                                                        <span className="text-muted-foreground">
-                                                            {__(
-                                                                'Select labels...',
-                                                            )}
-                                                        </span>
-                                                    )}
-                                                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                                                </Button>
-                                            </PopoverTrigger>
-                                            <PopoverContent
-                                                className="w-full p-0"
-                                                align="start"
-                                            >
-                                                <Command>
-                                                    <CommandInput
-                                                        placeholder={__(
-                                                            'Search labels...',
-                                                        )}
-                                                    />
-                                                    <CommandList>
-                                                        <CommandEmpty>
-                                                            {__(
-                                                                'No labels found.',
-                                                            )}
-                                                        </CommandEmpty>
-                                                        {labels.map((label) => {
-                                                            const isSelected =
-                                                                filters.labelIds.includes(
-                                                                    label.id,
-                                                                );
-                                                            const colorClasses =
-                                                                getLabelColorClasses(
-                                                                    label.color,
-                                                                );
-                                                            return (
-                                                                <CommandItem
-                                                                    key={
-                                                                        label.id
-                                                                    }
-                                                                    onSelect={() =>
-                                                                        handleLabelToggle(
-                                                                            label.id,
-                                                                        )
-                                                                    }
-                                                                >
-                                                                    <div
-                                                                        className={cn(
-                                                                            'mr-1 flex size-4 items-center justify-center rounded-sm border border-primary p-1',
-                                                                            isSelected
-                                                                                ? 'bg-primary/10 text-primary-foreground'
-                                                                                : 'opacity-50 [&_svg]:invisible',
-                                                                        )}
-                                                                    >
-                                                                        <Check className="size-3" />
-                                                                    </div>
-                                                                    <div className="flex items-center gap-2">
-                                                                        <div
-                                                                            className={cn(
-                                                                                'flex h-5 w-5 items-center justify-center rounded-full',
-                                                                                colorClasses.bg,
-                                                                            )}
-                                                                        >
-                                                                            <Tag
-                                                                                className={cn(
-                                                                                    'h-3 w-3',
-                                                                                    colorClasses.text,
-                                                                                )}
-                                                                            />
-                                                                        </div>
-                                                                        <span>
-                                                                            {
-                                                                                label.name
-                                                                            }
-                                                                        </span>
-                                                                    </div>
-                                                                </CommandItem>
-                                                            );
-                                                        })}
-                                                    </CommandList>
-                                                </Command>
-                                            </PopoverContent>
-                                        </Popover>
+                                {!inlineCategoryLabel && (
+                                    <div className="space-y-2">
+                                        <FormLabel>{__('Labels')}</FormLabel>
+                                        <div className="pt-2">
+                                            <LabelMultiSelect
+                                                labels={labels}
+                                                selectedIds={filters.labelIds}
+                                                onToggle={handleLabelToggle}
+                                                triggerClassName="w-full"
+                                            />
+                                        </div>
                                     </div>
-                                </div>
+                                )}
 
                                 {!hideAccountFilter && (
                                     <div className="space-y-2">
@@ -601,6 +403,198 @@ export function TransactionFilters({
                 {actions ? <div className="w-full">{actions}</div> : null}
             </div>
         </div>
+    );
+}
+
+interface CategoryMultiSelectProps {
+    categories: Category[];
+    selectedIds: string[];
+    onToggle: (id: string) => void;
+    triggerClassName?: string;
+}
+
+function CategoryMultiSelect({
+    categories,
+    selectedIds,
+    onToggle,
+    triggerClassName,
+}: CategoryMultiSelectProps) {
+    const [open, setOpen] = useState(false);
+    const isUncategorizedSelected = selectedIds.includes(
+        UNCATEGORIZED_CATEGORY_ID,
+    );
+
+    return (
+        <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger asChild>
+                <Button
+                    variant="outline"
+                    role="combobox"
+                    className={cn('justify-between', triggerClassName)}
+                >
+                    {selectedIds.length > 0 ? (
+                        <span className="truncate">
+                            {selectedIds.length} {__('selected')}
+                        </span>
+                    ) : (
+                        <span className="text-muted-foreground">
+                            {__('Categories')}
+                        </span>
+                    )}
+                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-full p-0" align="start">
+                <Command>
+                    <CommandInput placeholder={__('Search categories...')} />
+                    <CommandList>
+                        <CommandEmpty>{__('No category found.')}</CommandEmpty>
+                        <CommandItem
+                            onSelect={() => onToggle(UNCATEGORIZED_CATEGORY_ID)}
+                        >
+                            <div
+                                className={cn(
+                                    'mr-1 flex size-4 items-center justify-center rounded-sm border border-primary p-1',
+                                    isUncategorizedSelected
+                                        ? 'bg-primary/10 text-primary-foreground'
+                                        : 'opacity-50 [&_svg]:invisible',
+                                )}
+                            >
+                                <Check className="size-3" />
+                            </div>
+                            <div className="flex items-center gap-2">
+                                <div className="flex h-5 w-5 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800">
+                                    <Icons.HelpCircle className="h-3 w-3 text-zinc-500" />
+                                </div>
+                                {__('Uncategorized')}
+                            </div>
+                        </CommandItem>
+                        {categories.map((category) => {
+                            const isSelected = selectedIds.includes(
+                                category.id,
+                            );
+                            const colorClasses = getCategoryColorClasses(
+                                category.color,
+                            );
+                            return (
+                                <CommandItem
+                                    key={category.id}
+                                    onSelect={() => onToggle(category.id)}
+                                >
+                                    <div
+                                        className={cn(
+                                            'mr-1 flex size-4 items-center justify-center rounded-sm border border-primary p-1',
+                                            isSelected
+                                                ? 'bg-primary/10 text-primary-foreground'
+                                                : 'opacity-50 [&_svg]:invisible',
+                                        )}
+                                    >
+                                        <Check className="size-3" />
+                                    </div>
+                                    <div className="flex items-center gap-2">
+                                        <div
+                                            className={cn(
+                                                'flex h-5 w-5 items-center justify-center rounded-full',
+                                                colorClasses.bg,
+                                            )}
+                                        >
+                                            <CategoryIcon category={category} />
+                                        </div>
+                                        <span>{category.name}</span>
+                                    </div>
+                                </CommandItem>
+                            );
+                        })}
+                    </CommandList>
+                </Command>
+            </PopoverContent>
+        </Popover>
+    );
+}
+
+interface LabelMultiSelectProps {
+    labels: Label[];
+    selectedIds: string[];
+    onToggle: (id: string) => void;
+    triggerClassName?: string;
+}
+
+function LabelMultiSelect({
+    labels,
+    selectedIds,
+    onToggle,
+    triggerClassName,
+}: LabelMultiSelectProps) {
+    const [open, setOpen] = useState(false);
+
+    return (
+        <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger asChild>
+                <Button
+                    variant="outline"
+                    role="combobox"
+                    className={cn('justify-between', triggerClassName)}
+                >
+                    {selectedIds.length > 0 ? (
+                        <span className="truncate">
+                            {selectedIds.length} {__('selected')}
+                        </span>
+                    ) : (
+                        <span className="text-muted-foreground">
+                            {__('Labels')}
+                        </span>
+                    )}
+                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-full p-0" align="start">
+                <Command>
+                    <CommandInput placeholder={__('Search labels...')} />
+                    <CommandList>
+                        <CommandEmpty>{__('No labels found.')}</CommandEmpty>
+                        {labels.map((label) => {
+                            const isSelected = selectedIds.includes(label.id);
+                            const colorClasses = getLabelColorClasses(
+                                label.color,
+                            );
+                            return (
+                                <CommandItem
+                                    key={label.id}
+                                    onSelect={() => onToggle(label.id)}
+                                >
+                                    <div
+                                        className={cn(
+                                            'mr-1 flex size-4 items-center justify-center rounded-sm border border-primary p-1',
+                                            isSelected
+                                                ? 'bg-primary/10 text-primary-foreground'
+                                                : 'opacity-50 [&_svg]:invisible',
+                                        )}
+                                    >
+                                        <Check className="size-3" />
+                                    </div>
+                                    <div className="flex items-center gap-2">
+                                        <div
+                                            className={cn(
+                                                'flex h-5 w-5 items-center justify-center rounded-full',
+                                                colorClasses.bg,
+                                            )}
+                                        >
+                                            <Tag
+                                                className={cn(
+                                                    'h-3 w-3',
+                                                    colorClasses.text,
+                                                )}
+                                            />
+                                        </div>
+                                        <span>{label.name}</span>
+                                    </div>
+                                </CommandItem>
+                            );
+                        })}
+                    </CommandList>
+                </Command>
+            </PopoverContent>
+        </Popover>
     );
 }
 

--- a/resources/js/hooks/use-analysis-data.ts
+++ b/resources/js/hooks/use-analysis-data.ts
@@ -1,0 +1,109 @@
+import { type TransactionFilters } from '@/types/transaction';
+import { format } from 'date-fns';
+import { useCallback, useEffect, useState } from 'react';
+
+export const ANALYSIS_DIMENSIONS = [
+    'category',
+    'month',
+    'account',
+    'label',
+] as const;
+
+export type AnalysisDimension = (typeof ANALYSIS_DIMENSIONS)[number];
+
+export interface AnalysisSummary {
+    income: number;
+    expense: number;
+    net: number;
+    count: number;
+}
+
+export interface AnalysisGroup {
+    key: string | null;
+    amount: number;
+    count: number;
+}
+
+export interface AnalysisData {
+    summary: AnalysisSummary;
+    groups: AnalysisGroup[];
+    isLoading: boolean;
+}
+
+const emptySummary: AnalysisSummary = {
+    income: 0,
+    expense: 0,
+    net: 0,
+    count: 0,
+};
+
+function buildQuery(
+    filters: TransactionFilters,
+    groupBy: AnalysisDimension,
+): string {
+    const params = new URLSearchParams({ group_by: groupBy });
+
+    if (filters.dateFrom) {
+        params.set('date_from', format(filters.dateFrom, 'yyyy-MM-dd'));
+    }
+    if (filters.dateTo) {
+        params.set('date_to', format(filters.dateTo, 'yyyy-MM-dd'));
+    }
+    if (filters.amountMin !== null) {
+        params.set('amount_min', filters.amountMin.toString());
+    }
+    if (filters.amountMax !== null) {
+        params.set('amount_max', filters.amountMax.toString());
+    }
+    if (filters.categoryIds.length > 0) {
+        params.set('category_ids', filters.categoryIds.join(','));
+    }
+    if (filters.accountIds.length > 0) {
+        params.set('account_ids', filters.accountIds.join(','));
+    }
+    if (filters.labelIds.length > 0) {
+        params.set('label_ids', filters.labelIds.join(','));
+    }
+    if (filters.creditorName) {
+        params.set('creditor_name', filters.creditorName);
+    }
+    if (filters.debtorName) {
+        params.set('debtor_name', filters.debtorName);
+    }
+    if (filters.searchText) {
+        params.set('search', filters.searchText);
+    }
+
+    return params.toString();
+}
+
+export function useAnalysisData(
+    filters: TransactionFilters,
+    groupBy: AnalysisDimension,
+): AnalysisData & { refetch: () => void } {
+    const [summary, setSummary] = useState<AnalysisSummary>(emptySummary);
+    const [groups, setGroups] = useState<AnalysisGroup[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+
+    const query = buildQuery(filters, groupBy);
+
+    const fetchData = useCallback(async () => {
+        setIsLoading(true);
+        try {
+            const response = await fetch(`/api/analysis?${query}`);
+            const data = await response.json();
+            setSummary(data.summary ?? emptySummary);
+            setGroups(data.groups ?? []);
+        } catch (error) {
+            console.error('Failed to fetch analysis data:', error);
+        } finally {
+            setIsLoading(false);
+        }
+    }, [query]);
+
+    useEffect(() => {
+        fetchData();
+    }, [fetchData]);
+
+    return { summary, groups, isLoading, refetch: fetchData };
+}

--- a/resources/js/lib/transaction-filter-serialization.ts
+++ b/resources/js/lib/transaction-filter-serialization.ts
@@ -76,3 +76,23 @@ export function deserializeFilters(
 export function hasActiveFilters(filters: TransactionFilters): boolean {
     return Object.keys(serializeFilters(filters)).length > 0;
 }
+
+/**
+ * Stable, order-insensitive fingerprint of a serialized filter set, so two
+ * filter sets that select the same things compare equal regardless of the
+ * order ids were added or which empty keys are present.
+ */
+export function filtersFingerprint(filters: SerializedFilters): string {
+    return JSON.stringify({
+        date_from: filters.date_from ?? null,
+        date_to: filters.date_to ?? null,
+        amount_min: filters.amount_min ?? null,
+        amount_max: filters.amount_max ?? null,
+        category_ids: [...(filters.category_ids ?? [])].sort(),
+        account_ids: [...(filters.account_ids ?? [])].sort(),
+        label_ids: [...(filters.label_ids ?? [])].sort(),
+        creditor_name: filters.creditor_name ?? '',
+        debtor_name: filters.debtor_name ?? '',
+        search: filters.search ?? '',
+    });
+}

--- a/resources/js/lib/transaction-filter-serialization.ts
+++ b/resources/js/lib/transaction-filter-serialization.ts
@@ -1,0 +1,78 @@
+import { type TransactionFilters } from '@/types/transaction';
+import { format } from 'date-fns';
+
+/** Persisted, snake_case representation of a filter set (matches the backend query params). */
+export interface SerializedFilters {
+    date_from?: string;
+    date_to?: string;
+    amount_min?: number;
+    amount_max?: number;
+    category_ids?: string[];
+    account_ids?: string[];
+    label_ids?: string[];
+    creditor_name?: string;
+    debtor_name?: string;
+    search?: string;
+}
+
+export function serializeFilters(
+    filters: TransactionFilters,
+): SerializedFilters {
+    const result: SerializedFilters = {};
+
+    if (filters.dateFrom) {
+        result.date_from = format(filters.dateFrom, 'yyyy-MM-dd');
+    }
+    if (filters.dateTo) {
+        result.date_to = format(filters.dateTo, 'yyyy-MM-dd');
+    }
+    if (filters.amountMin !== null) {
+        result.amount_min = filters.amountMin;
+    }
+    if (filters.amountMax !== null) {
+        result.amount_max = filters.amountMax;
+    }
+    if (filters.categoryIds.length > 0) {
+        result.category_ids = filters.categoryIds;
+    }
+    if (filters.accountIds.length > 0) {
+        result.account_ids = filters.accountIds;
+    }
+    if (filters.labelIds.length > 0) {
+        result.label_ids = filters.labelIds;
+    }
+    if (filters.creditorName) {
+        result.creditor_name = filters.creditorName;
+    }
+    if (filters.debtorName) {
+        result.debtor_name = filters.debtorName;
+    }
+    if (filters.searchText) {
+        result.search = filters.searchText;
+    }
+
+    return result;
+}
+
+export function deserializeFilters(
+    data: SerializedFilters,
+): TransactionFilters {
+    return {
+        dateFrom: data.date_from
+            ? new Date(data.date_from + 'T00:00:00')
+            : null,
+        dateTo: data.date_to ? new Date(data.date_to + 'T00:00:00') : null,
+        amountMin: data.amount_min ?? null,
+        amountMax: data.amount_max ?? null,
+        categoryIds: data.category_ids ?? [],
+        accountIds: data.account_ids ?? [],
+        labelIds: data.label_ids ?? [],
+        creditorName: data.creditor_name ?? '',
+        debtorName: data.debtor_name ?? '',
+        searchText: data.search ?? '',
+    };
+}
+
+export function hasActiveFilters(filters: TransactionFilters): boolean {
+    return Object.keys(serializeFilters(filters)).length > 0;
+}

--- a/resources/js/pages/analysis/index.tsx
+++ b/resources/js/pages/analysis/index.tsx
@@ -24,7 +24,7 @@ import { type Account } from '@/types/account';
 import { type Category } from '@/types/category';
 import { type Label } from '@/types/label';
 import { type TransactionFilters } from '@/types/transaction';
-import { formatMonthFromYearMonth } from '@/utils/date';
+import { formatMonthName } from '@/utils/date';
 import { __ } from '@/utils/i18n';
 import { Head, usePage } from '@inertiajs/react';
 import { endOfMonth, parseISO, startOfMonth } from 'date-fns';
@@ -106,7 +106,12 @@ export default function AnalysisPage({ categories, accounts, labels }: Props) {
                     ? (labelsById.get(key)?.name ?? __('Unknown label'))
                     : __('No label');
             case 'month':
-                return key ? formatMonthFromYearMonth(key, locale) : '';
+                // Aggregated across years, so the key is a month number (01-12).
+                // `groups` can briefly hold the previous dimension's keys while a
+                // refetch is in flight, so only format well-formed month numbers.
+                return key && /^(0[1-9]|1[0-2])$/.test(key)
+                    ? formatMonthName(key, locale)
+                    : '';
         }
     };
 
@@ -131,13 +136,13 @@ export default function AnalysisPage({ categories, accounts, labels }: Props) {
         [groups, dimension, categoriesById, accountsById, labelsById, locale],
     );
 
-    // Time dimensions read most naturally newest-first in the list.
+    // Months read most naturally in calendar order (Jan → Dec) in the list.
     const breakdownRows = useMemo(() => {
         if (!isTimeDimension(dimension)) {
             return rows;
         }
         return [...rows].sort((a, b) =>
-            (b.key ?? '').localeCompare(a.key ?? ''),
+            (a.key ?? '').localeCompare(b.key ?? ''),
         );
     }, [rows, dimension]);
 

--- a/resources/js/pages/analysis/index.tsx
+++ b/resources/js/pages/analysis/index.tsx
@@ -1,0 +1,276 @@
+import {
+    AnalysisBreakdown,
+    type ResolvedRow,
+} from '@/components/analysis/analysis-breakdown';
+import {
+    AnalysisChart,
+    type AnalysisChartPoint,
+} from '@/components/analysis/analysis-chart';
+import { AnalysisSummaryCards } from '@/components/analysis/analysis-summary-cards';
+import HeadingSmall from '@/components/heading-small';
+import { TransactionFilters as TransactionFiltersComponent } from '@/components/transactions/transaction-filters';
+import { Button } from '@/components/ui/button';
+import {
+    ANALYSIS_DIMENSIONS,
+    type AnalysisDimension,
+    useAnalysisData,
+} from '@/hooks/use-analysis-data';
+import { useLocale } from '@/hooks/use-locale';
+import AppSidebarLayout from '@/layouts/app/app-sidebar-layout';
+import { cn } from '@/lib/utils';
+import { analysis } from '@/routes';
+import { type BreadcrumbItem } from '@/types';
+import { type Account } from '@/types/account';
+import { type Category } from '@/types/category';
+import { type Label } from '@/types/label';
+import { type TransactionFilters } from '@/types/transaction';
+import { formatMonthFromYearMonth } from '@/utils/date';
+import { __ } from '@/utils/i18n';
+import { Head, usePage } from '@inertiajs/react';
+import { endOfMonth, parseISO, startOfMonth } from 'date-fns';
+import { useMemo, useState } from 'react';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: 'Analysis',
+        href: analysis().url,
+    },
+];
+
+const emptyFilters: TransactionFilters = {
+    dateFrom: null,
+    dateTo: null,
+    amountMin: null,
+    amountMax: null,
+    categoryIds: [],
+    accountIds: [],
+    labelIds: [],
+    creditorName: '',
+    debtorName: '',
+    searchText: '',
+};
+
+const dimensionLabels: Record<AnalysisDimension, string> = {
+    category: __('Category'),
+    month: __('Month'),
+    account: __('Account'),
+    label: __('Label'),
+};
+
+const isTimeDimension = (dimension: AnalysisDimension): boolean =>
+    dimension === 'month';
+
+interface Props {
+    categories: Category[];
+    accounts: Account[];
+    labels: Label[];
+}
+
+export default function AnalysisPage({ categories, accounts, labels }: Props) {
+    const locale = useLocale();
+    const { auth } = usePage<{
+        auth: { user: { currency_code: string } };
+    }>().props;
+    const currency = auth.user.currency_code;
+
+    const [filters, setFilters] = useState<TransactionFilters>(emptyFilters);
+    const [dimension, setDimension] = useState<AnalysisDimension>('category');
+
+    const { summary, groups, isLoading } = useAnalysisData(filters, dimension);
+
+    const categoriesById = useMemo(
+        () => new Map(categories.map((category) => [category.id, category])),
+        [categories],
+    );
+    const accountsById = useMemo(
+        () => new Map(accounts.map((account) => [account.id, account])),
+        [accounts],
+    );
+    const labelsById = useMemo(
+        () => new Map(labels.map((label) => [label.id, label])),
+        [labels],
+    );
+
+    const resolveLabel = (key: string | null): string => {
+        switch (dimension) {
+            case 'category':
+                return key
+                    ? (categoriesById.get(key)?.name ?? __('Uncategorized'))
+                    : __('Uncategorized');
+            case 'account':
+                return key
+                    ? (accountsById.get(key)?.name ?? __('Unknown account'))
+                    : __('No account');
+            case 'label':
+                return key
+                    ? (labelsById.get(key)?.name ?? __('Unknown label'))
+                    : __('No label');
+            case 'month':
+                return key ? formatMonthFromYearMonth(key, locale) : '';
+        }
+    };
+
+    const rows: ResolvedRow[] = useMemo(
+        () =>
+            groups.map((group) => ({
+                key: group.key,
+                label: resolveLabel(group.key),
+                amount: group.amount,
+                count: group.count,
+                category: group.key ? categoriesById.get(group.key) : undefined,
+                account:
+                    dimension === 'account' && group.key
+                        ? accountsById.get(group.key)
+                        : undefined,
+                labelColor:
+                    dimension === 'label' && group.key
+                        ? labelsById.get(group.key)?.color
+                        : undefined,
+            })),
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [groups, dimension, categoriesById, accountsById, labelsById, locale],
+    );
+
+    // Time dimensions read most naturally newest-first in the list.
+    const breakdownRows = useMemo(() => {
+        if (!isTimeDimension(dimension)) {
+            return rows;
+        }
+        return [...rows].sort((a, b) =>
+            (b.key ?? '').localeCompare(a.key ?? ''),
+        );
+    }, [rows, dimension]);
+
+    // The chart shows time ascending; categorical dimensions show the top buckets.
+    const chartData: AnalysisChartPoint[] = useMemo(() => {
+        const points = rows.map((row) => ({
+            key: row.key ?? '__null__',
+            label: row.label,
+            amount: row.amount,
+        }));
+
+        if (isTimeDimension(dimension)) {
+            return points.sort((a, b) => a.key.localeCompare(b.key));
+        }
+
+        return points.slice(0, 12);
+    }, [rows, dimension]);
+
+    function handleDrill(row: ResolvedRow) {
+        switch (dimension) {
+            case 'category':
+                setFilters((previous) => ({
+                    ...previous,
+                    categoryIds: [row.key ?? 'uncategorized'],
+                }));
+                setDimension('month');
+                break;
+            case 'account':
+                if (!row.key) {
+                    return;
+                }
+                setFilters((previous) => ({
+                    ...previous,
+                    accountIds: previous.accountIds.includes(row.key!)
+                        ? previous.accountIds
+                        : [...previous.accountIds, row.key!],
+                }));
+                setDimension('category');
+                break;
+            case 'label':
+                if (!row.key) {
+                    return;
+                }
+                setFilters((previous) => ({
+                    ...previous,
+                    labelIds: previous.labelIds.includes(row.key!)
+                        ? previous.labelIds
+                        : [...previous.labelIds, row.key!],
+                }));
+                setDimension('category');
+                break;
+            case 'month':
+                if (!row.key) {
+                    return;
+                }
+                setFilters((previous) => ({
+                    ...previous,
+                    dateFrom: startOfMonth(parseISO(`${row.key}-01`)),
+                    dateTo: endOfMonth(parseISO(`${row.key}-01`)),
+                }));
+                setDimension('category');
+                break;
+        }
+    }
+
+    const breakdownTitle = __('Breakdown by :dimension', {
+        dimension: dimensionLabels[dimension].toLowerCase(),
+    });
+
+    return (
+        <AppSidebarLayout breadcrumbs={breadcrumbs}>
+            <Head title={__('Analysis')} />
+
+            <div className="space-y-6 p-6">
+                <HeadingSmall
+                    title={__('Analysis')}
+                    description={__(
+                        'Drill into your income and expenses across any dimension',
+                    )}
+                />
+
+                <TransactionFiltersComponent
+                    filters={filters}
+                    onFiltersChange={setFilters}
+                    categories={categories}
+                    labels={labels}
+                    accounts={accounts}
+                    isKeySet={true}
+                    hideSearch
+                    inlineCategoryLabel
+                />
+
+                <AnalysisSummaryCards
+                    summary={summary}
+                    currency={currency}
+                    loading={isLoading}
+                />
+
+                <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm text-muted-foreground">
+                        {__('Group by')}
+                    </span>
+                    {ANALYSIS_DIMENSIONS.map((option) => (
+                        <Button
+                            key={option}
+                            size="sm"
+                            variant={
+                                dimension === option ? 'default' : 'outline'
+                            }
+                            onClick={() => setDimension(option)}
+                            className={cn(dimension === option && 'shadow-sm')}
+                        >
+                            {dimensionLabels[option]}
+                        </Button>
+                    ))}
+                </div>
+
+                <AnalysisChart
+                    title={breakdownTitle}
+                    data={chartData}
+                    currency={currency}
+                    loading={isLoading}
+                    scrollable={dimension === 'month'}
+                />
+
+                <AnalysisBreakdown
+                    title={breakdownTitle}
+                    rows={breakdownRows}
+                    currency={currency}
+                    loading={isLoading}
+                    onDrill={handleDrill}
+                />
+            </div>
+        </AppSidebarLayout>
+    );
+}

--- a/resources/js/providers/menu-item-provider.tsx
+++ b/resources/js/providers/menu-item-provider.tsx
@@ -1,9 +1,10 @@
 import { index as accountsIndex } from '@/actions/App/Http/Controllers/AccountController';
 import { index as budgetsIndex } from '@/actions/App/Http/Controllers/BudgetController';
 import { index as transactionsIndex } from '@/actions/App/Http/Controllers/TransactionController';
-import { cashflow, dashboard } from '@/routes';
+import { analysis, cashflow, dashboard } from '@/routes';
 import { Features, NavItem } from '@/types';
 import {
+    ChartColumnBig,
     CreditCard,
     LayoutGrid,
     PiggyBank,
@@ -18,6 +19,7 @@ const mobileLabels: Record<string, Record<string, string>> = {
         accounts: 'Accounts',
         transactions: 'Movements',
         budgets: 'Budget',
+        analysis: 'Analysis',
     },
     es: {
         dashboard: 'Inicio',
@@ -25,6 +27,7 @@ const mobileLabels: Record<string, Record<string, string>> = {
         accounts: 'Cuentas',
         transactions: 'Movim.',
         budgets: 'Presup.',
+        analysis: 'Análisis',
     },
 };
 
@@ -74,6 +77,13 @@ export function getMainNavItems(features: Features, locale: string): NavItem[] {
             mobileTitle: getMobileLabel('budgets', locale),
             href: budgetsIndex(),
             icon: PiggyBank,
+        },
+        {
+            type: 'nav-item',
+            title: 'Analysis',
+            mobileTitle: getMobileLabel('analysis', locale),
+            href: analysis(),
+            icon: ChartColumnBig,
         },
     );
 

--- a/resources/js/utils/date.ts
+++ b/resources/js/utils/date.ts
@@ -56,6 +56,21 @@ export function formatMonthFromYearMonth(
 }
 
 /**
+ * Format a month number (1-12 or "01".."12") to its full name (e.g. "January"),
+ * ignoring the year. Capitalizes the first letter for locales that lowercase months.
+ */
+export function formatMonthName(
+    month: string | number,
+    locale: string = 'en-US',
+): string {
+    const monthIndex =
+        (typeof month === 'string' ? parseInt(month, 10) : month) - 1;
+    const formatted = formatDate(new Date(2000, monthIndex, 1), 'MMMM', locale);
+
+    return formatted.charAt(0).toUpperCase() + formatted.slice(1);
+}
+
+/**
  * Format a date to show month and year (e.g., "January 2026" or "Enero 2026")
  * Capitalizes the first letter
  */

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Api\AnalysisController;
 use App\Http\Controllers\Api\CashflowAnalyticsController;
 use App\Http\Controllers\Api\DashboardAnalyticsController;
 use App\Http\Controllers\Api\ImportDataController;
+use App\Http\Controllers\Api\SavedFilterController;
 use App\Http\Controllers\Api\TransactionController;
 use App\Http\Controllers\EncryptionController;
 use App\Http\Controllers\Sync\TransactionSyncController;
@@ -60,4 +61,9 @@ Route::middleware(['web', 'auth'])->group(function () {
 
     // Expense / income analysis
     Route::get('analysis', [AnalysisController::class, 'index'])->name('api.analysis.index');
+
+    // Saved filters (shared between transactions and analysis screens)
+    Route::get('saved-filters', [SavedFilterController::class, 'index'])->name('api.saved-filters.index');
+    Route::post('saved-filters', [SavedFilterController::class, 'store'])->name('api.saved-filters.store');
+    Route::delete('saved-filters/{savedFilter}', [SavedFilterController::class, 'destroy'])->name('api.saved-filters.destroy');
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -65,5 +65,6 @@ Route::middleware(['web', 'auth'])->group(function () {
     // Saved filters (shared between transactions and analysis screens)
     Route::get('saved-filters', [SavedFilterController::class, 'index'])->name('api.saved-filters.index');
     Route::post('saved-filters', [SavedFilterController::class, 'store'])->name('api.saved-filters.store');
+    Route::patch('saved-filters/{savedFilter}', [SavedFilterController::class, 'update'])->name('api.saved-filters.update');
     Route::delete('saved-filters/{savedFilter}', [SavedFilterController::class, 'destroy'])->name('api.saved-filters.destroy');
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\AccountBalanceController;
 use App\Http\Controllers\Api\AccountController;
+use App\Http\Controllers\Api\AnalysisController;
 use App\Http\Controllers\Api\CashflowAnalyticsController;
 use App\Http\Controllers\Api\DashboardAnalyticsController;
 use App\Http\Controllers\Api\ImportDataController;
@@ -56,4 +57,7 @@ Route::middleware(['web', 'auth'])->group(function () {
         Route::get('trend', [CashflowAnalyticsController::class, 'trend']);
         Route::get('breakdown', [CashflowAnalyticsController::class, 'breakdown']);
     });
+
+    // Expense / income analysis
+    Route::get('analysis', [AnalysisController::class, 'index'])->name('api.analysis.index');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\AccountController;
+use App\Http\Controllers\AnalysisController;
 use App\Http\Controllers\BudgetController;
 use App\Http\Controllers\CashflowController;
 use App\Http\Controllers\DashboardController;
@@ -108,6 +109,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
 Route::middleware(['auth', 'verified', 'onboarded', 'subscribed'])->group(function () {
     Route::get('dashboard', DashboardController::class)->name('dashboard');
     Route::get('cashflow', CashflowController::class)->name('cashflow');
+    Route::get('analysis', AnalysisController::class)->name('analysis');
 
     Route::get('accounts', [AccountController::class, 'index'])->name('accounts.list');
     Route::get('accounts/{account}', [AccountController::class, 'show'])->name('accounts.show');

--- a/tests/Feature/AnalysisTest.php
+++ b/tests/Feature/AnalysisTest.php
@@ -100,9 +100,10 @@ test('uncategorized transactions group under a null key', function () {
     expect($groups[0]['amount'])->toBe(-1500);
 });
 
-test('groups by month bucket transactions by year-month', function () {
+test('groups by month bucket transactions by calendar month across years', function () {
     makeTransaction(['amount' => -1000, 'transaction_date' => '2026-01-15']);
     makeTransaction(['amount' => -2000, 'transaction_date' => '2026-01-20']);
+    makeTransaction(['amount' => -4000, 'transaction_date' => '2025-01-10']); // different year, same month
     makeTransaction(['amount' => -5000, 'transaction_date' => '2026-02-10']);
 
     $groups = collect($this->getJson('/api/analysis?group_by=month')
@@ -110,9 +111,10 @@ test('groups by month bucket transactions by year-month', function () {
         ->json('groups'))
         ->keyBy('key');
 
-    expect($groups['2026-01']['amount'])->toBe(-3000);
-    expect($groups['2026-01']['count'])->toBe(2);
-    expect($groups['2026-02']['amount'])->toBe(-5000);
+    // All January transactions collapse together regardless of year.
+    expect($groups['01']['amount'])->toBe(-7000);
+    expect($groups['01']['count'])->toBe(3);
+    expect($groups['02']['amount'])->toBe(-5000);
 });
 
 test('groups by label count a transaction once per label and bucket unlabeled separately', function () {

--- a/tests/Feature/AnalysisTest.php
+++ b/tests/Feature/AnalysisTest.php
@@ -1,0 +1,200 @@
+<?php
+
+use App\Enums\CategoryType;
+use App\Models\Account;
+use App\Models\Category;
+use App\Models\ExchangeRate;
+use App\Models\Label;
+use App\Models\Transaction;
+use App\Models\User;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    Http::fake();
+
+    $this->user = User::factory()->create(['currency_code' => 'USD']);
+    $this->actingAs($this->user);
+
+    $this->account = Account::factory()->create([
+        'user_id' => $this->user->id,
+        'currency_code' => 'USD',
+    ]);
+});
+
+function makeTransaction(array $attributes = []): Transaction
+{
+    return Transaction::factory()->create(array_merge([
+        'user_id' => test()->user->id,
+        'account_id' => test()->account->id,
+        'currency_code' => 'USD',
+        'transaction_date' => now(),
+    ], $attributes));
+}
+
+test('analysis endpoint requires authentication', function () {
+    auth()->logout();
+
+    $this->getJson('/api/analysis?group_by=category')->assertUnauthorized();
+});
+
+test('analysis responses are not cached between users', function () {
+    $this->getJson('/api/analysis?group_by=category')
+        ->assertOk()
+        ->assertHeader('Cache-Control', 'no-store, private');
+});
+
+test('group_by is required and constrained', function () {
+    $this->getJson('/api/analysis')->assertStatus(422);
+    $this->getJson('/api/analysis?group_by=bogus')->assertStatus(422);
+});
+
+test('summary splits income, expense, net and count by sign', function () {
+    makeTransaction(['amount' => 100000]);
+    makeTransaction(['amount' => 30000]);
+    makeTransaction(['amount' => -40000]);
+
+    $this->getJson('/api/analysis?group_by=category')
+        ->assertOk()
+        ->assertJson([
+            'summary' => [
+                'income' => 130000,
+                'expense' => 40000,
+                'net' => 90000,
+                'count' => 3,
+            ],
+        ]);
+});
+
+test('groups by category sum signed amounts and sort by magnitude', function () {
+    $food = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'type' => CategoryType::Expense,
+    ]);
+    $rent = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'type' => CategoryType::Expense,
+    ]);
+
+    makeTransaction(['category_id' => $food->id, 'amount' => -2000]);
+    makeTransaction(['category_id' => $food->id, 'amount' => -3000]);
+    makeTransaction(['category_id' => $rent->id, 'amount' => -90000]);
+
+    $groups = $this->getJson('/api/analysis?group_by=category')
+        ->assertOk()
+        ->json('groups');
+
+    expect($groups)->toHaveCount(2);
+    expect($groups[0])->toMatchArray(['key' => $rent->id, 'amount' => -90000, 'count' => 1]);
+    expect($groups[1])->toMatchArray(['key' => $food->id, 'amount' => -5000, 'count' => 2]);
+});
+
+test('uncategorized transactions group under a null key', function () {
+    makeTransaction(['category_id' => null, 'amount' => -1500]);
+
+    $groups = $this->getJson('/api/analysis?group_by=category')
+        ->assertOk()
+        ->json('groups');
+
+    expect($groups)->toHaveCount(1);
+    expect($groups[0]['key'])->toBeNull();
+    expect($groups[0]['amount'])->toBe(-1500);
+});
+
+test('groups by month bucket transactions by year-month', function () {
+    makeTransaction(['amount' => -1000, 'transaction_date' => '2026-01-15']);
+    makeTransaction(['amount' => -2000, 'transaction_date' => '2026-01-20']);
+    makeTransaction(['amount' => -5000, 'transaction_date' => '2026-02-10']);
+
+    $groups = collect($this->getJson('/api/analysis?group_by=month')
+        ->assertOk()
+        ->json('groups'))
+        ->keyBy('key');
+
+    expect($groups['2026-01']['amount'])->toBe(-3000);
+    expect($groups['2026-01']['count'])->toBe(2);
+    expect($groups['2026-02']['amount'])->toBe(-5000);
+});
+
+test('groups by label count a transaction once per label and bucket unlabeled separately', function () {
+    $trip = Label::factory()->create(['user_id' => $this->user->id]);
+    $work = Label::factory()->create(['user_id' => $this->user->id]);
+
+    $multi = makeTransaction(['amount' => -6000]);
+    $multi->labels()->sync([$trip->id, $work->id]);
+
+    makeTransaction(['amount' => -1000]); // no label
+
+    $groups = collect($this->getJson('/api/analysis?group_by=label')
+        ->assertOk()
+        ->json('groups'))
+        ->keyBy(fn (array $group): string => $group['key'] ?? '__null__');
+
+    expect($groups[$trip->id]['amount'])->toBe(-6000);
+    expect($groups[$work->id]['amount'])->toBe(-6000);
+    expect($groups['__null__']['amount'])->toBe(-1000);
+});
+
+test('filters restrict the analyzed transactions', function () {
+    $keep = Category::factory()->create(['user_id' => $this->user->id]);
+    $drop = Category::factory()->create(['user_id' => $this->user->id]);
+
+    makeTransaction(['category_id' => $keep->id, 'amount' => -1000]);
+    makeTransaction(['category_id' => $drop->id, 'amount' => -9000]);
+
+    $response = $this->getJson('/api/analysis?'.http_build_query([
+        'group_by' => 'category',
+        'category_ids' => $keep->id,
+    ]))->assertOk();
+
+    expect($response->json('summary.expense'))->toBe(1000);
+    expect($response->json('groups'))->toHaveCount(1);
+    expect($response->json('groups.0.key'))->toBe($keep->id);
+});
+
+test('category and label filters combine with OR', function () {
+    $category = Category::factory()->create(['user_id' => $this->user->id]);
+    $label = Label::factory()->create(['user_id' => $this->user->id]);
+
+    makeTransaction(['category_id' => $category->id, 'amount' => -1000]);
+
+    $labelled = makeTransaction(['category_id' => null, 'amount' => -2000]);
+    $labelled->labels()->sync([$label->id]);
+
+    makeTransaction(['category_id' => null, 'amount' => -9000]); // matches neither
+
+    $response = $this->getJson('/api/analysis?'.http_build_query([
+        'group_by' => 'category',
+        'category_ids' => $category->id,
+        'label_ids' => $label->id,
+    ]))->assertOk();
+
+    expect($response->json('summary.expense'))->toBe(3000);
+    expect($response->json('summary.count'))->toBe(2);
+});
+
+test('foreign currency amounts are converted to the user currency', function () {
+    $date = '2026-03-10';
+
+    $eurAccount = Account::factory()->create([
+        'user_id' => $this->user->id,
+        'currency_code' => 'EUR',
+    ]);
+
+    ExchangeRate::factory()->create([
+        'base_currency' => 'usd',
+        'date' => $date,
+        'rates' => ['eur' => 0.80],
+    ]);
+
+    // 8000 EUR cents / 0.80 = 10000 USD cents
+    makeTransaction([
+        'account_id' => $eurAccount->id,
+        'currency_code' => 'EUR',
+        'amount' => -8000,
+        'transaction_date' => $date,
+    ]);
+
+    $this->getJson('/api/analysis?group_by=category')
+        ->assertOk()
+        ->assertJson(['summary' => ['expense' => 10000]]);
+});

--- a/tests/Feature/SavedFilterTest.php
+++ b/tests/Feature/SavedFilterTest.php
@@ -72,6 +72,38 @@ test('the same name can be reused by a different user', function () {
         ->assertCreated();
 });
 
+test('a user can update their own saved filter', function () {
+    $savedFilter = SavedFilter::factory()->create([
+        'user_id' => $this->user->id,
+        'filters' => ['search' => 'old'],
+    ]);
+
+    $response = $this->patchJson("/api/saved-filters/{$savedFilter->id}", [
+        'filters' => ['search' => 'new', 'category_ids' => ['food']],
+    ])->assertOk();
+
+    expect($response->json('data.filters.search'))->toBe('new');
+
+    $this->assertDatabaseHas('saved_filters', [
+        'id' => $savedFilter->id,
+        'name' => $savedFilter->name,
+    ]);
+    expect($savedFilter->fresh()->filters)->toBe([
+        'search' => 'new',
+        'category_ids' => ['food'],
+    ]);
+});
+
+test('a user cannot update another user saved filter', function () {
+    $savedFilter = SavedFilter::factory()->create(['filters' => ['search' => 'old']]);
+
+    $this->patchJson("/api/saved-filters/{$savedFilter->id}", [
+        'filters' => ['search' => 'hacked'],
+    ])->assertForbidden();
+
+    expect($savedFilter->fresh()->filters)->toBe(['search' => 'old']);
+});
+
 test('a user can delete their own saved filter', function () {
     $savedFilter = SavedFilter::factory()->create(['user_id' => $this->user->id]);
 

--- a/tests/Feature/SavedFilterTest.php
+++ b/tests/Feature/SavedFilterTest.php
@@ -1,0 +1,89 @@
+<?php
+
+use App\Models\SavedFilter;
+use App\Models\User;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+});
+
+test('saved filters endpoints require authentication', function () {
+    auth()->logout();
+
+    $this->getJson('/api/saved-filters')->assertUnauthorized();
+});
+
+test('lists only the current user saved filters ordered by name', function () {
+    SavedFilter::factory()->create(['user_id' => $this->user->id, 'name' => 'Zurich trip']);
+    SavedFilter::factory()->create(['user_id' => $this->user->id, 'name' => 'Apartment bills']);
+    SavedFilter::factory()->create(['name' => 'Someone else']);
+
+    $response = $this->getJson('/api/saved-filters')->assertOk();
+
+    expect($response->json('data'))->toHaveCount(2);
+    expect($response->json('data.0.name'))->toBe('Apartment bills');
+    expect($response->json('data.1.name'))->toBe('Zurich trip');
+});
+
+test('stores a saved filter for the current user', function () {
+    $payload = [
+        'name' => 'Trip to Japan',
+        'filters' => [
+            'label_ids' => ['11111111-1111-1111-1111-111111111111'],
+            'category_ids' => ['food'],
+            'date_from' => '2026-01-01',
+        ],
+    ];
+
+    $response = $this->postJson('/api/saved-filters', $payload)->assertCreated();
+
+    expect($response->json('data.name'))->toBe('Trip to Japan');
+    expect($response->json('data.filters.category_ids'))->toBe(['food']);
+
+    $this->assertDatabaseHas('saved_filters', [
+        'user_id' => $this->user->id,
+        'name' => 'Trip to Japan',
+    ]);
+});
+
+test('name is required and unique per user', function () {
+    SavedFilter::factory()->create(['user_id' => $this->user->id, 'name' => 'Duplicate']);
+
+    $this->postJson('/api/saved-filters', ['filters' => []])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['name', 'filters']);
+
+    $this->postJson('/api/saved-filters', ['name' => 'Duplicate', 'filters' => []])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['name']);
+});
+
+test('the same name can be reused by a different user', function () {
+    SavedFilter::factory()->create(['user_id' => $this->user->id, 'name' => 'Shared name']);
+
+    $other = User::factory()->create();
+
+    $this->actingAs($other)
+        ->postJson('/api/saved-filters', [
+            'name' => 'Shared name',
+            'filters' => ['search' => 'groceries'],
+        ])
+        ->assertCreated();
+});
+
+test('a user can delete their own saved filter', function () {
+    $savedFilter = SavedFilter::factory()->create(['user_id' => $this->user->id]);
+
+    $this->deleteJson("/api/saved-filters/{$savedFilter->id}")->assertOk();
+
+    $this->assertDatabaseMissing('saved_filters', ['id' => $savedFilter->id]);
+});
+
+test('a user cannot delete another user saved filter', function () {
+    $savedFilter = SavedFilter::factory()->create();
+
+    $this->deleteJson("/api/saved-filters/{$savedFilter->id}")->assertForbidden();
+
+    $this->assertDatabaseHas('saved_filters', ['id' => $savedFilter->id]);
+});

--- a/tests/Feature/TransactionFilterTest.php
+++ b/tests/Feature/TransactionFilterTest.php
@@ -191,6 +191,42 @@ test('filter by label', function () {
     );
 });
 
+test('category and label filters combine with OR', function () {
+    $category = Category::factory()->create(['user_id' => $this->user->id]);
+    $label = Label::factory()->create(['user_id' => $this->user->id]);
+
+    // Matches by category only
+    Transaction::factory()->plaintext()->create([
+        'user_id' => $this->user->id,
+        'account_id' => $this->account->id,
+        'category_id' => $category->id,
+    ]);
+
+    // Matches by label only (different category)
+    $txWithLabel = Transaction::factory()->plaintext()->create([
+        'user_id' => $this->user->id,
+        'account_id' => $this->account->id,
+        'category_id' => null,
+    ]);
+    $txWithLabel->labels()->attach($label->id);
+
+    // Matches neither
+    Transaction::factory()->plaintext()->create([
+        'user_id' => $this->user->id,
+        'account_id' => $this->account->id,
+        'category_id' => null,
+    ]);
+
+    $response = actingAs($this->user)->get(route('transactions.index', [
+        'category_ids' => $category->id,
+        'label_ids' => $label->id,
+    ]));
+
+    $response->assertInertia(fn ($page) => $page
+        ->has('transactions.data', 2)
+    );
+});
+
 test('search matches description', function () {
     Transaction::factory()->plaintext()->create([
         'user_id' => $this->user->id,


### PR DESCRIPTION
## Summary

A new **Analysis** screen to drill into income and expenses across any dimension, plus **saved filters** shared with the transactions screen.

### Analysis screen
- New top-level **Analysis** page + nav item.
- Reuses the transaction filter bar (categories + labels surfaced inline, search hidden) to define the dataset.
- Group by **Category · Month · Account · Label**; click a breakdown row to drill in (re-pivots / adds the filter).
- Summary cards (income / spent / net / count), an adaptive chart, and a ranked breakdown.
- All amounts converted to the user's currency (per-transaction historical rate), mirroring the cashflow analytics pattern.
- **Group by month** aggregates across years (all Januarys together).

### Filters (shared, also affects the transactions screen)
- **Category + label filters now combine with OR.**
- Selected category/label options sort to the top (snapshotted on open so they don't reshuffle while toggling).
- **Saved filters**: name and persist a filter set (per user, server-side), load/delete from a "Saved" dropdown, available on both screens.
- The Saved control surfaces the **active** saved filter and offers **Update** (save over) when you edit it, instead of forcing a new one each time.

## Commits
- `feat(analysis): add expense/income analysis screen`
- `feat(filters): show selected category/label options first`
- `feat(analysis): aggregate group-by-month across years`
- `feat(filters): add saved filters shared across transactions and analysis`
- `feat(filters): surface active saved filter and allow updating in place`

## Testing
- `tests/Feature/AnalysisTest.php` — summary by sign, grouping per dimension, uncategorized buckets, month-across-years, OR filters, multi-currency conversion.
- `tests/Feature/SavedFilterTest.php` — auth, per-user listing/uniqueness, store/update/delete with ownership checks.
- `tests/Feature/TransactionFilterTest.php` — added category∨label OR case.
- Pint, ESLint, and tsc clean on touched files.

## Notes
- Saved filters store only the shared filter set, not the analysis `group_by` dimension, so the same saved filter is meaningful on both screens.
- A DB migration adds the `saved_filters` table.