### PR TITLE
fix(pwa): open OAuth links in the browser instead of the installed app

### DIFF
--- a/public/favicon/site.webmanifest
+++ b/public/favicon/site.webmanifest
@@ -6,9 +6,7 @@
   "scope": "/",
   "id": "/",
   "display": "standalone",
-  "launch_handler": {
-    "client_mode": "focus-existing"
-  },
+  "handle_links": "not-preferred",
   "orientation": "portrait-primary",
   "theme_color": "#1b1b18",
   "background_color": "#ffffff",

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -34,38 +34,6 @@ import { __, setTranslations } from './utils/i18n';
 
 installChunkLoadRecovery();
 
-// The installed PWA claims the whole origin (manifest scope "/"), so on mobile an
-// OAuth link (e.g. from ChatGPT connecting over MCP) gets captured into the app.
-// Paired with launch_handler "focus-existing", the launcher hands us the target
-// URL instead of dropping it and showing the dashboard — navigate there so the
-// OAuth consent screen actually loads. Non-OAuth launches keep their place.
-type LaunchParams = { targetURL?: string };
-
-const launchQueue = (
-    window as Window & {
-        launchQueue?: {
-            setConsumer(consumer: (params: LaunchParams) => void): void;
-        };
-    }
-).launchQueue;
-
-if (launchQueue) {
-    launchQueue.setConsumer(({ targetURL }) => {
-        if (!targetURL) {
-            return;
-        }
-
-        const target = new URL(targetURL);
-
-        if (
-            target.pathname.startsWith('/oauth/') &&
-            target.href !== window.location.href
-        ) {
-            window.location.href = targetURL;
-        }
-    });
-}
-
 Sentry.init({
     dsn: import.meta.env.SENTRY_LARAVEL_DSN,
     environment: import.meta.env.MODE,


### PR DESCRIPTION
## Problem

Connecting the MCP connector from **ChatGPT on Android mobile** fails. Claude works because it opens the OAuth flow in an in-app browser (Custom Tab); ChatGPT's link gets routed into the installed Whisper Money PWA, and once the flow is inside the standalone app the redirect back to the OAuth client can't complete.

## Root cause (confirmed on an Android emulator)

The installed PWA is a Chrome **WebAPK** that auto-verifies as an **Android App Link handler** for the whole origin (`scope: "/"`):

```
AutoVerify=true
Domain verification state: whisper.money: verified
```

So Android routes `https://whisper.money/*` — including `/oauth/authorize` — into the app instead of a browser. Narrowing `scope` to exclude `/oauth` isn't viable: the app's routes are flat and share no prefix.

## Fix

Set `"handle_links": "not-preferred"` in the web app manifest, which tells the browser **not** to route in-scope links into the installed app — they open in the browser, where the OAuth round-trip (authorize → consent → redirect back to the client) completes. The app still launches normally from its home-screen icon.

This **replaces** the `launch_handler` + `launchQueue` approach from #701, which targeted the wrong stage (it kept the flow *inside* the PWA). That change is reverted here.

## Verification / caveat

`handle_links` on Android WebAPKs has incomplete/uncertain support, and it couldn't be validated in isolation on the emulator (a throwaway test domain never minted its own WebAPK). It's a safe, additive, reversible manifest field — worst case it's a no-op.

**Must be verified on a real device:** after deploy, reinstall the PWA on the phone (forces the WebAPK to re-mint from the new manifest) and retry the ChatGPT connect → the authorize page should open in the browser, not the app.

If Android ignores `handle_links`, the guaranteed fallback is narrowing the PWA `scope` so `/oauth` is out of it (at the cost of the browser toolbar appearing on hard reloads of non-`/dashboard` pages).