### PR TITLE
fix(ai): stop a learned rule title from 500-ing the user's category change

### DIFF
--- a/app/Http/Requests/Settings/StoreAutomationRuleRequest.php
+++ b/app/Http/Requests/Settings/StoreAutomationRuleRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Settings;
 
 use App\Http\Requests\Concerns\ValidatesUserOwnedResources;
+use App\Models\AutomationRule;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -26,7 +27,7 @@ class StoreAutomationRuleRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'title' => ['required', 'string', 'max:255'],
+            'title' => ['required', 'string', 'max:'.AutomationRule::MAX_TITLE_LENGTH],
             'priority' => ['required', 'integer', 'min:0'],
             'rules_json' => ['required', 'json', function ($attribute, $value, $fail) {
                 $decoded = json_decode($value, true);

--- a/app/Models/AutomationRule.php
+++ b/app/Models/AutomationRule.php
@@ -6,6 +6,7 @@ use App\Enums\RuleOrigin;
 use App\Models\Concerns\BelongsToSpace;
 use Database\Factories\AutomationRuleFactory;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -21,6 +22,8 @@ class AutomationRule extends Model
 {
     /** @use HasFactory<AutomationRuleFactory> */
     use BelongsToSpace, HasFactory, HasUuids, SoftDeletes;
+
+    public const MAX_TITLE_LENGTH = 255;
 
     protected $fillable = [
         'user_id',
@@ -46,6 +49,22 @@ class AutomationRule extends Model
             'priority' => 'integer',
             'origin' => RuleOrigin::class,
         ];
+    }
+
+    /**
+     * Generated titles are assembled from bank-supplied merchant names and AI
+     * tokens, neither of which the column bounds. Truncating here is the one
+     * place that covers every generator, so an oversized title can never abort
+     * the action that produced it. User-authored titles never reach this: the
+     * form request rejects anything over the same limit with a 422.
+     *
+     * @return Attribute<never, string|null>
+     */
+    protected function title(): Attribute
+    {
+        return Attribute::set(
+            fn (?string $value): ?string => $value === null ? null : mb_substr($value, 0, self::MAX_TITLE_LENGTH),
+        );
     }
 
     /**

--- a/app/Models/AutomationRule.php
+++ b/app/Models/AutomationRule.php
@@ -6,7 +6,6 @@ use App\Enums\RuleOrigin;
 use App\Models\Concerns\BelongsToSpace;
 use Database\Factories\AutomationRuleFactory;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -57,14 +56,12 @@ class AutomationRule extends Model
      * place that covers every generator, so an oversized title can never abort
      * the action that produced it. User-authored titles never reach this: the
      * form request rejects anything over the same limit with a 422.
-     *
-     * @return Attribute<never, string|null>
      */
-    protected function title(): Attribute
+    public function setTitleAttribute(?string $value): void
     {
-        return Attribute::set(
-            fn (?string $value): ?string => $value === null ? null : mb_substr($value, 0, self::MAX_TITLE_LENGTH),
-        );
+        $this->attributes['title'] = $value === null
+            ? null
+            : mb_substr($value, 0, self::MAX_TITLE_LENGTH);
     }
 
     /**

--- a/app/Services/Ai/AiRuleLearner.php
+++ b/app/Services/Ai/AiRuleLearner.php
@@ -37,6 +37,17 @@ class AiRuleLearner
     private const MIN_SOLE_TOKEN_LENGTH = 5;
 
     /**
+     * Rule titles are built from bank-supplied merchant names, and some banks
+     * stuff the whole statement line (dates, amounts, running balance) into
+     * them. Cap each token so the "→ Category" tail stays readable, and the
+     * whole title so it can never overflow the varchar(255) column — an
+     * oversized title used to abort the user's category change with a 500.
+     */
+    private const MAX_TOKEN_LABEL_LENGTH = 40;
+
+    private const MAX_TITLE_LENGTH = 255;
+
+    /**
      * Per-user document-frequency corpus, memoized for the lifetime of this
      * instance. A bulk correction runs learnFromCorrection once per transaction
      * for the same user, and the description corpus is immutable while only
@@ -513,16 +524,28 @@ class AiRuleLearner
         $categoryName = Category::query()->whereKey($categoryId)->value('name') ?? '';
 
         if ($tokens === []) {
-            return trim($categoryName.' (AI)');
+            return $this->fit(trim($categoryName.' (AI)'));
         }
 
-        $label = implode(', ', array_map(fn (string $token): string => Str::title($token), array_slice($tokens, 0, 3)));
+        $label = implode(', ', array_map(
+            fn (string $token): string => Str::limit(Str::title($token), self::MAX_TOKEN_LABEL_LENGTH),
+            array_slice($tokens, 0, 3),
+        ));
 
         if (count($tokens) > 3) {
             $label .= '…';
         }
 
-        return trim($label.' → '.$categoryName);
+        return $this->fit(trim($label.' → '.$categoryName));
+    }
+
+    /**
+     * Keep a generated title within the column, whatever the merchant and
+     * category names hold.
+     */
+    private function fit(string $title): string
+    {
+        return Str::limit($title, self::MAX_TITLE_LENGTH, '');
     }
 
     private function normalize(string $value): string

--- a/app/Services/Ai/AiRuleLearner.php
+++ b/app/Services/Ai/AiRuleLearner.php
@@ -39,13 +39,13 @@ class AiRuleLearner
     /**
      * Rule titles are built from bank-supplied merchant names, and some banks
      * stuff the whole statement line (dates, amounts, running balance) into
-     * them. Cap each token so the "→ Category" tail stays readable, and the
-     * whole title so it can never overflow the varchar(255) column — an
-     * oversized title used to abort the user's category change with a 500.
+     * them. Cap each part so the whole "Merchant, Merchant → Category" title
+     * stays readable and well inside the column, rather than being cut off at
+     * the end by the model's truncation backstop.
      */
     private const MAX_TOKEN_LABEL_LENGTH = 40;
 
-    private const MAX_TITLE_LENGTH = 255;
+    private const MAX_CATEGORY_LABEL_LENGTH = 60;
 
     /**
      * Per-user document-frequency corpus, memoized for the lifetime of this
@@ -521,14 +521,18 @@ class AiRuleLearner
      */
     private function title(string $categoryId, array $tokens): string
     {
-        $categoryName = Category::query()->whereKey($categoryId)->value('name') ?? '';
+        $categoryName = Str::limit(
+            Category::query()->whereKey($categoryId)->value('name') ?? '',
+            self::MAX_CATEGORY_LABEL_LENGTH,
+            '…',
+        );
 
         if ($tokens === []) {
-            return $this->fit(trim($categoryName.' (AI)'));
+            return trim($categoryName.' (AI)');
         }
 
         $label = implode(', ', array_map(
-            fn (string $token): string => Str::limit(Str::title($token), self::MAX_TOKEN_LABEL_LENGTH),
+            fn (string $token): string => Str::limit(Str::title($token), self::MAX_TOKEN_LABEL_LENGTH, '…'),
             array_slice($tokens, 0, 3),
         ));
 
@@ -536,16 +540,7 @@ class AiRuleLearner
             $label .= '…';
         }
 
-        return $this->fit(trim($label.' → '.$categoryName));
-    }
-
-    /**
-     * Keep a generated title within the column, whatever the merchant and
-     * category names hold.
-     */
-    private function fit(string $title): string
-    {
-        return Str::limit($title, self::MAX_TITLE_LENGTH, '');
+        return trim($label.' → '.$categoryName);
     }
 
     private function normalize(string $value): string

--- a/app/Services/Ai/CategoryOverrideHandler.php
+++ b/app/Services/Ai/CategoryOverrideHandler.php
@@ -7,6 +7,7 @@ use App\Enums\RuleOrigin;
 use App\Models\AutomationRule;
 use App\Models\CategoryCorrection;
 use App\Models\Transaction;
+use Throwable;
 
 /**
  * Runs when a user overrides a transaction's category. If the category being
@@ -44,6 +45,20 @@ class CategoryOverrideHandler
             return null;
         }
 
+        try {
+            return $this->learn($transaction, $newCategoryId, $aiDriven);
+        } catch (Throwable $e) {
+            // Learning is a side-effect of the correction, never the point of it.
+            // A failure here must not abort the category change the user asked
+            // for — nor, in a bulk correction, every transaction after it.
+            report($e);
+
+            return null;
+        }
+    }
+
+    private function learn(Transaction $transaction, ?string $newCategoryId, bool $aiDriven): ?AutomationRule
+    {
         // The correction signal calibrates AI accuracy, so only AI assignments
         // are logged — a correction rule overruling itself is not an AI miss.
         if ($aiDriven) {

--- a/tests/Feature/Ai/AiRuleLearnerTest.php
+++ b/tests/Feature/Ai/AiRuleLearnerTest.php
@@ -288,8 +288,11 @@ it('keeps the generated title within the column when the bank stuffs the stateme
         );
     }
 
+    // Each merchant is shortened enough that the whole title stays well inside
+    // the column and the "→ Category" tail survives.
     expect($rule)->not->toBeNull()
-        ->and(mb_strlen($rule->refresh()->title))->toBeLessThanOrEqual(255)
+        ->and(mb_strlen($rule->refresh()->title))->toBeLessThan(AutomationRule::MAX_TITLE_LENGTH)
         ->and($rule->title)->toContain($target->name)
+        ->and($rule->title)->toStartWith('15/06 12/06 Pago Con Tarjeta En Discos,…, ')
         ->and($rule->rules_json['or'])->toHaveCount(2);
 });

--- a/tests/Feature/Ai/AiRuleLearnerTest.php
+++ b/tests/Feature/Ai/AiRuleLearnerTest.php
@@ -257,3 +257,39 @@ it('never reuses a user-owned rule, even for the same category', function () {
     expect($aiRule->id)->not->toBe($userRule->id)
         ->and($aiRule->origin)->toBe(RuleOrigin::Ai);
 });
+
+it('keeps the generated title within the column when the bank stuffs the statement line into the merchant name', function () {
+    $user = User::factory()->create();
+    $target = Category::factory()->for($user)->create([
+        'name' => 'Hobbies y otras actividades de ocio',
+        'type' => CategoryType::Expense,
+        'cashflow_direction' => CategoryCashflowDirection::Outflow,
+    ]);
+    $existing = expenseCategory($user);
+
+    // Real payload from PHP-LARAVEL-53: the bank sends the whole statement line
+    // (dates, concept, amount, running balance, card number) as the merchant, so
+    // two corrections alone already overflow the title column.
+    $statementLines = [
+        "15/06 12/06 Pago Con Tarjeta En Discos, Libros, Fotos Y Pc's -59,00 189,27 | 4940197152806468 Classpass* Monthly",
+        '01/06 31/05 Pago Con Tarjeta En Restaurantes Y Cafeterias -9,00 1.819,59 | 4940197152806468 Dirty Castelldefels Castelldefelses',
+    ];
+    $learner = app(AiRuleLearner::class);
+    $rule = null;
+
+    foreach ($statementLines as $statementLine) {
+        $rule = $learner->learnFromCorrection(
+            Transaction::factory()->plaintext()->create([
+                'user_id' => $user->id,
+                'category_id' => $existing->id,
+                'creditor_name' => $statementLine,
+            ]),
+            $target->id,
+        );
+    }
+
+    expect($rule)->not->toBeNull()
+        ->and(mb_strlen($rule->refresh()->title))->toBeLessThanOrEqual(255)
+        ->and($rule->title)->toContain($target->name)
+        ->and($rule->rules_json['or'])->toHaveCount(2);
+});

--- a/tests/Feature/Ai/CategoryOverrideHandlerTest.php
+++ b/tests/Feature/Ai/CategoryOverrideHandlerTest.php
@@ -13,6 +13,7 @@ use App\Services\Ai\AiRuleLearner;
 use App\Services\Ai\CategorizationOutcome;
 use App\Services\Ai\CategoryOverrideHandler;
 use App\Services\AutomationRuleService;
+use Illuminate\Support\Facades\Exceptions;
 
 function cohCategory(User $user): Category
 {
@@ -379,4 +380,22 @@ it('learns nothing from an encrypted-description transaction without a merchant'
 
     expect($learned)->toBeNull()
         ->and(AutomationRule::query()->origin(RuleOrigin::Correction)->count())->toBe(0);
+});
+
+it('still applies the correction when learning blows up', function () {
+    $user = User::factory()->create();
+    $target = cohCategory($user);
+    $transaction = cohMerchantTxn($user, 'Mercadona');
+    $transaction->update(['category_source' => CategorySource::Ai]);
+
+    $this->mock(AiRuleLearner::class)
+        ->shouldReceive('forgetFromAiRules')
+        ->andThrow(new RuntimeException('learning exploded'));
+
+    Exceptions::fake();
+
+    $rule = app(CategoryOverrideHandler::class)->record($transaction, $target->id);
+
+    Exceptions::assertReported(RuntimeException::class);
+    expect($rule)->toBeNull();
 });

--- a/tests/Feature/AutomationRuleTest.php
+++ b/tests/Feature/AutomationRuleTest.php
@@ -453,3 +453,12 @@ test('automation rules serialize full nested category and labels', function () {
     expect(array_keys($serialized['labels'][0]))
         ->toEqualCanonicalizing(['id', 'user_id', 'name', 'color', 'created_at', 'updated_at', 'deleted_at']);
 });
+
+test('a generated title is truncated to fit the column instead of failing the write', function () {
+    $rule = AutomationRule::factory()->create([
+        'user_id' => User::factory()->create()->id,
+        'title' => str_repeat('a', AutomationRule::MAX_TITLE_LENGTH + 50),
+    ]);
+
+    expect(mb_strlen($rule->refresh()->title))->toBe(AutomationRule::MAX_TITLE_LENGTH);
+});


### PR DESCRIPTION
## The bug

Sentry [PHP-LARAVEL-53](https://whisper-money.sentry.io/issues/PHP-LARAVEL-53) — `SQLSTATE[22001]: Data too long for column 'title'` on `PATCH /transactions/{transaction}`. 6 events, 1 user.

Changing a transaction's category learns a forward-looking automation rule, and `AiRuleLearner::title()` rebuilds the rule's title from the merchant names it matches. This user's bank puts the **entire statement line** in `creditor_name`:

```
15/06 12/06 Pago Con Tarjeta En Discos, Libros, Fotos Y Pc's -59,00 189,27 | 4940197152806468 Classpass* Monthly
```

Two corrections into the same category produced a 279-char title against a `varchar(255)` column, so `$rule->save()` threw and took the whole request with it. Since `creditor_name` is itself capped at 255 on ingest, a single correction can overflow it too.

## The fix

1. **`AiRuleLearner::title()`** caps each merchant token (40 chars) and the category name (60), so the title stays readable instead of merely short — the `→ Category` tail is the part that carries the meaning.
2. **A `title` mutator on `AutomationRule`** truncates to the column width. Both reviews flagged that fixing the learner alone leaves the sibling generator, `ApplyRuleSuggestions::title()`, unguarded: it joins three AI match tokens that are each validated at `max:255`, so it can overflow the same column and 500 the accept-suggestions step **during onboarding**. The mutator covers every generator, present and future, in one place. User-authored titles never reach it — `StoreAutomationRuleRequest` already rejects longer ones with a 422.
3. **Learning can no longer abort the correction.** `CategoryOverrideHandler::record()` runs before the transaction is saved and outside any DB transaction, so the incident left the correction logged and the ai rules stripped while the category the user asked for was never written. `bulkUpdate` is worse: it records every transaction before the mass update, so one throw mutated rules for the earlier ones and categorized none of them. A learning failure is now reported and swallowed — both callers already handle "nothing learned".

## Tests

- `AiRuleLearnerTest` — replays the exact production payload; reproduces the identical `SQLSTATE[22001]` on the pre-fix code and asserts the title stays inside the column with the category still visible.
- `AutomationRuleTest` — the mutator truncates rather than failing the write.
- `CategoryOverrideHandlerTest` — a throwing learner is reported, not propagated.

191 tests green locally (`tests/Feature/Ai` + the three automation-rule suites) against the MySQL testcontainer; `pint --test` clean.

## Deliberately out of scope

- **Dead-weight rules.** With such a merchant name the learned clause is `creditor_name == "…-59,00 189,27 | …"` — it contains amounts and a running balance, so it can never match again, yet it accumulates one clause per correction and the UI toasts *"Learned: similar transactions will be categorized automatically"*. The review's prod data says length is the wrong guard (62 long merchant names DO repeat, across 490 transactions); the right one is rejecting the statement-line *signature* (an embedded `dd/mm` or `nn,nn`) in `merchantKey()` so it falls through to the already-guarded description-token path. Worth its own PR.
- **Rules list UI**: a long title sits in a `whitespace-nowrap` cell and pushes the actions column off-screen (`settings/automation-rules.tsx`).
- **Unbounded writes of the same class elsewhere**, found while reviewing: `transactions.currency_code` `varchar(3)` written unvalidated from the Enable Banking payload (`TransactionSyncService.php:179`), and `banking_connections.aspsp_name`/`aspsp_logo` with no `max:` rule in `StartAuthorizationRequest`.

Fixes PHP-LARAVEL-53