### PR TITLE
feat(subscriptions): add an A/B price experiment (€3.99 control vs €8.99 high)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,6 +115,11 @@ STRIPE_PRO_YEARLY_LOOKUP_KEY=whisper_pro_yearly
 # Free trial per plan, in days. Set to 0 to charge that plan immediately.
 STRIPE_PRO_MONTHLY_TRIAL_DAYS=7
 STRIPE_PRO_YEARLY_TRIAL_DAYS=15
+# Price A/B test. Empty = off (everyone pays the control price). Set the date only
+# after `stripe:sync-prices` has created the variant tiers. Set FORCE_VARIANT to
+# control/high to roll the winner out to everyone.
+PRICE_EXPERIMENT_STARTED_AT=
+PRICE_EXPERIMENT_FORCE_VARIANT=
 
 # Sentry / Bugsink Error Tracking
 SENTRY_LARAVEL_DSN=

--- a/app/Console/Commands/SyncStripePricesCommand.php
+++ b/app/Console/Commands/SyncStripePricesCommand.php
@@ -17,7 +17,7 @@ class SyncStripePricesCommand extends Command
 
     public function handle(): int
     {
-        $plans = config('subscriptions.plans', []);
+        $plans = $this->plansToSync();
         $currency = config('cashier.currency', 'eur');
         $dryRun = $this->option('dry-run');
 
@@ -34,60 +34,11 @@ class SyncStripePricesCommand extends Command
         $this->info('Syncing Stripe prices from config...');
         $this->newLine();
 
-        $created = 0;
-        $transferred = 0;
-        $skipped = 0;
+        $counts = ['created' => 0, 'transferred' => 0, 'skipped' => 0];
 
         foreach ($plans as $planKey => $plan) {
-            $lookupKey = $plan['stripe_lookup_key'] ?? null;
-
-            if (! $lookupKey) {
-                $this->warn("  [{$planKey}] No stripe_lookup_key defined — skipping.");
-                $skipped++;
-
-                continue;
-            }
-
-            $amountInCents = (int) round($plan['price'] * 100);
-            $billingPeriod = $plan['billing_period'] ?? null;
-            $productId = config('subscriptions.products.pro');
-            $formattedAmount = Money::format($amountInCents, $currency);
-
-            $this->line("  <options=bold>{$plan['name']}</>");
-
             try {
-                $existing = $this->findPriceByLookupKey($lookupKey);
-
-                if ($existing) {
-                    if ($this->priceMatches($existing, $amountInCents, $currency, $billingPeriod)) {
-                        $this->line("    <fg=green>✓</> Already in sync ({$existing->id})");
-                        $skipped++;
-
-                        continue;
-                    }
-
-                    $this->line('    <fg=yellow>↻</> Price changed — creating new price and transferring lookup key...');
-
-                    if (! $dryRun) {
-                        $price = $this->createPrice($productId, $amountInCents, $currency, $billingPeriod, $lookupKey, transferLookupKey: true);
-                        $this->line("    <fg=green>✓</> Transferred to {$price->id} ({$formattedAmount}/{$billingPeriod})");
-                    } else {
-                        $this->line("    <fg=cyan>[dry-run]</> Would create new price and transfer lookup key '{$lookupKey}'");
-                    }
-
-                    $transferred++;
-                } else {
-                    $this->line('    <fg=yellow>+</> No existing price — creating...');
-
-                    if (! $dryRun) {
-                        $price = $this->createPrice($productId, $amountInCents, $currency, $billingPeriod, $lookupKey, transferLookupKey: false);
-                        $this->line("    <fg=green>✓</> Created {$price->id} ({$formattedAmount}/{$billingPeriod})");
-                    } else {
-                        $this->line("    <fg=cyan>[dry-run]</> Would create price '{$lookupKey}' at {$formattedAmount}/{$billingPeriod}");
-                    }
-
-                    $created++;
-                }
+                $counts[$this->syncPlan($planKey, $plan, $currency, $dryRun)]++;
             } catch (ApiErrorException $e) {
                 $this->error("    ✗ Stripe API error: {$e->getMessage()}");
 
@@ -98,9 +49,93 @@ class SyncStripePricesCommand extends Command
         $this->newLine();
 
         $suffix = $dryRun ? ' (dry-run)' : '';
-        $this->info("{$created} created, {$transferred} updated, {$skipped} skipped{$suffix}.");
+        $this->info("{$counts['created']} created, {$counts['transferred']} updated, {$counts['skipped']} skipped{$suffix}.");
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * Create the Stripe price for one plan, transfer the lookup key onto a new
+     * price when the amount changed, or leave it alone when it already matches.
+     *
+     * @param  array<string, mixed>  $plan
+     * @return 'created'|'transferred'|'skipped'
+     *
+     * @throws ApiErrorException
+     */
+    private function syncPlan(string $planKey, array $plan, string $currency, bool $dryRun): string
+    {
+        $lookupKey = $plan['stripe_lookup_key'] ?? null;
+
+        if (! $lookupKey) {
+            $this->warn("  [{$planKey}] No stripe_lookup_key defined — skipping.");
+
+            return 'skipped';
+        }
+
+        $amountInCents = (int) round($plan['price'] * 100);
+        $billingPeriod = $plan['billing_period'] ?? null;
+        $productId = config('subscriptions.products.pro');
+        $formattedAmount = Money::format($amountInCents, $currency);
+
+        $this->line("  <options=bold>{$plan['name']}</>");
+
+        $existing = $this->findPriceByLookupKey($lookupKey);
+
+        if ($existing) {
+            if ($this->priceMatches($existing, $amountInCents, $currency, $billingPeriod)) {
+                $this->line("    <fg=green>✓</> Already in sync ({$existing->id})");
+
+                return 'skipped';
+            }
+
+            $this->line('    <fg=yellow>↻</> Price changed — creating new price and transferring lookup key...');
+
+            if (! $dryRun) {
+                $price = $this->createPrice($productId, $amountInCents, $currency, $billingPeriod, $lookupKey, transferLookupKey: true);
+                $this->line("    <fg=green>✓</> Transferred to {$price->id} ({$formattedAmount}/{$billingPeriod})");
+            } else {
+                $this->line("    <fg=cyan>[dry-run]</> Would create new price and transfer lookup key '{$lookupKey}'");
+            }
+
+            return 'transferred';
+        }
+
+        $this->line('    <fg=yellow>+</> No existing price — creating...');
+
+        if (! $dryRun) {
+            $price = $this->createPrice($productId, $amountInCents, $currency, $billingPeriod, $lookupKey, transferLookupKey: false);
+            $this->line("    <fg=green>✓</> Created {$price->id} ({$formattedAmount}/{$billingPeriod})");
+        } else {
+            $this->line("    <fg=cyan>[dry-run]</> Would create price '{$lookupKey}' at {$formattedAmount}/{$billingPeriod}");
+        }
+
+        return 'created';
+    }
+
+    /**
+     * The base plans plus the price-experiment variant tiers, flattened into one
+     * list so each gets its own Stripe price and lookup key. Name and billing
+     * period are inherited from the matching base plan.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private function plansToSync(): array
+    {
+        $plans = (array) config('subscriptions.plans', []);
+
+        foreach ((array) config('subscriptions.price_experiment.variants', []) as $variant => $variantPlans) {
+            foreach ((array) $variantPlans as $planKey => $spec) {
+                $plans["{$planKey}.{$variant}"] = [
+                    ...$plans[$planKey] ?? [],
+                    'name' => ($plans[$planKey]['name'] ?? ucfirst($planKey))." (price: {$variant})",
+                    'price' => $spec['price'],
+                    'stripe_lookup_key' => $spec['lookup'],
+                ];
+            }
+        }
+
+        return $plans;
     }
 
     /**

--- a/app/Http/Controllers/SubscriptionController.php
+++ b/app/Http/Controllers/SubscriptionController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Enums\UpsellSource;
 use App\Models\User;
 use App\Models\UserLead;
+use App\Services\Subscriptions\PriceExperiment;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
@@ -62,7 +63,9 @@ class SubscriptionController extends Controller
             abort(400, 'Invalid plan selected');
         }
 
-        $priceId = $this->resolvePriceIdByLookupKey($plan['stripe_lookup_key']);
+        $priceId = $this->resolvePriceIdByLookupKey(
+            PriceExperiment::lookupKeyFor($request->user(), $planKey),
+        );
 
         $subscriptionBuilder = $request->user()
             ->newSubscription('default', $priceId);

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -10,6 +10,7 @@ use App\Jobs\PurgeResidualEncryptionArtifactsJob;
 use App\Models\BankingConnection;
 use App\Models\User;
 use App\Services\CurrencyOptions;
+use App\Services\Subscriptions\PriceExperiment;
 use Closure;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Http\Request;
@@ -92,7 +93,7 @@ class HandleInertiaRequests extends Middleware
             'subscriptionsEnabled' => config('subscriptions.enabled', false),
             'aiCategorizationUpsellRate' => (int) config('ai_categorization.upsell_sample_rate'),
             'pricing' => [
-                'plans' => config('subscriptions.plans', []),
+                'plans' => PriceExperiment::plansFor($user),
                 'defaultPlan' => config('subscriptions.default_plan', 'monthly'),
                 'bestValuePlan' => config('subscriptions.best_value_plan', null),
                 'promo' => config('subscriptions.promo', []),

--- a/app/Services/Subscriptions/PriceExperiment.php
+++ b/app/Services/Subscriptions/PriceExperiment.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Services\Subscriptions;
+
+use App\Models\User;
+use Carbon\CarbonImmutable;
+
+/**
+ * A/B split on the price of the paid plan: `control` keeps the plans.* prices,
+ * `high` swaps in the variant tier. Users who registered before `started_at` —
+ * and everyone while it is null — are `legacy` and pay the control price, so
+ * this is inert until the experiment is switched on.
+ *
+ * ponytail: the assignment is a pure salted hash of the user id, not a stored
+ * Pennant feature. Nothing has to be persisted, read back or purged afterwards,
+ * and a report can reproduce the split in SQL with CRC32(CONCAT('price:', id)).
+ * Move it to Pennant only if an experiment ever needs a non-deterministic or
+ * hand-overridden per-user assignment.
+ */
+class PriceExperiment
+{
+    public const LEGACY = 'legacy';
+
+    public const CONTROL = 'control';
+
+    public const HIGH = 'high';
+
+    /**
+     * The 'price:' salt decouples this split from any other crc32-based split on
+     * the same user id, so experiments never share buckets.
+     */
+    public static function variantFor(User $user): string
+    {
+        $forced = config('subscriptions.price_experiment.force_variant');
+
+        if (in_array($forced, [self::CONTROL, self::HIGH], true)) {
+            return $forced;
+        }
+
+        $startedAt = config('subscriptions.price_experiment.started_at');
+
+        if ($startedAt === null || $user->created_at?->lt(CarbonImmutable::parse($startedAt))) {
+            return self::LEGACY;
+        }
+
+        return crc32('price:'.$user->getKey()) % 2 === 0 ? self::CONTROL : self::HIGH;
+    }
+
+    /**
+     * The plans config with the user's variant applied: price, original_price and
+     * Stripe lookup key. Feeds both the shared pricing prop and checkout, so what
+     * is shown is always what is charged. Guests get the control config.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public static function plansFor(?User $user): array
+    {
+        $plans = (array) config('subscriptions.plans', []);
+
+        if ($user === null) {
+            return $plans;
+        }
+
+        $overrides = (array) config('subscriptions.price_experiment.variants.'.self::variantFor($user), []);
+
+        foreach ($overrides as $planKey => $override) {
+            if (! isset($plans[$planKey])) {
+                continue;
+            }
+
+            $plans[$planKey]['price'] = $override['price'];
+            $plans[$planKey]['original_price'] = $override['original_price'] ?? null;
+            $plans[$planKey]['stripe_lookup_key'] = $override['lookup'];
+        }
+
+        return $plans;
+    }
+
+    /**
+     * Stripe lookup key to charge for a plan, resolved from the user's variant
+     * server-side and never from the request, so nobody can pick the cheap price.
+     */
+    public static function lookupKeyFor(User $user, string $planKey): string
+    {
+        return (string) (self::plansFor($user)[$planKey]['stripe_lookup_key'] ?? '');
+    }
+}

--- a/app/Services/Subscriptions/PriceExperiment.php
+++ b/app/Services/Subscriptions/PriceExperiment.php
@@ -16,6 +16,11 @@ use Carbon\CarbonImmutable;
  * and a report can reproduce the split in SQL with CRC32(CONCAT('price:', id)).
  * Move it to Pennant only if an experiment ever needs a non-deterministic or
  * hand-overridden per-user assignment.
+ *
+ * @api The variant names are the vocabulary the experiment is configured and read
+ *      with — they are the accepted values of PRICE_EXPERIMENT_FORCE_VARIANT and
+ *      what a funnel report attributes users by — even though production only
+ *      calls plansFor()/lookupKeyFor().
  */
 class PriceExperiment
 {

--- a/app/Services/Subscriptions/PriceExperiment.php
+++ b/app/Services/Subscriptions/PriceExperiment.php
@@ -44,7 +44,15 @@ class PriceExperiment
 
         $startedAt = config('subscriptions.price_experiment.started_at');
 
-        if ($startedAt === null || $user->created_at?->lt(CarbonImmutable::parse($startedAt))) {
+        // blank(), not === null: an empty PRICE_EXPERIMENT_STARTED_AT in the env
+        // reads back as '', and treating that as a start date would launch the
+        // experiment — charging the high price — on an ops typo. Same for a user
+        // with no signup date: fall back to the price they already know.
+        if (blank($startedAt) || $user->created_at === null) {
+            return self::LEGACY;
+        }
+
+        if ($user->created_at->lt(CarbonImmutable::parse($startedAt))) {
             return self::LEGACY;
         }
 

--- a/config/subscriptions.php
+++ b/config/subscriptions.php
@@ -17,6 +17,42 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Price Experiment
+    |--------------------------------------------------------------------------
+    |
+    | A/B test on the price of the paid plan. Users who register on or after
+    | `started_at` are split 50/50 into `control` (the plans.* prices below) and
+    | `high` (the variant tier); anyone older keeps the control price. While
+    | `started_at` is null the experiment is off. Set `force_variant` to
+    | control/high to roll a winner out to everyone without a deploy.
+    |
+    | Each variant needs its own Stripe price — run `php artisan stripe:sync-prices`
+    | BEFORE setting `started_at`. The yearly price is the monthly × 6, matching
+    | the control plan structure.
+    |
+    */
+
+    'price_experiment' => [
+        'started_at' => env('PRICE_EXPERIMENT_STARTED_AT'),
+        'force_variant' => env('PRICE_EXPERIMENT_FORCE_VARIANT'),
+        'variants' => [
+            'high' => [
+                'monthly' => [
+                    'price' => 8.99,
+                    'original_price' => null,
+                    'lookup' => 'whisper_pro_monthly_high',
+                ],
+                'yearly' => [
+                    'price' => 53.94,
+                    'original_price' => 107.88,
+                    'lookup' => 'whisper_pro_yearly_high',
+                ],
+            ],
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Stripe Product IDs
     |--------------------------------------------------------------------------
     |

--- a/tests/Feature/PriceExperimentTest.php
+++ b/tests/Feature/PriceExperimentTest.php
@@ -32,13 +32,15 @@ it('keeps users who registered before the experiment on the control price', func
     expect(PriceExperiment::variantFor($user))->toBe(PriceExperiment::LEGACY);
 });
 
-it('treats everyone as legacy while the experiment is off', function () {
-    config(['subscriptions.price_experiment.started_at' => null]);
+it('treats everyone as legacy while the experiment is off', function (?string $startedAt) {
+    // An empty PRICE_EXPERIMENT_STARTED_AT in the env reads back as '', so an
+    // ops typo must not launch the experiment and start charging the high price.
+    config(['subscriptions.price_experiment.started_at' => $startedAt]);
 
     $user = User::factory()->create(['created_at' => CarbonImmutable::parse('2026-06-10')]);
 
     expect(PriceExperiment::variantFor($user))->toBe(PriceExperiment::LEGACY);
-});
+})->with([null, '', '   ']);
 
 it('pins every user to the forced winner price', function () {
     config(['subscriptions.price_experiment.force_variant' => PriceExperiment::HIGH]);

--- a/tests/Feature/PriceExperimentTest.php
+++ b/tests/Feature/PriceExperimentTest.php
@@ -1,0 +1,155 @@
+<?php
+
+use App\Http\Middleware\HandleInertiaRequests;
+use App\Models\User;
+use App\Services\Subscriptions\PriceExperiment;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+use Laravel\Cashier\Checkout;
+use Laravel\Cashier\SubscriptionBuilder;
+
+beforeEach(function () {
+    config([
+        'subscriptions.enabled' => true,
+        'subscriptions.price_experiment.started_at' => '2026-06-01',
+        'subscriptions.price_experiment.force_variant' => null,
+        'subscriptions.price_experiment.variants.high' => [
+            'monthly' => ['price' => 8.99, 'original_price' => null, 'lookup' => 'whisper_pro_monthly_high'],
+            'yearly' => ['price' => 53.94, 'original_price' => 107.88, 'lookup' => 'whisper_pro_yearly_high'],
+        ],
+        'subscriptions.plans.monthly.price' => 3.99,
+        'subscriptions.plans.monthly.stripe_lookup_key' => 'whisper_pro_monthly',
+        'subscriptions.plans.yearly.price' => 23.88,
+        'subscriptions.plans.yearly.stripe_lookup_key' => 'whisper_pro_yearly',
+    ]);
+});
+
+it('keeps users who registered before the experiment on the control price', function () {
+    $user = User::factory()->create(['created_at' => CarbonImmutable::parse('2026-05-20')]);
+
+    expect(PriceExperiment::variantFor($user))->toBe(PriceExperiment::LEGACY);
+});
+
+it('treats everyone as legacy while the experiment is off', function () {
+    config(['subscriptions.price_experiment.started_at' => null]);
+
+    $user = User::factory()->create(['created_at' => CarbonImmutable::parse('2026-06-10')]);
+
+    expect(PriceExperiment::variantFor($user))->toBe(PriceExperiment::LEGACY);
+});
+
+it('pins every user to the forced winner price', function () {
+    config(['subscriptions.price_experiment.force_variant' => PriceExperiment::HIGH]);
+
+    $legacy = User::factory()->create(['created_at' => CarbonImmutable::parse('2026-05-01')]);
+    $fresh = User::factory()->create(['created_at' => CarbonImmutable::parse('2026-06-10')]);
+
+    expect(PriceExperiment::variantFor($legacy))->toBe(PriceExperiment::HIGH)
+        ->and(PriceExperiment::variantFor($fresh))->toBe(PriceExperiment::HIGH);
+});
+
+it('ignores an invalid forced variant', function () {
+    config(['subscriptions.price_experiment.force_variant' => 'bogus']);
+
+    $user = User::factory()->create(['created_at' => CarbonImmutable::parse('2026-05-01')]);
+
+    expect(PriceExperiment::variantFor($user))->toBe(PriceExperiment::LEGACY);
+});
+
+it('splits post-start users across control and high and stays stable per user', function () {
+    $variants = [];
+
+    for ($i = 0; $i < 40; $i++) {
+        $user = User::factory()->create(['created_at' => CarbonImmutable::parse('2026-06-10')]);
+        $assigned = PriceExperiment::variantFor($user);
+        $variants[] = $assigned;
+
+        expect(PriceExperiment::variantFor($user))->toBe($assigned);
+    }
+
+    expect(array_values(array_unique($variants)))->toEqualCanonicalizing([
+        PriceExperiment::CONTROL,
+        PriceExperiment::HIGH,
+    ]);
+});
+
+it('salts the split so it does not mirror a plain crc32 bucket of the same id', function () {
+    // An unsalted crc32(id) % 2 would tie this experiment to the buckets of every
+    // other experiment on the same ids forever. The two splits must disagree.
+    $disagreements = 0;
+
+    for ($i = 0; $i < 50; $i++) {
+        $id = (string) Str::uuid();
+        $salted = crc32('price:'.$id) % 2;
+
+        if ($salted !== crc32($id) % 2) {
+            $disagreements++;
+        }
+    }
+
+    expect($disagreements)->toBeGreaterThan(0);
+});
+
+it('applies the variant price and lookup key for a high-price user', function () {
+    config(['subscriptions.price_experiment.force_variant' => PriceExperiment::HIGH]);
+    $user = User::factory()->create(['created_at' => CarbonImmutable::parse('2026-06-10')]);
+
+    $plans = PriceExperiment::plansFor($user);
+
+    expect($plans['monthly']['price'])->toBe(8.99)
+        ->and($plans['monthly']['stripe_lookup_key'])->toBe('whisper_pro_monthly_high')
+        ->and($plans['yearly']['price'])->toBe(53.94)
+        ->and($plans['yearly']['original_price'])->toBe(107.88)
+        ->and(PriceExperiment::lookupKeyFor($user, 'monthly'))->toBe('whisper_pro_monthly_high')
+        ->and(PriceExperiment::lookupKeyFor($user, 'yearly'))->toBe('whisper_pro_yearly_high');
+});
+
+it('leaves control-price users on the config prices', function () {
+    config(['subscriptions.price_experiment.force_variant' => PriceExperiment::CONTROL]);
+    $user = User::factory()->create(['created_at' => CarbonImmutable::parse('2026-06-10')]);
+
+    $plans = PriceExperiment::plansFor($user);
+
+    expect($plans['monthly']['price'])->toBe(3.99)
+        ->and($plans['monthly']['stripe_lookup_key'])->toBe('whisper_pro_monthly')
+        ->and(PriceExperiment::lookupKeyFor($user, 'monthly'))->toBe('whisper_pro_monthly');
+});
+
+it('shows the assigned variant price on the paywall', function () {
+    config(['subscriptions.price_experiment.force_variant' => PriceExperiment::HIGH]);
+    $user = User::factory()->onboarded()->create(['created_at' => CarbonImmutable::parse('2026-06-10')]);
+
+    $this->actingAs($user)
+        ->get(route('subscribe'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('subscription/paywall')
+            ->where('pricing.plans.monthly.price', 8.99)
+            ->where('pricing.plans.yearly.price', 53.94));
+});
+
+it('charges the assigned variant price id at checkout, not a client-supplied one', function () {
+    config(['subscriptions.price_experiment.force_variant' => PriceExperiment::HIGH]);
+    Cache::put('stripe_price_id:whisper_pro_monthly_high', 'price_high_monthly', now()->addHour());
+
+    $checkout = Mockery::mock(Checkout::class);
+    $checkout->shouldReceive('toResponse')->andReturn(new RedirectResponse('https://stripe.test/session'));
+
+    $builder = Mockery::mock(SubscriptionBuilder::class)->shouldIgnoreMissing();
+    $builder->shouldReceive('checkout')->once()->andReturn($checkout);
+
+    $user = Mockery::mock(User::class)->shouldIgnoreMissing();
+    $user->shouldReceive('hasVerifiedEmail')->andReturn(true);
+    $user->shouldReceive('hasProPlan')->andReturn(false);
+    $user->shouldReceive('newSubscription')
+        ->once()
+        ->with('default', 'price_high_monthly')
+        ->andReturn($builder);
+
+    $this->withoutMiddleware(HandleInertiaRequests::class);
+    $this->actingAs($user);
+
+    $this->get(route('subscribe.checkout', ['plan' => 'monthly']))->assertRedirect();
+});

--- a/tests/Feature/SyncStripePricesCommandTest.php
+++ b/tests/Feature/SyncStripePricesCommandTest.php
@@ -68,6 +68,8 @@ beforeEach(function () {
         ],
         'subscriptions.products.pro' => 'prod_test123',
         'cashier.currency' => 'eur',
+        // Base-plan tests isolate the plans loop; variant syncing has its own test.
+        'subscriptions.price_experiment.variants' => [],
     ]);
 });
 
@@ -147,5 +149,27 @@ test('returns success and warns when no plans are configured', function () {
 
     $this->artisan('stripe:sync-prices')
         ->expectsOutputToContain('No plans found')
+        ->assertSuccessful();
+});
+
+test('syncs the price-experiment variant tiers alongside the base plans', function () {
+    config([
+        'subscriptions.price_experiment.variants' => [
+            'high' => [
+                'monthly' => ['price' => 8.99, 'lookup' => 'whisper_pro_monthly_high'],
+                'yearly' => ['price' => 53.94, 'lookup' => 'whisper_pro_yearly_high'],
+            ],
+        ],
+    ]);
+
+    // Base plans already in sync; both high tiers are new → 2 created, 2 skipped.
+    bindMockStripeClientForSync([
+        'whisper_pro_monthly' => makeStripePrice('price_monthly', 399, 'eur', 'month'),
+        'whisper_pro_yearly' => makeStripePrice('price_yearly', 2388, 'eur', 'year'),
+    ]);
+
+    $this->artisan('stripe:sync-prices')
+        ->expectsOutputToContain('(price: high)')
+        ->expectsOutputToContain('2 created, 0 updated, 2 skipped')
         ->assertSuccessful();
 });


### PR DESCRIPTION
## What

An A/B price experiment to find the price that **maximizes contribution margin per new user**, not just conversion. **Inert until `PRICE_EXPERIMENT_STARTED_AT` is set** — merging changes nothing in production.

| Arm | Monthly | Annual (= monthly × 6) |
|-----|---------|------------------------|
| A · control | €3.99 | €23.88 *(unchanged)* |
| B · high | €8.99 | €53.94 |

New signups only; earlier users stay `legacy`/control. Two arms rather than the originally designed A/B/C: at current signup volume three arms leave the CM metric underpowered, and the wide €3.99↔€8.99 gap maximizes the detectable signal.

## Rebuilt on top of #762

This branch was written against the #600 trial experiment. #762 then ended that experiment and deleted `ExperimentOffer`, `SubscriptionExperiment`, `ExperimentFunnelCollector`, `ProportionSignificance` and `BinomialProportion` — the exact foundation this extended.

Rather than resurrect them, the branch was reset onto `main` and rewritten: **1478 → 401 insertions, 19 → 8 files.** The previous version is preserved at the tag [`price-experiment-full`](https://github.com/whisper-money/whisper-money/tree/price-experiment-full).

## How it works

- **`App\Services\Subscriptions\PriceExperiment`** — `variantFor` / `plansFor` / `lookupKeyFor`, gated by `PRICE_EXPERIMENT_STARTED_AT`, winner pinned via `PRICE_EXPERIMENT_FORCE_VARIANT` (env-only, no deploy).
- Assignment is a **salted hash**, `crc32('price:'.$id) % 2` — deliberately *not* a stored Pennant feature. Nothing needs persisting, reading back, or purging when the experiment ends (#762 needed a migration to delete 1,890 stored assignments). It also costs no query on the render path, and a report can reproduce the split in SQL with `CRC32(CONCAT('price:', id))`. The salt keeps the split independent from any other crc32-based one on the same ids.
- Checkout resolves the lookup key **server-side only**, so a client can't self-select the cheaper price. `HandleInertiaRequests` makes the shared `pricing.plans` prop variant-aware, so the paywall and the upgrade dialogs show exactly what will be charged — no frontend change needed.
- **`stripe:sync-prices`** now also creates the variant tiers.

## Measurement is deliberately not in this PR

The previous version shipped ~1100 lines of measurement: `stats:price-experiment-funnel`, its collector, `WelchTTest`, `Normal`, `SampleRatioMismatch`, `MonthlyEquivalentPrices`, a weekly schedule entry and their tests. All of it is cut here.

Every input is reconstructible at any time — the bucket is deterministic, and `created_at`, subscriptions and connections are all stored — so no data is lost by not capturing it weekly. And the design calls for deciding **only at a pre-registered horizon**, which made a weekly Discord report whose largest field read *"⚠️ MONITORING ONLY — do not call a winner from this"* mostly ceremony.

It gets rebuilt from the tag when there is data worth reading. Checking mid-flight that the split is really 50/50 needs no code:

```sql
SELECT CRC32(CONCAT('price:', id)) % 2 AS arm, COUNT(*)
FROM users WHERE created_at >= '<started_at>' GROUP BY arm;
```

The analysis design itself still stands and is recorded for the horizon: CM/user primary via Welch (the €8.99 arm carries far more revenue variance, so pooled-variance is invalid), conversion as a Fisher-exact guardrail against control, SRM chi-square on assigned and matured counts, cost from *currently-active* connections, and a guard that every arm price id resolves in the Stripe product map.

## Incidental

`SyncStripePricesCommand::handle` was already at cyclomatic complexity 11 on `main`; touching one line surfaced it in the `crap` check. The per-plan body moved into `syncPlan()` — pure extraction, same output.

## Before launching (in order)

1. `php artisan stripe:sync-prices` — creates the €8.99 / €53.94 tiers under the lookup keys `whisper_pro_monthly_high` and `whisper_pro_yearly_high`. **Must run before step 2.**
2. Set `PRICE_EXPERIMENT_STARTED_AT` to the launch date.
3. Compute and pre-register the horizon N from the real signup rate — no peeking before it.

The #600 trial experiment is over, so price is automatically the only moving variable; there is nothing to pin.

## Tests

Pest coverage for the gate, the forced-variant pin, the salt, split stability per user, the variant prices and lookup keys, the paywall prop, server-side checkout resolution, and variant syncing in `stripe:sync-prices`. Affected suites green locally; `pint` and `php artisan crap` clean.
