### PR TITLE
feat(currencies): add Hong Kong Dollar (HKD)

### DIFF
--- a/config/currencies.php
+++ b/config/currencies.php
@@ -176,5 +176,11 @@ return [
             'allows_primary' => true,
             'allows_account' => true,
         ],
+        [
+            'code' => 'HKD',
+            'name' => 'Hong Kong Dollar',
+            'allows_primary' => true,
+            'allows_account' => true,
+        ],
     ],
 ];

--- a/lang/es.json
+++ b/lang/es.json
@@ -1551,6 +1551,7 @@
     "Ghanaian Cedi": "Cedi ghanés",
     "Swedish Krona": "Corona sueca",
     "Guatemalan Quetzal": "Quetzal guatemalteco",
+    "Hong Kong Dollar": "Dólar de Hong Kong",
     "Take control of your finances with privacy-first money tracking. Let's set up your account in just a few minutes.": "Toma el control de tus finanzas con un seguimiento privado de tu dinero. Vamos a configurar tu cuenta en pocos minutos.",
     "Tap": "Toca",
     "Tap the": "Toca el botón",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1503,6 +1503,7 @@
     "Ghanaian Cedi": "Cedi ghanéen",
     "Swedish Krona": "Couronne suédoise",
     "Guatemalan Quetzal": "Quetzal guatémaltèque",
+    "Hong Kong Dollar": "Dollar de Hong Kong",
     "Take control of your finances with privacy-first money tracking. Let's set up your account in just a few minutes.": "Prenez le contrôle de vos finances grâce au suivi de l'argent privé. Nous créerons votre compte dans quelques minutes.",
     "Tap": "Touche",
     "Tap the": "Touchez le bouton",


### PR DESCRIPTION
Adds HKD (Hong Kong Dollar) as a selectable currency for both users (primary/display) and individual accounts, following `docs/adding-a-currency.md`.

## Changes
- `config/currencies.php` — new entry with `allows_primary => true`, `allows_account => true`
- `lang/es.json` — Spanish name ("Dólar de Hong Kong")
- `lang/fr.json` — French name ("Dollar de Hong Kong")

## Verification
- Provider covers `hkd` at a sane rate (EUR→HKD ≈ 8.99) via `@fawazahmed0/currency-api`.
- No custom symbol added — `Intl.NumberFormat` renders "HK$" on its own (symbol map is optional per the doc).
- Validation, dropdowns, and conversion all derive from config automatically; no code changes needed.