### PR TITLE
fix(transactions): let date column size to its content

### DIFF
--- a/resources/js/components/transactions/transaction-columns.tsx
+++ b/resources/js/components/transactions/transaction-columns.tsx
@@ -99,7 +99,7 @@ export function createTransactionColumns({
             accessorKey: 'transaction_date',
             meta: {
                 label: __('Date'),
-                cellClassName: 'max-w-[90px] whitespace-normal pr-1',
+                cellClassName: 'whitespace-normal',
             },
             header: ({ column }) => {
                 return (


### PR DESCRIPTION
## What

Remove the fixed `max-w-[90px]` cap (and `pr-1`) on the transaction date cell so the date column sizes to its content instead of wrapping awkwardly.

## Why

The 90px cap forced the formatted date to wrap onto two lines in the transactions table.