### PR TITLE
fix(onboarding): stop the AI rule-suggestion step from hanging forever

### DIFF
--- a/app/Jobs/GenerateRuleSuggestionsJob.php
+++ b/app/Jobs/GenerateRuleSuggestionsJob.php
@@ -2,10 +2,14 @@
 
 namespace App\Jobs;
 
+use App\Enums\SuggestionRunStatus;
 use App\Models\SuggestionRun;
 use App\Services\Ai\GenerateRuleSuggestions;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Str;
+use RuntimeException;
+use Throwable;
 
 class GenerateRuleSuggestionsJob implements ShouldQueue
 {
@@ -23,5 +27,27 @@ class GenerateRuleSuggestionsJob implements ShouldQueue
         $this->run->loadMissing('user');
 
         $generator->run($this->run);
+    }
+
+    /**
+     * A job timeout or fatal worker crash escapes the try/catch inside
+     * {@see GenerateRuleSuggestions::run()}, so mark the run as failed here too —
+     * otherwise it stays "processing" forever and the onboarding client spins
+     * indefinitely. Report the cause so we actually hear about these.
+     */
+    public function failed(?Throwable $exception): void
+    {
+        report($exception ?? new RuntimeException('GenerateRuleSuggestionsJob failed without an exception.'));
+
+        $run = $this->run->fresh();
+
+        if ($run === null || $run->status->isFinished()) {
+            return;
+        }
+
+        $run->forceFill([
+            'status' => SuggestionRunStatus::Failed,
+            'error' => Str::limit($exception?->getMessage() ?? 'Job failed (timeout or worker crash).', 500),
+        ])->save();
     }
 }

--- a/resources/js/components/onboarding/step-ai-suggestions-timeout.test.tsx
+++ b/resources/js/components/onboarding/step-ai-suggestions-timeout.test.tsx
@@ -1,0 +1,70 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { StepAiSuggestions } from './step-ai-suggestions';
+
+const { get, post } = vi.hoisted(() => ({ get: vi.fn(), post: vi.fn() }));
+
+vi.mock('axios', () => ({
+    default: { get, post, isAxiosError: () => false },
+}));
+
+vi.mock('@inertiajs/react', () => ({
+    router: { reload: vi.fn() },
+}));
+
+const processingState = {
+    available: true,
+    consented: true,
+    requires_upgrade: false,
+    eligible: true,
+    transaction_count: 4000,
+    min_transactions: 50,
+    auto_select_confidence: 0.8,
+    throttled: false,
+    throttled_until: null,
+    run: { id: 'run-1', status: 'processing', suggestions_count: 0 },
+    suggestions: [],
+};
+
+describe('StepAiSuggestions polling timeout', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        get.mockResolvedValue({ data: processingState });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        get.mockReset();
+        post.mockReset();
+    });
+
+    it('stops spinning and shows the failed screen when the run never finishes in time', async () => {
+        render(
+            <StepAiSuggestions
+                categories={[]}
+                hasConnectedAccount={false}
+                onComplete={vi.fn()}
+            />,
+        );
+
+        // Spins while the run stays "processing".
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(
+            screen.getByText('This can take up to two minutes.'),
+        ).toBeInTheDocument();
+
+        // Past the client-side deadline it gives up instead of polling forever.
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(3 * 60_000 + 3000);
+        });
+
+        expect(
+            screen.getByText('We couldn’t generate suggestions'),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText('This can take up to two minutes.'),
+        ).not.toBeInTheDocument();
+    });
+});

--- a/resources/js/components/onboarding/step-ai-suggestions.tsx
+++ b/resources/js/components/onboarding/step-ai-suggestions.tsx
@@ -18,6 +18,11 @@ import axios from 'axios';
 import { Loader2, PartyPopper, Sparkles, Wand2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+// Client-side give-up: the backend marks the run failed on timeout/crash, but
+// this guarantees the spinner resolves even if the worker dies before it can.
+// A little beyond the "up to two minutes" the UI promises.
+const MAX_POLL_MS = 3 * 60_000;
+
 interface SuggestionState {
     available: boolean;
     consented: boolean;
@@ -52,10 +57,12 @@ export function StepAiSuggestions({
     const [drafts, setDrafts] = useState<Record<string, SuggestionDraft>>({});
     const [busy, setBusy] = useState(false);
     const [submitting, setSubmitting] = useState(false);
+    const [timedOut, setTimedOut] = useState(false);
     const [summary, setSummary] = useState<AcceptResponse['summary'] | null>(
         null,
     );
     const pollRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+    const deadlineRef = useRef(0);
     const onCompleteRef = useRef(onComplete);
     onCompleteRef.current = onComplete;
 
@@ -88,20 +95,41 @@ export function StepAiSuggestions({
         data?.run?.status === 'pending' || data?.run?.status === 'processing';
 
     const poll = useCallback(async () => {
-        const { data } = await axios.get<SuggestionState>(show().url);
-        applyState(data);
-        if (isRunning(data)) {
-            pollRef.current = setTimeout(poll, 3000);
+        try {
+            const { data } = await axios.get<SuggestionState>(show().url);
+            applyState(data);
+            if (!isRunning(data)) {
+                return;
+            }
+        } catch {
+            // Transient failure (network blip, expired session, 5xx). Keep
+            // retrying until the deadline instead of silently dying here.
         }
+        // Guarantee the client never spins forever: if the run hasn't reached a
+        // terminal status in time (e.g. the worker was killed before it could
+        // mark the run failed), surface the failed state so the user can retry
+        // or skip.
+        if (Date.now() >= deadlineRef.current) {
+            setTimedOut(true);
+            return;
+        }
+        pollRef.current = setTimeout(poll, 3000);
     }, [applyState]);
+
+    const startPolling = useCallback(() => {
+        setTimedOut(false);
+        deadlineRef.current = Date.now() + MAX_POLL_MS;
+        poll();
+    }, [poll]);
 
     const startGenerate = useCallback(async () => {
         setBusy(true);
+        setTimedOut(false);
         try {
             const { data } = await axios.post<SuggestionState>(generate().url);
             applyState(data);
             if (isRunning(data)) {
-                poll();
+                startPolling();
             }
         } catch (error) {
             if (axios.isAxiosError(error) && error.response?.status === 422) {
@@ -110,7 +138,7 @@ export function StepAiSuggestions({
         } finally {
             setBusy(false);
         }
-    }, [applyState, poll]);
+    }, [applyState, startPolling]);
 
     useEffect(() => {
         let cancelled = false;
@@ -124,7 +152,7 @@ export function StepAiSuggestions({
                 applyState(data);
 
                 if (isRunning(data)) {
-                    poll();
+                    startPolling();
                 } else if (
                     data.consented &&
                     data.eligible &&
@@ -253,7 +281,7 @@ export function StepAiSuggestions({
         );
     }
 
-    if (!state || busy || isRunning(state)) {
+    if (!timedOut && (!state || busy || isRunning(state))) {
         return (
             <Centered>
                 <StepHeader
@@ -275,6 +303,12 @@ export function StepAiSuggestions({
                 </p>
             </Centered>
         );
+    }
+
+    // ponytail: unreachable — timedOut only flips after state has loaded; the
+    // guard just restores non-null narrowing for the branches below.
+    if (!state) {
+        return null;
     }
 
     if (!state.consented) {
@@ -320,7 +354,7 @@ export function StepAiSuggestions({
         );
     }
 
-    if (state.run?.status === 'failed') {
+    if (timedOut || state.run?.status === 'failed') {
         return (
             <Centered>
                 <StepHeader

--- a/tests/Feature/Ai/GenerateRuleSuggestionsJobTest.php
+++ b/tests/Feature/Ai/GenerateRuleSuggestionsJobTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Enums\SuggestionRunStatus;
+use App\Jobs\GenerateRuleSuggestionsJob;
+use App\Models\SuggestionRun;
+use Illuminate\Queue\TimeoutExceededException;
+use Illuminate\Support\Facades\Exceptions;
+
+it('marks a stuck run as failed when the job dies outside the try/catch', function () {
+    Exceptions::fake();
+
+    $run = SuggestionRun::factory()->create(['status' => SuggestionRunStatus::Processing]);
+
+    (new GenerateRuleSuggestionsJob($run))->failed(
+        new TimeoutExceededException('timed out'),
+    );
+
+    expect($run->refresh()->status)->toBe(SuggestionRunStatus::Failed)
+        ->and($run->error)->toBe('timed out');
+
+    Exceptions::assertReported(TimeoutExceededException::class);
+});
+
+it('does not overwrite a run that already reached a terminal status', function () {
+    Exceptions::fake();
+
+    $run = SuggestionRun::factory()->create([
+        'status' => SuggestionRunStatus::Completed,
+        'suggestions_count' => 3,
+    ]);
+
+    (new GenerateRuleSuggestionsJob($run))->failed(new RuntimeException('late failure'));
+
+    expect($run->refresh()->status)->toBe(SuggestionRunStatus::Completed)
+        ->and($run->suggestions_count)->toBe(3);
+});


### PR DESCRIPTION
## Problem

A user reported being stuck forever on the onboarding "Looking for patterns" step (the "Polishing your suggestions…" spinner). Confirmed in prod: their `suggestion_runs` row has been stuck in `processing` for a week, and `failed_jobs` shows `TimeoutExceededException: GenerateRuleSuggestionsJob has timed out`.

### Root cause

- The user has 4,163 transactions — the largest onboarding dataset (max with a completed run was 3,481). The Gemini generation exceeded the job's `$timeout = 120`.
- The worker timeout is raised **outside** the `try/catch` in `GenerateRuleSuggestions::run()`, so the code that sets `status = Failed` never ran.
- `GenerateRuleSuggestionsJob` had **no `failed()` handler** (5 other jobs do), so nothing flipped the run to `Failed`. It stayed `processing`, `show()` kept returning `processing`, and the client polled every 3s forever.
- The timeout never reached Sentry, so it was invisible. Only 1 user affected, but it's a latent bug that recurs on any large account.

## Fix

**Backend** — add `failed()` to `GenerateRuleSuggestionsJob`: mark the run `Failed` (only if not already terminal) and `report()` the exception so these surface in Sentry.

**Frontend** (`step-ai-suggestions.tsx`) — belt-and-suspenders so the client never spins forever even if the worker dies before it can mark the run:
- `poll()` now guards against transient errors (network blip / expired session / 5xx) instead of silently dying.
- A client-side deadline (3 min, just beyond the "up to two minutes" copy) surfaces the existing "couldn't generate" screen with **Try again / Skip**.

Not included: raising the timeout / capping the number of groups sent to Gemini so large accounts *complete* instead of just being able to skip. Follow-up if we want big accounts to get suggestions.

## Tests

- `tests/Feature/Ai/GenerateRuleSuggestionsJobTest.php` — `failed()` marks the run `Failed` + reports; doesn't overwrite an already-terminal run.
- `resources/js/components/onboarding/step-ai-suggestions-timeout.test.tsx` — after the deadline the spinner gives way to the failed screen.

Green locally: pint, prettier, eslint, backend + frontend tests.