### PR TITLE
feat(settings): make mobile settings nav read as a tappable menu

### DIFF
--- a/resources/js/layouts/settings/layout.tsx
+++ b/resources/js/layouts/settings/layout.tsx
@@ -227,7 +227,7 @@ export default function SettingsLayout({ children }: PropsWithChildren) {
                         onValueChange={(value) => router.visit(value)}
                     >
                         <SelectTrigger
-                            className="w-full"
+                            className="h-11 bg-muted font-medium [&>svg:last-child]:opacity-100"
                             data-testid="settings-mobile-nav-trigger"
                         >
                             <div className="flex w-full flex-row items-center gap-2">


### PR DESCRIPTION
## Problem

On mobile, many users don't realize the dropdown at the top of Settings is a navigation menu — they don't know they can tap it. The trigger was a shadcn `Select` left with the default form-field look (transparent background, faint chevron), so once you're on a page it reads as a static label rather than a control.

## Change

Restyle the mobile settings-nav `SelectTrigger` (in `resources/js/layouts/settings/layout.tsx`) so it reads as a tappable menu button:

- `bg-muted` — filled background instead of a transparent input.
- `h-11` — 44px touch target (recommended mobile minimum, up from 36px).
- `font-medium` — the label reads as a control, not plain text.
- `[&>svg:last-child]:opacity-100` — the chevron goes from barely-visible to a clear "this opens" affordance.

Scope is the mobile block only (`lg:hidden`); the desktop sidebar is untouched. Uses theme tokens, so light and dark mode are both covered.

## Demo
<img width="390" height="844" alt="settings-menu-dark-open" src="https://github.com/user-attachments/assets/9ed7856a-0048-40a2-8e6e-07b24b4cb844" />
<img width="390" height="844" alt="settings-menu-dark-closed" src="https://github.com/user-attachments/assets/5b8b2b7a-c31c-4c55-b224-1f87f554e361" />
<img width="390" height="844" alt="settings-menu-light-open" src="https://github.com/user-attachments/assets/4f6abb55-38b8-4e38-9322-12b555082dad" />
<img width="390" height="844" alt="settings-menu-light-closed" src="https://github.com/user-attachments/assets/e08babf7-fe9d-46d7-abd6-329962d34eaf" />

## Testing

Pure Tailwind class change with no behavior change (the `Select` → `router.visit` navigation is unchanged), so no unit test is added — a CSS-class assertion would be brittle. Verified live in the browser at mobile width in both light and dark mode, closed and open.