### PR TITLE
fix: skip demo reset when demo account is disabled

### DIFF
--- a/app/Console/Commands/ResetDemoAccountCommand.php
+++ b/app/Console/Commands/ResetDemoAccountCommand.php
@@ -40,6 +40,14 @@ class ResetDemoAccountCommand extends Command
 
     public function handle(): int
     {
+        $demoEnabled = config('app.demo.enabled');
+
+        if (! $demoEnabled) {
+            $this->info('Demo account is not enabled');
+
+            return self::SUCCESS;
+        }
+
         $demoEmail = config('app.demo.email');
         $demoPassword = config('app.demo.password');
 

--- a/tests/Feature/Console/ResetDemoAccountCommandTest.php
+++ b/tests/Feature/Console/ResetDemoAccountCommandTest.php
@@ -4,9 +4,18 @@ use App\Models\User;
 
 beforeEach(function () {
     config(['app.demo' => [
+        'enabled' => true,
         'email' => 'demo@whisper.money',
         'password' => 'demo',
     ]]);
+});
+
+test('demo:reset does nothing when the demo account is disabled', function () {
+    config(['app.demo.enabled' => false]);
+
+    $this->artisan('demo:reset')->assertSuccessful();
+
+    expect(User::where('email', 'demo@whisper.money')->exists())->toBeFalse();
 });
 
 test('demo:reset fails if demo email is not configured', function () {


### PR DESCRIPTION
## What

`demo:reset` now bails out early with an info message when `config('app.demo.enabled')` is falsy, instead of rebuilding the demo account regardless of the `DEMO_ENABLED` flag.

## Why

The `DEMO_ENABLED` config existed but the command ignored it, so a scheduled reset would recreate demo data on environments where the demo account is turned off.