### PR TITLE
feat(mcp): filter search_transactions by label

### DIFF
--- a/app/Mcp/Tools/McpTool.php
+++ b/app/Mcp/Tools/McpTool.php
@@ -3,8 +3,10 @@
 namespace App\Mcp\Tools;
 
 use App\Enums\PlanFeature;
+use App\Models\Label;
 use App\Models\Space;
 use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 use Laravel\Mcp\Request;
@@ -100,5 +102,37 @@ abstract class McpTool extends Tool
         }
 
         return $space;
+    }
+
+    /**
+     * Resolve every label id passed under $key, asserting each belongs to the
+     * space. Returns an empty collection when the argument is absent or empty.
+     *
+     * @return Collection<int, Label>
+     */
+    protected function labelsInSpace(Request $request, Space $space, string $key): Collection
+    {
+        $ids = collect($request->get($key, []))
+            ->map(fn (mixed $id): string => (string) $id)
+            ->filter()
+            ->unique()
+            ->values();
+
+        if ($ids->isEmpty()) {
+            /** @var Collection<int, Label> $empty */
+            $empty = Label::query()->whereRaw('1 = 0')->get();
+
+            return $empty;
+        }
+
+        $labels = Label::query()->forSpace($space)->whereIn('id', $ids)->get();
+
+        if ($labels->count() !== $ids->count()) {
+            throw ValidationException::withMessages([
+                $key => "One or more label ids do not exist in space {$space->id}. Call list_labels to see valid ids.",
+            ]);
+        }
+
+        return $labels;
     }
 }

--- a/app/Mcp/Tools/SearchTransactions.php
+++ b/app/Mcp/Tools/SearchTransactions.php
@@ -23,6 +23,7 @@ class SearchTransactions extends McpTool
             'query' => $schema->string()->description('Free text matched against description, creditor and debtor names.'),
             'account_id' => $schema->string()->description('Restrict to a single account id.'),
             'category_id' => $schema->string()->description('Restrict to a single category id.'),
+            'label_ids' => $schema->array()->items($schema->string())->description('Restrict to transactions carrying any of these label ids. Call list_labels to see valid ids.'),
             'from' => $schema->string()->description('Earliest transaction date, YYYY-MM-DD.'),
             'to' => $schema->string()->description('Latest transaction date, YYYY-MM-DD.'),
             'min_amount' => $schema->integer()->description('Minimum signed amount in minor units (cents).'),
@@ -42,9 +43,15 @@ class SearchTransactions extends McpTool
 
         $space = $this->resolveSpace($request, $user);
 
+        $labelIds = collect($request->get('label_ids', []))
+            ->map(fn (mixed $id): string => (string) $id)
+            ->filter()
+            ->unique()
+            ->values();
+
         $transactions = Transaction::query()
             ->forSpace($space)
-            ->with(['account:id,name', 'category:id,name,type'])
+            ->with(['account:id,name', 'category:id,name,type', 'labels:id,name'])
             ->when($request->string('query')->toString() !== '', function ($query) use ($request): void {
                 $term = '%'.$request->string('query')->toString().'%';
                 $query->where(function ($q) use ($term): void {
@@ -55,6 +62,7 @@ class SearchTransactions extends McpTool
             })
             ->when($request->string('account_id')->toString() !== '', fn ($query) => $query->where('account_id', $request->string('account_id')->toString()))
             ->when($request->string('category_id')->toString() !== '', fn ($query) => $query->where('category_id', $request->string('category_id')->toString()))
+            ->when($labelIds->isNotEmpty(), fn ($query) => $query->whereHas('labels', fn ($q) => $q->whereIn('labels.id', $labelIds->all())))
             ->when($request->string('from')->toString() !== '', fn ($query) => $query->whereDate('transaction_date', '>=', $request->string('from')->toString()))
             ->when($request->string('to')->toString() !== '', fn ($query) => $query->whereDate('transaction_date', '<=', $request->string('to')->toString()))
             ->when($request->has('min_amount'), fn ($query) => $query->where('amount', '>=', $request->integer('min_amount')))
@@ -75,6 +83,10 @@ class SearchTransactions extends McpTool
                 'source' => $transaction->source->value,
                 'creditor_name' => $transaction->creditor_name,
                 'debtor_name' => $transaction->debtor_name,
+                'labels' => $transaction->labels
+                    ->map(fn ($label): array => ['id' => $label->id, 'name' => $label->name])
+                    ->values()
+                    ->all(),
             ]);
 
         return $this->json([

--- a/app/Mcp/Tools/SearchTransactions.php
+++ b/app/Mcp/Tools/SearchTransactions.php
@@ -11,7 +11,7 @@ use Laravel\Mcp\Server\Attributes\Description;
 use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
 
 #[IsReadOnly]
-#[Description('Search and filter the user\'s transactions by text, category, account, date range and amount. Amounts are integers in minor units (cents). Use this to analyse spending or to find recurring charges by grouping results by merchant.')]
+#[Description('Search and filter the user\'s transactions by text, category, account, label, date range and amount. Amounts are integers in minor units (cents). Use this to analyse spending or to find recurring charges by grouping results by merchant.')]
 class SearchTransactions extends McpTool
 {
     /**
@@ -43,11 +43,7 @@ class SearchTransactions extends McpTool
 
         $space = $this->resolveSpace($request, $user);
 
-        $labelIds = collect($request->get('label_ids', []))
-            ->map(fn (mixed $id): string => (string) $id)
-            ->filter()
-            ->unique()
-            ->values();
+        $labels = $this->labelsInSpace($request, $space, 'label_ids');
 
         $transactions = Transaction::query()
             ->forSpace($space)
@@ -62,7 +58,7 @@ class SearchTransactions extends McpTool
             })
             ->when($request->string('account_id')->toString() !== '', fn ($query) => $query->where('account_id', $request->string('account_id')->toString()))
             ->when($request->string('category_id')->toString() !== '', fn ($query) => $query->where('category_id', $request->string('category_id')->toString()))
-            ->when($labelIds->isNotEmpty(), fn ($query) => $query->whereHas('labels', fn ($q) => $q->whereIn('labels.id', $labelIds->all())))
+            ->when($labels->isNotEmpty(), fn ($query) => $query->whereHas('labels', fn ($q) => $q->whereIn('labels.id', $labels->pluck('id')->all())))
             ->when($request->string('from')->toString() !== '', fn ($query) => $query->whereDate('transaction_date', '>=', $request->string('from')->toString()))
             ->when($request->string('to')->toString() !== '', fn ($query) => $query->whereDate('transaction_date', '<=', $request->string('to')->toString()))
             ->when($request->has('min_amount'), fn ($query) => $query->where('amount', '>=', $request->integer('min_amount')))

--- a/app/Mcp/Tools/WriteTool.php
+++ b/app/Mcp/Tools/WriteTool.php
@@ -9,7 +9,6 @@ use App\Models\Label;
 use App\Models\Space;
 use App\Models\Transaction;
 use App\Models\User;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;
 use Laravel\Mcp\Request;
@@ -112,38 +111,6 @@ abstract class WriteTool extends McpTool
         }
 
         return $label;
-    }
-
-    /**
-     * Resolve every label id passed under $key, asserting each belongs to the
-     * space. Returns an empty collection when the argument is absent or empty.
-     *
-     * @return Collection<int, Label>
-     */
-    protected function labelsInSpace(Request $request, Space $space, string $key): Collection
-    {
-        $ids = collect($request->get($key, []))
-            ->map(fn (mixed $id): string => (string) $id)
-            ->filter()
-            ->unique()
-            ->values();
-
-        if ($ids->isEmpty()) {
-            /** @var Collection<int, Label> $empty */
-            $empty = Label::query()->whereRaw('1 = 0')->get();
-
-            return $empty;
-        }
-
-        $labels = Label::query()->forSpace($space)->whereIn('id', $ids)->get();
-
-        if ($labels->count() !== $ids->count()) {
-            throw ValidationException::withMessages([
-                $key => "One or more label ids do not exist in space {$space->id}. Call list_labels to see valid ids.",
-            ]);
-        }
-
-        return $labels;
     }
 
     /**

--- a/tests/Feature/Mcp/McpToolsTest.php
+++ b/tests/Feature/Mcp/McpToolsTest.php
@@ -71,6 +71,16 @@ it('filters transactions by label id', function () {
         ->assertDontSee('Unlabelled Dinner');
 });
 
+it('rejects a label id the user cannot access', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    $foreignLabel = Label::factory()->create(['user_id' => $other->id]);
+
+    WhisperMoneyServer::actingAs($user)
+        ->tool(SearchTransactions::class, ['label_ids' => [$foreignLabel->id]])
+        ->assertHasErrors();
+});
+
 it('never exposes another user\'s transactions', function () {
     $user = User::factory()->create();
     $userAccount = Account::factory()->create(['user_id' => $user->id]);

--- a/tests/Feature/Mcp/McpToolsTest.php
+++ b/tests/Feature/Mcp/McpToolsTest.php
@@ -7,6 +7,7 @@ use App\Mcp\Tools\ListSpaces;
 use App\Mcp\Tools\SearchTransactions;
 use App\Models\Account;
 use App\Models\Category;
+use App\Models\Label;
 use App\Models\Transaction;
 use App\Models\User;
 
@@ -43,6 +44,31 @@ it('searches transactions scoped to the user\'s space', function () {
         ->tool(SearchTransactions::class, ['query' => 'Blue Bottle'])
         ->assertOk()
         ->assertSee('Blue Bottle Coffee');
+});
+
+it('filters transactions by label id', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->create(['user_id' => $user->id]);
+    $label = Label::factory()->create(['user_id' => $user->id]);
+
+    $labelled = Transaction::factory()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'description' => 'Labelled Lunch',
+    ]);
+    $labelled->labels()->attach($label->id);
+
+    Transaction::factory()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'description' => 'Unlabelled Dinner',
+    ]);
+
+    WhisperMoneyServer::actingAs($user)
+        ->tool(SearchTransactions::class, ['label_ids' => [$label->id]])
+        ->assertOk()
+        ->assertSee('Labelled Lunch')
+        ->assertDontSee('Unlabelled Dinner');
 });
 
 it('never exposes another user\'s transactions', function () {


### PR DESCRIPTION
## What

Adds label filtering to the `search_transactions` MCP tool. It's the one filter the web transactions view has that the MCP surface was missing.

- New optional `label_ids` array param. Returns transactions carrying **any** of the given labels (OR-semantics), matching the web app's label filter (`Transaction::scopeApplyFilters`).
- Combines with the other filters (account, category, date, amount) with AND, consistent with how the tool already treats them — so `category_id` + `label_ids` means "in that category **and** carrying one of these labels".
- Each returned transaction now also exposes its `labels` (`id`, `name`), so the agent can see why a row matched, consistent with what the write tools already return.

## Validation & consistency

- `label_ids` are validated against the space via `labelsInSpace`, promoted from `WriteTool` to the shared `McpTool` base so read and write tools use one implementation. An unknown or stale label id now returns the same actionable *"call list_labels"* error the rest of the MCP surface gives, instead of a silent empty result.
- The tool `#[Description]` now mentions `label`, so agents discover the capability without inspecting each param.

## Tests

- `search_transactions` filters by label id (matching row in, unlabelled row out).
- A foreign/unknown label id is rejected with an error.
- Full MCP read + write suites stay green (26 tests) — confirms moving `labelsInSpace` to the base didn't regress the write tools.

Pint, Larastan and the affected Pest suites pass locally.
