### PR TITLE
fix(ui): make input borders visible in dark mode

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -134,7 +134,7 @@
     --destructive: oklch(0.396 0.141 25.723);
     --destructive-foreground: oklch(0.637 0.237 25.331);
     --border: oklch(0.325 0 0);
-    --input: oklch(0.269 0 0);
+    --input: oklch(0.41 0 0);
     --ring: oklch(0.439 0 0);
     --chart-1: var(--color-zinc-200);
     --chart-2: var(--color-zinc-300);


### PR DESCRIPTION
## What

Bump the dark-mode `--input` color from `oklch(0.269)` to `oklch(0.41)`.

## Why

In dark mode the `--input` value sat almost on top of the background (`oklch(0.225)`), so the shared `border-input` was nearly invisible on every form control. Checkboxes were especially hard to spot.

Since inputs, checkboxes, radios, selects and textareas all share `border-input`, this single variable raises their border contrast at once (Δ luminosity vs background goes from 0.044 → 0.185) while staying below the focus ring (`0.439`), so focus still stands out and every control keeps a consistent design.

As a nice side effect, the subtle `bg-input/30` and `bg-input/50` fills (radio, outline button) also read a touch more clearly.