### PR TITLE
test(drip): deflake AI consent onboarding-grace boundary test

### DIFF
--- a/tests/Feature/SendAiConsentFollowUpEmailsCommandTest.php
+++ b/tests/Feature/SendAiConsentFollowUpEmailsCommandTest.php
@@ -9,6 +9,10 @@ use App\Models\UserMailLog;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Mail;
 
+// Freeze time so day-relative timestamps land on exact boundaries; without this the
+// two now() calls below drift by microseconds and tip the "exactly 3 days" case over.
+beforeEach(fn () => $this->freezeTime());
+
 /**
  * Creates a user whose AI consent was recorded $acceptedDaysAgo days ago, having
  * signed up $signedUpDaysAgo days ago.


### PR DESCRIPTION
## Problem

`SendAiConsentFollowUpEmailsCommandTest > it treats consent exactly three days after signup as onboarding` fails intermittently on `main` (more likely under parallel load):

```
The unexpected [App\Jobs\Drip\SendAiConsentFollowUpEmailJob] job was dispatched.
```

## Root cause

The `userWithConsent()` helper builds two timestamps from separate `now()` calls:

```php
User::factory()->create(['created_at' => now()->subDays($signedUpDaysAgo)]); // now() at T1
$user->aiConsents()->create(['accepted_at' => now()->subDays($acceptedDaysAgo)]); // now() at T2 > T1
```

The command treats consent given more than `ONBOARDING_GRACE_DAYS` (3) after signup as a post-onboarding opt-in:

```php
if ($consent->accepted_at->lessThanOrEqualTo($user->created_at->copy()->addDays(3))) {
    continue; // skip
}
```

For the boundary case (`signedUpDaysAgo: 5, acceptedDaysAgo: 2`), `created_at + 3 days = T1 - 2 days` and `accepted_at = T2 - 2 days`. Because `T2 > T1` by microseconds, `accepted_at` lands just *after* the grace boundary, the `<=` returns `false`, and the job is dispatched — failing the assertion.

## Fix

Freeze time for the test file so all day-relative timestamps land on exact boundaries. The command logic is correct and unchanged.

## Testing

```
php artisan test tests/Feature/SendAiConsentFollowUpEmailsCommandTest.php
# 9 passed
```