### PR TITLE
fix(mcp): keep Passport signing keys at 600 in production

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -109,6 +109,13 @@ chown -R www-data:www-data /app/storage /app/bootstrap/cache
 chmod -R 775 /app/storage /app/bootstrap/cache
 chmod 664 /app/storage/logs/laravel.log
 
+# Passport signing keys must stay private: the recursive chmod above widens them
+# to 775, but league/oauth2-server rejects any mode other than 600/660 and logs a
+# warning on every /oauth/authorize and /mcp/oauth request. Lock them back down.
+if [ -f /app/storage/oauth-private.key ]; then
+    chmod 600 /app/storage/oauth-private.key /app/storage/oauth-public.key
+fi
+
 echo "=== Startup complete, launching services ==="
 
 # Start supervisor


### PR DESCRIPTION
## Problem
Production logs a warning on every `/oauth/authorize` and `/mcp/oauth` request (Sentry PHP-LARAVEL-4N / PHP-LARAVEL-4M):

> Key file "file:///app/storage/oauth-private.key" permissions are not correct, recommend changing to 600 or 660 instead of 775

The keys exist (the Docker entrypoint generates them), but the entrypoint's recursive `chmod -R 775 /app/storage` — which runs *after* key generation to fix storage ownership — widens `oauth-private.key`/`oauth-public.key` to 775. league/oauth2-server (used by Passport) checks the key-file mode when it loads the key and rejects anything but 600/660, emitting this warning. A 775 private signing key is also world/group-readable, which it should never be.

## Fix
Re-tighten the two Passport key files to `600` in `docker/entrypoint.sh`, right after the recursive storage `chmod`. It runs on every boot, so it also repairs keys already sitting at 775 on a persisted `storage/` volume.

## Notes
- No app-code change — deploy script only.
- CI (`passport:keys`) and local/worktree key generation already produce 600 keys and never run the recursive 775 chmod, so this is production-entrypoint-only.
- Follow-up to #691 (OAuth 2.1 for Claude Desktop & ChatGPT).