### PR TITLE
feat(ai): make the AI provider configurable (any laravel/ai provider, incl. local Ollama)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -140,14 +140,34 @@ DEMO_EMAIL=demo@whisper.money
 DEMO_PASSWORD=demo
 DEMO_ENCRYPTION_KEY=demo
 
-# AI rule suggestions (powered by laravel/ai + Gemini)
+# AI features (transaction categorization + rule suggestions, powered by laravel/ai)
+#
+# Provider is configurable independently of the model and defaults to Gemini.
+# Set AI_PROVIDER to switch every AI feature at once (e.g. "ollama" for fully
+# local, private processing); the per-feature vars below override it. Any
+# provider from config/ai.php works ("gemini", "ollama", "openai", ...).
+# AI_PROVIDER=gemini
+# AI_SUGGESTIONS_PROVIDER=gemini
+# AI_CATEGORIZATION_PROVIDER=gemini
+
+# --- Gemini (default provider) ---
 GEMINI_API_KEY=
 GEMINI_BASE_URL=
-# Model is overridable without a deploy; defaults to a Flash-tier model.
 # GEMINI_BASE_URL is optional — leave empty to use Google AI Studio
 # (https://generativelanguage.googleapis.com/v1beta). Only set it for a
 # proxy or Vertex AI gateway.
+
+# --- Ollama (local, self-hosted models — no API key needed) ---
+# Point OLLAMA_URL at your Ollama server and set the model vars below to a
+# pulled model (e.g. gemma3:12b). OLLAMA_API_KEY is only needed behind an
+# authenticating proxy.
+# OLLAMA_URL=http://localhost:11434
+# OLLAMA_API_KEY=
+
+# Model is overridable without a deploy; defaults to a Flash-tier Gemini model.
+# When using Ollama, set these to a locally available model (e.g. gemma3:12b).
 AI_SUGGESTIONS_MODEL=gemini-flash-latest
+# AI_CATEGORIZATION_MODEL=gemini-flash-latest
 AI_SUGGESTIONS_MIN_GROUP_COUNT=2
 AI_SUGGESTIONS_MAX_GROUPS=40
 AI_SUGGESTIONS_CONFIDENCE_FLOOR=0.3

--- a/.env.example
+++ b/.env.example
@@ -144,8 +144,9 @@ DEMO_ENCRYPTION_KEY=demo
 #
 # Provider is configurable independently of the model and defaults to Gemini.
 # Set AI_PROVIDER to switch every AI feature at once (e.g. "ollama" for fully
-# local, private processing); the per-feature vars below override it. Any
-# provider from config/ai.php works ("gemini", "ollama", "openai", ...).
+# local, private processing); the per-feature vars below override it. Accepts
+# any laravel/ai provider ("gemini", "ollama", "openai", ...); an unknown value
+# fails fast.
 # AI_PROVIDER=gemini
 # AI_SUGGESTIONS_PROVIDER=gemini
 # AI_CATEGORIZATION_PROVIDER=gemini

--- a/README.md
+++ b/README.md
@@ -176,9 +176,10 @@ The template includes:
 Whisper Money's AI features (transaction categorization and automation-rule
 suggestions) run on [`laravel/ai`](https://github.com/laravel/ai) and default to
 Google **Gemini**. The provider is configurable independently of the model, so
-you can point the app at any provider from `config/ai.php` — including a
+you can point the app at any provider supported by `laravel/ai` — including a
 self-hosted **[Ollama](https://ollama.com)** server for fully local, private AI
-processing that never leaves your infrastructure.
+processing that never leaves your infrastructure. An unknown provider fails
+fast at startup of the AI feature.
 
 | Variable                     | Default              | Description                                                            |
 | ---------------------------- | -------------------- | --------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -176,10 +176,15 @@ The template includes:
 Whisper Money's AI features (transaction categorization and automation-rule
 suggestions) run on [`laravel/ai`](https://github.com/laravel/ai) and default to
 Google **Gemini**. The provider is configurable independently of the model, so
-you can point the app at any provider supported by `laravel/ai` — including a
-self-hosted **[Ollama](https://ollama.com)** server for fully local, private AI
-processing that never leaves your infrastructure. An unknown provider fails
-fast at startup of the AI feature.
+you can point the app at **any text provider `laravel/ai` supports** — `gemini`,
+`openai`, `anthropic`, `azure`, `groq`, `xai`, `deepseek`, `mistral`, or a
+self-hosted **[Ollama](https://ollama.com)** server. Ollama is the headline case
+because it keeps AI processing fully local and private — data never leaves your
+infrastructure — but the switch is generic.
+
+Each provider needs its own credentials configured for `laravel/ai` (e.g.
+`GEMINI_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `OLLAMA_URL`). An
+unknown or non-text provider fails fast when the AI feature runs.
 
 | Variable                     | Default              | Description                                                            |
 | ---------------------------- | -------------------- | --------------------------------------------------------------------- |
@@ -192,7 +197,7 @@ fast at startup of the AI feature.
 | `OLLAMA_URL`                 | `http://localhost:11434` | Ollama server URL (used when the provider is `ollama`).           |
 | `OLLAMA_API_KEY`             | -                    | Optional; only needed behind an authenticating proxy.                 |
 
-### Using a local Ollama model
+### Example: fully local AI with Ollama
 
 ```dotenv
 AI_PROVIDER=ollama
@@ -202,7 +207,9 @@ AI_CATEGORIZATION_MODEL=gemma3:12b
 ```
 
 Make sure the model is pulled on the Ollama server first (`ollama pull gemma3:12b`).
-Gemini remains the default, so existing deployments are unaffected.
+Any other provider follows the same pattern: set `AI_PROVIDER`, that provider's
+credentials, and the `*_MODEL` vars to one of its models. Gemini remains the
+default, so existing deployments are unaffected.
 
 ## Star History
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,39 @@ The template includes:
 | `STRIPE_KEY`            | -       | Stripe publishable key                             |
 | `STRIPE_SECRET`         | -       | Stripe secret key                                  |
 | `STRIPE_WEBHOOK_SECRET` | -       | Stripe webhook signing secret                      |
+| `AI_PROVIDER`           | `gemini`| AI provider for every AI feature (`gemini`, `ollama`, `openai`, ...) |
+
+## AI Provider
+
+Whisper Money's AI features (transaction categorization and automation-rule
+suggestions) run on [`laravel/ai`](https://github.com/laravel/ai) and default to
+Google **Gemini**. The provider is configurable independently of the model, so
+you can point the app at any provider from `config/ai.php` — including a
+self-hosted **[Ollama](https://ollama.com)** server for fully local, private AI
+processing that never leaves your infrastructure.
+
+| Variable                     | Default              | Description                                                            |
+| ---------------------------- | -------------------- | --------------------------------------------------------------------- |
+| `AI_PROVIDER`                | `gemini`             | Provider for all AI features. Set once to switch everything.          |
+| `AI_SUGGESTIONS_PROVIDER`    | `AI_PROVIDER`        | Override the provider for rule suggestions only.                      |
+| `AI_CATEGORIZATION_PROVIDER` | `AI_PROVIDER`        | Override the provider for transaction categorization only.            |
+| `AI_SUGGESTIONS_MODEL`       | `gemini-flash-latest`| Model used for rule suggestions.                                      |
+| `AI_CATEGORIZATION_MODEL`    | `gemini-flash-latest`| Model used for transaction categorization.                            |
+| `GEMINI_API_KEY`             | -                    | Required when the provider is `gemini`.                               |
+| `OLLAMA_URL`                 | `http://localhost:11434` | Ollama server URL (used when the provider is `ollama`).           |
+| `OLLAMA_API_KEY`             | -                    | Optional; only needed behind an authenticating proxy.                 |
+
+### Using a local Ollama model
+
+```dotenv
+AI_PROVIDER=ollama
+OLLAMA_URL=http://ollama.example.local:11434
+AI_SUGGESTIONS_MODEL=gemma3:12b
+AI_CATEGORIZATION_MODEL=gemma3:12b
+```
+
+Make sure the model is pulled on the Ollama server first (`ollama pull gemma3:12b`).
+Gemini remains the default, so existing deployments are unaffected.
 
 ## Star History
 

--- a/app/Services/Ai/CategorizeTransactions.php
+++ b/app/Services/Ai/CategorizeTransactions.php
@@ -9,7 +9,6 @@ use App\Models\Transaction;
 use App\Models\User;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
-use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Exceptions\FailoverableException;
 use Throwable;
 
@@ -170,7 +169,7 @@ class CategorizeTransactions
 
         $response = (new TransactionCategorizationAgent)->prompt(
             $payload,
-            provider: Lab::Gemini,
+            provider: (string) config('ai_categorization.provider'),
             model: (string) config('ai_categorization.model'),
         );
 

--- a/app/Services/Ai/CategorizeTransactions.php
+++ b/app/Services/Ai/CategorizeTransactions.php
@@ -9,6 +9,7 @@ use App\Models\Transaction;
 use App\Models\User;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Exceptions\FailoverableException;
 use Throwable;
 
@@ -169,7 +170,7 @@ class CategorizeTransactions
 
         $response = (new TransactionCategorizationAgent)->prompt(
             $payload,
-            provider: (string) config('ai_categorization.provider'),
+            provider: Lab::from((string) config('ai_categorization.provider')),
             model: (string) config('ai_categorization.model'),
         );
 

--- a/app/Services/Ai/LaravelAiRuleSuggestionGenerator.php
+++ b/app/Services/Ai/LaravelAiRuleSuggestionGenerator.php
@@ -5,6 +5,7 @@ namespace App\Services\Ai;
 use App\Ai\Agents\RuleSuggestionAgent;
 use App\Services\Ai\Contracts\RuleSuggestionGenerator;
 use Illuminate\Support\Facades\Log;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Exceptions\FailoverableException;
 use Throwable;
 
@@ -90,7 +91,7 @@ class LaravelAiRuleSuggestionGenerator implements RuleSuggestionGenerator
 
         $response = (new RuleSuggestionAgent)->prompt(
             $payload,
-            provider: (string) config('ai_suggestions.provider'),
+            provider: Lab::from((string) config('ai_suggestions.provider')),
             model: (string) config('ai_suggestions.model'),
         );
 

--- a/app/Services/Ai/LaravelAiRuleSuggestionGenerator.php
+++ b/app/Services/Ai/LaravelAiRuleSuggestionGenerator.php
@@ -5,7 +5,6 @@ namespace App\Services\Ai;
 use App\Ai\Agents\RuleSuggestionAgent;
 use App\Services\Ai\Contracts\RuleSuggestionGenerator;
 use Illuminate\Support\Facades\Log;
-use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Exceptions\FailoverableException;
 use Throwable;
 
@@ -91,7 +90,7 @@ class LaravelAiRuleSuggestionGenerator implements RuleSuggestionGenerator
 
         $response = (new RuleSuggestionAgent)->prompt(
             $payload,
-            provider: Lab::Gemini,
+            provider: (string) config('ai_suggestions.provider'),
             model: (string) config('ai_suggestions.model'),
         );
 

--- a/config/ai_categorization.php
+++ b/config/ai_categorization.php
@@ -4,14 +4,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Model
+    | Provider & model
     |--------------------------------------------------------------------------
     |
-    | The Gemini model used to categorize transactions. Cost is negligible at
-    | any tier for this task, so the model is chosen for accuracy, not price.
-    | Kept env-overridable so it can be swapped without a deploy.
+    | The laravel/ai provider and model used to categorize transactions. The
+    | provider defaults to Gemini for backward compatibility, but any provider
+    | configured in config/ai.php works — set it to "ollama" (with OLLAMA_URL)
+    | to keep AI processing fully local and private. Both are env-overridable so
+    | they can be swapped without a deploy; "AI_PROVIDER" switches every AI
+    | feature at once, and the feature-specific var overrides it. Cost is
+    | negligible at any tier for this task, so the model is chosen for accuracy.
     |
     */
+
+    'provider' => env('AI_CATEGORIZATION_PROVIDER', env('AI_PROVIDER', 'gemini')),
 
     'model' => env('AI_CATEGORIZATION_MODEL', 'gemini-flash-latest'),
 

--- a/config/ai_categorization.php
+++ b/config/ai_categorization.php
@@ -7,13 +7,11 @@ return [
     | Provider & model
     |--------------------------------------------------------------------------
     |
-    | The laravel/ai provider and model used to categorize transactions. The
-    | provider defaults to Gemini for backward compatibility, but any provider
-    | configured in config/ai.php works — set it to "ollama" (with OLLAMA_URL)
-    | to keep AI processing fully local and private. Both are env-overridable so
-    | they can be swapped without a deploy; "AI_PROVIDER" switches every AI
-    | feature at once, and the feature-specific var overrides it. Cost is
-    | negligible at any tier for this task, so the model is chosen for accuracy.
+    | Provider and model for transaction categorization, both env-overridable.
+    | The provider defaults to Gemini but accepts any laravel/ai provider (a
+    | valid Laravel\Ai\Enums\Lab case — an unknown value fails fast). Cost is
+    | negligible at any tier, so the model is chosen for accuracy. See the
+    | README "AI Provider" section for the shared options (e.g. local Ollama).
     |
     */
 

--- a/config/ai_suggestions.php
+++ b/config/ai_suggestions.php
@@ -7,13 +7,11 @@ return [
     | Provider & model
     |--------------------------------------------------------------------------
     |
-    | The laravel/ai provider and model used to generate automation-rule
-    | suggestions. The provider defaults to Gemini for backward compatibility,
-    | but any provider configured in config/ai.php works — set it to "ollama"
-    | (with OLLAMA_URL) to keep AI processing fully local and private. Both are
-    | env-overridable so they can be swapped without a deploy; "AI_PROVIDER"
-    | switches every AI feature at once, and the feature-specific var overrides
-    | it. Any Flash-tier model is appropriate for this constrained task.
+    | Provider and model for automation-rule suggestions, both env-overridable.
+    | The provider defaults to Gemini but accepts any laravel/ai provider (a
+    | valid Laravel\Ai\Enums\Lab case — an unknown value fails fast). Any
+    | Flash-tier model suits this constrained task. See the README "AI Provider"
+    | section for the shared options (e.g. local Ollama, the AI_PROVIDER switch).
     |
     */
 

--- a/config/ai_suggestions.php
+++ b/config/ai_suggestions.php
@@ -4,14 +4,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Model
+    | Provider & model
     |--------------------------------------------------------------------------
     |
-    | The Gemini model used to generate automation-rule suggestions. Kept in
-    | config (env-overridable) so the model can be swapped without a deploy.
-    | Any Flash-tier model is appropriate for this constrained task.
+    | The laravel/ai provider and model used to generate automation-rule
+    | suggestions. The provider defaults to Gemini for backward compatibility,
+    | but any provider configured in config/ai.php works — set it to "ollama"
+    | (with OLLAMA_URL) to keep AI processing fully local and private. Both are
+    | env-overridable so they can be swapped without a deploy; "AI_PROVIDER"
+    | switches every AI feature at once, and the feature-specific var overrides
+    | it. Any Flash-tier model is appropriate for this constrained task.
     |
     */
+
+    'provider' => env('AI_SUGGESTIONS_PROVIDER', env('AI_PROVIDER', 'gemini')),
 
     'model' => env('AI_SUGGESTIONS_MODEL', 'gemini-flash-latest'),
 

--- a/tests/Feature/Ai/CategorizeTransactionsTest.php
+++ b/tests/Feature/Ai/CategorizeTransactionsTest.php
@@ -178,6 +178,56 @@ it('reports unexpected failures and does not schedule a retry so real bugs are n
     Queue::assertNotPushed(RetryTransientAiCategorizationJob::class);
 });
 
+it('routes prompts through the configured provider so local Ollama can be used', function () {
+    config()->set('ai_categorization.provider', 'ollama');
+    config()->set('ai_categorization.model', 'gemma3:12b');
+
+    $user = User::factory()->create();
+    $category = groceries($user);
+    $transaction = uncategorized($user);
+
+    $index = leafIndex(CategoryCatalog::forUser($user), $category->id);
+
+    TransactionCategorizationAgent::fake([
+        ['results' => [[
+            'ref' => $transaction->id,
+            'category_index' => $index,
+            'confidence' => 0.95,
+            'merchant_unambiguous' => true,
+        ]]],
+    ]);
+
+    app(CategorizeTransactions::class)->forTransactions($user, collect([$transaction]));
+
+    TransactionCategorizationAgent::assertPrompted(
+        fn ($prompt): bool => (string) $prompt->provider === 'ollama'
+            && $prompt->model === 'gemma3:12b',
+    );
+});
+
+it('defaults the categorization provider to gemini for backward compatibility', function () {
+    $user = User::factory()->create();
+    $category = groceries($user);
+    $transaction = uncategorized($user);
+
+    $index = leafIndex(CategoryCatalog::forUser($user), $category->id);
+
+    TransactionCategorizationAgent::fake([
+        ['results' => [[
+            'ref' => $transaction->id,
+            'category_index' => $index,
+            'confidence' => 0.95,
+            'merchant_unambiguous' => true,
+        ]]],
+    ]);
+
+    app(CategorizeTransactions::class)->forTransactions($user, collect([$transaction]));
+
+    TransactionCategorizationAgent::assertPrompted(
+        fn ($prompt): bool => (string) $prompt->provider === 'gemini',
+    );
+});
+
 it('skips results whose category index does not resolve', function () {
     $user = User::factory()->create();
     groceries($user);

--- a/tests/Feature/Ai/RuleSuggestionGeneratorTest.php
+++ b/tests/Feature/Ai/RuleSuggestionGeneratorTest.php
@@ -39,6 +39,37 @@ it('skips the model entirely when there are no groups', function () {
     expect($generator->generate([], []))->toBe([]);
 });
 
+it('prompts the configured provider and model, defaulting to gemini', function () {
+    RuleSuggestionAgent::fake([['suggestions' => []]]);
+
+    (new LaravelAiRuleSuggestionGenerator)->generate(
+        groups: [benchGroup('alpha')],
+        categoryOptions: [['id' => 'cat-1', 'name' => 'X', 'path' => 'X', 'type' => 'expense', 'direction' => 'outflow', 'is_leaf' => true]],
+    );
+
+    RuleSuggestionAgent::assertPrompted(
+        fn ($prompt): bool => (string) $prompt->provider === 'gemini'
+            && $prompt->model === (string) config('ai_suggestions.model'),
+    );
+});
+
+it('routes prompts through Ollama when the provider is configured for local AI', function () {
+    config()->set('ai_suggestions.provider', 'ollama');
+    config()->set('ai_suggestions.model', 'gemma3:12b');
+
+    RuleSuggestionAgent::fake([['suggestions' => []]]);
+
+    (new LaravelAiRuleSuggestionGenerator)->generate(
+        groups: [benchGroup('alpha')],
+        categoryOptions: [['id' => 'cat-1', 'name' => 'X', 'path' => 'X', 'type' => 'expense', 'direction' => 'outflow', 'is_leaf' => true]],
+    );
+
+    RuleSuggestionAgent::assertPrompted(
+        fn ($prompt): bool => (string) $prompt->provider === 'ollama'
+            && $prompt->model === 'gemma3:12b',
+    );
+});
+
 function genSuggestion(string $key): array
 {
     return [

--- a/tests/Feature/Ai/RuleSuggestionGeneratorTest.php
+++ b/tests/Feature/Ai/RuleSuggestionGeneratorTest.php
@@ -70,6 +70,17 @@ it('routes prompts through Ollama when the provider is configured for local AI',
     );
 });
 
+it('fails fast with a clear error when the configured provider is unknown', function () {
+    config()->set('ai_suggestions.provider', 'not-a-provider');
+
+    RuleSuggestionAgent::fake([['suggestions' => []]]);
+
+    expect(fn () => (new LaravelAiRuleSuggestionGenerator)->generate(
+        groups: [benchGroup('alpha')],
+        categoryOptions: [['id' => 'cat-1', 'name' => 'X', 'path' => 'X', 'type' => 'expense', 'direction' => 'outflow', 'is_leaf' => true]],
+    ))->toThrow(ValueError::class);
+});
+
 function genSuggestion(string $key): array
 {
     return [


### PR DESCRIPTION
## Summary

Closes #716.

Both AI execution paths hard-coded `provider: Lab::Gemini`, so even though `laravel/ai` already understands `OLLAMA_URL` and the model was env-overridable, no other provider could ever be reached by the actual UI features. This makes the **AI provider configurable**, keeping **Gemini as the default** so existing deployments are unaffected.

Although issue #716 asked specifically for **Ollama**, the fix is generic: because the provider is resolved through the `Laravel\Ai\Enums\Lab` enum, this unlocks **any text provider `laravel/ai` supports** — `gemini`, `openai`, `anthropic`, `azure`, `groq`, `xai`, `deepseek`, `mistral`, and self-hosted `ollama`. Ollama is the headline case (fully local, private processing), but nothing in the code is Ollama-specific.

> Note: each provider still needs its own credentials configured for `laravel/ai` (e.g. `GEMINI_API_KEY`, `OPENAI_API_KEY`, `OLLAMA_URL`), and only text-capable providers apply — a non-text or unknown provider fails fast.

## Changes

- **`config/ai_suggestions.php` / `config/ai_categorization.php`** — add a `provider` key. Each reads its own `AI_SUGGESTIONS_PROVIDER` / `AI_CATEGORIZATION_PROVIDER`, both falling back to a shared `AI_PROVIDER` and finally `gemini`. So `AI_PROVIDER=<provider>` flips every AI feature at once, and either feature can still be overridden individually.
- **`app/Services/Ai/CategorizeTransactions.php` / `app/Services/Ai/LaravelAiRuleSuggestionGenerator.php`** — resolve the configured provider to the `Laravel\Ai\Enums\Lab` enum via `Lab::from((string) config('...provider'))` and pass it to `prompt()` (the SDK recommends referencing providers by the `Lab` enum rather than a plain string). `Lab::from()` also **validates** the value: an unknown provider fails fast with a clear `ValueError` instead of erroring deep in the provider stack.
- **`.env.example`** — document the provider vars plus an Ollama block (`OLLAMA_URL`, `OLLAMA_API_KEY`, `AI_CATEGORIZATION_MODEL`), kept commented so defaults stay Gemini.
- **`README.md`** — new *AI Provider* section: the generic provider switch, the list of supported text providers, and a local-Ollama example.
- **Tests** — cover the `gemini` default and a non-Gemini (`ollama`) override for both the categorization and rule-suggestion paths, plus the fail-fast `ValueError` on an unknown provider.

## Usage

Any supported provider follows the same pattern — set `AI_PROVIDER`, that provider's credentials, and the `*_MODEL` vars. Example, fully local/private with Ollama:

```dotenv
AI_PROVIDER=ollama
OLLAMA_URL=http://ollama.example.local:11434
AI_SUGGESTIONS_MODEL=gemma3:12b
AI_CATEGORIZATION_MODEL=gemma3:12b
```

## Validation

- `./vendor/bin/pest tests/Feature/Ai` → **128 passed**.
- `vendor/bin/pint` and `vendor/bin/phpstan` (level 5) → clean.
- **End-to-end against a real Ollama server** (`gemma3:12b`), through the actual application code (not faked):
  - Categorization: `MERCADONA COMPRA` → *Groceries*, confidence 0.95.
  - Rule suggestion: `netflix` → *Subscriptions*, structured output intact.

## Backward compatibility

Default provider is unchanged (`gemini`); no env changes are required for existing installs.