### PR TITLE
fix(banking): hide Update Credentials for providers without an update path

### DIFF
--- a/resources/js/pages/settings/connections.test.tsx
+++ b/resources/js/pages/settings/connections.test.tsx
@@ -113,4 +113,35 @@ describe('ConnectionsPage', () => {
             screen.getAllByRole('button', { name: /reconnect/i }),
         ).toHaveLength(2);
     });
+
+    it('offers Update Credentials only for providers with an update path', () => {
+        render(
+            <ConnectionsPage
+                connections={[
+                    makeConnection({
+                        id: 'c-indexa',
+                        provider: 'indexacapital',
+                        aspsp_name: 'Indexa Capital',
+                        status: 'error',
+                        error_message:
+                            'Authentication failed. Your credentials may have expired or been revoked.',
+                    }),
+                    makeConnection({
+                        id: 'c-wise',
+                        provider: 'wise',
+                        aspsp_name: 'Wise',
+                        status: 'error',
+                        error_message:
+                            'Authentication failed. Your credentials may have expired or been revoked.',
+                    }),
+                ]}
+            />,
+        );
+
+        // Indexa Capital is updatable; Wise has no update path, so only one
+        // Update Credentials button is rendered.
+        expect(
+            screen.getAllByRole('button', { name: /update credentials/i }),
+        ).toHaveLength(1);
+    });
 });

--- a/resources/js/pages/settings/connections.tsx
+++ b/resources/js/pages/settings/connections.tsx
@@ -141,6 +141,18 @@ export default function ConnectionsPage({ connections }: Props) {
         );
     }
 
+    function canUpdateCredentials(connection: BankingConnection): boolean {
+        // Wise authenticates with an API key but has no credential-update path
+        // (neither the dialog nor the backend handle it), so don't offer the
+        // button for it — it would open an empty, unusable dialog.
+        return (
+            hasAuthError(connection) &&
+            ['indexacapital', 'binance', 'bitpanda', 'coinbase'].includes(
+                connection.provider,
+            )
+        );
+    }
+
     function isEnableBankingAuthError(connection: BankingConnection): boolean {
         return (
             connection.status === 'error' &&
@@ -302,7 +314,7 @@ export default function ConnectionsPage({ connections }: Props) {
                                                             )}
                                                         </DropdownMenuItem>
                                                     )}
-                                                    {hasAuthError(
+                                                    {canUpdateCredentials(
                                                         connection,
                                                     ) && (
                                                         <DropdownMenuItem
@@ -426,7 +438,7 @@ export default function ConnectionsPage({ connections }: Props) {
                                                                 )}
                                                         </p>
                                                         <div className="flex flex-wrap items-center gap-3">
-                                                            {hasAuthError(
+                                                            {canUpdateCredentials(
                                                                 connection,
                                                             ) && (
                                                                 <Button


### PR DESCRIPTION
## What

Fixes a dead-end in the banking connections UI: a **Wise** connection in an
auth-error state showed an **Update Credentials** button that opened an empty,
unusable dialog.

Wise authenticates with an API key (so `isApiKeyProvider` is true), but it has
no credential-update path — neither `UpdateCredentialsDialog` nor the backend
`UpdateConnectionCredentialsRequest`/`ConnectionController` handle it. The
button was gated only on `hasAuthError`, so it appeared for Wise too and led
nowhere.

## Fix

Add a `canUpdateCredentials()` gate that also checks the provider is one the
update flow supports (`indexacapital`, `binance`, `bitpanda`, `coinbase`), and
use it for both Update Credentials affordances (dropdown item + inline error
card button).

## Tests

`connections.test.tsx`: with two auth-errored connections (Indexa Capital +
Wise), exactly one Update Credentials button renders (Indexa only).

Pre-existing on `main`; found during review of the Interactive Brokers work.
