### PR TITLE
fix(banking): stop unclassified bank responses from silently killing a connection

### DIFF
--- a/app/Exceptions/Banking/ExpiredBankingSessionException.php
+++ b/app/Exceptions/Banking/ExpiredBankingSessionException.php
@@ -6,6 +6,12 @@ use Exception;
 use Illuminate\Contracts\Debug\ShouldntReport;
 use Throwable;
 
+/**
+ * The provider will serve nothing more on this connection until the user
+ * authorizes it again. A lapsed consent window is the common cause but not the
+ * only one — a session revoked at the bank, or superseded by a newer
+ * authorization, lands here too.
+ */
 class ExpiredBankingSessionException extends Exception implements ShouldntReport
 {
     public function __construct(

--- a/app/Services/Banking/EnableBankingProvider.php
+++ b/app/Services/Banking/EnableBankingProvider.php
@@ -127,11 +127,12 @@ class EnableBankingProvider implements BankingProviderInterface
                 );
             }
 
-            if ($this->isTransientServerError($e)) {
+            if ($this->isTransientServerError($e) || $this->isPsuActionRequired($e)) {
                 throw new TransientBankingProviderException(
-                    'EnableBanking returned a server error while fetching account transactions.',
+                    'EnableBanking could not serve account transactions right now.',
                     provider: 'enablebanking',
                     statusCode: $e->response->status(),
+                    providerCode: $this->detailErrorName($e),
                     previous: $e,
                 );
             }
@@ -187,11 +188,12 @@ class EnableBankingProvider implements BankingProviderInterface
                 );
             }
 
-            if ($this->isTransientServerError($e)) {
+            if ($this->isTransientServerError($e) || $this->isPsuActionRequired($e)) {
                 throw new TransientBankingProviderException(
-                    'EnableBanking returned a server error while fetching account balances.',
+                    'EnableBanking could not serve account balances right now.',
                     provider: 'enablebanking',
                     statusCode: $e->response->status(),
+                    providerCode: $this->detailErrorName($e),
                     previous: $e,
                 );
             }
@@ -257,36 +259,49 @@ class EnableBankingProvider implements BankingProviderInterface
     }
 
     /**
-     * Whether the bank will not serve this connection again until the user
-     * authorizes it afresh. Three codes, one remedy — the user reconnects:
-     *
-     * - 401 EXPIRED_SESSION: the consent window lapsed.
-     * - 401 CLOSED_SESSION: the session was closed (revoked at the bank, or
-     *   superseded by a newer authorization).
-     * - 403 PsuActionRequiredException: the bank wants the user present —
-     *   typically a fresh SCA before it will keep serving unattended access.
+     * Whether the session itself is gone, so the bank will serve nothing more
+     * on this connection until the user authorizes it afresh: the consent
+     * window lapsed (EXPIRED_SESSION), or the session was closed — revoked at
+     * the bank, or superseded by a newer authorization (CLOSED_SESSION).
      */
     private function requiresReconnect(RequestException $e): bool
     {
-        $body = $this->errorBody($e);
-        $detail = $body['detail'] ?? null;
+        return $e->response->status() === 401
+            && in_array($this->errorBody($e)['error'] ?? null, ['EXPIRED_SESSION', 'CLOSED_SESSION'], true);
+    }
 
-        return match ($e->response->status()) {
-            401 => in_array($body['error'] ?? null, ['EXPIRED_SESSION', 'CLOSED_SESSION'], true),
-            403 => is_array($detail) && ($detail['error_name'] ?? null) === 'PsuActionRequiredException',
-            default => false,
-        };
+    /**
+     * The bank asked for the user to be present — nominally a fresh SCA before
+     * it keeps serving unattended access.
+     *
+     * Deliberately treated as transient rather than as a reconnect: in the one
+     * burst we have seen, nine connections at nine different banks, all with
+     * months of consent left, failed inside the same nine-minute sync window
+     * hours after syncing cleanly, and none recurred. That is the provider
+     * faulting, not nine users revoking consent. Expiring a connection is a
+     * one-way door — the only way out is a full reauthorization with SCA — so
+     * this must not expire one on first sight. If it turns out to be genuine,
+     * the consent lapses on its own and 401 EXPIRED_SESSION takes over.
+     */
+    private function isPsuActionRequired(RequestException $e): bool
+    {
+        return $e->response->status() === 403
+            && $this->detailErrorName($e) === 'PsuActionRequiredException';
     }
 
     private function isInaccessibleAccount(RequestException $e): bool
     {
-        $detail = $this->errorBody($e)['detail'] ?? null;
-        $errorName = is_array($detail) ? ($detail['error_name'] ?? null) : null;
-
         // ponytail: the documented per-account 400; widen if other terminal
         // account-level codes surface for a single account.
         return $e->response->status() === 400
-            && $errorName === 'AccountNotAccessibleException';
+            && $this->detailErrorName($e) === 'AccountNotAccessibleException';
+    }
+
+    private function detailErrorName(RequestException $e): ?string
+    {
+        $detail = $this->errorBody($e)['detail'] ?? null;
+
+        return is_array($detail) ? ($detail['error_name'] ?? null) : null;
     }
 
     private function isWrongPeriod(RequestException $e): bool
@@ -327,10 +342,14 @@ class EnableBankingProvider implements BankingProviderInterface
                 // as application errors.
                 $isExpected = $this->isAspspError($exception)
                     || $this->requiresReconnect($exception)
+                    || $this->isPsuActionRequired($exception)
                     || $response->status() === 422;
 
                 Log::log($isExpected ? 'warning' : 'error', 'EnableBanking API error', [
                     'status' => $response->status(),
+                    // Which endpoint failed tells one bad account apart from a
+                    // whole connection or a provider-wide wave.
+                    'path' => $response->effectiveUri()?->getPath(),
                     'body' => $response->json(),
                     'exception' => get_class($exception),
                 ]);

--- a/app/Services/Banking/EnableBankingProvider.php
+++ b/app/Services/Banking/EnableBankingProvider.php
@@ -106,9 +106,9 @@ class EnableBankingProvider implements BankingProviderInterface
                 previous: $e,
             );
         } catch (RequestException $e) {
-            if ($this->isExpiredSession($e)) {
+            if ($this->requiresReconnect($e)) {
                 throw new ExpiredBankingSessionException(
-                    'EnableBanking session expired while fetching account transactions.',
+                    'EnableBanking needs the user to reconnect before it will serve account transactions.',
                     previous: $e,
                 );
             }
@@ -173,9 +173,9 @@ class EnableBankingProvider implements BankingProviderInterface
                 previous: $e,
             );
         } catch (RequestException $e) {
-            if ($this->isExpiredSession($e)) {
+            if ($this->requiresReconnect($e)) {
                 throw new ExpiredBankingSessionException(
-                    'EnableBanking session expired while fetching account balances.',
+                    'EnableBanking needs the user to reconnect before it will serve account balances.',
                     previous: $e,
                 );
             }
@@ -256,14 +256,26 @@ class EnableBankingProvider implements BankingProviderInterface
         return $e->response->status() >= 500;
     }
 
-    private function isExpiredSession(RequestException $e): bool
+    /**
+     * Whether the bank will not serve this connection again until the user
+     * authorizes it afresh. Three codes, one remedy — the user reconnects:
+     *
+     * - 401 EXPIRED_SESSION: the consent window lapsed.
+     * - 401 CLOSED_SESSION: the session was closed (revoked at the bank, or
+     *   superseded by a newer authorization).
+     * - 403 PsuActionRequiredException: the bank wants the user present —
+     *   typically a fresh SCA before it will keep serving unattended access.
+     */
+    private function requiresReconnect(RequestException $e): bool
     {
         $body = $this->errorBody($e);
+        $detail = $body['detail'] ?? null;
 
-        // ponytail: only the documented EXPIRED_SESSION code; widen if other
-        // terminal "reconnect required" session codes (e.g. revoked) surface.
-        return $e->response->status() === 401
-            && ($body['error'] ?? null) === 'EXPIRED_SESSION';
+        return match ($e->response->status()) {
+            401 => in_array($body['error'] ?? null, ['EXPIRED_SESSION', 'CLOSED_SESSION'], true),
+            403 => is_array($detail) && ($detail['error_name'] ?? null) === 'PsuActionRequiredException',
+            default => false,
+        };
     }
 
     private function isInaccessibleAccount(RequestException $e): bool
@@ -308,16 +320,18 @@ class EnableBankingProvider implements BankingProviderInterface
             ->connectTimeout(5)
             ->withToken($this->generateJwt())
             ->acceptJson()
-            ->throw(function ($response, $exception) {
-                $body = $response->json();
-                $error = is_array($body) ? ($body['error'] ?? null) : null;
-                $isExpected = ($response->status() === 400 && $error === 'ASPSP_ERROR')
-                    || ($response->status() === 401 && $error === 'EXPIRED_SESSION')
+            ->throw(function ($response, RequestException $exception) {
+                // Expected outcomes of an unattended sync — a flaky bank connector,
+                // a consent the user has to renew, a period the bank won't serve —
+                // are the caller's to handle, so they log as warnings rather than
+                // as application errors.
+                $isExpected = $this->isAspspError($exception)
+                    || $this->requiresReconnect($exception)
                     || $response->status() === 422;
 
                 Log::log($isExpected ? 'warning' : 'error', 'EnableBanking API error', [
                     'status' => $response->status(),
-                    'body' => $body,
+                    'body' => $response->json(),
                     'exception' => get_class($exception),
                 ]);
             });

--- a/database/migrations/2026_08_09_150908_retry_enable_banking_connections_stuck_after_auth_failures.php
+++ b/database/migrations/2026_08_09_150908_retry_enable_banking_connections_stuck_after_auth_failures.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Enums\BankingConnectionStatus;
+use App\Enums\BankingProvider;
+use App\Jobs\SyncBankingConnectionJob;
+use App\Models\BankingConnection;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Give the connections this bug stranded a way back.
+     *
+     * An unclassified 401/403 from Enable Banking was read as an auth failure,
+     * which parks the connection in Error with consecutive_sync_failures above
+     * the scheduled-retry ceiling. Both the scheduler and `banking:sync` filter
+     * those out, so nothing ever dispatched them again — and since their consent
+     * had not actually lapsed they never showed up in the "reconnect your bank"
+     * notice either. They simply stopped syncing, silently, some of them for
+     * months.
+     *
+     * Clearing the counter puts them back in the scheduled rotation, where the
+     * fixed classification decides their real fate: they resume, or the bank
+     * says the consent is gone and they expire properly — with the email and the
+     * notice the user should have had all along.
+     */
+    public function up(): void
+    {
+        BankingConnection::query()
+            ->where('provider', BankingProvider::EnableBanking)
+            ->where('status', BankingConnectionStatus::Error)
+            ->where('consecutive_sync_failures', '>=', SyncBankingConnectionJob::MAX_SCHEDULED_RETRIES)
+            ->update(['consecutive_sync_failures' => 0]);
+    }
+
+    public function down(): void
+    {
+        // One-off repair: the counters it cleared carried no information worth
+        // restoring, and re-parking these connections would only re-strand them.
+    }
+};

--- a/lang/es.json
+++ b/lang/es.json
@@ -2322,5 +2322,10 @@
     "over :count whole months": "sobre :count meses completos",
     "vs. average": "vs. media",
     "Income & expenses per month": "Ingresos y gastos por mes",
-    "Monthly trend needs at least one whole calendar month.": "La tendencia mensual necesita al menos un mes natural completo."
+    "Monthly trend needs at least one whole calendar month.": "La tendencia mensual necesita al menos un mes natural completo.",
+    "Action required: reconnect :provider": "Acción necesaria: vuelve a conectar :provider",
+    "Reconnect your :provider account": "Vuelve a conectar tu cuenta de :provider",
+    "Your :provider connection has expired, so we cannot sync new transactions until you reconnect it.": "Tu conexión con :provider ha dejado de ser válida, así que no podemos sincronizar nuevos movimientos hasta que vuelvas a conectarla.",
+    "Reconnect Account": "Volver a conectar",
+    "If the button does not work, open your connection settings and reconnect :provider from there.": "Si el botón no funciona, abre los ajustes de tus conexiones y vuelve a conectar :provider desde ahí."
 }

--- a/tests/Feature/OpenBanking/EnableBankingProviderTest.php
+++ b/tests/Feature/OpenBanking/EnableBankingProviderTest.php
@@ -362,3 +362,96 @@ PEM;
 
     return new EnableBankingProvider('test-app-id', $path);
 }
+
+test('getTransactions treats a PSU-action-required 403 as needing a reconnect', function () {
+    // The bank wants the user present again (typically a fresh SCA) before it
+    // will keep serving unattended access. Payload shape from PHP-LARAVEL-3J.
+    Http::fake([
+        'api.enablebanking.com/accounts/ext-123/transactions*' => Http::response([
+            'code' => 403,
+            'message' => 'Internal error.',
+            'detail' => [
+                'message' => 'Internal error.',
+                'error_name' => 'PsuActionRequiredException',
+            ],
+        ], 403),
+    ]);
+
+    $provider = enableBankingProviderForTest();
+
+    try {
+        $provider->getTransactions('ext-123', now()->toDateString(), now()->toDateString());
+    } catch (ExpiredBankingSessionException $e) {
+        expect($e)->toBeInstanceOf(ShouldntReport::class)
+            ->and($e->getPrevious())->toBeInstanceOf(RequestException::class);
+
+        return;
+    }
+
+    test()->fail('Expected expired banking session exception.');
+});
+
+test('getTransactions treats a closed session 401 as needing a reconnect', function () {
+    Http::fake([
+        'api.enablebanking.com/accounts/ext-123/transactions*' => Http::response([
+            'code' => 401,
+            'message' => 'Session is closed',
+            'error' => 'CLOSED_SESSION',
+            'detail' => null,
+        ], 401),
+    ]);
+
+    $provider = enableBankingProviderForTest();
+
+    try {
+        $provider->getTransactions('ext-123', now()->toDateString(), now()->toDateString());
+    } catch (ExpiredBankingSessionException $e) {
+        expect($e)->toBeInstanceOf(ShouldntReport::class);
+
+        return;
+    }
+
+    test()->fail('Expected expired banking session exception.');
+});
+
+test('getBalances treats a PSU-action-required 403 as needing a reconnect', function () {
+    Http::fake([
+        'api.enablebanking.com/accounts/ext-123/balances' => Http::response([
+            'code' => 403,
+            'message' => 'Internal error.',
+            'detail' => [
+                'message' => 'Internal error.',
+                'error_name' => 'PsuActionRequiredException',
+            ],
+        ], 403),
+    ]);
+
+    $provider = enableBankingProviderForTest();
+
+    try {
+        $provider->getBalances('ext-123');
+    } catch (ExpiredBankingSessionException $e) {
+        expect($e)->toBeInstanceOf(ShouldntReport::class);
+
+        return;
+    }
+
+    test()->fail('Expected expired banking session exception.');
+});
+
+test('a 403 the bank sends for another reason still surfaces as a request exception', function () {
+    // Only the documented PSU-action code means "reconnect"; a bare 403 stays an
+    // error we want to hear about rather than silently expiring the connection.
+    Http::fake([
+        'api.enablebanking.com/accounts/ext-123/transactions*' => Http::response([
+            'code' => 403,
+            'message' => 'Forbidden',
+            'detail' => null,
+        ], 403),
+    ]);
+
+    $provider = enableBankingProviderForTest();
+
+    expect(fn () => $provider->getTransactions('ext-123', now()->toDateString(), now()->toDateString()))
+        ->toThrow(RequestException::class);
+});

--- a/tests/Feature/OpenBanking/EnableBankingProviderTest.php
+++ b/tests/Feature/OpenBanking/EnableBankingProviderTest.php
@@ -363,9 +363,9 @@ PEM;
     return new EnableBankingProvider('test-app-id', $path);
 }
 
-test('getTransactions treats a PSU-action-required 403 as needing a reconnect', function () {
-    // The bank wants the user present again (typically a fresh SCA) before it
-    // will keep serving unattended access. Payload shape from PHP-LARAVEL-3J.
+test('getTransactions treats a PSU-action-required 403 as transient rather than expiring the connection', function () {
+    // Payload shape from PHP-LARAVEL-3J. Expiring a connection is a one-way
+    // door, so a single one of these must leave it schedulable and self-healing.
     Http::fake([
         'api.enablebanking.com/accounts/ext-123/transactions*' => Http::response([
             'code' => 403,
@@ -381,14 +381,16 @@ test('getTransactions treats a PSU-action-required 403 as needing a reconnect', 
 
     try {
         $provider->getTransactions('ext-123', now()->toDateString(), now()->toDateString());
-    } catch (ExpiredBankingSessionException $e) {
+    } catch (TransientBankingProviderException $e) {
         expect($e)->toBeInstanceOf(ShouldntReport::class)
+            ->and($e->statusCode)->toBe(403)
+            ->and($e->providerCode)->toBe('PsuActionRequiredException')
             ->and($e->getPrevious())->toBeInstanceOf(RequestException::class);
 
         return;
     }
 
-    test()->fail('Expected expired banking session exception.');
+    test()->fail('Expected transient banking provider exception.');
 });
 
 test('getTransactions treats a closed session 401 as needing a reconnect', function () {
@@ -406,7 +408,8 @@ test('getTransactions treats a closed session 401 as needing a reconnect', funct
     try {
         $provider->getTransactions('ext-123', now()->toDateString(), now()->toDateString());
     } catch (ExpiredBankingSessionException $e) {
-        expect($e)->toBeInstanceOf(ShouldntReport::class);
+        expect($e)->toBeInstanceOf(ShouldntReport::class)
+            ->and($e->getPrevious())->toBeInstanceOf(RequestException::class);
 
         return;
     }
@@ -414,7 +417,7 @@ test('getTransactions treats a closed session 401 as needing a reconnect', funct
     test()->fail('Expected expired banking session exception.');
 });
 
-test('getBalances treats a PSU-action-required 403 as needing a reconnect', function () {
+test('getBalances treats a PSU-action-required 403 as transient rather than expiring the connection', function () {
     Http::fake([
         'api.enablebanking.com/accounts/ext-123/balances' => Http::response([
             'code' => 403,
@@ -430,23 +433,58 @@ test('getBalances treats a PSU-action-required 403 as needing a reconnect', func
 
     try {
         $provider->getBalances('ext-123');
-    } catch (ExpiredBankingSessionException $e) {
-        expect($e)->toBeInstanceOf(ShouldntReport::class);
+    } catch (TransientBankingProviderException $e) {
+        expect($e)->toBeInstanceOf(ShouldntReport::class)
+            ->and($e->getPrevious())->toBeInstanceOf(RequestException::class);
 
         return;
     }
 
-    test()->fail('Expected expired banking session exception.');
+    test()->fail('Expected transient banking provider exception.');
 });
 
 test('a 403 the bank sends for another reason still surfaces as a request exception', function () {
-    // Only the documented PSU-action code means "reconnect"; a bare 403 stays an
-    // error we want to hear about rather than silently expiring the connection.
+    // Only the documented PSU-action code is classified; a bare 403 stays an
+    // error we want to hear about.
     Http::fake([
         'api.enablebanking.com/accounts/ext-123/transactions*' => Http::response([
             'code' => 403,
             'message' => 'Forbidden',
             'detail' => null,
+        ], 403),
+    ]);
+
+    $provider = enableBankingProviderForTest();
+
+    expect(fn () => $provider->getTransactions('ext-123', now()->toDateString(), now()->toDateString()))
+        ->toThrow(RequestException::class);
+});
+
+test('a 401 with an unrecognised code still surfaces as a request exception', function () {
+    // Only the documented session codes mean "reconnect". Widening this to any
+    // 401 would silently expire every connection during a credentials bug of
+    // our own, and expiring is a one-way door.
+    Http::fake([
+        'api.enablebanking.com/accounts/ext-123/transactions*' => Http::response([
+            'code' => 401,
+            'message' => 'Invalid token',
+            'error' => 'INVALID_TOKEN',
+            'detail' => null,
+        ], 401),
+    ]);
+
+    $provider = enableBankingProviderForTest();
+
+    expect(fn () => $provider->getTransactions('ext-123', now()->toDateString(), now()->toDateString()))
+        ->toThrow(RequestException::class);
+});
+
+test('a 403 whose detail is not an object is not mistaken for a known code', function () {
+    Http::fake([
+        'api.enablebanking.com/accounts/ext-123/transactions*' => Http::response([
+            'code' => 403,
+            'message' => 'Forbidden',
+            'detail' => 'Forbidden',
         ], 403),
     ]);
 


### PR DESCRIPTION
> **Draft on purpose.** The migration can put connections into `Expired`, which sends `BankingConnectionExpiredEmail` to real users — up to ~18 of them shortly after deploy. That is the right outcome (they have been broken for weeks without being told), but outbound email to real users should be a human's call, not an autonomous one. Everything else here is ready.

## The bug

Sentry [PHP-LARAVEL-3J](https://whisper-money.sentry.io/issues/PHP-LARAVEL-3J) — `RequestException: HTTP 403` in `EnableBankingProvider::getTransactions`. 45 events, 10 users, regressed.

`EnableBankingProvider` classifies known upstream failures into domain exceptions and rethrows the rest as a bare `RequestException`. Two responses were unclassified:

- `401 {"error":"CLOSED_SESSION"}`
- `403 {"detail":{"error_name":"PsuActionRequiredException"}}`

`SyncBankingConnectionJob` reads any bare 401/403 as an auth failure: the connection goes to `Error` with `consecutive_sync_failures = MAX_SCHEDULED_RETRIES + 1`. Both the scheduler and `banking:sync` filter that out, so **the connection is never dispatched again**. Enable Banking's syncer has `notifiesOnAuthFailure() === false`, and the "reconnect your bank" notice only counts `Expired` connections — so nothing told the user. Their bank sync was dead, silently.

Prod confirms the damage: **18 connections across 17 users** stranded that way, 14 with this bug's exact error message, the oldest not synced since **2026-05-06**.

## What each response now does

**`401 CLOSED_SESSION` → expired session.** The session is genuinely gone (revoked at the bank, or superseded by a newer authorization) and only the user can fix it. It now joins `EXPIRED_SESSION`: connection marked `Expired`, reconnect email sent, notice shown, not reported as an application error.

**`403 PsuActionRequiredException` → transient.** My first pass expired these too; the product review pulled the prod data and it says otherwise. The nine connections that hit this on 2026-08-05 had all synced cleanly at 18:00 the evening before, failed inside the same **nine-minute** window, all had months of consent left, and none has recurred in the four days since. Nine users at nine different banks do not revoke consent inside nine minutes — that is the provider faulting behind a generic `"Internal error."` envelope.

Expiring is a one-way door: expired connections are never dispatched, manual sync is refused, and the only way out is a full reauthorization with SCA. Expiring on first sight would have pushed nine users through a re-consent they did not need. So it is classified transient: the connection stays schedulable and self-heals next cycle, and the error logs as a warning instead of being reported. If a PSU action really is required, the consent lapses on its own and the 401 path takes over.

A 403 or 401 the bank sends for any other reason still surfaces exactly as before — tested, because widening either check to "any 401/403" would silently expire every connection during a credentials bug of our own.

## Rescuing the stranded connections

The classification fix cannot reach the 18 already-parked rows: they are excluded from dispatch before any of this code runs. The migration clears their failure counter so the next scheduled cycle re-evaluates them through the fixed path — they resume, or they expire properly, with the email and the notice the user should have had months ago.

Also: the reconnect email's five keys were missing from `lang/es.json`, so Spanish users got it in English. Unenforced because the localization test only scans `resources/js`.

## Tests

`tests/Feature/OpenBanking` — 319 green, including 6 new provider cases (both new codes on `getTransactions` and `getBalances`, plus negative cases for an unrecognised 401 code, a bare 403, and a non-object `detail`). The job-level behaviour — `Expired` + email + not reported — is already covered end to end in `SyncRetryAndLoggingTest`, through the real syncer.

## Follow-ups (not in this PR)

- **`Expired` badge next to a future "Expires:" date.** `markExpired()` doesn't touch `valid_until`, and this fix expires connections whose window hasn't lapsed, so `settings/connections.tsx:411` will show both. Hide the line for expired connections or backdate the field.
- **Forensics gap.** `logSyncAttempt` records no `error_class`/`error_message` on the expired path, so a provider-wide wave becomes indistinguishable from ordinary consent churn in `banking_sync_logs` — that is exactly the data that disproved my first reading here.
- **Reconnect loop.** `AuthorizationController` sets the connection back to `Active` and syncs immediately; if the bank refuses again the user gets a second "reconnect" email seconds later.
- **`banking:sync --connection=<id>` obeys the health filter**, so ops has no escape hatch for a stranded connection.
- **Duplicated catch ladders** in `getTransactions`/`getBalances` — the shape that let a code get classified in one and not the other.

Fixes PHP-LARAVEL-3J