### PR TITLE
feat(currency): add THB (Thai Baht)

### DIFF
--- a/config/currencies.php
+++ b/config/currencies.php
@@ -182,5 +182,11 @@ return [
             'allows_primary' => true,
             'allows_account' => true,
         ],
+        [
+            'code' => 'THB',
+            'name' => 'Thai Baht',
+            'allows_primary' => true,
+            'allows_account' => true,
+        ],
     ],
 ];

--- a/lang/es.json
+++ b/lang/es.json
@@ -1566,6 +1566,7 @@
     "Terms of Service - Whisper Money": "Términos de Servicio - Whisper Money",
     "Terms of service for Whisper Money. Review the rules and regulations for using our platform.": "Términos de servicio de Whisper Money. Revisa las reglas y regulaciones para usar nuestra plataforma.",
     "Terms of service for Whisper Money. Review the rules and regulations for using our secure personal finance platform.": "Términos de servicio de Whisper Money. Revisa las reglas y regulaciones para usar nuestra plataforma segura de finanzas personales.",
+    "Thai Baht": "Baht tailandés",
     "Thanks again for being part of this journey!": "¡Gracias de nuevo por ser parte de este viaje!",
     "Thanks for being interested in what we're building!": "¡Gracias por estar interesado en lo que estamos construyendo!",
     "Thanks for being one of the first.": "Gracias por estar entre los primeros.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1521,6 +1521,7 @@
     "Terms of Service - Whisper Money": "Conditions d'utilisation - Whisper Money",
     "Terms of service for Whisper Money. Review the rules and regulations for using our platform.": "Conditions d'utilisation de Whisper Money. Consultez les règles et réglementations d’utilisation de notre plateforme.",
     "Terms of service for Whisper Money. Review the rules and regulations for using our secure personal finance platform.": "Conditions d'utilisation de Whisper Money. Consultez les règles et réglementations d’utilisation de notre plateforme sécurisée de finances personnelles.",
+    "Thai Baht": "Baht thaïlandais",
     "Thanks again for being part of this journey!": "Merci encore d'avoir fait partie de ce voyage !",
     "Thanks for being interested in what we're building!": "Merci de vous intéresser à ce que nous construisons !",
     "Thanks for being one of the first.": "Merci d'être parmi les premiers.",

--- a/resources/js/utils/currency.ts
+++ b/resources/js/utils/currency.ts
@@ -27,6 +27,7 @@ export function getCurrencySymbol(currencyCode: string): string {
         DOP: 'RD$',
         NGN: '₦',
         SEK: 'kr',
+        THB: '฿',
     };
     return symbols[currencyCode] || currencyCode;
 }


### PR DESCRIPTION
## What
Add the Thai Baht as a supported currency.

## Compatibility
Provider covers `thb` (standard ISO 4217). The conversion service lowercases codes and fetches `thb.min.json` — same path RSD/NZD use. `exchange_rates` stores rates as JSON, so any 3-letter code works. Validation rules and Inertia currency props auto-derive from config.

## Changes
- `config/currencies.php` — THB entry (`allows_primary` + `allows_account`)
- `lang/es.json` — Spanish translation
- `lang/fr.json` — French translation
- `resources/js/utils/currency.ts` — short symbol (฿) for THB

Follows the RSD addition (#567) exactly; no code changes needed.