### PR TITLE
fix: start the new transaction form with no account preselected

### DIFF
--- a/resources/js/components/transactions/edit-transaction-dialog.tsx
+++ b/resources/js/components/transactions/edit-transaction-dialog.tsx
@@ -129,12 +129,7 @@ export function EditTransactionDialog({
             const initialAccount = availableAccounts.find(
                 (account) => account.id === initialAccountId,
             );
-            setAccountId(
-                initialAccount?.id ??
-                    (availableAccounts.length > 0
-                        ? availableAccounts[0].id
-                        : ''),
-            );
+            setAccountId(initialAccount?.id ?? '');
             setCategoryId('null');
             setSelectedLabelIds([]);
             setNotes('');


### PR DESCRIPTION
## Summary
When the add/edit transaction dialog resets, it no longer auto-selects the first transactional account — the account field starts empty so the user must pick one deliberately (avoids accidentally booking a transaction to the wrong account).

🤖 Generated with [Claude Code](https://claude.com/claude-code)