### PR TITLE
fix(worktree): remove double slash in storage/keys copy path

### DIFF
--- a/worktree.sh
+++ b/worktree.sh
@@ -3,7 +3,7 @@
 ROOT_PATH=$1
 
 cp "$ROOT_PATH/.env" .env
-cp -r "$ROOT_PATH//storage/keys" ./storage/keys
+cp -r "$ROOT_PATH/storage/keys" ./storage/keys
 
 bun i
 composer install


### PR DESCRIPTION
Fixes a typo in `worktree.sh` where the source path had a double slash (`$ROOT_PATH//storage/keys`) when copying signing keys into a new worktree.