### PR TITLE
fix(settings): vertically center rows in automation rules and labels tables

### DIFF
--- a/resources/js/pages/settings/automation-rules.tsx
+++ b/resources/js/pages/settings/automation-rules.tsx
@@ -155,7 +155,10 @@ function AutomationRuleRow({
                         {row
                             .getVisibleCells()
                             .map((cell: Cell<AutomationRule, unknown>) => (
-                                <TableCell key={cell.id}>
+                                <TableCell
+                                    key={cell.id}
+                                    className="align-middle"
+                                >
                                     {flexRender(
                                         cell.column.columnDef.cell,
                                         cell.getContext(),

--- a/resources/js/pages/settings/labels.tsx
+++ b/resources/js/pages/settings/labels.tsx
@@ -121,7 +121,10 @@ function LabelRow({ row }: { row: Row<Label> }) {
                         {row
                             .getVisibleCells()
                             .map((cell: Cell<Label, unknown>) => (
-                                <TableCell key={cell.id}>
+                                <TableCell
+                                    key={cell.id}
+                                    className="align-middle"
+                                >
                                     {flexRender(
                                         cell.column.columnDef.cell,
                                         cell.getContext(),


### PR DESCRIPTION
## What

Row contents in the **Automation rules** and **Labels** settings tables were not vertically centered — the title, badges and the actions ("…") button sat slightly above the row's vertical center.

## Why

The shared `TableCell` defaults to `align-top`, while the actions button is centered. That mismatch pushed the text/badges up relative to the menu. Overriding the data cells with `align-middle` in both tables makes every element line up.

## Changes

- `resources/js/pages/settings/automation-rules.tsx` — `align-middle` on body cells
- `resources/js/pages/settings/labels.tsx` — `align-middle` on body cells

## Before / After

**Automation rules**

![Automation rules row alignment](https://gist.githubusercontent.com/victor-falcon/484b068be905222a188b081dadec434e/raw/a68085cbe6eb9f05a981f95a49b5e7e288bdac01/automation-rules-row-alignment.png)

**Labels**

![Labels row alignment](https://gist.githubusercontent.com/victor-falcon/484b068be905222a188b081dadec434e/raw/a68085cbe6eb9f05a981f95a49b5e7e288bdac01/labels-row-alignment.png)
