### PR TITLE
feat(currency): add RSD (Serbian Dinar)

### DIFF
--- a/config/currencies.php
+++ b/config/currencies.php
@@ -146,5 +146,11 @@ return [
             'allows_primary' => false,
             'allows_account' => true,
         ],
+        [
+            'code' => 'RSD',
+            'name' => 'Serbian Dinar',
+            'allows_primary' => true,
+            'allows_account' => true,
+        ],
     ],
 ];

--- a/lang/es.json
+++ b/lang/es.json
@@ -1495,6 +1495,7 @@
     "Syncing balances…": "Sincronizando balances…",
     "Syncing transactions and balances…": "Sincronizando transacciones y balances…",
     "System": "Sistema",
+    "Serbian Dinar": "Dinar Serbio",
     "Take control of your finances with privacy-first money tracking. Let's set up your account in just a few minutes.": "Toma el control de tus finanzas con un seguimiento privado de tu dinero. Vamos a configurar tu cuenta en pocos minutos.",
     "Tap": "Toca",
     "Tap the": "Toca el botón",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1473,6 +1473,7 @@
     "Syncing balances…": "Synchronisation des soldes…",
     "Syncing transactions and balances…": "Synchronisation des transactions et des soldes…",
     "System": "Système",
+    "Serbian Dinar": "Dinar Serbe",
     "Take control of your finances with privacy-first money tracking. Let's set up your account in just a few minutes.": "Prenez le contrôle de vos finances grâce au suivi de l'argent privé. Nous créerons votre compte dans quelques minutes.",
     "Tap": "Touche",
     "Tap the": "Touchez le bouton",


### PR DESCRIPTION
## What
Add Serbian Dinar (RSD) as a supported currency.

## Compatibility
Conversion provider `@fawazahmed0/currency-api` covers RSD (standard ISO 4217). Conversion service lowercases codes and fetches `rsd.min.json` - same path NZD uses. `exchange_rates` table stores rates as JSON, so any 3-letter code works. Validation rules and Inertia currency props auto-derive from config via `CurrencyOptions`.

## Changes
- `config/currencies.php` - RSD entry (`allows_primary` + `allows_account`)
- `lang/es.json` - Spanish translation
- `lang/fr.json` - French translation

## Tests
Haven't tested them locally, but should pass