### PR TITLE
fix(encryption): never delete or warn billed users when the subscriptions flag is off

### DIFF
--- a/app/Console/Commands/Concerns/FindsUsersWithLegacyEncryption.php
+++ b/app/Console/Commands/Concerns/FindsUsersWithLegacyEncryption.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands\Concerns;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
+use Laravel\Cashier\Subscription;
 
 trait FindsUsersWithLegacyEncryption
 {
@@ -33,11 +34,32 @@ trait FindsUsersWithLegacyEncryption
      * Drop users who are still being billed. These accounts must never be emailed a
      * deletion warning nor deleted while a subscription or trial is active.
      *
+     * Unlike {@see User::hasActiveSubscriptionOrTrial()}, this check is intentionally
+     * independent of the `subscriptions.enabled` feature flag: that flag controls whether
+     * the paywall is enforced, not whether real Stripe subscriptions exist. A destructive
+     * command must never delete a paying customer just because the flag is off in the
+     * runtime that happens to execute it.
+     *
      * @param  Collection<int, User>  $users
      * @return Collection<int, User>
      */
     protected function excludeBilledUsers(Collection $users): Collection
     {
-        return $users->reject(fn (User $user): bool => $user->hasActiveSubscriptionOrTrial())->values();
+        return $users->reject(fn (User $user): bool => $this->isBilled($user))->values();
+    }
+
+    /**
+     * Whether the user is on a generic trial or holds a subscription that is still
+     * valid and not merely coasting through its grace period (it will not renew).
+     */
+    private function isBilled(User $user): bool
+    {
+        if ($user->onGenericTrial()) {
+            return true;
+        }
+
+        return $user->subscriptions->contains(
+            fn (Subscription $subscription): bool => $subscription->valid() && ! $subscription->onGracePeriod()
+        );
     }
 }

--- a/app/Console/Commands/Concerns/FindsUsersWithLegacyEncryption.php
+++ b/app/Console/Commands/Concerns/FindsUsersWithLegacyEncryption.php
@@ -5,7 +5,6 @@ namespace App\Console\Commands\Concerns;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
-use Laravel\Cashier\Subscription;
 
 trait FindsUsersWithLegacyEncryption
 {
@@ -34,32 +33,17 @@ trait FindsUsersWithLegacyEncryption
      * Drop users who are still being billed. These accounts must never be emailed a
      * deletion warning nor deleted while a subscription or trial is active.
      *
-     * Unlike {@see User::hasActiveSubscriptionOrTrial()}, this check is intentionally
-     * independent of the `subscriptions.enabled` feature flag: that flag controls whether
-     * the paywall is enforced, not whether real Stripe subscriptions exist. A destructive
-     * command must never delete a paying customer just because the flag is off in the
-     * runtime that happens to execute it.
+     * {@see User::isBilled()} is used instead of {@see User::hasActiveSubscriptionOrTrial()}
+     * because it is independent of the `subscriptions.enabled` feature flag: that flag
+     * controls whether the paywall is enforced, not whether real Stripe subscriptions
+     * exist. A destructive command must never delete a paying customer just because the
+     * flag is off in the runtime that happens to execute it.
      *
      * @param  Collection<int, User>  $users
      * @return Collection<int, User>
      */
     protected function excludeBilledUsers(Collection $users): Collection
     {
-        return $users->reject(fn (User $user): bool => $this->isBilled($user))->values();
-    }
-
-    /**
-     * Whether the user is on a generic trial or holds a subscription that is still
-     * valid and not merely coasting through its grace period (it will not renew).
-     */
-    private function isBilled(User $user): bool
-    {
-        if ($user->onGenericTrial()) {
-            return true;
-        }
-
-        return $user->subscriptions->contains(
-            fn (Subscription $subscription): bool => $subscription->valid() && ! $subscription->onGracePeriod()
-        );
+        return $users->reject(fn (User $user): bool => $user->isBilled())->values();
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -409,10 +409,21 @@ class User extends Authenticatable implements HasLocalePreference, MustVerifyEma
      */
     public function hasActiveSubscriptionOrTrial(): bool
     {
-        if (! config('subscriptions.enabled')) {
-            return false;
-        }
+        return config('subscriptions.enabled') && $this->isBilled();
+    }
 
+    /**
+     * Whether the user is on a generic trial or holds a subscription that is still
+     * valid and not merely coasting through its grace period (it will not renew).
+     *
+     * Unlike hasActiveSubscriptionOrTrial() this is independent of the
+     * `subscriptions.enabled` flag: that flag controls whether the paywall is
+     * enforced, not whether real Stripe subscriptions exist. Destructive flows that
+     * must never touch a paying customer (the encryption cleanup commands) rely on
+     * this flag-independent check.
+     */
+    public function isBilled(): bool
+    {
         if ($this->onGenericTrial()) {
             return true;
         }

--- a/tests/Feature/Console/DeleteEncryptedDataAccountsCommandTest.php
+++ b/tests/Feature/Console/DeleteEncryptedDataAccountsCommandTest.php
@@ -45,6 +45,59 @@ test('it never deletes a subscribed user even when the subscriptions flag is off
     expect(User::whereKey($subscribed->id)->exists())->toBeTrue();
 });
 
+test('it never deletes a trialing subscriber', function () {
+    config(['subscriptions.enabled' => false]);
+
+    $trialing = User::factory()->create(['last_active_at' => now()->subDays(30)]);
+    Transaction::factory()->for($trialing)->create();
+    $trialing->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => 'sub_trial123',
+        'stripe_status' => 'trialing',
+        'stripe_price' => 'price_test123',
+        'trial_ends_at' => now()->addDays(5),
+    ]);
+
+    artisan('encryption:delete-accounts', ['--force' => true])->assertSuccessful();
+
+    expect(User::whereKey($trialing->id)->exists())->toBeTrue();
+});
+
+test('it never deletes a past-due subscriber', function () {
+    config(['subscriptions.enabled' => false]);
+
+    $pastDue = User::factory()->create(['last_active_at' => now()->subDays(30)]);
+    Transaction::factory()->for($pastDue)->create();
+    $pastDue->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => 'sub_pastdue123',
+        'stripe_status' => 'past_due',
+        'stripe_price' => 'price_test123',
+    ]);
+
+    artisan('encryption:delete-accounts', ['--force' => true])->assertSuccessful();
+
+    expect(User::whereKey($pastDue->id)->exists())->toBeTrue();
+});
+
+test('it deletes a subscriber who is only in the cancellation grace period', function () {
+    config(['subscriptions.enabled' => false]);
+
+    $grace = User::factory()->create(['last_active_at' => now()->subDays(30)]);
+    Transaction::factory()->for($grace)->create();
+    $grace->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => 'sub_grace123',
+        'stripe_status' => 'active',
+        'stripe_price' => 'price_test123',
+        'ends_at' => now()->addDays(5),
+    ]);
+
+    artisan('encryption:delete-accounts', ['--force' => true])->assertSuccessful();
+
+    expect(User::whereKey($grace->id)->exists())->toBeFalse();
+});
+
 test('it never deletes the demo account', function () {
     $demo = User::factory()->create([
         'email' => config('app.demo.email'),

--- a/tests/Feature/Console/DeleteEncryptedDataAccountsCommandTest.php
+++ b/tests/Feature/Console/DeleteEncryptedDataAccountsCommandTest.php
@@ -28,8 +28,8 @@ test('it soft-deletes users with encrypted data who did not sign in within the g
     expect(User::whereKey($clean->id)->exists())->toBeTrue();
 });
 
-test('it never deletes a subscribed user', function () {
-    config(['subscriptions.enabled' => true]);
+test('it never deletes a subscribed user even when the subscriptions flag is off', function () {
+    config(['subscriptions.enabled' => false]);
 
     $subscribed = User::factory()->create(['last_active_at' => now()->subDays(30)]);
     Transaction::factory()->for($subscribed)->create();

--- a/tests/Feature/Console/NotifyEncryptedDataRemovalCommandTest.php
+++ b/tests/Feature/Console/NotifyEncryptedDataRemovalCommandTest.php
@@ -28,8 +28,8 @@ test('it queues a warning email for users with encrypted transactions or account
     Queue::assertNotPushed(SendUpdateEmailJob::class, fn (SendUpdateEmailJob $job) => $job->user->is($clean));
 });
 
-test('it never warns a subscribed user', function () {
-    config(['subscriptions.enabled' => true]);
+test('it never warns a subscribed user even when the subscriptions flag is off', function () {
+    config(['subscriptions.enabled' => false]);
 
     $subscribed = User::factory()->create();
     Transaction::factory()->for($subscribed)->create();

--- a/tests/Feature/Console/NotifyEncryptedDataRemovalCommandTest.php
+++ b/tests/Feature/Console/NotifyEncryptedDataRemovalCommandTest.php
@@ -45,6 +45,42 @@ test('it never warns a subscribed user even when the subscriptions flag is off',
     Queue::assertNotPushed(SendUpdateEmailJob::class);
 });
 
+test('it never warns a trialing or past-due subscriber even when the subscriptions flag is off', function (string $status) {
+    config(['subscriptions.enabled' => false]);
+
+    $billed = User::factory()->create();
+    Transaction::factory()->for($billed)->create();
+    $billed->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => "sub_{$status}",
+        'stripe_status' => $status,
+        'stripe_price' => 'price_test123',
+        'trial_ends_at' => $status === 'trialing' ? now()->addDays(5) : null,
+    ]);
+
+    artisan('encryption:notify-removal', ['--force' => true])->assertSuccessful();
+
+    Queue::assertNotPushed(SendUpdateEmailJob::class);
+})->with(['trialing', 'past_due']);
+
+test('it warns a subscriber who is only in the cancellation grace period', function () {
+    config(['subscriptions.enabled' => false]);
+
+    $grace = User::factory()->create();
+    Transaction::factory()->for($grace)->create();
+    $grace->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => 'sub_grace123',
+        'stripe_status' => 'active',
+        'stripe_price' => 'price_test123',
+        'ends_at' => now()->addDays(5),
+    ]);
+
+    artisan('encryption:notify-removal', ['--force' => true])->assertSuccessful();
+
+    Queue::assertPushed(SendUpdateEmailJob::class, fn (SendUpdateEmailJob $job) => $job->user->is($grace));
+});
+
 test('it queues on the emails queue', function () {
     $user = User::factory()->create();
     Transaction::factory()->for($user)->create();


### PR DESCRIPTION
## Problem

`encryption:delete-accounts` (soft-deletes/anonymizes inactive users with legacy encrypted data) and `encryption:notify-removal` (emails a deletion warning) both skip billed users via `excludeBilledUsers()`. That guard delegated to `User::hasActiveSubscriptionOrTrial()`, which short-circuits to `false` whenever `config('subscriptions.enabled')` is off:

```php
if (! config('subscriptions.enabled')) {
    return false; // everyone counts as "not billed"
}
```

`subscriptions.enabled` defaults to `false` (`env('SUBSCRIPTIONS_ENABLED', false)`, and it ships `false` in `.env.production.example`). So in any runtime where that flag isn't explicitly `true`, the "never delete a paying customer" safeguard silently does nothing — active subscribers leak straight into the delete/notify list.

This was caught on a real dry-run: paying customer `oliver@snell.me` (active subscription, no `ends_at`, no trial) appeared in the deletion list. A second active subscriber was one run away from the same fate. No account was actually deleted — it surfaced at the dry-run stage.

## Fix

The paywall flag controls whether the paywall is *enforced*, not whether real Stripe subscriptions *exist*. A destructive command must never key its safety net off that flag.

- Extract a flag-independent `User::isBilled()` (generic trial, or any subscription that is `valid()` and not merely on its cancellation grace period) as the single source of truth.
- Derive `hasActiveSubscriptionOrTrial()` from it: `config('subscriptions.enabled') && $this->isBilled()` — UI/paywall paths keep the exact same behavior.
- `excludeBilledUsers()` now uses `isBilled()`, so the deletion/notification guard holds regardless of the flag.

`isBilled()` scans every subscription rather than only the `default` one — strictly more conservative for a destructive command (the app only ever creates `default` subscriptions today, so it's equivalent in practice).

## Behavior

| State | Deleted / warned? |
|---|---|
| active / trialing / past_due subscription | spared |
| generic trial | spared |
| cancellation grace period (canceled, will not renew) | deletable (unchanged, intended) |
| ended / canceled / no subscription | deletable |

## Testing

- New regression tests lock the fixed scenario (subscriber spared with the flag **off**) plus the trialing, past_due and grace-period branches, for both `encryption:delete-accounts` and `encryption:notify-removal`.
- Ran the real `encryption:delete-accounts --dry-run` against a prod-shaped dataset with the flag off: active subscribers (including the real `oliver@snell.me` record) are now excluded; non-subscribers still listed.
- `DeleteEncryptedDataAccountsCommandTest`, `NotifyEncryptedDataRemovalCommandTest`, `DeleteAccountPageTest`, `SubscriptionTest` all green.

## Confirmed in production

Verified on the prod host, in the exact runtime that executes the command:

```
subscriptions.enabled = false          # effective config, despite the .env intent
oliver@snell.me: billed=false, status=active, valid=true
```

So `hasActiveSubscriptionOrTrial()` short-circuits to `false` and the active paying customer `oliver@snell.me` lands in the deletion list. With this change (`isBilled()`, flag-independent) he is excluded regardless of the flag.

> Note (out of scope for this PR): `subscriptions.enabled=false` in prod also makes `hasProPlan()` return `true` for everyone, so the paywall is effectively disabled. If unintended, set `SUBSCRIPTIONS_ENABLED=true` and rebuild the config cache — independent of this destructive-command hardening.
