### PR TITLE
feat(currency): add NZD (New Zealand Dollar)

### DIFF
--- a/config/currencies.php
+++ b/config/currencies.php
@@ -45,6 +45,12 @@ return [
             'allows_account' => true,
         ],
         [
+            'code' => 'NZD',
+            'name' => 'New Zealand Dollar',
+            'allows_primary' => true,
+            'allows_account' => true,
+        ],
+        [
             'code' => 'CNY',
             'name' => 'Chinese Yuan',
             'allows_primary' => true,

--- a/lang/es.json
+++ b/lang/es.json
@@ -976,6 +976,7 @@
     "Neutral": "Neutro",
     "Never": "Nunca",
     "New": "Nuevo",
+    "New Zealand Dollar": "Dólar neozelandés",
     "New password": "Nueva contraseña",
     "New transactions from connected banks": "Nuevas transacciones de bancos conectados",
     "New transactions synced, :name!": "¡Nuevas transacciones sincronizadas, :name!",

--- a/resources/js/utils/currency.ts
+++ b/resources/js/utils/currency.ts
@@ -23,6 +23,7 @@ export function getCurrencySymbol(currencyCode: string): string {
         EUR: '€',
         GBP: '£',
         JPY: '¥',
+        NZD: 'NZ$',
         DOP: 'RD$',
     };
     return symbols[currencyCode] || currencyCode;


### PR DESCRIPTION
## What
Add New Zealand Dollar (NZD) as a supported currency.

## Compatibility
Conversion provider `@fawazahmed0/currency-api` covers NZD (standard ISO 4217). Conversion service lowercases codes and fetches `nzd.min.json` — same path AUD uses. `exchange_rates` table stores rates as JSON, so any 3-letter code works. Validation rules and Inertia currency props auto-derive from config via `CurrencyOptions`.

## Changes
- `config/currencies.php` — NZD entry (`allows_primary` + `allows_account`)
- `resources/js/utils/currency.ts` — `NZ$` symbol
- `lang/es.json` — Spanish translation (name passes through `__()`)

## Tests
Currency + translation suites pass.