### PR TITLE
fix(i18n): keep Discord brand name untranslated in French

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -578,7 +578,7 @@
   "Disconnect": "Déconnecter",
   "Disconnect Bank": "Déconnecter la banque",
   "Disconnecting...": "Déconnexion...",
-  "Discord": "Discorde",
+  "Discord": "Discord",
   "Discord for 80% off": "Discord avec 80% de réduction",
   "Do not show": "Ne pas montrer",
   "Do not show in Sankey": "Ne pas se présenter à Sankey",


### PR DESCRIPTION
## What

French translation rendered the **Discord** brand name as "Discorde". Brand names stay as-is — fixed `lang/fr.json` line 581.

## Check

Swept all brand tokens (Discord, Stripe, GitHub, Google, etc.) in `fr.json`. Only this one was mistranslated; the rest keep the brand correctly.