### PR TITLE
chore(sentry): migrate Vite source map upload from Bugsink to Sentry

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,10 +5,17 @@ import react from '@vitejs/plugin-react';
 import laravel from 'laravel-vite-plugin';
 import { defineConfig } from 'vite';
 
+// Only upload source maps when the build has a Sentry auth token (production
+// CI). The same flag gates map generation, so a build without the token never
+// emits .js.map files there is nothing to leak into public/build/assets/.
+const sentryAuthToken = process.env.SENTRY_AUTH_TOKEN;
+
 export default defineConfig({
     envPrefix: ['VITE_', 'SENTRY_LARAVEL_DSN'],
     build: {
-        sourcemap: true,
+        // 'hidden' emits maps for upload but omits the sourceMappingURL comment,
+        // so browsers never fetch them even in the window before they're deleted.
+        sourcemap: sentryAuthToken ? 'hidden' : false,
     },
     plugins: [
         laravel({
@@ -25,19 +32,23 @@ export default defineConfig({
         wayfinder({
             formVariants: true,
         }),
-        sentryVitePlugin({
-            url: 'https://bugsink.whisper.money/',
-            authToken: 'b0f46d1bdc25b9a998f540542e027e9faf0a2e8a',
-            org: 'bugsinkhasnoorgs',
-            project: 'ignoredfornow',
-            release: {
-                create: false,
-                finalize: false,
-            },
-            sourcemaps: {
-                filesToDeleteAfterUpload: ['**/*.js.map'],
-            },
-        }),
+        ...(sentryAuthToken
+            ? [
+                  sentryVitePlugin({
+                      url: 'https://de.sentry.io/',
+                      authToken: sentryAuthToken,
+                      org: 'whisper-money',
+                      project: 'frontend',
+                      release: {
+                          create: false,
+                          finalize: false,
+                      },
+                      sourcemaps: {
+                          filesToDeleteAfterUpload: ['**/*.js.map'],
+                      },
+                  }),
+              ]
+            : []),
     ],
     esbuild: {
         jsx: 'automatic',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -38,7 +38,10 @@ export default defineConfig({
                       url: 'https://de.sentry.io/',
                       authToken: sentryAuthToken,
                       org: 'whisper-money',
-                      project: 'frontend',
+                      // Frontend JS errors are captured into the php-laravel
+                      // project (see app.tsx Sentry.init using SENTRY_LARAVEL_DSN),
+                      // so maps must be uploaded there to symbolicate them.
+                      project: 'php-laravel',
                       release: {
                           create: false,
                           finalize: false,


### PR DESCRIPTION
## What

Migrate the Vite source map upload from the decommissioned Bugsink instance to Sentry. Bugsink is no longer used error tracking is fully on Sentry.

- Point `sentryVitePlugin` at the Sentry EU region (`https://de.sentry.io/`), org `whisper-money`, project `php-laravel`.
- Read the auth token from `process.env.SENTRY_AUTH_TOKEN` instead of hardcoding it.
- Remove the hardcoded Bugsink URL, org, project, and auth token.

Source maps go to `php-laravel` (not `frontend`) because frontend JS errors are captured there app.tsx initializes Sentry with `SENTRY_LARAVEL_DSN`, and the live JS issues (e.g. `PHP-LARAVEL-2Y`, platform `javascript`, `assets/app-*.js` frames) confirm it. The `frontend` Sentry project is effectively unused (only 2 stale, resolved, local-dev PHP errors, 0 users in 90 days) candidate for deletion, tracked as a follow-up.

## Source map leak fix

A single flag (`SENTRY_AUTH_TOKEN` present) now gates **both** map generation and upload, so the "maps generated but never deleted" leak into `public/build/assets/` can no longer happen:

- **With token** (production CI): `sourcemap: 'hidden'` → maps are emitted, uploaded, then deleted. `'hidden'` omits the `sourceMappingURL` comment, so browsers never fetch them even in the window before deletion.
- **Without token** (local/dev/CI): `sourcemap: false` → no maps emitted. Nothing to leak, nothing to upload.

## Follow-ups (outside this file)

- [ ] **Rotate the old Bugsink token** (`b0f46d1b…a2e8a`) it is removed here but remains in git history.
- [ ] **Provide `SENTRY_AUTH_TOKEN` to the production build** so uploads actually run. `Dockerfile.production` runs `bun run build:ssr` without it today; inject it via a BuildKit `--mount=type=secret` (not an `ARG`, which persists in image history). Until then uploads are skipped safely, but frontend stacks stay minified.
- [ ] **Delete the unused `frontend` Sentry project** (or repurpose it) all frontend errors go to `php-laravel`.