### PR TITLE
feat(mcp): recommend desktop for AI connector setup

### DIFF
--- a/lang/es.json
+++ b/lang/es.json
@@ -1,4 +1,6 @@
 {
+    "Set this up on a computer": "Configúralo desde un ordenador",
+    "Signing in and approving works fine in a desktop browser, but usually breaks in a phone's in-app browser. Once it's connected, you can chat with Whisper Money from Claude or ChatGPT on your phone as usual.": "El inicio de sesión y la aprobación funcionan bien en un navegador de escritorio, pero suelen fallar en el navegador interno del móvil. Una vez conectado, puedes chatear con Whisper Money desde Claude o ChatGPT en el móvil con normalidad.",
     "Learned: similar transactions will be categorized automatically.": "Aprendido: las transacciones similares se categorizarán automáticamente.",
     "Learned from your correction": "Aprendida de tu corrección",
     "Undo": "Deshacer",

--- a/resources/js/pages/settings/mcp.tsx
+++ b/resources/js/pages/settings/mcp.tsx
@@ -53,6 +53,7 @@ import {
     ChevronDown,
     Copy,
     KeyRound,
+    MonitorSmartphone,
     RefreshCw,
     ShieldAlert,
     Trash2,
@@ -259,6 +260,18 @@ export default function Mcp() {
                             </CardDescription>
                         </CardHeader>
                         <CardContent className="space-y-4">
+                            <div className="flex gap-3 rounded-md border bg-muted/50 p-3 text-sm">
+                                <MonitorSmartphone className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                                <p className="text-muted-foreground">
+                                    <span className="font-medium text-foreground">
+                                        {__('Set this up on a computer')}.
+                                    </span>{' '}
+                                    {__(
+                                        "Signing in and approving works fine in a desktop browser, but usually breaks in a phone's in-app browser. Once it's connected, you can chat with Whisper Money from Claude or ChatGPT on your phone as usual.",
+                                    )}
+                                </p>
+                            </div>
+
                             <ToggleGroup
                                 type="single"
                                 value={connector}


### PR DESCRIPTION
## What

Adds a short note at the top of the "How to connect" card on the AI Connector screen (`settings/mcp.tsx`):

> **Set this up on a computer.** Signing in and approving works fine in a desktop browser, but usually breaks in a phone's in-app browser. Once it's connected, you can chat with Whisper Money from Claude or ChatGPT on your phone as usual.

## Why

The OAuth sign-in + consent step is unreliable inside a phone's in-app browser (the installed PWA captures the authorize link on Android). Rather than fight every mobile edge case, steer people to create the connection on desktop, where it works cleanly — the connection then carries over, so they can chat from the mobile apps normally.

Copy run through the humanizer (no em dashes, plain and direct). Spanish translation added to `lang/es.json` (required by the i18n CI check).