### PR TITLE
fix(transactions): improve mobile analysis button affordance

### DIFF
--- a/resources/js/components/transactions/transaction-actions-menu.tsx
+++ b/resources/js/components/transactions/transaction-actions-menu.tsx
@@ -8,11 +8,6 @@ import {
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import {
-    Popover,
-    PopoverContent,
-    PopoverTrigger,
-} from '@/components/ui/popover';
-import {
     Tooltip,
     TooltipContent,
     TooltipProvider,
@@ -73,6 +68,7 @@ export function TransactionActionsMenu({
     const isMobile = useIsMobile();
     const [importDrawerOpen, setImportDrawerOpen] = useState(false);
     const [analysisDrawerOpen, setAnalysisDrawerOpen] = useState(false);
+    const [analysisHintOpen, setAnalysisHintOpen] = useState(false);
     const [isReEvaluating, setIsReEvaluating] = useState(false);
     const { reEvaluateAll } = useReEvaluateAllTransactions();
 
@@ -80,6 +76,9 @@ export function TransactionActionsMenu({
 
     const handleAnalysisClick = () => {
         if (!canAnalyze) {
+            if (isMobile) {
+                setAnalysisHintOpen((open) => !open);
+            }
             return;
         }
         setAnalysisDrawerOpen(true);
@@ -124,34 +123,35 @@ export function TransactionActionsMenu({
             <ButtonGroup>
                 {features.transactionAnalysis &&
                     (isMobile ? (
-                        canAnalyze ? (
-                            <Button
-                                variant="outline"
-                                onClick={handleAnalysisClick}
+                        <TooltipProvider>
+                            <Tooltip
+                                open={!canAnalyze && analysisHintOpen}
+                                onOpenChange={setAnalysisHintOpen}
                             >
-                                <BarChart3 className="h-5 w-5" />
-                                {__('Analysis')}
-                            </Button>
-                        ) : (
-                            <Popover>
-                                <PopoverTrigger asChild>
+                                <TooltipTrigger asChild>
                                     <Button
                                         variant="outline"
-                                        className="cursor-help opacity-50"
-                                        aria-disabled
+                                        className={
+                                            !canAnalyze
+                                                ? 'cursor-not-allowed opacity-50'
+                                                : ''
+                                        }
+                                        aria-disabled={!canAnalyze}
+                                        onClick={handleAnalysisClick}
                                     >
                                         <BarChart3 className="h-5 w-5" />
                                         {__('Analysis')}
                                     </Button>
-                                </PopoverTrigger>
-                                <PopoverContent
-                                    align="start"
-                                    className="text-sm"
-                                >
-                                    {__('Apply a filter to enable this button')}
-                                </PopoverContent>
-                            </Popover>
-                        )
+                                </TooltipTrigger>
+                                {!canAnalyze && (
+                                    <TooltipContent>
+                                        {__(
+                                            'Apply a filter to enable this button',
+                                        )}
+                                    </TooltipContent>
+                                )}
+                            </Tooltip>
+                        </TooltipProvider>
                     ) : (
                         <TooltipProvider>
                             <Tooltip>

--- a/resources/js/components/transactions/transaction-actions-menu.tsx
+++ b/resources/js/components/transactions/transaction-actions-menu.tsx
@@ -2,13 +2,6 @@ import { categorize } from '@/actions/App/Http/Controllers/TransactionController
 import { Button } from '@/components/ui/button';
 import { ButtonGroup } from '@/components/ui/button-group';
 import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogHeader,
-    DialogTitle,
-} from '@/components/ui/dialog';
-import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
@@ -130,20 +123,35 @@ export function TransactionActionsMenu({
             <ButtonGroup>
                 {features.transactionAnalysis &&
                     (isMobile ? (
-                        <Button
-                            variant="outline"
-                            size="icon"
-                            className={
-                                !canAnalyze
-                                    ? 'cursor-not-allowed opacity-50'
-                                    : ''
-                            }
-                            aria-disabled={!canAnalyze}
-                            aria-label={__('Analysis')}
-                            onClick={handleAnalysisClick}
-                        >
-                            <BarChart3 className="h-5 w-5" />
-                        </Button>
+                        <TooltipProvider>
+                            <Tooltip
+                                open={!canAnalyze && analysisHintOpen}
+                                onOpenChange={setAnalysisHintOpen}
+                            >
+                                <TooltipTrigger asChild>
+                                    <Button
+                                        variant="outline"
+                                        className={
+                                            !canAnalyze
+                                                ? 'cursor-not-allowed opacity-50'
+                                                : ''
+                                        }
+                                        aria-disabled={!canAnalyze}
+                                        onClick={handleAnalysisClick}
+                                    >
+                                        <BarChart3 className="h-5 w-5" />
+                                        {__('Analysis')}
+                                    </Button>
+                                </TooltipTrigger>
+                                {!canAnalyze && (
+                                    <TooltipContent>
+                                        {__(
+                                            'Apply a filter to enable this button',
+                                        )}
+                                    </TooltipContent>
+                                )}
+                            </Tooltip>
+                        </TooltipProvider>
                     ) : (
                         <TooltipProvider>
                             <Tooltip>
@@ -211,32 +219,36 @@ export function TransactionActionsMenu({
                     </Tooltip>
                 </TooltipProvider>
 
-                <TooltipProvider>
-                    <Tooltip>
-                        <TooltipTrigger asChild>
-                            <Button
-                                variant="outline"
-                                className={
-                                    !isKeySet
-                                        ? 'cursor-not-allowed opacity-50'
-                                        : ''
-                                }
-                                onClick={handleAddTransaction}
-                                aria-label={__('Add transaction')}
-                            >
-                                <Plus className="h-5 w-5" />
-                                <span className="hidden sm:inline">
-                                    {__('Transaction')}
-                                </span>
-                            </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                            {!isKeySet
-                                ? __('Unlock encryption to add transactions')
-                                : __('Create a new transaction')}
-                        </TooltipContent>
-                    </Tooltip>
-                </TooltipProvider>
+                {!isMobile && (
+                    <TooltipProvider>
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <Button
+                                    variant="outline"
+                                    className={
+                                        !isKeySet
+                                            ? 'cursor-not-allowed opacity-50'
+                                            : ''
+                                    }
+                                    onClick={handleAddTransaction}
+                                    aria-label={__('Add transaction')}
+                                >
+                                    <Plus className="h-5 w-5" />
+                                    <span className="hidden sm:inline">
+                                        {__('Transaction')}
+                                    </span>
+                                </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                                {!isKeySet
+                                    ? __(
+                                          'Unlock encryption to add transactions',
+                                      )
+                                    : __('Create a new transaction')}
+                            </TooltipContent>
+                        </Tooltip>
+                    </TooltipProvider>
+                )}
 
                 <DropdownMenu>
                     <TooltipProvider>
@@ -258,6 +270,15 @@ export function TransactionActionsMenu({
                         </Tooltip>
                     </TooltipProvider>
                     <DropdownMenuContent align="end">
+                        {isMobile && (
+                            <DropdownMenuItem
+                                onClick={handleAddTransaction}
+                                disabled={!isKeySet}
+                            >
+                                <Plus className="mr-2 h-4 w-4" />
+                                {__('Add transaction')}
+                            </DropdownMenuItem>
+                        )}
                         <DropdownMenuItem
                             onClick={handleOpenImportDrawer}
                             disabled={!isKeySet}
@@ -293,17 +314,6 @@ export function TransactionActionsMenu({
                     filters={filters}
                 />
             )}
-
-            <Dialog open={analysisHintOpen} onOpenChange={setAnalysisHintOpen}>
-                <DialogContent>
-                    <DialogHeader>
-                        <DialogTitle>{__('Analysis')}</DialogTitle>
-                        <DialogDescription>
-                            {__('Apply a filter to enable this button')}
-                        </DialogDescription>
-                    </DialogHeader>
-                </DialogContent>
-            </Dialog>
         </>
     );
 }

--- a/resources/js/components/transactions/transaction-actions-menu.tsx
+++ b/resources/js/components/transactions/transaction-actions-menu.tsx
@@ -8,6 +8,11 @@ import {
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from '@/components/ui/popover';
+import {
     Tooltip,
     TooltipContent,
     TooltipProvider,
@@ -68,7 +73,6 @@ export function TransactionActionsMenu({
     const isMobile = useIsMobile();
     const [importDrawerOpen, setImportDrawerOpen] = useState(false);
     const [analysisDrawerOpen, setAnalysisDrawerOpen] = useState(false);
-    const [analysisHintOpen, setAnalysisHintOpen] = useState(false);
     const [isReEvaluating, setIsReEvaluating] = useState(false);
     const { reEvaluateAll } = useReEvaluateAllTransactions();
 
@@ -76,9 +80,6 @@ export function TransactionActionsMenu({
 
     const handleAnalysisClick = () => {
         if (!canAnalyze) {
-            if (isMobile) {
-                setAnalysisHintOpen(true);
-            }
             return;
         }
         setAnalysisDrawerOpen(true);
@@ -123,35 +124,34 @@ export function TransactionActionsMenu({
             <ButtonGroup>
                 {features.transactionAnalysis &&
                     (isMobile ? (
-                        <TooltipProvider>
-                            <Tooltip
-                                open={!canAnalyze && analysisHintOpen}
-                                onOpenChange={setAnalysisHintOpen}
+                        canAnalyze ? (
+                            <Button
+                                variant="outline"
+                                onClick={handleAnalysisClick}
                             >
-                                <TooltipTrigger asChild>
+                                <BarChart3 className="h-5 w-5" />
+                                {__('Analysis')}
+                            </Button>
+                        ) : (
+                            <Popover>
+                                <PopoverTrigger asChild>
                                     <Button
                                         variant="outline"
-                                        className={
-                                            !canAnalyze
-                                                ? 'cursor-not-allowed opacity-50'
-                                                : ''
-                                        }
-                                        aria-disabled={!canAnalyze}
-                                        onClick={handleAnalysisClick}
+                                        className="cursor-help opacity-50"
+                                        aria-disabled
                                     >
                                         <BarChart3 className="h-5 w-5" />
                                         {__('Analysis')}
                                     </Button>
-                                </TooltipTrigger>
-                                {!canAnalyze && (
-                                    <TooltipContent>
-                                        {__(
-                                            'Apply a filter to enable this button',
-                                        )}
-                                    </TooltipContent>
-                                )}
-                            </Tooltip>
-                        </TooltipProvider>
+                                </PopoverTrigger>
+                                <PopoverContent
+                                    align="start"
+                                    className="text-sm"
+                                >
+                                    {__('Apply a filter to enable this button')}
+                                </PopoverContent>
+                            </Popover>
+                        )
                     ) : (
                         <TooltipProvider>
                             <Tooltip>


### PR DESCRIPTION
## Summary

Improves the transaction actions menu on mobile:

- **Tap-to-show tooltip instead of a modal** — when the Analysis button is tapped with no filter applied, it now shows the same tooltip used on desktop ("Apply a filter to enable this button") via a controlled Radix tooltip, instead of opening a separate modal dialog.
- **Always show the "Analysis" label on mobile** — previously the mobile button was icon-only, which made it hard to understand. It now shows the icon + label like desktop.
- **Move "Add transaction" into the more-actions dropdown on mobile** — frees up horizontal space so the Analysis label fits. On desktop the standalone Add transaction button is unchanged.

## Notes

- Reuses the existing `Add transaction` translation key (already in `lang/es.json`).
- Removed the now-unused `Dialog` import/markup.

## Test plan

- [ ] On mobile, tap Analysis with no filter → tooltip appears on tap, dismisses on tap outside.
- [ ] On mobile, the Analysis button shows its label.
- [ ] On mobile, "Add transaction" appears in the more-actions (⌄) dropdown.
- [ ] On desktop, behavior is unchanged (hover tooltip, standalone Add transaction button).