### PR TITLE
feat(landing): add go now button to redirect modal

### DIFF
--- a/lang/es.json
+++ b/lang/es.json
@@ -696,6 +696,7 @@
     "Get started at no cost. No bank connections included.": "Empieza sin coste. Sin conexiones bancarias incluidas.",
     "Get started quickly with your existing financial data.": "Comienza rápidamente con tus datos financieros existentes.",
     "Github": "Github",
+    "Go now": "Ir ahora",
     "Go to Dashboard": "Ir al Panel",
     "Go to Settings": "Ir a Configuración",
     "Go to your account's transaction history": "Ve al historial de transacciones de tu cuenta",

--- a/resources/js/components/landing/authenticated-redirect-dialog.test.tsx
+++ b/resources/js/components/landing/authenticated-redirect-dialog.test.tsx
@@ -63,6 +63,14 @@ describe('AuthenticatedRedirectDialog', () => {
         ).toBe('50');
     });
 
+    it('redirects immediately when clicking go now', () => {
+        render(<AuthenticatedRedirectDialog open />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Go now' }));
+
+        expect(mocks.routerVisit).toHaveBeenCalledWith(dashboard());
+    });
+
     it('cancels the redirect and closes the modal', () => {
         render(<AuthenticatedRedirectDialog open />);
 

--- a/resources/js/components/landing/authenticated-redirect-dialog.tsx
+++ b/resources/js/components/landing/authenticated-redirect-dialog.tsx
@@ -60,6 +60,11 @@ export default function AuthenticatedRedirectDialog({
         setIsOpen(false);
     }
 
+    function redirectNow(): void {
+        setProgress(100);
+        router.visit(dashboard());
+    }
+
     return (
         <Dialog open={isOpen}>
             <DialogContent showCloseButton={false}>
@@ -84,13 +89,16 @@ export default function AuthenticatedRedirectDialog({
                         style={{ width: `${progress}%` }}
                     />
                 </div>
-                <DialogFooter>
+                <DialogFooter className="sm:justify-between">
                     <Button
                         type="button"
                         variant="secondary"
                         onClick={cancelRedirect}
                     >
                         {__('Cancel')}
+                    </Button>
+                    <Button type="button" onClick={redirectNow}>
+                        {__('Go now')}
                     </Button>
                 </DialogFooter>
             </DialogContent>


### PR DESCRIPTION
## Summary

On the landing page, logged-in users see a modal with a three-second progress bar that redirects them to the dashboard. This adds a primary **Go now** button so users can skip the wait.

- Move **Cancel** button to the left, add primary **Go now** button on the right (`sm:justify-between`)
- `Go now` calls `router.visit(dashboard())` immediately
- Added `Go now` Spanish translation (CI enforces `es.json`)

## Testing

- Added test: redirects immediately when clicking go now
- All 4 dialog tests pass