### PR TITLE
fix(queue): add supervisor worker for the ai queue

### DIFF
--- a/docker/supervisor/supervisord.conf
+++ b/docker/supervisor/supervisord.conf
@@ -76,3 +76,14 @@ redirect_stderr=true
 stdout_logfile=/var/log/queue-worker.log
 stopwaitsecs=3600
 numprocs=2
+
+[program:queue-worker-ai]
+process_name=%(program_name)s_%(process_num)02d
+command=php /app/artisan queue:work database --queue=ai --sleep=1 --tries=3 --max-time=3600
+user=www-data
+autostart=true
+autorestart=true
+redirect_stderr=true
+stdout_logfile=/var/log/queue-worker-ai.log
+stopwaitsecs=3600
+numprocs=2


### PR DESCRIPTION
## Problem

AI-powered auto-categorization jobs (\`CategorizeTransactionWithAi\`) are placed in the dedicated \`ai\` queue (\`config/ai_categorization.php\` → \`'queue' => 'ai'\`), but **no supervisor script was consuming that queue in production**.

Observed result in production:
- **10,878 pending jobs** in the \`ai\` queue, all \`CategorizeTransactionWithAi\`, the oldest from 2026-06-15 (when the flag was enabled).
- **0 transactions** with \`category_source = 'ai'\` in the entire database. The AI never categorized anything in production.
- No \`failed_job\` in the \`ai\` queue: the jobs didn’t fail; they simply never ran.

## Fix

Add a \`queue-worker-ai\` program to \`docker/supervisor/supervisord.conf\`, replicating the pattern used for the \`emails\` and \`default\` workers. The `ai` queue is intentionally kept isolated (with its own worker) so that its backlog does not delay bank syncs.

After deployment, the worker starts automatically (`autostart=true`) and clears the accumulated backlog.