### PR TITLE
feat(currency): add GHS (Ghanaian Cedi)

### DIFF
--- a/config/currencies.php
+++ b/config/currencies.php
@@ -158,5 +158,11 @@ return [
             'allows_primary' => true,
             'allows_account' => true,
         ],
+        [
+            'code' => 'GHS',
+            'name' => 'Ghanaian Cedi',
+            'allows_primary' => true,
+            'allows_account' => true,
+        ],
     ],
 ];

--- a/lang/es.json
+++ b/lang/es.json
@@ -1546,6 +1546,7 @@
     "System": "Sistema",
     "Serbian Dinar": "Dinar Serbio",
     "Nigerian Naira": "Naira Nigeriano",
+    "Ghanaian Cedi": "Cedi ghanés",
     "Take control of your finances with privacy-first money tracking. Let's set up your account in just a few minutes.": "Toma el control de tus finanzas con un seguimiento privado de tu dinero. Vamos a configurar tu cuenta en pocos minutos.",
     "Tap": "Toca",
     "Tap the": "Toca el botón",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1501,6 +1501,7 @@
     "Syncing transactions and balances…": "Synchronisation des transactions et des soldes…",
     "System": "Système",
     "Serbian Dinar": "Dinar Serbe",
+    "Ghanaian Cedi": "Cedi ghanéen",
     "Take control of your finances with privacy-first money tracking. Let's set up your account in just a few minutes.": "Prenez le contrôle de vos finances grâce au suivi de l'argent privé. Nous créerons votre compte dans quelques minutes.",
     "Tap": "Touche",
     "Tap the": "Touchez le bouton",


### PR DESCRIPTION
## What
Add the Ghanaian Cedi as a supported currency.

## Note on GHC vs GHS
This was requested as "GHC". `GHC` is the **deprecated** pre-2007 code: the conversion provider (`@fawazahmed0/currency-api`) still exposes it, but its rate is scaled **×10 000** versus the modern cedi (≈113,749 GHC/USD vs ≈11.37 GHS/USD), because Ghana redenominated in 2007 (1 GHS = 10 000 GHC). Adding GHC would leave real-world balances inflated 10 000×. The current ISO 4217 code is **GHS**, which the provider covers at the correct rate — so we add GHS.

## Compatibility
Provider covers `ghs` (standard ISO 4217). The conversion service lowercases codes and fetches `ghs.min.json` — same path RSD/NZD use. `exchange_rates` stores rates as JSON, so any 3-letter code works. Validation rules and Inertia currency props auto-derive from config.

## Changes
- `config/currencies.php` — GHS entry (`allows_primary` + `allows_account`)
- `lang/es.json` — Spanish translation
- `lang/fr.json` — French translation

Follows the RSD addition (#567) exactly; no code changes needed.