### PR TITLE
feat(currencies): add Guatemalan Quetzal (GTQ)

### DIFF
--- a/config/currencies.php
+++ b/config/currencies.php
@@ -170,5 +170,11 @@ return [
             'allows_primary' => true,
             'allows_account' => true,
         ],
+        [
+            'code' => 'GTQ',
+            'name' => 'Guatemalan Quetzal',
+            'allows_primary' => true,
+            'allows_account' => true,
+        ],
     ],
 ];

--- a/lang/es.json
+++ b/lang/es.json
@@ -1550,6 +1550,7 @@
     "Nigerian Naira": "Naira Nigeriano",
     "Ghanaian Cedi": "Cedi ghanés",
     "Swedish Krona": "Corona sueca",
+    "Guatemalan Quetzal": "Quetzal guatemalteco",
     "Take control of your finances with privacy-first money tracking. Let's set up your account in just a few minutes.": "Toma el control de tus finanzas con un seguimiento privado de tu dinero. Vamos a configurar tu cuenta en pocos minutos.",
     "Tap": "Toca",
     "Tap the": "Toca el botón",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1502,6 +1502,7 @@
     "Serbian Dinar": "Dinar Serbe",
     "Ghanaian Cedi": "Cedi ghanéen",
     "Swedish Krona": "Couronne suédoise",
+    "Guatemalan Quetzal": "Quetzal guatémaltèque",
     "Take control of your finances with privacy-first money tracking. Let's set up your account in just a few minutes.": "Prenez le contrôle de vos finances grâce au suivi de l'argent privé. Nous créerons votre compte dans quelques minutes.",
     "Tap": "Touche",
     "Tap the": "Touchez le bouton",


### PR DESCRIPTION
## What

Adds the **Guatemalan Quetzal (GTQ)** as a selectable currency, both as a primary/display currency and as an account currency.

Following `docs/adding-a-currency.md`, this is a config-driven change: validation, the Inertia dropdown props, and conversion all derive from the config entry automatically.

## Changes

- `config/currencies.php` — new `GTQ` entry (`allows_primary` + `allows_account` both `true`)
- `lang/es.json` — Spanish name: `Quetzal guatemalteco` (enforced locale)
- `lang/fr.json` — French name: `Quetzal guatémaltèque` (optional locale)

## Compatibility with the conversion system (verified)

- **ISO 4217:** `GTQ` is the current code (not a deprecated/pre-redenomination code — avoids the GHC-style ×10000 trap).
- **Provider coverage:** `@fawazahmed0/currency-api` serves `gtq` at a sane rate (`1 GTQ ≈ 0.131 USD` → ~7.6 GTQ/USD).
- **Live conversion (tinker):** `100 GTQ → 13.13 USD` and `100 EUR → 873.19 GTQ` — both directions return real converted amounts, not the unconverted passthrough.
- **Options + translation:** `CurrencyOptions` returns GTQ in both `primaryOptions()` and `accountOptions()`, and renders `Quetzal guatemalteco` under the `es` locale.

## Tests

```
php artisan test --compact tests/Feature/CurrencyConversionServiceTest.php tests/Feature/LocalizationTest.php
# 16 passed
```

Skipped the optional custom symbol in `resources/js/utils/currency.ts` — `getCurrencySymbol` falls back to the code and `Intl.NumberFormat` renders its own glyph (GHS skipped it too).