### PR TITLE
fix(oauth): stop reporting client-facing OAuthServerException to Sentry

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -18,6 +18,7 @@ use Illuminate\Http\Request;
 use Illuminate\Queue\MaxAttemptsExceededException;
 use Laravel\Sanctum\Http\Middleware\CheckAbilities;
 use Laravel\Sanctum\Http\Middleware\CheckForAnyAbility;
+use League\OAuth2\Server\Exception\OAuthServerException;
 use Sentry\Laravel\Integration;
 
 return Application::configure(basePath: dirname(__DIR__))
@@ -65,4 +66,7 @@ return Application::configure(basePath: dirname(__DIR__))
 
         $exceptions->dontReportWhen(fn (Throwable $e): bool => $e instanceof MaxAttemptsExceededException
             && $e->job?->resolveName() === SyncBankingConnectionJob::class);
+
+        $exceptions->dontReportWhen(fn (Throwable $e): bool => $e instanceof OAuthServerException
+            && $e->getHttpStatusCode() < 500);
     })->create();

--- a/tests/Feature/Mcp/McpOAuthTest.php
+++ b/tests/Feature/Mcp/McpOAuthTest.php
@@ -2,8 +2,10 @@
 
 use App\Models\Label;
 use App\Models\User;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Support\Str;
 use Laravel\Passport\ClientRepository;
+use League\OAuth2\Server\Exception\OAuthServerException;
 
 use function Pest\Laravel\get;
 use function Pest\Laravel\postJson;
@@ -222,4 +224,24 @@ it('lets an OAuth connection use write tools', function () {
     $label = Label::query()->where('user_id', $user->id)->first();
     expect($label)->not->toBeNull();
     expect($label->name)->toBe('Groceries');
+});
+
+/**
+ * A client presenting an invalid/expired/wrong-signature bearer token to a
+ * Passport-guarded endpoint (e.g. an MCP request or the /mcp/oauth flow) makes
+ * league/oauth2-server throw an OAuthServerException. These are routine 4xx
+ * OAuth protocol responses returned to the client, not server faults, so they
+ * must not be reported to Sentry as errors (Sentry PHP-LARAVEL-4Q noise).
+ */
+test('does not report client-facing OAuthServerException (4xx)', function () {
+    expect(app(ExceptionHandler::class)->shouldReport(OAuthServerException::accessDenied()))->toBeFalse();
+    expect(app(ExceptionHandler::class)->shouldReport(OAuthServerException::invalidCredentials()))->toBeFalse();
+});
+
+/**
+ * A genuine server_error (500) inside the OAuth flow IS a real fault and must
+ * still be reported.
+ */
+test('still reports server_error OAuthServerException (5xx)', function () {
+    expect(app(ExceptionHandler::class)->shouldReport(OAuthServerException::serverError('boom')))->toBeTrue();
 });


### PR DESCRIPTION
## Problem
Sentry **PHP-LARAVEL-4Q** fires on POST `/mcp/oauth`: a client presents a bearer token with a bad/expired/wrong JWT signature ("Token signature mismatch"), Passport's `TokenGuard` → league/oauth2-server throws `OAuthServerException::accessDenied` (HTTP **401**). Laravel returns the correct 401 to the client (`handled: yes`) **but also reports it to Sentry as an error** — noise, not a server fault. It's recurring (fresh events after the initial ones).

These OAuth exceptions are, by design, client-facing 4xx protocol responses (expired/invalid tokens, denied consent, bad grants). Any public OAuth endpoint — and the MCP endpoint accepts dynamically-registered Claude/ChatGPT clients — sees a steady stream of them. They should not page as errors.

`OAuthServerException` does not implement `HttpExceptionInterface`, so Laravel's built-in `internalDontReport` does not already cover it.

## Fix
Add a `dontReportWhen` rule in `bootstrap/app.php` for `OAuthServerException` whose HTTP status is **< 500**, mirroring the existing `MaxAttemptsExceededException` guard right above it. `serverError` (500) — the only 5xx variant, the genuine "unexpected condition" case — still reports, so real OAuth-flow faults stay visible.

**Reporting-only change — no user-facing behavior changes.** Clients still receive the same 4xx OAuth error responses (status/body/headers unchanged).

## Tests
`tests/Feature/Mcp/McpOAuthTest.php`: assert `ExceptionHandler::shouldReport()` is `false` for `accessDenied()` (401) and `invalidCredentials()` (400), and `true` for `serverError()` (500).

## Notes
- Two independent reviews (architecture + product/bug): no must-fix, both "ship as-is".
- Follow-up (not code): a mass signing-key mismatch would fail as `access_denied` (401) and thus be suppressed here — the right way to catch that is an MCP success-rate / 401-rate alert, not error-count. Worth adding as an alert later.