### PR TITLE
feat(currencies): add Swedish Krona (SEK)

### DIFF
--- a/config/currencies.php
+++ b/config/currencies.php
@@ -164,5 +164,11 @@ return [
             'allows_primary' => true,
             'allows_account' => true,
         ],
+        [
+            'code' => 'SEK',
+            'name' => 'Swedish Krona',
+            'allows_primary' => true,
+            'allows_account' => true,
+        ],
     ],
 ];

--- a/lang/es.json
+++ b/lang/es.json
@@ -1549,6 +1549,7 @@
     "Serbian Dinar": "Dinar Serbio",
     "Nigerian Naira": "Naira Nigeriano",
     "Ghanaian Cedi": "Cedi ghanés",
+    "Swedish Krona": "Corona sueca",
     "Take control of your finances with privacy-first money tracking. Let's set up your account in just a few minutes.": "Toma el control de tus finanzas con un seguimiento privado de tu dinero. Vamos a configurar tu cuenta en pocos minutos.",
     "Tap": "Toca",
     "Tap the": "Toca el botón",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1501,6 +1501,7 @@
     "System": "Système",
     "Serbian Dinar": "Dinar Serbe",
     "Ghanaian Cedi": "Cedi ghanéen",
+    "Swedish Krona": "Couronne suédoise",
     "Take control of your finances with privacy-first money tracking. Let's set up your account in just a few minutes.": "Prenez le contrôle de vos finances grâce au suivi de l'argent privé. Nous créerons votre compte dans quelques minutes.",
     "Tap": "Touche",
     "Tap the": "Touchez le bouton",

--- a/resources/js/utils/currency.ts
+++ b/resources/js/utils/currency.ts
@@ -26,6 +26,7 @@ export function getCurrencySymbol(currencyCode: string): string {
         NZD: 'NZ$',
         DOP: 'RD$',
         NGN: '₦',
+        SEK: 'kr',
     };
     return symbols[currencyCode] || currencyCode;
 }


### PR DESCRIPTION
## What

Adds **Swedish Krona (SEK)** as a currency available for both user primary/display currencies and individual account currencies (including bank accounts).

## Why

Config-driven per `docs/adding-a-currency.md`. `App\Services\CurrencyOptions` reads `config/currencies.php` and feeds validation (`in:` rules), the Inertia dropdown props, and conversion — so a single config entry wires the whole feature.

## Changes

- `config/currencies.php` — SEK entry (`allows_primary: true`, `allows_account: true`)
- `lang/es.json` — `"Swedish Krona": "Corona sueca"` (enforced locale)
- `lang/fr.json` — `"Swedish Krona": "Couronne suédoise"` (optional)
- `resources/js/utils/currency.ts` — `SEK: 'kr'` short symbol

## Verification

Confirmed the `@fawazahmed0/currency-api` provider covers `sek` at a sane rate (SEK→EUR ≈ 0.091 → EUR→SEK ≈ 11).

## Test

```bash
php artisan test --compact tests/Feature/CurrencyConversionServiceTest.php tests/Feature/LocalizationTest.php
```