### PR TITLE
refactor(requests): share category cashflow direction resolution

### DIFF
--- a/app/Http/Requests/Concerns/ResolvesCategoryCashflowDirection.php
+++ b/app/Http/Requests/Concerns/ResolvesCategoryCashflowDirection.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Concerns;
+
+use App\Enums\CategoryCashflowDirection;
+use App\Enums\CategoryType;
+
+trait ResolvesCategoryCashflowDirection
+{
+    /**
+     * Derive the cashflow direction from the category type before validation runs.
+     */
+    protected function prepareForValidation(): void
+    {
+        $type = CategoryType::tryFrom((string) $this->input('type'));
+
+        if (in_array($type, [CategoryType::Savings, CategoryType::Investment], true)) {
+            $this->merge([
+                'cashflow_direction' => CategoryCashflowDirection::Outflow->value,
+            ]);
+
+            return;
+        }
+
+        if ($type !== CategoryType::Transfer) {
+            $this->merge([
+                'cashflow_direction' => CategoryCashflowDirection::Hidden->value,
+            ]);
+
+            return;
+        }
+
+        $this->merge([
+            'cashflow_direction' => $this->input('cashflow_direction', CategoryCashflowDirection::Hidden->value),
+        ]);
+    }
+}

--- a/app/Http/Requests/Settings/StoreCategoryRequest.php
+++ b/app/Http/Requests/Settings/StoreCategoryRequest.php
@@ -5,43 +5,21 @@ namespace App\Http\Requests\Settings;
 use App\Enums\CategoryCashflowDirection;
 use App\Enums\CategoryColor;
 use App\Enums\CategoryType;
+use App\Http\Requests\Concerns\ResolvesCategoryCashflowDirection;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
 class StoreCategoryRequest extends FormRequest
 {
+    use ResolvesCategoryCashflowDirection;
+
     /**
      * Determine if the user is authorized to make this request.
      */
     public function authorize(): bool
     {
         return true;
-    }
-
-    protected function prepareForValidation(): void
-    {
-        $type = CategoryType::tryFrom((string) $this->input('type'));
-
-        if (in_array($type, [CategoryType::Savings, CategoryType::Investment], true)) {
-            $this->merge([
-                'cashflow_direction' => CategoryCashflowDirection::Outflow->value,
-            ]);
-
-            return;
-        }
-
-        if ($type !== CategoryType::Transfer) {
-            $this->merge([
-                'cashflow_direction' => CategoryCashflowDirection::Hidden->value,
-            ]);
-
-            return;
-        }
-
-        $this->merge([
-            'cashflow_direction' => $this->input('cashflow_direction', CategoryCashflowDirection::Hidden->value),
-        ]);
     }
 
     /**

--- a/app/Http/Requests/Settings/UpdateCategoryRequest.php
+++ b/app/Http/Requests/Settings/UpdateCategoryRequest.php
@@ -5,43 +5,21 @@ namespace App\Http\Requests\Settings;
 use App\Enums\CategoryCashflowDirection;
 use App\Enums\CategoryColor;
 use App\Enums\CategoryType;
+use App\Http\Requests\Concerns\ResolvesCategoryCashflowDirection;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
 class UpdateCategoryRequest extends FormRequest
 {
+    use ResolvesCategoryCashflowDirection;
+
     /**
      * Determine if the user is authorized to make this request.
      */
     public function authorize(): bool
     {
         return true;
-    }
-
-    protected function prepareForValidation(): void
-    {
-        $type = CategoryType::tryFrom((string) $this->input('type'));
-
-        if (in_array($type, [CategoryType::Savings, CategoryType::Investment], true)) {
-            $this->merge([
-                'cashflow_direction' => CategoryCashflowDirection::Outflow->value,
-            ]);
-
-            return;
-        }
-
-        if ($type !== CategoryType::Transfer) {
-            $this->merge([
-                'cashflow_direction' => CategoryCashflowDirection::Hidden->value,
-            ]);
-
-            return;
-        }
-
-        $this->merge([
-            'cashflow_direction' => $this->input('cashflow_direction', CategoryCashflowDirection::Hidden->value),
-        ]);
     }
 
     /**


### PR DESCRIPTION
## What

`StoreCategoryRequest` and `UpdateCategoryRequest` had identical 24-line `prepareForValidation()` deriving `cashflow_direction` from category type.

Moved to `app/Http/Requests/Concerns/ResolvesCategoryCashflowDirection` trait.

## Stats

- **-48 / +43 lines** (net small, removes a whole duplicated logic block that must stay in sync)

## Checks

- `php artisan test --filter=Categor` — 104 passed (565 assertions)
- `vendor/bin/pint --dirty` — pass

Part of duplication-removal series (#475–#478).