### PR TITLE
style: pulse the AI categorize sparkle icon

### DIFF
--- a/resources/js/components/transactions/category-cell.tsx
+++ b/resources/js/components/transactions/category-cell.tsx
@@ -150,7 +150,7 @@ export function CategoryCell({
                         className="inline-flex"
                         aria-label={__('Let AI categorize your transactions')}
                     >
-                        <AiSparkleIcon className="h-3.5 w-3.5 opacity-50 transition-opacity hover:opacity-100" />
+                        <AiSparkleIcon className="h-3.5 w-3.5 animate-pulse transition-opacity hover:opacity-100" />
                     </button>
                 </TooltipTrigger>
                 <TooltipContent>


### PR DESCRIPTION
## What

Replace the static `opacity-50` on the AI categorize sparkle icon with `animate-pulse`, so the affordance gently pulses to draw attention. Hover still fades to full opacity.

## Why

Makes the "let AI categorize your transactions" entry point more discoverable in the transactions table.

## Testing

Visual-only Tailwind class change; no logic affected.