### PR TITLE
fix(mcp): serve OAuth authorize on a dedicated host so the PWA can't capture it

### DIFF
--- a/public/favicon/site.webmanifest
+++ b/public/favicon/site.webmanifest
@@ -6,7 +6,6 @@
   "scope": "/",
   "id": "/",
   "display": "standalone",
-  "handle_links": "not-preferred",
   "orientation": "portrait-primary",
   "theme_color": "#1b1b18",
   "background_color": "#ffffff",


### PR DESCRIPTION
## Problem

Connecting the MCP connector from **ChatGPT on Android** fails. The installed Whisper Money PWA is a Chrome **WebAPK** that auto-verifies as an Android **App Link handler** for the whole app origin (manifest `scope: "/"`), so `https://whisper.money/oauth/authorize` gets routed **into the app**. Once the flow is inside the standalone app, the redirect back to the OAuth client can't complete → the connection fails. (Claude works because it opens OAuth in a Custom Tab.)

Confirmed on an Android emulator: `AutoVerify=true`, `whisper.money: verified` on the WebAPK.

## Why not `handle_links` (reverts #707)

`handle_links: "not-preferred"` is **origin-wide** — it would push *every* `whisper.money` link (bank-auth callback, email verification, shared deep links) to the browser, not just `/oauth`. We want links to keep opening the installed app. So this PR drops it.

## Fix (surgical)

Move the OAuth **authorization server** to a dedicated host outside the PWA scope. `config('mcp.authorization_server')` becomes env-driven (`MCP_AUTHORIZATION_SERVER`); in prod it's `https://oauth.whisper.money`.

Because every endpoint derives from the request host (no forced root URL), pointing the auth server at the subdomain makes `issuer` + `authorize`/`token`/`register` all resolve to `oauth.whisper.money` — **same origin as each other**, so there's no cross-origin metadata mismatch for strict clients. The protected resource (`/mcp/oauth`) and **all other app links stay on `whisper.money`**, so deep-linking into the installed app is fully preserved. Only the OAuth flow leaves the app — into the browser, where the round-trip completes.

`oauth.whisper.money` is a different origin than the WebAPK scope → the installed app never captures it.

## Deploy steps (required to activate)

1. Merge + deploy.
2. Set `MCP_AUTHORIZATION_SERVER=https://oauth.whisper.money` in prod env, redeploy. (DNS already points there; SSL cert propagating.)
3. Verify the discovery chain resolves to the subdomain (I'll curl it), then test the ChatGPT connect on a real phone.

Safe until step 2: with the env var unset, `authorization_server` stays `null` → current behavior (uses the app URL). No effect on local/dev.

## Tests

Added a Pest test asserting that when `mcp.authorization_server` is configured, the protected-resource metadata advertises the dedicated host and the auth-server metadata (fetched from that host) keeps `issuer` + all endpoints on it. Session is unaffected (`SESSION_DOMAIN=null` → host-only cookies); the app has no `TrustHosts` restriction so it already serves the subdomain.