### PR TITLE
chore: ignore .playwright-mcp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ yarn-error.log
 .claude/settings.local.json
 .php-version
 .pint.cache
+/.playwright-mcp


### PR DESCRIPTION
Add `/.playwright-mcp` to `.gitignore` so the Playwright MCP working directory isn't tracked.