### PR TITLE
feat(subscriptions): reframe pay_now paywall copy around try-and-refund

### DIFF
--- a/lang/es.json
+++ b/lang/es.json
@@ -1,8 +1,9 @@
 {
     "This subscription is no longer eligible for a self-service refund.": "Esta suscripción ya no es elegible para una devolución automática.",
     "Your payment was refunded, your subscription was canceled, and your bank connections were disconnected.": "Te hemos devuelto el pago, cancelado la suscripción y desconectado tus cuentas bancarias.",
-    "You'll be charged :amount today": "Se te cobrará :amount hoy",
-    "Changed your mind? Get a full refund yourself from Settings within the first :days days — no questions asked.": "¿Cambias de idea? Solicita tú mismo la devolución completa desde Ajustes durante los primeros :days días, sin preguntas.",
+    "Try it for :days days": "Pruébalo durante :days días",
+    "Don't like it? Get a full refund with one tap from Settings — no questions asked.": "¿No te gusta? Obtén la devolución completa con un click desde Ajustes, sin preguntas.",
+    "You pay :amount today, refunded in full if you cancel within :days days.": "Pagas :amount hoy y te lo devolvemos íntegro si cancelas en los primeros :days días.",
     ":days-day free trial": "Prueba gratis de :days días",
     "You won't be charged until your :days-day trial ends. Cancel anytime before then.": "No se te cobrará hasta que termine tu prueba de :days días. Cancela cuando quieras antes de eso.",
     "Money-back guarantee": "Garantía de devolución",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1,8 +1,9 @@
 {
     "This subscription is no longer eligible for a self-service refund.": "Cet abonnement n'est plus éligible à un remboursement automatique.",
     "Your payment was refunded, your subscription was canceled, and your bank connections were disconnected.": "Votre paiement a été remboursé, votre abonnement annulé et vos comptes bancaires déconnectés.",
-    "You'll be charged :amount today": "Vous serez débité de :amount aujourd'hui",
-    "Changed your mind? Get a full refund yourself from Settings within the first :days days — no questions asked.": "Vous avez changé d'avis ? Demandez vous-même un remboursement complet depuis les Paramètres durant les :days premiers jours, sans condition.",
+    "Try it for :days days": "Essayez-le pendant :days jours",
+    "Don't like it? Get a full refund with one tap from Settings — no questions asked.": "Vous n'aimez pas ? Obtenez un remboursement intégral en un clic depuis les Paramètres, sans condition.",
+    "You pay :amount today, refunded in full if you cancel within :days days.": "Vous payez :amount aujourd'hui, intégralement remboursé si vous annulez dans les :days jours.",
     ":days-day free trial": "Essai gratuit de :days jours",
     "You won't be charged until your :days-day trial ends. Cancel anytime before then.": "Vous ne serez débité qu'à la fin de votre essai de :days jours. Annulez à tout moment avant.",
     "Money-back guarantee": "Garantie de remboursement",

--- a/resources/js/pages/subscription/paywall.tsx
+++ b/resources/js/pages/subscription/paywall.tsx
@@ -59,12 +59,19 @@ function TrialTerms({
         return (
             <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-center text-sm dark:border-emerald-900 dark:bg-emerald-950/40">
                 <p className="font-medium text-emerald-900 dark:text-emerald-200">
-                    {__("You'll be charged :amount today", { amount })}
+                    {__('Try it for :days days', {
+                        days: offer.refundWindowDays,
+                    })}
                 </p>
                 <p className="mt-1 text-emerald-800/80 dark:text-emerald-300/80">
                     {__(
-                        'Changed your mind? Get a full refund yourself from Settings within the first :days days — no questions asked.',
-                        { days: offer.refundWindowDays },
+                        "Don't like it? Get a full refund with one tap from Settings — no questions asked.",
+                    )}
+                </p>
+                <p className="mt-1 text-xs text-emerald-700/70 dark:text-emerald-300/60">
+                    {__(
+                        'You pay :amount today, refunded in full if you cancel within :days days.',
+                        { amount, days: offer.refundWindowDays },
                     )}
                 </p>
             </div>


### PR DESCRIPTION
## What

Follow-up to #600. Reframes the **pay_now** paywall message so the emphasis is on *trying it risk-free*, not on being charged today.

**Before**
> You'll be charged €3.99 today
> Changed your mind? Get a full refund yourself from Settings within the first 3 days — no questions asked.

**After**
> **Try it for 3 days**
> Don't like it? Get a full refund with one tap from Settings — no questions asked.
> _You pay €3.99 today, refunded in full if you cancel within 3 days._ (muted footnote)

## Why

The upfront-charge headline reads as friction. Leading with "try it / one-tap refund" frames pay_now as risk-free while the charge stays **honestly disclosed** as a muted footnote — so it's never a surprise at refund time (and avoids chargeback risk). Amount and day counts stay dynamic per plan/variant.

## Notes
- Only the pay_now branch of `TrialTerms` changes; control/reduced trials untouched.
- Spanish + French translations updated; the two orphaned old keys removed.
- Lint, tsc (paywall), and `LocalizationTest` pass; no test asserted the literal copy.