### PR TITLE
fix(accounts): don't draw the invested overlay for a single data point

### DIFF
--- a/resources/js/components/accounts/account-balance-chart.tsx
+++ b/resources/js/components/accounts/account-balance-chart.tsx
@@ -601,6 +601,25 @@ export function AccountBalanceChart({
         return null;
     }, [activeChartData, currentInvestedAmount, hasCurrencyToggle]);
 
+    // A lone invested point (e.g. a freshly connected account whose history was
+    // backfilled with balances but cost basis only for the latest date) renders
+    // as a single dot with nothing to connect to. Only draw the invested
+    // overlay once there are at least two points to plot.
+    const hasInvestedSeries = useMemo(
+        () =>
+            activeChartData.filter(
+                (point) =>
+                    point.invested_amount !== null &&
+                    point.invested_amount !== undefined,
+            ).length >= 2,
+        [activeChartData],
+    );
+
+    const showInvestedOverlay =
+        showInvestmentBenefits &&
+        activeCurrentInvestedAmount !== null &&
+        hasInvestedSeries;
+
     const activeShortTrend = useMemo(() => {
         if (currencyMode !== 'user' || !hasCurrencyToggle) return shortTrend;
         const historicalData = activeChartData.filter((d) => !d.projected);
@@ -1043,23 +1062,20 @@ export function AccountBalanceChart({
                                         activeDot={{ r: 5 }}
                                         fillOpacity={1}
                                     />
-                                    {showInvestmentBenefits &&
-                                        activeCurrentInvestedAmount !==
-                                            null && (
-                                            <Line
-                                                dataKey="invested_amount"
-                                                type="monotone"
-                                                stroke="var(--color-chart-6)"
-                                                strokeWidth={1.5}
-                                                strokeDasharray="2 2"
-                                                dot={false}
-                                                activeDot={{ r: 4 }}
-                                                connectNulls
-                                            />
-                                        )}
+                                    {showInvestedOverlay && (
+                                        <Line
+                                            dataKey="invested_amount"
+                                            type="monotone"
+                                            stroke="var(--color-chart-6)"
+                                            strokeWidth={1.5}
+                                            strokeDasharray="2 2"
+                                            dot={false}
+                                            activeDot={{ r: 4 }}
+                                            connectNulls
+                                        />
+                                    )}
                                 </AreaChart>
-                            ) : showInvestmentBenefits &&
-                              activeCurrentInvestedAmount !== null ? (
+                            ) : showInvestedOverlay ? (
                                 <ComposedChart
                                     accessibilityLayer
                                     data={activeChartData.slice(1)}


### PR DESCRIPTION
## What

Fixes a cosmetic chart glitch for investment accounts that have a cost-basis
(`invested_amount`) value for only **one** date.

The dashed "invested" overlay on the account balance chart is gated on
`showInvestmentBenefits && activeCurrentInvestedAmount !== null`. With a single
invested data point the `<Line connectNulls>` has nothing to connect to and
renders as a lone dot, which reads as a broken/half-drawn chart. This happens
for a freshly connected account whose history is backfilled with balances but
whose cost basis is only known for the latest point (e.g. providers that don't
expose historical cost basis).

## Fix

Add a `hasInvestedSeries` guard (≥ 2 non-null invested points) and only draw the
overlay when it holds. Accounts with a full invested series (e.g. Indexa
Capital, which records invested on every date) are unaffected.

## Notes

`account-balance-chart.tsx` has no existing test harness (recharts component);
this is a small render guard, verified via type-check and lint. Found during
review of the Interactive Brokers work, but the guard is provider-agnostic.
