### PR TITLE
fix(perf): batch feature flag resolution in shared Inertia data

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -164,14 +164,23 @@ class HandleInertiaRequests extends Middleware
     {
         $user = request()->user();
 
+        if (! $user) {
+            return [
+                'cashflow' => true,
+                'calculateBalancesOnImport' => false,
+                'transactionAnalysis' => false,
+            ];
+        }
+
+        $features = Feature::for($user)->values([
+            CalculateBalancesOnImport::class,
+            TransactionAnalysis::class,
+        ]);
+
         return [
             'cashflow' => true,
-            'calculateBalancesOnImport' => $user
-                ? Feature::for($user)->active(CalculateBalancesOnImport::class)
-                : false,
-            'transactionAnalysis' => $user
-                ? Feature::for($user)->active(TransactionAnalysis::class)
-                : false,
+            'calculateBalancesOnImport' => $features[CalculateBalancesOnImport::class] !== false,
+            'transactionAnalysis' => $features[TransactionAnalysis::class] !== false,
         ];
     }
 


### PR DESCRIPTION
## What

Collapse the two Pennant feature-flag checks in `HandleInertiaRequests::resolveFeatureFlags()` into a single `Feature::for($user)->values([...])` call.

## Why

The `transactionAnalysis` flag added in #496 introduced a **second** Pennant DB lookup that runs on **every** page. That pushed the account show page from 18 → 19 queries, breaking the `performance-tests` job on `main`:

```
Account Show: Expected at most 18 queries, but 19 were executed.
```

Batching keeps shared data at a single query regardless of how many flags we add, so this fixes the regression without bumping the threshold.

## Testing

- `./vendor/bin/pest --testsuite=Performance` — 25 passed
- `tests/Feature/InertiaSharedDataTest.php` — 8 passed
- Pint clean