### PR TITLE
feat(budgets): enable email notifications by default and coalesce alerts per transaction

### DIFF
--- a/app/Http/Controllers/BudgetController.php
+++ b/app/Http/Controllers/BudgetController.php
@@ -128,9 +128,9 @@ class BudgetController extends Controller
                 'period_start_day' => $request->period_start_day,
                 'rollover_type' => $request->rollover_type,
                 'is_catch_all' => $request->boolean('is_catch_all'),
-                'notify_on_new_transaction' => $setting->budget_notify_on_new_transaction ?? false,
-                'notify_on_close_to_limit' => $setting->budget_notify_on_close_to_limit ?? false,
-                'notify_on_over_limit' => $setting->budget_notify_on_over_limit ?? false,
+                'notify_on_new_transaction' => $setting->budget_notify_on_new_transaction ?? true,
+                'notify_on_close_to_limit' => $setting->budget_notify_on_close_to_limit ?? true,
+                'notify_on_over_limit' => $setting->budget_notify_on_over_limit ?? true,
             ]);
 
             $budget->categories()->sync($request->category_ids ?? []);

--- a/app/Http/Controllers/Settings/NotificationPreferenceController.php
+++ b/app/Http/Controllers/Settings/NotificationPreferenceController.php
@@ -38,9 +38,9 @@ class NotificationPreferenceController extends Controller
         return Inertia::render('settings/notifications', [
             'notifyOnBankTransactionsSynced' => $user->wantsBankTransactionsSyncedEmail(),
             'budgetDefaults' => [
-                'notify_on_new_transaction' => (bool) ($setting->budget_notify_on_new_transaction ?? false),
-                'notify_on_close_to_limit' => (bool) ($setting->budget_notify_on_close_to_limit ?? false),
-                'notify_on_over_limit' => (bool) ($setting->budget_notify_on_over_limit ?? false),
+                'notify_on_new_transaction' => (bool) ($setting->budget_notify_on_new_transaction ?? true),
+                'notify_on_close_to_limit' => (bool) ($setting->budget_notify_on_close_to_limit ?? true),
+                'notify_on_over_limit' => (bool) ($setting->budget_notify_on_over_limit ?? true),
             ],
             'budgets' => $user->budgets()
                 ->orderBy('name')

--- a/app/Services/BudgetNotificationService.php
+++ b/app/Services/BudgetNotificationService.php
@@ -59,45 +59,46 @@ class BudgetNotificationService
     private function processPeriod(User $user, Transaction $transaction, BudgetPeriod $period, bool $isNewlyAssigned): void
     {
         $budget = $period->budget;
+        $allocated = $period->allocated_amount;
 
+        // A single incoming transaction must raise at most one email per budget.
+        // A limit alert outranks the plain "new transaction" notice, so try the
+        // most severe applicable event first and stop once one is sent. The
+        // triggering transaction rides along so the email still shows what pushed
+        // the budget over. A budget with no limit can't be "close" or "over".
+        if ($allocated > 0) {
+            $ratio = $period->spentAmount() / $allocated;
+
+            if ($ratio >= 1.0) {
+                // Claim the over-limit slot atomically so concurrent workers can't
+                // both send. Also claim "close" so a later dip into the close range
+                // doesn't raise a second, lower-severity alarm for the same period.
+                if ($budget->notify_on_over_limit && $this->claim($period, ['over_limit_notified', 'close_to_limit_notified'])) {
+                    $this->send($user, $period, BudgetNotificationType::OverLimit, $transaction);
+
+                    return;
+                }
+            } elseif ($ratio >= self::CLOSE_TO_LIMIT_THRESHOLD) {
+                if ($budget->notify_on_close_to_limit && $this->claim($period, ['close_to_limit_notified'])) {
+                    $this->send($user, $period, BudgetNotificationType::CloseToLimit, $transaction);
+
+                    return;
+                }
+            } else {
+                // Dropped back below both thresholds (e.g. a refund) — allow the
+                // next crossing to notify again.
+                BudgetPeriod::query()
+                    ->whereKey($period->id)
+                    ->where(fn ($query) => $query->where('close_to_limit_notified', true)->orWhere('over_limit_notified', true))
+                    ->update(['close_to_limit_notified' => false, 'over_limit_notified' => false]);
+            }
+        }
+
+        // No limit alert fired (no limit, opted out, or already notified this
+        // crossing) — fall back to the new-transaction notice if opted in.
         if ($isNewlyAssigned && $budget->notify_on_new_transaction) {
             $this->send($user, $period, BudgetNotificationType::NewTransaction, $transaction);
         }
-
-        $allocated = $period->allocated_amount;
-
-        // A budget with no limit can't be "close" or "over" in any useful way.
-        if ($allocated <= 0) {
-            return;
-        }
-
-        $ratio = $period->spentAmount() / $allocated;
-
-        if ($ratio >= 1.0) {
-            // Claim the over-limit slot atomically so concurrent workers can't
-            // both send. Also claim "close" so a later dip into the close range
-            // doesn't raise a second, lower-severity alarm for the same period.
-            if ($budget->notify_on_over_limit && $this->claim($period, ['over_limit_notified', 'close_to_limit_notified'])) {
-                $this->send($user, $period, BudgetNotificationType::OverLimit);
-            }
-
-            return;
-        }
-
-        if ($ratio >= self::CLOSE_TO_LIMIT_THRESHOLD) {
-            if ($budget->notify_on_close_to_limit && $this->claim($period, ['close_to_limit_notified'])) {
-                $this->send($user, $period, BudgetNotificationType::CloseToLimit);
-            }
-
-            return;
-        }
-
-        // Dropped back below both thresholds (e.g. a refund) — allow the next
-        // crossing to notify again.
-        BudgetPeriod::query()
-            ->whereKey($period->id)
-            ->where(fn ($query) => $query->where('close_to_limit_notified', true)->orWhere('over_limit_notified', true))
-            ->update(['close_to_limit_notified' => false, 'over_limit_notified' => false]);
     }
 
     /**

--- a/database/factories/UserSettingFactory.php
+++ b/database/factories/UserSettingFactory.php
@@ -25,9 +25,9 @@ class UserSettingFactory extends Factory
             'include_loans_in_net_worth_chart' => true,
             'include_real_estate_in_net_worth_chart' => true,
             'notify_on_bank_transactions_synced' => true,
-            'budget_notify_on_new_transaction' => false,
-            'budget_notify_on_close_to_limit' => false,
-            'budget_notify_on_over_limit' => false,
+            'budget_notify_on_new_transaction' => true,
+            'budget_notify_on_close_to_limit' => true,
+            'budget_notify_on_over_limit' => true,
         ];
     }
 

--- a/database/migrations/2026_07_24_100000_enable_budget_notifications_by_default.php
+++ b/database/migrations/2026_07_24_100000_enable_budget_notifications_by_default.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Budget email notifications shipped opt-in (default false). Product decision
+     * is to have them on by default, so flip the `user_settings` column defaults
+     * and turn every existing budget and setting on. Budgets are seeded from the
+     * user's `user_settings` defaults at creation, so the `budgets` columns keep
+     * their own default and only need the one-off backfill here.
+     */
+    public function up(): void
+    {
+        Schema::table('user_settings', function (Blueprint $table) {
+            $table->boolean('budget_notify_on_new_transaction')->default(true)->change();
+            $table->boolean('budget_notify_on_close_to_limit')->default(true)->change();
+            $table->boolean('budget_notify_on_over_limit')->default(true)->change();
+        });
+
+        DB::table('user_settings')->update([
+            'budget_notify_on_new_transaction' => true,
+            'budget_notify_on_close_to_limit' => true,
+            'budget_notify_on_over_limit' => true,
+        ]);
+
+        DB::table('budgets')->update([
+            'notify_on_new_transaction' => true,
+            'notify_on_close_to_limit' => true,
+            'notify_on_over_limit' => true,
+        ]);
+    }
+
+    /**
+     * Restores the column defaults only. The one-off backfill above is not
+     * reversible (the pre-flip per-row values are unrecoverable), so rolling
+     * back leaves existing budgets and settings with notifications still on.
+     */
+    public function down(): void
+    {
+        Schema::table('user_settings', function (Blueprint $table) {
+            $table->boolean('budget_notify_on_new_transaction')->default(false)->change();
+            $table->boolean('budget_notify_on_close_to_limit')->default(false)->change();
+            $table->boolean('budget_notify_on_over_limit')->default(false)->change();
+        });
+    }
+};

--- a/tests/Feature/BudgetNotificationTest.php
+++ b/tests/Feature/BudgetNotificationTest.php
@@ -102,17 +102,42 @@ test('renders every budget notification email variant', function () {
     ]);
     $this->service->assignTransaction($transaction);
 
+    // Every variant can carry the triggering transaction now that a limit alert
+    // coalesces the "new transaction" notice into itself.
     foreach (BudgetNotificationType::cases() as $type) {
         $html = (new BudgetNotificationEmail(
             $this->user,
             $period->budget,
             $period->fresh(),
             $type,
-            $type === BudgetNotificationType::NewTransaction ? $transaction : null,
+            $transaction,
         ))->render();
 
-        expect($html)->toContain($period->budget->name);
+        expect($html)
+            ->toContain($period->budget->name)
+            ->toContain(route('notifications.index'));
     }
+});
+
+test('a single limit-crossing transaction sends only the over-limit email', function () {
+    Mail::fake();
+    budgetPeriodFor($this->user, $this->category, 1000, [
+        'notify_on_new_transaction' => true,
+        'notify_on_close_to_limit' => true,
+        'notify_on_over_limit' => true,
+    ]);
+
+    // One transaction takes the budget straight past its limit: the user should
+    // get a single email — the over-limit one — that still names the transaction.
+    $transaction = assignExpense($this->service, $this->user, $this->category, 1500);
+
+    expect(Mail::queued(BudgetNotificationEmail::class))->toHaveCount(1);
+    Mail::assertQueued(
+        BudgetNotificationEmail::class,
+        fn (BudgetNotificationEmail $mail) => $mail->type === BudgetNotificationType::OverLimit
+            && $mail->transaction?->is($transaction)
+            && $mail->hasTo($this->user->email),
+    );
 });
 
 test('does not resend the over limit email on later transactions', function () {

--- a/tests/Feature/Settings/BudgetNotificationPreferenceTest.php
+++ b/tests/Feature/Settings/BudgetNotificationPreferenceTest.php
@@ -49,6 +49,26 @@ test('a user cannot update another user budget notifications', function () {
     expect($budget->fresh()->notify_on_over_limit)->toBeFalse();
 });
 
+test('a new budget enables all notifications by default', function () {
+    $user = User::factory()->create(['onboarded_at' => now()]);
+    $category = Category::factory()->create(['user_id' => $user->id]);
+
+    $this->actingAs($user)->post('/budgets', [
+        'name' => 'Default Budget',
+        'period_type' => 'monthly',
+        'period_start_day' => 1,
+        'category_ids' => [$category->id],
+        'rollover_type' => 'reset',
+        'allocated_amount' => 100000,
+    ])->assertRedirect();
+
+    $budget = Budget::where('user_id', $user->id)->firstOrFail();
+
+    expect($budget->notify_on_new_transaction)->toBeTrue()
+        ->and($budget->notify_on_close_to_limit)->toBeTrue()
+        ->and($budget->notify_on_over_limit)->toBeTrue();
+});
+
 test('a new budget inherits the user notification defaults', function () {
     $user = User::factory()->create(['onboarded_at' => now()]);
     UserSetting::factory()->for($user)->create([


### PR DESCRIPTION
## What

Follow-up to #731 (per-budget email notifications). Two changes:

1. **Enable budget email notifications by default.** They shipped opt-in with every toggle defaulting to `false`, so no one received them. They are now on by default.
2. **Coalesce budget alerts into one email per transaction.** A single transaction that crossed a budget's limit could send two emails for the same budget (the "new transaction" notice *and* the over/close-limit alert). Now at most one email is sent per budget per assignment.

## Enable by default

- `user_settings.budget_notify_on_*` column defaults flipped to `true`, and **all existing `user_settings` and `budgets` rows are backfilled to `true`** so current users and budgets start notifying — not just new ones.
- `BudgetController::store` and `NotificationPreferenceController::index` fall back to `true` when a user has no settings row yet.
- `UserSettingFactory` reflects the new default.
- The `budgets` columns keep their own `false` DB default on purpose: new budgets are seeded from the user's `user_settings` defaults at creation, so only the one-off backfill is needed there.

## Coalescing

`BudgetNotificationService::processPeriod` now sends **at most one email per budget per transaction assignment**, picking the most severe applicable event with priority **over-limit > close-to-limit > new-transaction**, and passes the triggering transaction through to whichever fires. So a transaction that pushes a budget over its limit produces a single over-limit email that still names the transaction and shows how far over the budget is.

Preserved from #731: the atomic per-period `close_to_limit_notified` / `over_limit_notified` claim (one email per crossing, safe under concurrent workers), the reset-and-re-notify path when spending drops back below the threshold, and the no-emails-on-historical-backfill guarantee. Coalescing is **per budget** — a transaction matching two different budgets still sends one email to each.

## Trade-offs (deliberate)

- **`notify_on_new_transaction` is on by default**, which means one email per transaction assigned to any budget (no batching yet — flagged in #731). A catch-all budget matches every expense, so this can be high-volume; the whole-user-base backfill also produces a send spike on first sync after deploy. Batching the new-transaction type into a daily digest (mirroring the bank-sync digest) is the natural follow-up if volume proves noisy.
- The migration backfill is intentionally unconditional and one-way for data: `down()` restores the column defaults but not the backfilled row values.

## Every email links to the settings page

Each budget email already carries a "Manage notifications in notification settings" link (`route('notifications.index')`) so users can turn any of them off. A render-test assertion now locks this in.

## Tests

- Coalescing: a single limit-crossing transaction sends exactly one over-limit email that references the triggering transaction.
- On-by-default: a new budget created without custom preferences enables all three types.
- All existing #731 sending/preference tests still pass (dedup, re-notify after drop, no-limit budgets, historical backfill sends nothing, enabling while already over).

QA (backend): rendered the coalesced over-limit email and confirmed it names the transaction, shows "Over by", and links to the settings page; verified the migration backfill flips pre-existing `false` rows to `true` against a real DB.
