### PR TITLE
feat(auth): add REGISTRATION_ENABLED env to disable public sign-ups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,10 +89,11 @@ AWS_USE_PATH_STYLE_ENDPOINT=false
 
 HIDE_AUTH_BUTTONS=false
 
+# Optional. Defaults to true when unset, so existing installs keep public sign-ups.
 # Set to false to close public sign-ups while keeping login open (invite/admin-created
-# accounts only). When disabled, the /register routes are not registered and every
-# registration CTA is hidden; /login stays fully available.
-REGISTRATION_ENABLED=true
+# accounts only): the /register routes are not registered and every registration CTA
+# is hidden, while /login stays fully available.
+# REGISTRATION_ENABLED=false
 
 VITE_APP_NAME="${APP_NAME}"
 

--- a/.env.example
+++ b/.env.example
@@ -89,6 +89,11 @@ AWS_USE_PATH_STYLE_ENDPOINT=false
 
 HIDE_AUTH_BUTTONS=false
 
+# Set to false to close public sign-ups while keeping login open (invite/admin-created
+# accounts only). When disabled, the /register routes are not registered and every
+# registration CTA is hidden; /login stays fully available.
+REGISTRATION_ENABLED=true
+
 VITE_APP_NAME="${APP_NAME}"
 
 # PostHog Analytics

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ The template includes:
 | ----------------------- | ------- | -------------------------------------------------- |
 | `DRIP_EMAILS_ENABLED`   | `true`  | Enable drip emails (welcome, onboarding, feedback) |
 | `HIDE_AUTH_BUTTONS`     | `false` | Hide login/register buttons on landing page        |
+| `REGISTRATION_ENABLED`  | `true`  | Set to `false` to close public sign-ups (the `/register` routes are disabled and every registration CTA is hidden) while keeping `/login` open |
 | `SUBSCRIPTIONS_ENABLED` | `false` | Enable Stripe subscriptions                        |
 | `STRIPE_KEY`            | -       | Stripe publishable key                             |
 | `STRIPE_SECRET`         | -       | Stripe secret key                                  |

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -143,8 +143,8 @@ return [
     |
     */
 
-    'features' => [
-        Features::registration(),
+    'features' => array_values(array_filter([
+        env('REGISTRATION_ENABLED', true) ? Features::registration() : null,
         Features::resetPasswords(),
         Features::emailVerification(),
         Features::twoFactorAuthentication([
@@ -152,6 +152,6 @@ return [
             'confirmPassword' => true,
             // 'window' => 0
         ]),
-    ],
+    ])),
 
 ];

--- a/resources/js/pages/welcome.tsx
+++ b/resources/js/pages/welcome.tsx
@@ -1665,7 +1665,13 @@ const PRO_ONLY_FEATURES = [
     'Priority support',
 ];
 
-function FreePlanCard({ features }: { features: string[] }) {
+function FreePlanCard({
+    features,
+    canRegister = false,
+}: {
+    features: string[];
+    canRegister?: boolean;
+}) {
     const excluded = new Set(PRO_ONLY_FEATURES);
 
     return (
@@ -1717,12 +1723,15 @@ function FreePlanCard({ features }: { features: string[] }) {
                     })}
                 </ul>
 
-                <Link href="/register" className="mt-8">
+                <Link
+                    href={canRegister ? '/register' : '/login'}
+                    className="mt-8"
+                >
                     <Button
                         className="w-full cursor-pointer border-[#e3e3e0] bg-transparent py-5 text-base text-[#1b1b18] shadow-sm transition-all hover:bg-[#f5f5f4] dark:border-[#3E3E3A] dark:text-[#EDEDEC] dark:hover:bg-[#1f1f1e]"
                         variant="outline"
                     >
-                        {__('Get Started Free')}
+                        {canRegister ? __('Get Started Free') : __('Log in')}
                     </Button>
                 </Link>
             </div>
@@ -1736,6 +1745,7 @@ function LandingPlanCard({
     isBestValue,
     currency,
     locale,
+    canRegister = false,
 }: {
     plan: Plan;
     isDefault: boolean;
@@ -1744,6 +1754,7 @@ function LandingPlanCard({
     promoBadge: string;
     currency: string;
     locale: string;
+    canRegister?: boolean;
 }) {
     const monthlyEquivalent =
         plan.billing_period === 'year' ? plan.price / 12 : plan.price;
@@ -1825,7 +1836,10 @@ function LandingPlanCard({
                     ))}
                 </ul>
 
-                <Link href="/register" className="mt-8">
+                <Link
+                    href={canRegister ? '/register' : '/login'}
+                    className="mt-8"
+                >
                     <Button
                         className={cn(
                             'w-full cursor-pointer py-5 text-base shadow-sm transition-all',
@@ -1835,7 +1849,7 @@ function LandingPlanCard({
                         )}
                         variant={isDefault ? 'default' : 'outline'}
                     >
-                        {__('Get Started')}
+                        {canRegister ? __('Get Started') : __('Log in')}
                     </Button>
                 </Link>
             </div>
@@ -2318,11 +2332,17 @@ export default function Welcome({
                                     ) : (
                                         <div className="flex w-full flex-row gap-4">
                                             <Link
-                                                href="/register"
+                                                href={
+                                                    canRegister
+                                                        ? '/register'
+                                                        : '/login'
+                                                }
                                                 className="w-full"
                                             >
                                                 <Button className="text-shadow duration h-14 w-full cursor-pointer bg-gradient-to-t from-zinc-700 to-zinc-900 text-base text-white shadow-sm transition-all hover:from-zinc-800 hover:to-black hover:shadow-md dark:bg-[#eeeeec] dark:from-zinc-200 dark:to-zinc-300 dark:text-[#1C1C1A] dark:hover:bg-white hover:dark:from-zinc-50 dark:hover:shadow-md">
-                                                    {__('Get Started')}
+                                                    {canRegister
+                                                        ? __('Get Started')
+                                                        : __('Log in')}
                                                 </Button>
                                             </Link>
                                             {demoEnabled && (
@@ -2792,6 +2812,7 @@ export default function Welcome({
                                             features={[
                                                 ...planEntries[0][1].features,
                                             ]}
+                                            canRegister={canRegister}
                                         />
                                         {displayedPlanEntries.map(
                                             ([key, plan]) => (
@@ -2814,6 +2835,7 @@ export default function Welcome({
                                                     }
                                                     currency={pricing.currency}
                                                     locale={locale}
+                                                    canRegister={canRegister}
                                                 />
                                             ),
                                         )}
@@ -2907,9 +2929,17 @@ export default function Welcome({
                                     ) : isMobile ? (
                                         <InstallAppButton />
                                     ) : (
-                                        <Link href="/register">
+                                        <Link
+                                            href={
+                                                canRegister
+                                                    ? '/register'
+                                                    : '/login'
+                                            }
+                                        >
                                             <Button className="h-12 cursor-pointer bg-gradient-to-t from-zinc-700 to-zinc-900 px-8 text-base text-white shadow-sm transition-all hover:from-zinc-800 hover:to-black hover:shadow-md dark:from-zinc-200 dark:to-zinc-300 dark:text-[#1C1C1A] hover:dark:from-zinc-50">
-                                                {__('Get Started for Free')}
+                                                {canRegister
+                                                    ? __('Get Started for Free')
+                                                    : __('Log in')}
                                             </Button>
                                         </Link>
                                     )}

--- a/tests/Feature/Auth/RegistrationDisabledTest.php
+++ b/tests/Feature/Auth/RegistrationDisabledTest.php
@@ -1,36 +1,47 @@
 <?php
 
+use Illuminate\Support\Env;
 use Inertia\Testing\AssertableInertia as Assert;
 use Laravel\Fortify\Features;
+
+/**
+ * Force REGISTRATION_ENABLED for the current process. The framework loads .env
+ * immutably, so a plain putenv()/$_ENV write is ignored once the key is present.
+ * Clearing the repository entry first lets us override it deterministically.
+ */
+function setRegistrationEnabledEnv(?string $value): void
+{
+    $repository = Env::getRepository();
+    $repository->clear('REGISTRATION_ENABLED');
+
+    if ($value !== null) {
+        $repository->set('REGISTRATION_ENABLED', $value);
+    }
+}
 
 beforeEach(function () {
     config(['landing.hide_auth_buttons' => false]);
 });
 
 afterEach(function () {
-    putenv('REGISTRATION_ENABLED');
-    unset($_ENV['REGISTRATION_ENABLED'], $_SERVER['REGISTRATION_ENABLED']);
+    // Clear the override so sibling tests in the same worker fall back to the
+    // default (registration enabled).
+    setRegistrationEnabledEnv(null);
 });
 
 test('registration feature is enabled by default', function () {
-    putenv('REGISTRATION_ENABLED');
-    unset($_ENV['REGISTRATION_ENABLED'], $_SERVER['REGISTRATION_ENABLED']);
-
-    $config = require base_path('config/fortify.php');
-
-    expect($config['features'])->toContain(Features::registration());
+    expect(config('fortify.features'))->toContain(Features::registration());
 });
 
 test('registration feature is removed when REGISTRATION_ENABLED is false', function () {
-    putenv('REGISTRATION_ENABLED=false');
-    $_ENV['REGISTRATION_ENABLED'] = 'false';
+    setRegistrationEnabledEnv('false');
 
-    $config = require base_path('config/fortify.php');
+    $features = (require base_path('config/fortify.php'))['features'];
 
-    expect($config['features'])
+    expect($features)
         ->not->toContain(Features::registration())
-        ->and($config['features'])->toContain(Features::resetPasswords())
-        ->and($config['features'])->toContain(Features::emailVerification());
+        ->and($features)->toContain(Features::resetPasswords())
+        ->and($features)->toContain(Features::emailVerification());
 });
 
 test('the landing page advertises registration by default', function () {
@@ -69,9 +80,7 @@ test('the login page hides the sign-up link when registration is disabled', func
 });
 
 test('the register routes are not registered when registration is disabled', function () {
-    putenv('REGISTRATION_ENABLED=false');
-    $_ENV['REGISTRATION_ENABLED'] = 'false';
-    $_SERVER['REGISTRATION_ENABLED'] = 'false';
+    setRegistrationEnabledEnv('false');
 
     $this->refreshApplication();
 

--- a/tests/Feature/Auth/RegistrationDisabledTest.php
+++ b/tests/Feature/Auth/RegistrationDisabledTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use Inertia\Testing\AssertableInertia as Assert;
+use Laravel\Fortify\Features;
+
+beforeEach(function () {
+    config(['landing.hide_auth_buttons' => false]);
+});
+
+afterEach(function () {
+    putenv('REGISTRATION_ENABLED');
+    unset($_ENV['REGISTRATION_ENABLED'], $_SERVER['REGISTRATION_ENABLED']);
+});
+
+test('registration feature is enabled by default', function () {
+    putenv('REGISTRATION_ENABLED');
+    unset($_ENV['REGISTRATION_ENABLED'], $_SERVER['REGISTRATION_ENABLED']);
+
+    $config = require base_path('config/fortify.php');
+
+    expect($config['features'])->toContain(Features::registration());
+});
+
+test('registration feature is removed when REGISTRATION_ENABLED is false', function () {
+    putenv('REGISTRATION_ENABLED=false');
+    $_ENV['REGISTRATION_ENABLED'] = 'false';
+
+    $config = require base_path('config/fortify.php');
+
+    expect($config['features'])
+        ->not->toContain(Features::registration())
+        ->and($config['features'])->toContain(Features::resetPasswords())
+        ->and($config['features'])->toContain(Features::emailVerification());
+});
+
+test('the landing page advertises registration by default', function () {
+    $this->get('/')
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('welcome')
+            ->where('canRegister', true)
+        );
+});
+
+test('the landing page hides registration when the feature is disabled', function () {
+    config(['fortify.features' => [
+        Features::resetPasswords(),
+        Features::emailVerification(),
+    ]]);
+
+    $this->get('/')
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('welcome')
+            ->where('canRegister', false)
+        );
+});
+
+test('the login page hides the sign-up link when registration is disabled', function () {
+    config(['fortify.features' => [
+        Features::resetPasswords(),
+        Features::emailVerification(),
+    ]]);
+
+    $this->get(route('login'))
+        ->assertSuccessful()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('auth/login')
+            ->where('canRegister', false)
+        );
+});
+
+test('the register routes are not registered when registration is disabled', function () {
+    putenv('REGISTRATION_ENABLED=false');
+    $_ENV['REGISTRATION_ENABLED'] = 'false';
+    $_SERVER['REGISTRATION_ENABLED'] = 'false';
+
+    $this->refreshApplication();
+
+    expect(app('router')->has('register'))->toBeFalse()
+        ->and(app('router')->has('register.store'))->toBeFalse();
+
+    $this->withoutVite()->get('/register')->assertNotFound();
+
+    $this->post('/register', [
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ])->assertNotFound();
+
+    $this->withoutVite()->get(route('login'))->assertSuccessful();
+});


### PR DESCRIPTION
## Summary

Adds a dedicated `REGISTRATION_ENABLED` env var (default `true`) so self-hosters on a publicly reachable instance can **close public sign-ups while keeping login open** — the exact "sign-ups closed, login open, permanently" case from #711 that `HIDE_AUTH_BUTTONS` can't cover.

Closes #711.

## What changed

- **`config/fortify.php`** — the Fortify `registration()` feature is now conditional on `env('REGISTRATION_ENABLED', true)`. When disabled:
  - Fortify **never registers the `/register` routes** (GET form + POST submit → `404`), i.e. a real server-side block, not just a hidden button.
  - The existing `canRegister = Features::enabled(Features::registration())` flag flips to `false` automatically everywhere it's used (`routes/web.php`, `FortifyServiceProvider`, login page).
- **`resources/js/pages/welcome.tsx`** — the hardcoded `/register` CTAs (hero button, Free/paid pricing cards, final "Ready to take control" CTA) now respect `canRegister`, falling back to a `Log in` → `/login` button when sign-ups are closed. The header already gated its `Register` button on `canRegister`.
- **`.env.example` / `README.md`** — document the new variable.

**Backward compatible / optional:** `env('REGISTRATION_ENABLED', true)` defaults to `true`, so existing installs that upgrade without setting the var keep public sign-ups exactly as today. It's shown as a commented, optional example in `.env.example`.

`/login` and the "Iniciar sesión / Log in" button stay fully available in all cases. `AuthEntryPointService::guestRedirectRoute()` already redirects guests to `/login` when registration is disabled, so no dead `route('register')` calls remain.

## Tests

New `tests/Feature/Auth/RegistrationDisabledTest.php`:

- registration feature present by default / removed when `REGISTRATION_ENABLED=false` (config-level).
- landing page exposes `canRegister=true` by default and `false` when the feature is disabled.
- login page hides its sign-up link when registration is disabled.
- **`/register` GET + POST return 404 and the named routes are gone** when disabled (via `refreshApplication()` with the env set), while `/login` still returns 200.

All new tests pass; the wider `tests/Feature/Auth` + landing-override suites stay green (the one unrelated `Asia/Calcutta` legacy-timezone failure is a pre-existing tzdata quirk of the CI-less local box, not touched here). `pint`, `prettier --check`, and `eslint` are clean.

## Manual QA

Verified against a running instance (headless Chromium) in both states:

| `REGISTRATION_ENABLED=true` (default) | `REGISTRATION_ENABLED=false` |
| --- | --- |
| Header: `Log in` + `Register`; hero CTA `Get Started` → `/register` | Header: `Register` gone, only `Log in`; hero CTA `Log in` → `/login` |
| `GET /register` → `200` | `GET /register` → `404`, `GET /login` → `200`, `Route::has('register')` → `false` |