### PR TITLE
refactor(requests): share account detail validation rules

### DIFF
--- a/app/Http/Requests/Concerns/ValidatesAccountDetailRules.php
+++ b/app/Http/Requests/Concerns/ValidatesAccountDetailRules.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Requests\Concerns;
+
+use App\Enums\AccountType;
+use App\Enums\PropertyType;
+use Illuminate\Validation\Rule;
+
+trait ValidatesAccountDetailRules
+{
+    /**
+     * Validation rules for real estate detail fields.
+     *
+     * @return array<string, array<mixed>>
+     */
+    protected function realEstateDetailRules(bool $propertyTypeSometimes = false, bool $withRevaluation = true): array
+    {
+        $rules = [
+            'property_type' => [
+                ...($propertyTypeSometimes ? ['sometimes'] : []),
+                'required',
+                'string',
+                Rule::in(array_map(fn ($type) => $type->value, PropertyType::cases())),
+            ],
+            'address' => ['nullable', 'string', 'max:500'],
+            'purchase_price' => ['nullable', 'integer', 'min:0'],
+            'purchase_date' => ['nullable', 'date', 'before_or_equal:today'],
+            'area_value' => ['nullable', 'numeric', 'min:0', 'max:99999999.99'],
+            'area_unit' => ['nullable', 'string', Rule::in(['sqm', 'sqft', 'acres', 'hectares'])],
+            'linked_loan_account_id' => [
+                'nullable',
+                'string',
+                $this->userOwnedAccountOfType(AccountType::Loan),
+            ],
+            'notes' => ['nullable', 'string', 'max:2000'],
+        ];
+
+        if ($withRevaluation) {
+            $rules['revaluation_percentage'] = ['nullable', 'numeric', 'min:-100', 'max:100'];
+        }
+
+        return $rules;
+    }
+
+    /**
+     * Validation rules for loan detail fields.
+     *
+     * @return array<string, array<mixed>>
+     */
+    protected function loanDetailRules(): array
+    {
+        return [
+            'annual_interest_rate' => ['nullable', 'numeric', 'min:0', 'max:100'],
+            'loan_term_months' => ['nullable', 'integer', 'min:1', 'max:600'],
+            'loan_start_date' => ['nullable', 'date'],
+            'original_amount' => ['nullable', 'integer', 'min:0'],
+        ];
+    }
+}

--- a/app/Http/Requests/Settings/StoreAccountRequest.php
+++ b/app/Http/Requests/Settings/StoreAccountRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\Settings;
 
 use App\Enums\AccountType;
-use App\Enums\PropertyType;
+use App\Http\Requests\Concerns\ValidatesAccountDetailRules;
 use App\Http\Requests\Concerns\ValidatesUserOwnedResources;
 use App\Models\Account;
 use App\Services\CurrencyOptions;
@@ -13,7 +13,7 @@ use Illuminate\Validation\Rule;
 
 class StoreAccountRequest extends FormRequest
 {
-    use ValidatesUserOwnedResources;
+    use ValidatesAccountDetailRules, ValidatesUserOwnedResources;
 
     /**
      * Determine if the user is authorized to make this request.
@@ -53,35 +53,13 @@ class StoreAccountRequest extends FormRequest
         ];
 
         if ($isRealEstate) {
-            $rules = array_merge($rules, [
-                'property_type' => [
-                    'required',
-                    'string',
-                    Rule::in(array_map(fn ($type) => $type->value, PropertyType::cases())),
-                ],
-                'address' => ['nullable', 'string', 'max:500'],
-                'purchase_price' => ['nullable', 'integer', 'min:0'],
-                'purchase_date' => ['nullable', 'date', 'before_or_equal:today'],
-                'area_value' => ['nullable', 'numeric', 'min:0', 'max:99999999.99'],
-                'area_unit' => ['nullable', 'string', Rule::in(['sqm', 'sqft', 'acres', 'hectares'])],
-                'linked_loan_account_id' => [
-                    'nullable',
-                    'string',
-                    $this->userOwnedAccountOfType(AccountType::Loan),
-                ],
-                'notes' => ['nullable', 'string', 'max:2000'],
-                'revaluation_percentage' => ['nullable', 'numeric', 'min:-100', 'max:100'],
-            ]);
+            $rules = array_merge($rules, $this->realEstateDetailRules());
         }
 
         $isLoan = $this->input('type') === AccountType::Loan->value;
 
         if ($isLoan) {
-            $rules = array_merge($rules, [
-                'annual_interest_rate' => ['nullable', 'numeric', 'min:0', 'max:100'],
-                'loan_term_months' => ['nullable', 'integer', 'min:1', 'max:600'],
-                'loan_start_date' => ['nullable', 'date'],
-                'original_amount' => ['nullable', 'integer', 'min:0'],
+            $rules = array_merge($rules, $this->loanDetailRules(), [
                 'linked_real_estate_account_id' => [
                     'nullable',
                     'string',

--- a/app/Http/Requests/Settings/UpdateAccountRequest.php
+++ b/app/Http/Requests/Settings/UpdateAccountRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\Settings;
 
 use App\Enums\AccountType;
-use App\Enums\PropertyType;
+use App\Http\Requests\Concerns\ValidatesAccountDetailRules;
 use App\Http\Requests\Concerns\ValidatesUserOwnedResources;
 use App\Services\CurrencyOptions;
 use Illuminate\Contracts\Validation\ValidationRule;
@@ -12,7 +12,7 @@ use Illuminate\Validation\Rule;
 
 class UpdateAccountRequest extends FormRequest
 {
-    use ValidatesUserOwnedResources;
+    use ValidatesAccountDetailRules, ValidatesUserOwnedResources;
 
     /**
      * Determine if the user is authorized to make this request.
@@ -48,36 +48,13 @@ class UpdateAccountRequest extends FormRequest
         ];
 
         if ($isRealEstate) {
-            $rules = array_merge($rules, [
-                'property_type' => [
-                    'required',
-                    'string',
-                    Rule::in(array_map(fn ($type) => $type->value, PropertyType::cases())),
-                ],
-                'address' => ['nullable', 'string', 'max:500'],
-                'purchase_price' => ['nullable', 'integer', 'min:0'],
-                'purchase_date' => ['nullable', 'date', 'before_or_equal:today'],
-                'area_value' => ['nullable', 'numeric', 'min:0', 'max:99999999.99'],
-                'area_unit' => ['nullable', 'string', Rule::in(['sqm', 'sqft', 'acres', 'hectares'])],
-                'linked_loan_account_id' => [
-                    'nullable',
-                    'string',
-                    $this->userOwnedAccountOfType(AccountType::Loan),
-                ],
-                'notes' => ['nullable', 'string', 'max:2000'],
-                'revaluation_percentage' => ['nullable', 'numeric', 'min:-100', 'max:100'],
-            ]);
+            $rules = array_merge($rules, $this->realEstateDetailRules());
         }
 
         $isLoan = $this->input('type') === AccountType::Loan->value;
 
         if ($isLoan) {
-            $rules = array_merge($rules, [
-                'annual_interest_rate' => ['nullable', 'numeric', 'min:0', 'max:100'],
-                'loan_term_months' => ['nullable', 'integer', 'min:1', 'max:600'],
-                'loan_start_date' => ['nullable', 'date'],
-                'original_amount' => ['nullable', 'integer', 'min:0'],
-            ]);
+            $rules = array_merge($rules, $this->loanDetailRules());
         }
 
         return $rules;

--- a/app/Http/Requests/StoreRealEstateDetailRequest.php
+++ b/app/Http/Requests/StoreRealEstateDetailRequest.php
@@ -2,16 +2,14 @@
 
 namespace App\Http\Requests;
 
-use App\Enums\AccountType;
-use App\Enums\PropertyType;
+use App\Http\Requests\Concerns\ValidatesAccountDetailRules;
 use App\Http\Requests\Concerns\ValidatesUserOwnedResources;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Validation\Rule;
 
 class StoreRealEstateDetailRequest extends FormRequest
 {
-    use ValidatesUserOwnedResources;
+    use ValidatesAccountDetailRules, ValidatesUserOwnedResources;
 
     /**
      * Determine if the user is authorized to make this request.
@@ -28,23 +26,6 @@ class StoreRealEstateDetailRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            'property_type' => [
-                'required',
-                'string',
-                Rule::in(array_map(fn ($type) => $type->value, PropertyType::cases())),
-            ],
-            'address' => ['nullable', 'string', 'max:500'],
-            'purchase_price' => ['nullable', 'integer', 'min:0'],
-            'purchase_date' => ['nullable', 'date', 'before_or_equal:today'],
-            'area_value' => ['nullable', 'numeric', 'min:0', 'max:99999999.99'],
-            'area_unit' => ['nullable', 'string', Rule::in(['sqm', 'sqft', 'acres', 'hectares'])],
-            'linked_loan_account_id' => [
-                'nullable',
-                'string',
-                $this->userOwnedAccountOfType(AccountType::Loan),
-            ],
-            'notes' => ['nullable', 'string', 'max:2000'],
-        ];
+        return $this->realEstateDetailRules(withRevaluation: false);
     }
 }

--- a/app/Http/Requests/UpdateRealEstateDetailRequest.php
+++ b/app/Http/Requests/UpdateRealEstateDetailRequest.php
@@ -2,16 +2,14 @@
 
 namespace App\Http\Requests;
 
-use App\Enums\AccountType;
-use App\Enums\PropertyType;
+use App\Http\Requests\Concerns\ValidatesAccountDetailRules;
 use App\Http\Requests\Concerns\ValidatesUserOwnedResources;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Validation\Rule;
 
 class UpdateRealEstateDetailRequest extends FormRequest
 {
-    use ValidatesUserOwnedResources;
+    use ValidatesAccountDetailRules, ValidatesUserOwnedResources;
 
     /**
      * Determine if the user is authorized to make this request.
@@ -28,25 +26,6 @@ class UpdateRealEstateDetailRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            'property_type' => [
-                'sometimes',
-                'required',
-                'string',
-                Rule::in(array_map(fn ($type) => $type->value, PropertyType::cases())),
-            ],
-            'address' => ['nullable', 'string', 'max:500'],
-            'purchase_price' => ['nullable', 'integer', 'min:0'],
-            'purchase_date' => ['nullable', 'date', 'before_or_equal:today'],
-            'area_value' => ['nullable', 'numeric', 'min:0', 'max:99999999.99'],
-            'area_unit' => ['nullable', 'string', Rule::in(['sqm', 'sqft', 'acres', 'hectares'])],
-            'linked_loan_account_id' => [
-                'nullable',
-                'string',
-                $this->userOwnedAccountOfType(AccountType::Loan),
-            ],
-            'notes' => ['nullable', 'string', 'max:2000'],
-            'revaluation_percentage' => ['nullable', 'numeric', 'min:-100', 'max:100'],
-        ];
+        return $this->realEstateDetailRules(propertyTypeSometimes: true);
     }
 }


### PR DESCRIPTION
## What

Real-estate detail rule block (~10 fields) was duplicated in **4 requests**; loan detail block in **2**. Variants differ only by `sometimes` on `property_type` and presence of `revaluation_percentage`.

New `ValidatesAccountDetailRules` trait:

- `realEstateDetailRules(propertyTypeSometimes:, withRevaluation:)`
- `loanDetailRules()`

## Stats

- **-115 / +83 lines**; one source of truth for these field rules

## Checks

- `php artisan test --filter="Account|RealEstate|Loan"` — 355 passed (1744 assertions)
- `vendor/bin/pint --dirty` — pass

Part of duplication-removal series (#475–#480).