### PR TITLE
fix(auth): make build deterministic when REGISTRATION_ENABLED=false

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,7 +88,7 @@ AWS_USE_PATH_STYLE_ENDPOINT=false
 
 # Optional. Defaults to true when unset, so existing installs keep public sign-ups.
 # Set to false to close public sign-ups while keeping login open (invite/admin-created
-# accounts only): the /register routes are not registered and every registration CTA
+# accounts only): the /register routes return a 403 and every registration CTA
 # is hidden, while /login stays fully available.
 # REGISTRATION_ENABLED=false
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The template includes:
 | Variable                | Default | Description                                        |
 | ----------------------- | ------- | -------------------------------------------------- |
 | `DRIP_EMAILS_ENABLED`   | `true`  | Enable drip emails (welcome, onboarding, feedback) |
-| `REGISTRATION_ENABLED`  | `true`  | Set to `false` to close public sign-ups (the `/register` routes are disabled and every registration CTA is hidden) while keeping `/login` open |
+| `REGISTRATION_ENABLED`  | `true`  | Set to `false` to close public sign-ups (the `/register` routes return a 403 and every registration CTA is hidden) while keeping `/login` open |
 | `SUBSCRIPTIONS_ENABLED` | `false` | Enable Stripe subscriptions                        |
 | `STRIPE_KEY`            | -       | Stripe publishable key                             |
 | `STRIPE_SECRET`         | -       | Stripe secret key                                  |

--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -19,6 +19,8 @@ class CreateNewUser implements CreatesNewUsers
      */
     public function create(array $input): User
     {
+        abort_if(! config('auth.registration_enabled'), 403);
+
         Validator::make($input, [
             'name' => ['required', 'string', 'max:255'],
             'email' => [

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -74,7 +74,7 @@ class FortifyServiceProvider extends ServiceProvider
     {
         Fortify::loginView(fn (Request $request) => Inertia::render('auth/login', [
             'canResetPassword' => Features::enabled(Features::resetPasswords()),
-            'canRegister' => Features::enabled(Features::registration()),
+            'canRegister' => config('auth.registration_enabled'),
             'status' => $request->session()->get('status'),
         ]));
 
@@ -91,7 +91,11 @@ class FortifyServiceProvider extends ServiceProvider
             'status' => $request->session()->get('status'),
         ]));
 
-        Fortify::registerView(fn () => Inertia::render('auth/register'));
+        Fortify::registerView(function () {
+            abort_if(! config('auth.registration_enabled'), 403);
+
+            return Inertia::render('auth/register');
+        });
 
         Fortify::twoFactorChallengeView(fn () => Inertia::render('auth/two-factor-challenge'));
 

--- a/app/Services/AuthEntryPointService.php
+++ b/app/Services/AuthEntryPointService.php
@@ -4,7 +4,6 @@ namespace App\Services;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cookie;
-use Laravel\Fortify\Features;
 use Symfony\Component\HttpFoundation\Cookie as HttpFoundationCookie;
 
 class AuthEntryPointService
@@ -21,7 +20,7 @@ class AuthEntryPointService
     {
         if (
             $this->hasAuthenticatedBefore($request)
-            || ! Features::enabled(Features::registration())
+            || ! config('auth.registration_enabled')
         ) {
             return route('login');
         }

--- a/config/auth.php
+++ b/config/auth.php
@@ -22,6 +22,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Public Registration
+    |--------------------------------------------------------------------------
+    |
+    | When disabled, public sign-ups are closed: the /register routes return a
+    | 403 and every registration CTA is hidden, while /login stays open. The
+    | routes themselves remain registered so Wayfinder can generate their
+    | helpers and the frontend build is deterministic regardless of this flag.
+    |
+    */
+
+    'registration_enabled' => env('REGISTRATION_ENABLED', true),
+
+    /*
+    |--------------------------------------------------------------------------
     | Authentication Guards
     |--------------------------------------------------------------------------
     |

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -143,8 +143,14 @@ return [
     |
     */
 
-    'features' => array_values(array_filter([
-        env('REGISTRATION_ENABLED', true) ? Features::registration() : null,
+    /*
+     | Registration routes are always registered so Wayfinder can generate
+     | their route helpers and the frontend build stays deterministic. Whether
+     | sign-ups are actually accepted is gated at runtime via the
+     | "auth.registration_enabled" config value.
+     */
+    'features' => [
+        Features::registration(),
         Features::resetPasswords(),
         Features::emailVerification(),
         Features::twoFactorAuthentication([
@@ -152,6 +158,6 @@ return [
             'confirmPassword' => true,
             // 'window' => 0
         ]),
-    ])),
+    ],
 
 ];

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,7 +31,6 @@ use App\Models\Bank;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
-use Laravel\Fortify\Features;
 
 Route::get('/', function () {
     $popularBanks = Cache::remember('popular-banks', now()->addDay(), function () {
@@ -60,7 +59,7 @@ Route::get('/', function () {
     });
 
     return Inertia::render('welcome', [
-        'canRegister' => Features::enabled(Features::registration()),
+        'canRegister' => config('auth.registration_enabled'),
         'popularBanks' => $popularBanks,
     ]);
 })->name('home');

--- a/tests/Feature/Auth/RegistrationDisabledTest.php
+++ b/tests/Feature/Auth/RegistrationDisabledTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use Inertia\Testing\AssertableInertia as Assert;
+
+test('registration is enabled by default', function () {
+    expect(config('auth.registration_enabled'))->toBeTrue();
+});
+
+test('the register route helpers are always registered regardless of the flag', function () {
+    config(['auth.registration_enabled' => false]);
+
+    expect(app('router')->has('register'))->toBeTrue()
+        ->and(app('router')->has('register.store'))->toBeTrue();
+});
+
+test('the register view returns 403 when registration is disabled', function () {
+    config(['auth.registration_enabled' => false]);
+
+    $this->withoutVite()->get(route('register'))->assertForbidden();
+});
+
+test('the register store returns 403 when registration is disabled', function () {
+    config(['auth.registration_enabled' => false]);
+
+    $this->post(route('register.store'), [
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ])->assertForbidden();
+
+    $this->assertDatabaseMissing('users', ['email' => 'test@example.com']);
+});
+
+test('the landing page advertises registration by default', function () {
+    $this->get('/')
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('welcome')
+            ->where('canRegister', true)
+        );
+});
+
+test('the landing page hides registration when registration is disabled', function () {
+    config(['auth.registration_enabled' => false]);
+
+    $this->get('/')
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('welcome')
+            ->where('canRegister', false)
+        );
+});
+
+test('the login page hides the sign-up link when registration is disabled', function () {
+    config(['auth.registration_enabled' => false]);
+
+    $this->withoutVite()->get(route('login'))
+        ->assertSuccessful()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('auth/login')
+            ->where('canRegister', false)
+        );
+});

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -4,7 +4,6 @@ use App\Enums\CategoryType;
 use App\Models\Category;
 use App\Models\Transaction;
 use App\Models\User;
-use Laravel\Fortify\Features;
 
 test('new guests are redirected to the registration page', function () {
     $this->get(route('dashboard'))->assertRedirect(route('register'));
@@ -18,12 +17,7 @@ test('returning guests are redirected to the login page', function () {
 });
 
 test('new guests are redirected to the login page when registration is disabled', function () {
-    config([
-        'fortify.features' => array_values(array_filter(
-            config('fortify.features'),
-            fn (string $feature): bool => $feature !== Features::registration(),
-        )),
-    ]);
+    config(['auth.registration_enabled' => false]);
 
     $this->get(route('dashboard'))->assertRedirect(route('login'));
 });


### PR DESCRIPTION
## Problem

`bun run build` failed whenever `REGISTRATION_ENABLED=false`.

`config/fortify.php` only added `Features::registration()` when the env flag
was truthy, so with the flag off Fortify never registered the `/register`
routes. Wayfinder only generates helpers for registered routes, so the
`register` / `register.store` helpers imported by `resources/js/pages/auth/login.tsx`
and `resources/js/pages/auth/register.tsx` no longer resolved and the build
broke. The build outcome depended on an env flag — not deterministic.

## Fix

Decouple *route registration* from *whether sign-ups are accepted*:

- **Always register** `Features::registration()` in `config/fortify.php`, so the
  `/register` routes (and their Wayfinder helpers) always exist and the build is
  deterministic regardless of the flag.
- Gate acceptance at **runtime** via a new `config('auth.registration_enabled')`
  value (mapped from `env('REGISTRATION_ENABLED', true)`), the single source of truth.
- When registration is disabled:
  - `GET /register` (Fortify register view) and `POST /register` (`CreateNewUser`)
    return **403**.
  - Registration CTAs stay hidden via `canRegister` (login view + landing page).
  - Guests are redirected to `/login` (`AuthEntryPointService::guestRedirectRoute`).
- With the flag enabled (the default), registration behaves exactly as before.

## Tests

- Rewrote `tests/Feature/Auth/RegistrationDisabledTest.php` to the runtime
  mechanism: registration enabled by default, route helpers always registered
  regardless of the flag, `GET`/`POST /register` return 403 when disabled (and no
  user is created), and the landing/login CTAs hide.
- Updated the `DashboardTest` disabled-registration case to toggle
  `config('auth.registration_enabled')` instead of filtering the Fortify feature.
- Verified `bun run build` succeeds with `REGISTRATION_ENABLED=false` and that the
  `register` / `register.store` Wayfinder helpers are generated.

## Docs

- Updated `README.md` and `.env.example` to describe the 403 behavior (routes stay
  registered rather than being removed).
