### PR TITLE
fix(transactions): restore left padding when category is first column

### DIFF
--- a/resources/js/components/transactions/transaction-columns.tsx
+++ b/resources/js/components/transactions/transaction-columns.tsx
@@ -139,7 +139,7 @@ export function createTransactionColumns({
             meta: {
                 label: __('Category'),
                 cellClassName:
-                    'pl-0 max-w-[170px] !sm:max-w-[170px] md:max-w-[190px] !min-w-[170px] whitespace-normal',
+                    'pl-0 first:pl-2 max-w-[170px] !sm:max-w-[170px] md:max-w-[190px] !min-w-[170px] whitespace-normal',
             },
             header: () => __('Category'),
             cell: ({ row }) => {


### PR DESCRIPTION
## What

The category column in the transactions table drops its left padding (`pl-0`) so it aligns flush when preceded by other columns. But when the user hides the columns to its left (select, date), the category becomes the first column and loses the table's default left padding, sitting flush against the table edge.

## Fix

Add a `first:pl-2` Tailwind variant to the category cell. When the cell is `:first-child` (no column to its left), it restores the default `pl-2` padding; otherwise it keeps `pl-0`. The `:first-child` pseudo-class gives it higher specificity than `pl-0`, so it wins only in that case.

Columns hidden via view options are removed from the DOM (TanStack), so the category is `:first-child` exactly when it genuinely has no column to its left. Applies to both the header and body cells, since both consume `meta.cellClassName`.