### PR TITLE
fix(transactions): pad Category column when Date column is hidden

### DIFF
--- a/resources/js/components/transactions/transaction-columns.test.tsx
+++ b/resources/js/components/transactions/transaction-columns.test.tsx
@@ -1,0 +1,44 @@
+import type { DecryptedTransaction } from '@/types/transaction';
+import type { ColumnDef } from '@tanstack/react-table';
+import { describe, expect, it } from 'vitest';
+import { createTransactionColumns } from './transaction-columns';
+
+function categoryClassName(columns: ColumnDef<DecryptedTransaction>[]): string {
+    const category = columns.find(
+        (column) =>
+            'accessorKey' in column && column.accessorKey === 'category_id',
+    );
+
+    return (category?.meta as { cellClassName?: string }).cellClassName ?? '';
+}
+
+function buildColumns(isDateHidden: boolean) {
+    return createTransactionColumns({
+        categories: [],
+        accounts: [],
+        banks: [],
+        labels: [],
+        locale: 'en',
+        onEdit: () => {},
+        onDelete: () => {},
+        onUpdate: () => {},
+        onReEvaluateRules: () => {},
+        isDateHidden,
+    });
+}
+
+describe('createTransactionColumns category padding', () => {
+    it('collapses the Category left padding while the Date column is shown', () => {
+        const className = categoryClassName(buildColumns(false));
+
+        expect(className).toContain('pl-0');
+        expect(className).not.toContain('pl-2');
+    });
+
+    it('restores the Category left padding when the Date column is hidden', () => {
+        const className = categoryClassName(buildColumns(true));
+
+        expect(className).toContain('pl-2');
+        expect(className).not.toContain('pl-0');
+    });
+});

--- a/resources/js/components/transactions/transaction-columns.tsx
+++ b/resources/js/components/transactions/transaction-columns.tsx
@@ -42,6 +42,7 @@ interface CreateColumnsOptions {
         source: 'transaction_table',
     ) => void;
     onReEvaluateRules: (transaction: DecryptedTransaction) => void;
+    isDateHidden?: boolean;
 }
 
 export function createTransactionColumns({
@@ -55,6 +56,7 @@ export function createTransactionColumns({
     onUpdate,
     onCategorized,
     onReEvaluateRules,
+    isDateHidden = false,
 }: CreateColumnsOptions): ColumnDef<DecryptedTransaction>[] {
     return [
         {
@@ -138,8 +140,7 @@ export function createTransactionColumns({
             accessorKey: 'category_id',
             meta: {
                 label: __('Category'),
-                cellClassName:
-                    'pl-0 first:pl-2 max-w-[170px] !sm:max-w-[170px] md:max-w-[190px] !min-w-[170px] whitespace-normal',
+                cellClassName: `${isDateHidden ? 'pl-2' : 'pl-0'} max-w-[170px] !sm:max-w-[170px] md:max-w-[190px] !min-w-[170px] whitespace-normal`,
             },
             header: () => __('Category'),
             cell: ({ row }) => {

--- a/resources/js/components/transactions/transaction-list.tsx
+++ b/resources/js/components/transactions/transaction-list.tsx
@@ -820,6 +820,7 @@ export function TransactionList({
             onUpdate: updateTransaction,
             onCategorized: showAutomatizeToast,
             onReEvaluateRules: handleReEvaluateRules,
+            isDateHidden: columnVisibility.transaction_date === false,
         });
 
         if (hideColumns.length === 0) {
@@ -841,6 +842,7 @@ export function TransactionList({
         showAutomatizeToast,
         handleReEvaluateRules,
         hideColumns,
+        columnVisibility,
     ]);
 
     const table = useReactTable({


### PR DESCRIPTION
Closes #583

When the Date column is toggled off, the Category column becomes the leftmost data column. It carried a static `pl-0` (to sit tight after Date), so it ended up flush against the table edge with no left padding — visible at `< md` widths where the `select` checkbox column is hidden.

#582 tried a CSS `first:pl-2`, but the `select` cell (`hidden md:table-cell`) is `display:none` yet still the DOM `:first-child`, so `first:` never matches Category. This drives the padding from the Date column's visibility instead: keep `pl-0` while Date is shown, restore `pl-2` when it is hidden (replacing the inert `first:pl-2`).

## Test
`createTransactionColumns` unit test asserting the Category `cellClassName` flips `pl-0` ↔ `pl-2` with `isDateHidden`.