### PR TITLE
fix(ui): stop unusable web storage from white-screening the app

### DIFF
--- a/resources/js/components/transactions/edit-transaction-dialog.tsx
+++ b/resources/js/components/transactions/edit-transaction-dialog.tsx
@@ -27,6 +27,7 @@ import { useLocale } from '@/hooks/use-locale';
 import { decrypt, importKey } from '@/lib/crypto';
 import { getStoredKey } from '@/lib/key-storage';
 import { evaluateRulesForNewTransaction } from '@/lib/rule-engine';
+import { readStoredValue, writeStoredValue } from '@/lib/safe-storage';
 import { appendNoteIfNotPresent } from '@/lib/utils';
 import { transactionSyncService } from '@/services/transaction-sync';
 import {
@@ -101,7 +102,7 @@ export function EditTransactionDialog({
     >(new Map());
     const [updateAccountBalance, setUpdateAccountBalance] = useState(() => {
         if (typeof window !== 'undefined') {
-            const stored = localStorage.getItem(STORAGE_KEY_UPDATE_BALANCE);
+            const stored = readStoredValue(STORAGE_KEY_UPDATE_BALANCE);
             // Active by default; only an explicit opt-out turns it off.
             return stored === null ? true : stored === 'true';
         }
@@ -275,7 +276,7 @@ export function EditTransactionDialog({
 
     function handleUpdateBalanceChange(checked: boolean) {
         setUpdateAccountBalance(checked);
-        localStorage.setItem(STORAGE_KEY_UPDATE_BALANCE, String(checked));
+        writeStoredValue(STORAGE_KEY_UPDATE_BALANCE, String(checked));
     }
 
     async function handleSubmit(e: React.FormEvent) {

--- a/resources/js/hooks/use-appearance.tsx
+++ b/resources/js/hooks/use-appearance.tsx
@@ -2,6 +2,7 @@ import {
     addMediaQueryListener,
     removeMediaQueryListener,
 } from '@/lib/media-query';
+import { readStoredValue, writeStoredValue } from '@/lib/safe-storage';
 import { useCallback, useEffect, useState } from 'react';
 
 export type Appearance = 'light' | 'dark' | 'system';
@@ -44,7 +45,7 @@ const mediaQuery = () => {
 const handleSystemThemeChange = () => {
     if (typeof window === 'undefined') return;
 
-    const currentAppearance = localStorage.getItem('appearance') as Appearance;
+    const currentAppearance = readStoredValue('appearance') as Appearance;
     applyTheme(currentAppearance || 'system');
 };
 
@@ -52,7 +53,7 @@ export function initializeTheme() {
     if (typeof window === 'undefined') return;
 
     const savedAppearance =
-        (localStorage.getItem('appearance') as Appearance) || 'system';
+        (readStoredValue('appearance') as Appearance) || 'system';
 
     applyTheme(savedAppearance);
 
@@ -70,7 +71,7 @@ export function useAppearance() {
         setAppearance(mode);
 
         // Store in localStorage for client-side persistence...
-        localStorage.setItem('appearance', mode);
+        writeStoredValue('appearance', mode);
 
         // Store in cookie for SSR...
         setCookie('appearance', mode);
@@ -79,7 +80,7 @@ export function useAppearance() {
     }, []);
 
     useEffect(() => {
-        const savedAppearance = localStorage.getItem(
+        const savedAppearance = readStoredValue(
             'appearance',
         ) as Appearance | null;
 

--- a/resources/js/hooks/use-appearance.tsx
+++ b/resources/js/hooks/use-appearance.tsx
@@ -15,6 +15,22 @@ const prefersDark = () => {
     return window.matchMedia('(prefers-color-scheme: dark)').matches;
 };
 
+/**
+ * The preference cookie is the only channel that survives when localStorage is
+ * unavailable, and the server already renders the page from it. Reading it back
+ * keeps a no-storage user on the theme they chose instead of resetting them to
+ * "system" — and to light, on a light-OS device — on every load.
+ */
+const readCookie = (name: string): string | null => {
+    if (typeof document === 'undefined') {
+        return null;
+    }
+
+    const match = document.cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`));
+
+    return match ? decodeURIComponent(match[1]) : null;
+};
+
 const setCookie = (name: string, value: string, days = 365) => {
     if (typeof document === 'undefined') {
         return;
@@ -42,20 +58,20 @@ const mediaQuery = () => {
     return window.matchMedia('(prefers-color-scheme: dark)');
 };
 
+const storedAppearance = (): Appearance | null =>
+    (readStoredValue('appearance') ??
+        readCookie('appearance')) as Appearance | null;
+
 const handleSystemThemeChange = () => {
     if (typeof window === 'undefined') return;
 
-    const currentAppearance = readStoredValue('appearance') as Appearance;
-    applyTheme(currentAppearance || 'system');
+    applyTheme(storedAppearance() || 'system');
 };
 
 export function initializeTheme() {
     if (typeof window === 'undefined') return;
 
-    const savedAppearance =
-        (readStoredValue('appearance') as Appearance) || 'system';
-
-    applyTheme(savedAppearance);
+    applyTheme(storedAppearance() || 'system');
 
     // Add the event listener for system theme changes...
     const mql = mediaQuery();
@@ -80,11 +96,13 @@ export function useAppearance() {
     }, []);
 
     useEffect(() => {
-        const savedAppearance = readStoredValue(
-            'appearance',
-        ) as Appearance | null;
+        // Hydrate from what is already persisted — deliberately without writing
+        // it back, so mounting this hook cannot overwrite the cookie of a user
+        // whose localStorage is unavailable.
+        const saved = storedAppearance() || 'system';
 
-        updateAppearance(savedAppearance || 'system');
+        setAppearance(saved);
+        applyTheme(saved);
 
         return () => {
             const mql = mediaQuery();
@@ -92,7 +110,7 @@ export function useAppearance() {
                 removeMediaQueryListener(mql, handleSystemThemeChange);
             }
         };
-    }, [updateAppearance]);
+    }, []);
 
     return { appearance, updateAppearance } as const;
 }

--- a/resources/js/hooks/use-chart-color-scheme.tsx
+++ b/resources/js/hooks/use-chart-color-scheme.tsx
@@ -32,9 +32,14 @@ export function initializeChartColorScheme() {
         return;
     }
 
-    const saved =
-        (readStoredValue(STORAGE_KEY) as ChartColorScheme) || 'colorful';
-    applyColorScheme(saved);
+    // Only override what the server already rendered from the cookie: with no
+    // usable storage this would otherwise reset every user to "colorful",
+    // leaving the CSS palette fighting the scheme the charts draw with.
+    const saved = readStoredValue(STORAGE_KEY) as ChartColorScheme | null;
+
+    if (saved) {
+        applyColorScheme(saved);
+    }
 }
 
 export function useChartColorScheme() {

--- a/resources/js/hooks/use-chart-color-scheme.tsx
+++ b/resources/js/hooks/use-chart-color-scheme.tsx
@@ -1,3 +1,4 @@
+import { readStoredValue, writeStoredValue } from '@/lib/safe-storage';
 import { ChartColorScheme, SharedData } from '@/types';
 import { CategoryColor, getCategoryChartColor } from '@/types/category';
 import { usePage } from '@inertiajs/react';
@@ -32,7 +33,7 @@ export function initializeChartColorScheme() {
     }
 
     const saved =
-        (localStorage.getItem(STORAGE_KEY) as ChartColorScheme) || 'colorful';
+        (readStoredValue(STORAGE_KEY) as ChartColorScheme) || 'colorful';
     applyColorScheme(saved);
 }
 
@@ -42,15 +43,13 @@ export function useChartColorScheme() {
 
     const updateScheme = useCallback((newScheme: ChartColorScheme) => {
         setScheme(newScheme);
-        localStorage.setItem(STORAGE_KEY, newScheme);
+        writeStoredValue(STORAGE_KEY, newScheme);
         setCookie(STORAGE_KEY, newScheme);
         applyColorScheme(newScheme);
     }, []);
 
     useEffect(() => {
-        const saved = localStorage.getItem(
-            STORAGE_KEY,
-        ) as ChartColorScheme | null;
+        const saved = readStoredValue(STORAGE_KEY) as ChartColorScheme | null;
         updateScheme(saved || serverScheme || 'colorful');
     }, [serverScheme, updateScheme]);
 

--- a/resources/js/lib/chunk-load-recovery.ts
+++ b/resources/js/lib/chunk-load-recovery.ts
@@ -1,3 +1,5 @@
+import { getStorage } from './safe-storage';
+
 const CHUNK_LOAD_RELOAD_STORAGE_KEY =
     'whisper-money:chunk-load-reload-asset-signature';
 
@@ -58,7 +60,7 @@ export function installChunkLoadRecovery(): void {
     window.addEventListener('unhandledrejection', (event) => {
         if (
             reloadOnChunkLoadError(event.reason, {
-                storage: window.sessionStorage,
+                storage: getStorage('session'),
             })
         ) {
             event.preventDefault();
@@ -68,7 +70,7 @@ export function installChunkLoadRecovery(): void {
     window.addEventListener('error', (event) => {
         if (
             reloadOnChunkLoadError(event.error ?? event.message, {
-                storage: window.sessionStorage,
+                storage: getStorage('session'),
             })
         ) {
             event.preventDefault();

--- a/resources/js/lib/safe-storage.test.ts
+++ b/resources/js/lib/safe-storage.test.ts
@@ -1,7 +1,12 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { initializeTheme } from '@/hooks/use-appearance';
+import { initializeChartColorScheme } from '@/hooks/use-chart-color-scheme';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { readStoredValue, writeStoredValue } from './safe-storage';
 
-const realStorage = Object.getOwnPropertyDescriptor(window, 'localStorage');
+const realStorage = Object.getOwnPropertyDescriptor(
+    window,
+    'localStorage',
+) as PropertyDescriptor;
 
 const replaceStorage = (value: unknown) => {
     Object.defineProperty(window, 'localStorage', {
@@ -10,16 +15,17 @@ const replaceStorage = (value: unknown) => {
     });
 };
 
+const throwOnStorageAccess = () => {
+    Object.defineProperty(window, 'localStorage', {
+        configurable: true,
+        get: () => {
+            throw new DOMException('The operation is insecure.');
+        },
+    });
+};
+
 afterEach(() => {
-    if (realStorage) {
-        Object.defineProperty(window, 'localStorage', realStorage);
-
-        return;
-    }
-
-    // jsdom exposes localStorage on the prototype, so there is no own
-    // descriptor to put back — drop the override instead.
-    delete (window as { localStorage?: unknown }).localStorage;
+    Object.defineProperty(window, 'localStorage', realStorage);
 });
 
 describe('safe storage', () => {
@@ -48,12 +54,7 @@ describe('safe storage', () => {
     // Blocking cookies/site data makes the first access throw SecurityError —
     // PHP-LARAVEL-4Y, same boot frame.
     it('survives a localStorage that throws on access', () => {
-        Object.defineProperty(window, 'localStorage', {
-            configurable: true,
-            get: () => {
-                throw new DOMException('The operation is insecure.');
-            },
-        });
+        throwOnStorageAccess();
 
         expect(readStoredValue('appearance')).toBeNull();
         expect(() => writeStoredValue('appearance', 'dark')).not.toThrow();
@@ -68,5 +69,40 @@ describe('safe storage', () => {
         });
 
         expect(() => writeStoredValue('appearance', 'dark')).not.toThrow();
+    });
+});
+
+// The invariant that actually regressed is that nothing on the boot path reads
+// storage unguardedly — a helper that is safe on its own does not keep someone
+// from going back to a bare localStorage call in these two functions.
+describe('boot initializers', () => {
+    // jsdom ships no matchMedia; the boot path needs one to get as far as the
+    // storage read this guards.
+    beforeEach(() => {
+        window.matchMedia = ((query: string) => ({
+            matches: false,
+            media: query,
+            addEventListener: () => {},
+            removeEventListener: () => {},
+        })) as unknown as typeof window.matchMedia;
+    });
+
+    it.each([
+        ['a null localStorage', () => replaceStorage(null)],
+        ['a localStorage that throws on access', throwOnStorageAccess],
+    ])('start the app with %s', (_name, breakStorage) => {
+        breakStorage();
+
+        expect(() => initializeTheme()).not.toThrow();
+        expect(() => initializeChartColorScheme()).not.toThrow();
+    });
+
+    it('leaves the theme the server already applied alone when nothing is stored', () => {
+        replaceStorage(null);
+        document.cookie = 'appearance=dark';
+
+        initializeTheme();
+
+        expect(document.documentElement.classList.contains('dark')).toBe(true);
     });
 });

--- a/resources/js/lib/safe-storage.test.ts
+++ b/resources/js/lib/safe-storage.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { readStoredValue, writeStoredValue } from './safe-storage';
+
+const realStorage = Object.getOwnPropertyDescriptor(window, 'localStorage');
+
+const replaceStorage = (value: unknown) => {
+    Object.defineProperty(window, 'localStorage', {
+        configurable: true,
+        get: () => value,
+    });
+};
+
+afterEach(() => {
+    if (realStorage) {
+        Object.defineProperty(window, 'localStorage', realStorage);
+
+        return;
+    }
+
+    // jsdom exposes localStorage on the prototype, so there is no own
+    // descriptor to put back — drop the override instead.
+    delete (window as { localStorage?: unknown }).localStorage;
+});
+
+describe('safe storage', () => {
+    it('reads and writes through a working localStorage', () => {
+        const stored = new Map<string, string>();
+        replaceStorage({
+            getItem: (key: string) => stored.get(key) ?? null,
+            setItem: (key: string, value: string) => stored.set(key, value),
+        });
+
+        writeStoredValue('appearance', 'dark');
+
+        expect(readStoredValue('appearance')).toBe('dark');
+        expect(readStoredValue('never-set')).toBeNull();
+    });
+
+    // Android WebViews with DOM storage disabled expose the global as null,
+    // which is what crashed initializeTheme in PHP-LARAVEL-57.
+    it('survives a null localStorage', () => {
+        replaceStorage(null);
+
+        expect(readStoredValue('appearance')).toBeNull();
+        expect(() => writeStoredValue('appearance', 'dark')).not.toThrow();
+    });
+
+    // Blocking cookies/site data makes the first access throw SecurityError —
+    // PHP-LARAVEL-4Y, same boot frame.
+    it('survives a localStorage that throws on access', () => {
+        Object.defineProperty(window, 'localStorage', {
+            configurable: true,
+            get: () => {
+                throw new DOMException('The operation is insecure.');
+            },
+        });
+
+        expect(readStoredValue('appearance')).toBeNull();
+        expect(() => writeStoredValue('appearance', 'dark')).not.toThrow();
+    });
+
+    it('survives a storage whose setItem throws, e.g. an exhausted quota', () => {
+        replaceStorage({
+            getItem: () => null,
+            setItem: () => {
+                throw new DOMException('QuotaExceededError');
+            },
+        });
+
+        expect(() => writeStoredValue('appearance', 'dark')).not.toThrow();
+    });
+});

--- a/resources/js/lib/safe-storage.ts
+++ b/resources/js/lib/safe-storage.ts
@@ -1,0 +1,48 @@
+/**
+ * Web storage access that cannot take the app down with it.
+ *
+ * The globals are not always usable. Some Android WebViews expose them as
+ * `null` when the host app disables DOM storage, and browsers configured to
+ * block cookies/site data throw `SecurityError` on the very first access. At
+ * app boot — initializeTheme, initializeChartColorScheme, the landing page's
+ * locale effect — either one aborts the mount and white-screens the app
+ * (PHP-LARAVEL-57, PHP-LARAVEL-4Y).
+ *
+ * Note the try/catch is doing the real work and is not redundant with the
+ * optional chaining: the SecurityError is thrown by the property *read*
+ * itself, before `?.` ever gets to look at the value. Do not "simplify" it
+ * away. Same spirit as ./media-query.ts, which exists for the same class of
+ * boot-time crash.
+ *
+ * Reads fall back to null and writes quietly no-op, which is right for the
+ * display preferences using this. Do not route anything whose loss is a data
+ * problem rather than a cosmetic one (an encryption key, say) through it
+ * without telling the user it did not persist.
+ */
+export function getStorage(area: 'local' | 'session'): Storage | undefined {
+    try {
+        return (
+            (area === 'local' ? window.localStorage : window.sessionStorage) ??
+            undefined
+        );
+    } catch {
+        return undefined;
+    }
+}
+
+export function readStoredValue(key: string): string | null {
+    try {
+        return getStorage('local')?.getItem(key) ?? null;
+    } catch {
+        return null;
+    }
+}
+
+export function writeStoredValue(key: string, value: string): void {
+    try {
+        getStorage('local')?.setItem(key, value);
+    } catch {
+        // Storage disabled, private mode, or quota exhausted: the preference
+        // simply does not survive the session.
+    }
+}

--- a/resources/js/pages/welcome.tsx
+++ b/resources/js/pages/welcome.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Spinner } from '@/components/ui/spinner';
 import { tailwindColorClasses } from '@/components/user-info';
 import { usePwaInstall } from '@/hooks/use-pwa-install';
+import { readStoredValue, writeStoredValue } from '@/lib/safe-storage';
 import { cn } from '@/lib/utils';
 import { type SharedData } from '@/types';
 import { type CategoryColor, getCategoryColorClasses } from '@/types/category';
@@ -2102,10 +2103,10 @@ export default function Welcome({
 
         if (langParam && supportedLocales.includes(langParam)) {
             // Store the preference in localStorage
-            localStorage.setItem('whisper_landing_locale', langParam);
+            writeStoredValue('whisper_landing_locale', langParam);
         } else {
             // No query param - check if we have a stored preference
-            const storedLocale = localStorage.getItem('whisper_landing_locale');
+            const storedLocale = readStoredValue('whisper_landing_locale');
 
             if (
                 storedLocale &&
@@ -2117,7 +2118,7 @@ export default function Welcome({
                 return;
             } else if (!storedLocale && locale) {
                 // First visit - store the detected locale from session/header
-                localStorage.setItem('whisper_landing_locale', locale);
+                writeStoredValue('whisper_landing_locale', locale);
             }
         }
     }, [locale]);


### PR DESCRIPTION
## The bug

Two Sentry issues share one minified boot frame, `vq` → `initializeTheme()`:

- [PHP-LARAVEL-57](https://whisper-money.sentry.io/issues/PHP-LARAVEL-57) — `TypeError: Cannot read properties of null (reading 'getItem')`. Chrome Mobile WebView 131 / Android 15: the host app disabled DOM storage, so `window.localStorage` is `null`.
- [PHP-LARAVEL-4Y](https://whisper-money.sentry.io/issues/PHP-LARAVEL-4Y) — `SecurityError: The operation is insecure.`, 17 events. Blocking cookies/site data makes the very first access throw.

`app.tsx` runs `initializeTheme()` and `initializeChartColorScheme()` at module scope, before React mounts, so either one white-screens the app. Same class as PHP-LARAVEL-41 (Safari <14 `addEventListener`), which is why `lib/media-query.ts` exists — `lib/safe-storage.ts` is its sibling.

## What both reviews caught

My first pass only routed the two initializers, and **that would not have closed either issue**. Both events carry url `https://whisper.money/`, and the landing page reads `localStorage` unguarded in a mount effect (`welcome.tsx:2105`) — those users would have white-screened a few milliseconds later instead. There is also **no error boundary anywhere in this app**, so any throw in render or an effect unmounts the whole root; there is no "broken widget" failure mode.

So the fix also covers:

- **`welcome.tsx`** — the landing page's locale effect, the url both issues carry.
- **`chunk-load-recovery.ts:61,71`** — `window.sessionStorage` was evaluated in an argument list, *outside* the try/catch that guards its use. For the SecurityError cohort the global `error` listener itself threw, and that throw was reported as another error event, re-entering the same listener. It also meant chunk-load auto-recovery was dead precisely on the browsers most likely to hold stale assets.
- **`edit-transaction-dialog.tsx:104`** — a read inside a lazy `useState`, i.e. during render, on `/transactions` and account pages. Its `typeof window !== 'undefined'` guard checks the wrong axis: `window` exists, `window.localStorage` is null.

## Not just "doesn't crash" — the preference still works

Making the crash survivable exposed what happens next. The `appearance` cookie is unencrypted, `HandleAppearance` renders the page from it, and the blade applies it before any JS runs. Then `initializeTheme` read an empty localStorage, fell back to `'system'`, and stripped the `dark` class again — so a no-storage user who chose Dark got light on every load. The mount effect was worse: it called `updateAppearance`, which writes the cookie, so simply opening the app reset the one channel that still persisted for these users.

Now the cookie is read as a fallback, the mount effect hydrates without writing back, and `initializeChartColorScheme` only overrides the blade-rendered `data-chart-color` when something is actually stored (previously it reset everyone to `colorful`, leaving the CSS palette fighting the colors the charts draw with).

For users whose storage works, behaviour is unchanged: `readStoredValue` returns exactly what `getItem` returned, `null` included.

## Tests

7 vitest cases. The helper's four (working storage, null global, throwing getter, throwing `setItem`) plus three that pin the invariant that actually regressed — the boot initializers survive a null and a throwing storage, and leave the server's theme alone when nothing is stored. Verified they fail if `initializeTheme` goes back to a bare `localStorage` call; the helper-only tests do not.

## Follow-ups (not here)

- **An error boundary in `app.tsx`** — both reviews called this the highest-leverage item in the whole change. ~10 unguarded storage sites remain, and without a boundary each is a fresh white screen rather than a contained failure plus a Sentry report. It needs fallback UI and a visual check, so it deserves its own PR.
- **The remaining unguarded sites**, in blast-radius order: `lib/debug.ts:4` (called ~30× per rule evaluation from the rule engine, so auto-categorization dies for these users), `transaction-analysis-drawer.tsx` / `category-analysis-drawer.tsx` (drawers fail to open), `lib/key-storage.ts` (on a 1s interval, but gated behind the deprecated encryption setup — and note storage that silently fails to persist is the *wrong* policy for a key), `hooks/use-admin.tsx` (no call sites — delete it).
- Six call sites already hand-roll this exact try/catch idiom, which is the argument for the helper existing; folding them in would also remove three duplicated localStorage stubs from the test suite.

Fixes PHP-LARAVEL-57
Fixes PHP-LARAVEL-4Y