### PR TITLE
fix(budgets): keep per-transaction email notifications opt-in

### DIFF
--- a/app/Http/Controllers/BudgetController.php
+++ b/app/Http/Controllers/BudgetController.php
@@ -128,7 +128,7 @@ class BudgetController extends Controller
                 'period_start_day' => $request->period_start_day,
                 'rollover_type' => $request->rollover_type,
                 'is_catch_all' => $request->boolean('is_catch_all'),
-                'notify_on_new_transaction' => $setting->budget_notify_on_new_transaction ?? true,
+                'notify_on_new_transaction' => $setting->budget_notify_on_new_transaction ?? false,
                 'notify_on_close_to_limit' => $setting->budget_notify_on_close_to_limit ?? true,
                 'notify_on_over_limit' => $setting->budget_notify_on_over_limit ?? true,
             ]);

--- a/app/Http/Controllers/Settings/NotificationPreferenceController.php
+++ b/app/Http/Controllers/Settings/NotificationPreferenceController.php
@@ -38,7 +38,7 @@ class NotificationPreferenceController extends Controller
         return Inertia::render('settings/notifications', [
             'notifyOnBankTransactionsSynced' => $user->wantsBankTransactionsSyncedEmail(),
             'budgetDefaults' => [
-                'notify_on_new_transaction' => (bool) ($setting->budget_notify_on_new_transaction ?? true),
+                'notify_on_new_transaction' => (bool) ($setting->budget_notify_on_new_transaction ?? false),
                 'notify_on_close_to_limit' => (bool) ($setting->budget_notify_on_close_to_limit ?? true),
                 'notify_on_over_limit' => (bool) ($setting->budget_notify_on_over_limit ?? true),
             ],

--- a/database/factories/UserSettingFactory.php
+++ b/database/factories/UserSettingFactory.php
@@ -25,7 +25,7 @@ class UserSettingFactory extends Factory
             'include_loans_in_net_worth_chart' => true,
             'include_real_estate_in_net_worth_chart' => true,
             'notify_on_bank_transactions_synced' => true,
-            'budget_notify_on_new_transaction' => true,
+            'budget_notify_on_new_transaction' => false,
             'budget_notify_on_close_to_limit' => true,
             'budget_notify_on_over_limit' => true,
         ];

--- a/database/migrations/2026_07_24_100000_enable_budget_notifications_by_default.php
+++ b/database/migrations/2026_07_24_100000_enable_budget_notifications_by_default.php
@@ -9,27 +9,26 @@ return new class extends Migration
 {
     /**
      * Budget email notifications shipped opt-in (default false). Product decision
-     * is to have them on by default, so flip the `user_settings` column defaults
-     * and turn every existing budget and setting on. Budgets are seeded from the
-     * user's `user_settings` defaults at creation, so the `budgets` columns keep
-     * their own default and only need the one-off backfill here.
+     * is to have the limit alerts on by default, so flip those `user_settings`
+     * column defaults and turn them on for every existing budget and setting.
+     * The per-transaction notice stays opt-in: it fires on every single
+     * transaction, which is too noisy to enable for everyone. Budgets are seeded
+     * from the user's `user_settings` defaults at creation, so the `budgets`
+     * columns keep their own default and only need the one-off backfill here.
      */
     public function up(): void
     {
         Schema::table('user_settings', function (Blueprint $table) {
-            $table->boolean('budget_notify_on_new_transaction')->default(true)->change();
             $table->boolean('budget_notify_on_close_to_limit')->default(true)->change();
             $table->boolean('budget_notify_on_over_limit')->default(true)->change();
         });
 
         DB::table('user_settings')->update([
-            'budget_notify_on_new_transaction' => true,
             'budget_notify_on_close_to_limit' => true,
             'budget_notify_on_over_limit' => true,
         ]);
 
         DB::table('budgets')->update([
-            'notify_on_new_transaction' => true,
             'notify_on_close_to_limit' => true,
             'notify_on_over_limit' => true,
         ]);
@@ -43,7 +42,6 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('user_settings', function (Blueprint $table) {
-            $table->boolean('budget_notify_on_new_transaction')->default(false)->change();
             $table->boolean('budget_notify_on_close_to_limit')->default(false)->change();
             $table->boolean('budget_notify_on_over_limit')->default(false)->change();
         });

--- a/database/migrations/2026_07_24_100000_enable_budget_notifications_by_default.php
+++ b/database/migrations/2026_07_24_100000_enable_budget_notifications_by_default.php
@@ -9,26 +9,27 @@ return new class extends Migration
 {
     /**
      * Budget email notifications shipped opt-in (default false). Product decision
-     * is to have the limit alerts on by default, so flip those `user_settings`
-     * column defaults and turn them on for every existing budget and setting.
-     * The per-transaction notice stays opt-in: it fires on every single
-     * transaction, which is too noisy to enable for everyone. Budgets are seeded
-     * from the user's `user_settings` defaults at creation, so the `budgets`
-     * columns keep their own default and only need the one-off backfill here.
+     * is to have them on by default, so flip the `user_settings` column defaults
+     * and turn every existing budget and setting on. Budgets are seeded from the
+     * user's `user_settings` defaults at creation, so the `budgets` columns keep
+     * their own default and only need the one-off backfill here.
      */
     public function up(): void
     {
         Schema::table('user_settings', function (Blueprint $table) {
+            $table->boolean('budget_notify_on_new_transaction')->default(true)->change();
             $table->boolean('budget_notify_on_close_to_limit')->default(true)->change();
             $table->boolean('budget_notify_on_over_limit')->default(true)->change();
         });
 
         DB::table('user_settings')->update([
+            'budget_notify_on_new_transaction' => true,
             'budget_notify_on_close_to_limit' => true,
             'budget_notify_on_over_limit' => true,
         ]);
 
         DB::table('budgets')->update([
+            'notify_on_new_transaction' => true,
             'notify_on_close_to_limit' => true,
             'notify_on_over_limit' => true,
         ]);
@@ -42,6 +43,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('user_settings', function (Blueprint $table) {
+            $table->boolean('budget_notify_on_new_transaction')->default(false)->change();
             $table->boolean('budget_notify_on_close_to_limit')->default(false)->change();
             $table->boolean('budget_notify_on_over_limit')->default(false)->change();
         });

--- a/database/migrations/2026_07_25_102200_disable_budget_new_transaction_notifications.php
+++ b/database/migrations/2026_07_25_102200_disable_budget_new_transaction_notifications.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * The previous migration turned every budget notification on by default. The
+     * per-transaction notice is too noisy for that: it emails on every single
+     * transaction assigned to a budget, and a catch-all budget matches all of
+     * them. Put it back to opt-in — column default plus a one-off reset of the
+     * rows the force-enable touched — and leave the limit alerts on.
+     *
+     * Uses the query builder so `updated_at` is left alone, same as the
+     * force-enable did.
+     */
+    public function up(): void
+    {
+        Schema::table('user_settings', function (Blueprint $table) {
+            $table->boolean('budget_notify_on_new_transaction')->default(false)->change();
+        });
+
+        DB::table('user_settings')->update(['budget_notify_on_new_transaction' => false]);
+
+        DB::table('budgets')->update(['notify_on_new_transaction' => false]);
+    }
+
+    /**
+     * Restores the column default only; the reset above is not reversible.
+     */
+    public function down(): void
+    {
+        Schema::table('user_settings', function (Blueprint $table) {
+            $table->boolean('budget_notify_on_new_transaction')->default(true)->change();
+        });
+    }
+};

--- a/tests/Feature/Settings/BudgetNotificationPreferenceTest.php
+++ b/tests/Feature/Settings/BudgetNotificationPreferenceTest.php
@@ -15,8 +15,26 @@ test('notifications page lists the user budgets and defaults', function () {
     $response->assertInertia(fn ($page) => $page
         ->component('settings/notifications')
         ->has('budgets', 1)
-        ->has('budgetDefaults')
+        ->where('budgetDefaults.notify_on_new_transaction', false)
+        ->where('budgetDefaults.notify_on_close_to_limit', true)
+        ->where('budgetDefaults.notify_on_over_limit', true)
         ->where('budgets.0.name', 'Padel'));
+});
+
+test('a settings row created without the budget columns leaves the per-transaction default off', function () {
+    $user = User::factory()->create();
+
+    // Every settings controller writes only its own column, so the rest of the
+    // row falls back to the database defaults.
+    $user->setting()->updateOrCreate(
+        ['user_id' => $user->id],
+        ['notify_on_bank_transactions_synced' => true],
+    );
+
+    expect($user->fresh()->setting)
+        ->budget_notify_on_new_transaction->toBeFalse()
+        ->budget_notify_on_close_to_limit->toBeTrue()
+        ->budget_notify_on_over_limit->toBeTrue();
 });
 
 test('a budget notification toggle can be updated', function () {

--- a/tests/Feature/Settings/BudgetNotificationPreferenceTest.php
+++ b/tests/Feature/Settings/BudgetNotificationPreferenceTest.php
@@ -49,7 +49,7 @@ test('a user cannot update another user budget notifications', function () {
     expect($budget->fresh()->notify_on_over_limit)->toBeFalse();
 });
 
-test('a new budget enables all notifications by default', function () {
+test('a new budget enables the limit notifications by default but not the per-transaction one', function () {
     $user = User::factory()->create(['onboarded_at' => now()]);
     $category = Category::factory()->create(['user_id' => $user->id]);
 
@@ -64,7 +64,7 @@ test('a new budget enables all notifications by default', function () {
 
     $budget = Budget::where('user_id', $user->id)->firstOrFail();
 
-    expect($budget->notify_on_new_transaction)->toBeTrue()
+    expect($budget->notify_on_new_transaction)->toBeFalse()
         ->and($budget->notify_on_close_to_limit)->toBeTrue()
         ->and($budget->notify_on_over_limit)->toBeTrue();
 });


### PR DESCRIPTION
Budget email notifications shipped opt-in, then #733 turned all three on by default. The per-transaction notice is the wrong one to force on: it emails on **every single transaction** assigned to a budget, and a catch-all budget matches all of them. This puts it back to opt-in and leaves the limit alerts (close to limit, over limit) on by default.

## Why a second migration instead of editing the first one

`2026_07_24_100000_enable_budget_notifications_by_default` **has already run in production** (batch 76). Laravel never re-runs an applied migration, so editing it in place would have been inert: 382 budgets and 174 settings rows would keep the flag on, and the `user_settings` column default would stay `true`.

That default matters beyond new signups: every settings controller writes its own column through `setting()->updateOrCreate(...)`, so a user who merely changed their chart colour scheme would get a settings row with `budget_notify_on_new_transaction = 1` filled in by MySQL — silently opted in, with the checkbox rendering as checked.

So the original migration is restored to its merged form and a new one resets the flag: column default back to `false`, plus a one-off reset of existing `user_settings` and `budgets` rows. It uses the query builder, so `updated_at` is untouched — same as the force-enable did. 381 of the 382 affected budgets had not been touched by their owner since the deploy, so the reset undoes a force-enable rather than a user's choice.

## Changes

- New migration resetting `user_settings.budget_notify_on_new_transaction` (default + rows) and `budgets.notify_on_new_transaction`.
- `BudgetController::store` and `NotificationPreferenceController::index` fall back to `false` for the per-transaction flag when a user has no settings row.
- `UserSettingFactory` matches the new default.

Users who want the per-transaction notice can still turn it on per budget, or as their default for new budgets, in Settings → Notifications.

## QA

Ran the migration against a real database and checked the end state: `budget_notify_on_new_transaction` default `0` with all 151 settings rows and 333 budgets reset, both limit flags default `1` and left on.

Then drove real transactions through the listener and queue on a live budget (limit €300) and read the resulting mail off Mailhog:

| Event | Spent / limit | Email |
| --- | --- | --- |
| New transaction, default settings | €50 / €300 | none |
| Reaches 90% | €270 / €300 | «Presupuesto de Ocio» está cerca de su límite |
| Exceeds the limit | €320 / €300 | «Presupuesto de Ocio» ha superado su límite |
| New transaction, after opting in | €10 / €5000 | Nueva transacción en «Presupuesto de Ocio» |

Assignment still happens in every case — only the email is suppressed. 265 tests green across the Budget/Setting/Notification suites, including new assertions that the rendered defaults have the per-transaction flag off and that a settings row created without the budget columns does not opt the user in.
