### PR TITLE
fix(banking): strip the ISO 20022 remittance tag from transaction descriptions

### DIFF
--- a/app/Console/Commands/BackfillTransactionDescriptions.php
+++ b/app/Console/Commands/BackfillTransactionDescriptions.php
@@ -2,8 +2,10 @@
 
 namespace App\Console\Commands;
 
+use App\Models\AutomationRule;
 use App\Models\Transaction;
 use App\Models\User;
+use App\Services\Banking\Formatters\RemittanceTagFormatter;
 use App\Services\Banking\TransactionDescriptionFormatter;
 use Illuminate\Console\Command;
 
@@ -13,20 +15,17 @@ class BackfillTransactionDescriptions extends Command
         {--user= : Filter by user email address}
         {--dry-run : Preview what would be updated without making changes}';
 
-    protected $description = 'Re-apply the bank description formatters to already-imported transactions that still carry a raw remittance tag';
+    protected $description = 'Re-apply the bank description formatters to already-imported transactions that still carry a raw remittance tag, and rewrite the automation rules matching on it';
 
     public function handle(TransactionDescriptionFormatter $formatter): int
     {
         $isDryRun = (bool) $this->option('dry-run');
         $userEmail = $this->option('user');
+        $userId = null;
 
         if ($isDryRun) {
             $this->warn('DRY RUN — no changes will be saved.');
         }
-
-        $query = Transaction::query()
-            ->with('account.bank')
-            ->where('description', 'like', '/TXT/%');
 
         if ($userEmail) {
             $user = User::query()->where('email', $userEmail)->first();
@@ -37,12 +36,35 @@ class BackfillTransactionDescriptions extends Command
                 return self::FAILURE;
             }
 
-            $query->where('user_id', $user->id);
+            $userId = $user->id;
         }
 
-        $updated = 0;
+        $transactions = $this->reformatTransactions($formatter, $userId, $isDryRun);
 
-        $query->chunkById(500, function ($transactions) use ($formatter, $isDryRun, &$updated): void {
+        // User rules were written against the raw text ("description contains
+        // /TXT/D|MERCADONA"), so rewriting descriptions without rewriting the
+        // rules would silently stop them from ever matching again.
+        $rules = $this->reformatRules($formatter, $userId, $isDryRun);
+
+        $verb = $isDryRun ? 'would be reformatted' : 'reformatted';
+        $this->info("{$transactions} transaction(s) and {$rules} automation rule(s) {$verb}.");
+
+        return self::SUCCESS;
+    }
+
+    private function reformatTransactions(TransactionDescriptionFormatter $formatter, ?string $userId, bool $isDryRun): int
+    {
+        $query = Transaction::query()
+            ->with('account.bank')
+            ->whereNull('description_iv')
+            ->where('description', 'like', RemittanceTagFormatter::TAG.'%')
+            ->when($userId, fn ($q) => $q->where('user_id', $userId));
+
+        $reformatted = 0;
+
+        // chunkById: the update takes rows out of the result set, so a
+        // page-offset chunk() would skip half of them.
+        $query->chunkById(500, function ($transactions) use ($formatter, $isDryRun, &$reformatted): void {
             foreach ($transactions as $transaction) {
                 $formatted = $formatter->format($transaction->description, $transaction->account?->bank?->name);
 
@@ -50,22 +72,92 @@ class BackfillTransactionDescriptions extends Command
                     continue;
                 }
 
+                if ($this->output->isVerbose()) {
+                    $this->line("  {$transaction->description}  →  {$formatted['description']}");
+                }
+
                 if (! $isDryRun) {
-                    // Quietly: only the wording changes, so there is nothing for
-                    // the transaction listeners to react to.
+                    // Quietly: the only listener on TransactionUpdated assigns
+                    // budgets from the category, labels, amount and date, none
+                    // of which this touches.
                     $transaction->updateQuietly([
                         'description' => $formatted['description'],
                         'original_description' => $transaction->original_description ?? $formatted['original_description'],
                     ]);
                 }
 
-                $updated++;
+                $reformatted++;
             }
         });
 
-        $verb = $isDryRun ? 'would be reformatted' : 'reformatted';
-        $this->info("{$updated} transaction(s) {$verb}.");
+        return $reformatted;
+    }
 
-        return self::SUCCESS;
+    private function reformatRules(TransactionDescriptionFormatter $formatter, ?string $userId, bool $isDryRun): int
+    {
+        $reformatted = 0;
+
+        // No `like '%/TXT/%'` prefilter: whether the tag survives in the stored
+        // JSON with its slashes escaped depends on how the rule was written, so
+        // the formatter — not a fragile SQL pattern — decides what is tagged.
+        AutomationRule::query()
+            ->when($userId, fn ($q) => $q->where('user_id', $userId))
+            ->chunkById(500, function ($rules) use ($formatter, $isDryRun, &$reformatted): void {
+                foreach ($rules as $rule) {
+                    // The column holds the rule either as an array or as a JSON
+                    // string; whichever it was has to survive the rewrite.
+                    $stored = $rule->rules_json;
+                    $decoded = is_string($stored) ? json_decode($stored, true) : $stored;
+
+                    if (! is_array($decoded)) {
+                        continue;
+                    }
+
+                    $rewritten = $this->rewriteTaggedValues($decoded, $formatter);
+
+                    if ($rewritten === $decoded) {
+                        continue;
+                    }
+
+                    if ($this->output->isVerbose()) {
+                        $this->line("  rule {$rule->id}: ".json_encode($rewritten));
+                    }
+
+                    if (! $isDryRun) {
+                        $rule->rules_json = is_string($stored) ? json_encode($rewritten) : $rewritten;
+                        $rule->save();
+                    }
+
+                    $reformatted++;
+                }
+            });
+
+        return $reformatted;
+    }
+
+    /**
+     * Run every string literal in a rule tree through the formatter, so the
+     * text a rule matches on is normalized the same way descriptions now are.
+     * Untagged literals — operators, variable names, plain merchant text —
+     * come back unchanged.
+     *
+     * @param  array<mixed>  $node
+     * @return array<mixed>
+     */
+    private function rewriteTaggedValues(array $node, TransactionDescriptionFormatter $formatter): array
+    {
+        foreach ($node as $key => $value) {
+            if (is_array($value)) {
+                $node[$key] = $this->rewriteTaggedValues($value, $formatter);
+
+                continue;
+            }
+
+            if (is_string($value)) {
+                $node[$key] = $formatter->format($value, null)['description'];
+            }
+        }
+
+        return $node;
     }
 }

--- a/app/Console/Commands/BackfillTransactionDescriptions.php
+++ b/app/Console/Commands/BackfillTransactionDescriptions.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Transaction;
+use App\Models\User;
+use App\Services\Banking\TransactionDescriptionFormatter;
+use Illuminate\Console\Command;
+
+class BackfillTransactionDescriptions extends Command
+{
+    protected $signature = 'banking:backfill-descriptions
+        {--user= : Filter by user email address}
+        {--dry-run : Preview what would be updated without making changes}';
+
+    protected $description = 'Re-apply the bank description formatters to already-imported transactions that still carry a raw remittance tag';
+
+    public function handle(TransactionDescriptionFormatter $formatter): int
+    {
+        $isDryRun = (bool) $this->option('dry-run');
+        $userEmail = $this->option('user');
+
+        if ($isDryRun) {
+            $this->warn('DRY RUN — no changes will be saved.');
+        }
+
+        $query = Transaction::query()
+            ->with('account.bank')
+            ->where('description', 'like', '/TXT/%');
+
+        if ($userEmail) {
+            $user = User::query()->where('email', $userEmail)->first();
+
+            if (! $user) {
+                $this->error("User with email '{$userEmail}' not found.");
+
+                return self::FAILURE;
+            }
+
+            $query->where('user_id', $user->id);
+        }
+
+        $updated = 0;
+
+        $query->chunkById(500, function ($transactions) use ($formatter, $isDryRun, &$updated): void {
+            foreach ($transactions as $transaction) {
+                $formatted = $formatter->format($transaction->description, $transaction->account?->bank?->name);
+
+                if ($formatted['description'] === $transaction->description) {
+                    continue;
+                }
+
+                if (! $isDryRun) {
+                    // Quietly: only the wording changes, so there is nothing for
+                    // the transaction listeners to react to.
+                    $transaction->updateQuietly([
+                        'description' => $formatted['description'],
+                        'original_description' => $transaction->original_description ?? $formatted['original_description'],
+                    ]);
+                }
+
+                $updated++;
+            }
+        });
+
+        $verb = $isDryRun ? 'would be reformatted' : 'reformatted';
+        $this->info("{$updated} transaction(s) {$verb}.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Models/AutomationRule.php
+++ b/app/Models/AutomationRule.php
@@ -14,7 +14,11 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
- * @property array<string, mixed> $rules_json
+ * Rules written before the store request stopped double-encoding the payload
+ * came back out of the array cast as the JSON string it wrapped, so readers
+ * have to cope with both shapes — see AutomationRuleService::normalizeRuleJson.
+ *
+ * @property array<string, mixed>|string $rules_json
  * @property RuleOrigin $origin
  */
 class AutomationRule extends Model

--- a/app/Services/Banking/Formatters/BankFormatter.php
+++ b/app/Services/Banking/Formatters/BankFormatter.php
@@ -4,7 +4,7 @@ namespace App\Services\Banking\Formatters;
 
 interface BankFormatter
 {
-    public function matches(string $bankName): bool;
+    public function matches(string $description, ?string $bankName): bool;
 
     public function format(string $description): string;
 }

--- a/app/Services/Banking/Formatters/BbvaFormatter.php
+++ b/app/Services/Banking/Formatters/BbvaFormatter.php
@@ -19,9 +19,9 @@ class BbvaFormatter implements BankFormatter
         'de', 'del', 'la', 'las', 'los', 'el', 'en', 'y', 'a', 'al', 'por', 'con', 'para',
     ];
 
-    public function matches(string $bankName): bool
+    public function matches(string $description, ?string $bankName): bool
     {
-        return mb_strtolower($bankName) === 'bbva';
+        return $bankName !== null && mb_strtolower($bankName) === 'bbva';
     }
 
     public function format(string $description): string

--- a/app/Services/Banking/Formatters/RemittanceTagFormatter.php
+++ b/app/Services/Banking/Formatters/RemittanceTagFormatter.php
@@ -11,20 +11,20 @@ namespace App\Services\Banking\Formatters;
  */
 class RemittanceTagFormatter implements BankFormatter
 {
-    private const TAG = '/TXT/';
+    public const TAG = '/TXT/';
 
     /**
-     * Debit/credit marker the bank prepends to the text (`D|`, `H|`). It only
-     * repeats the sign of the amount.
+     * Debit/credit marker the bank prepends to the text (`D` for debe, `H` for
+     * haber). It only repeats the sign of the amount.
      */
-    private const CREDIT_DEBIT_MARKER = '/^[A-Z]\|/';
+    private const CREDIT_DEBIT_MARKER = '/^[DH]\|/';
 
     /**
-     * Card purchases carry the purchase date — often glued to a truncated
-     * merchant name — plus the settlement date after a pipe:
-     * `CONDIS SANT JUST DESV07/07/26|20260714`.
+     * Card payments carry the settlement date after a pipe, usually preceded by
+     * the purchase date glued to a truncated merchant name:
+     * `CONDIS SANT JUST DESV07/07/26|20260714`, `RECIBO MES TARJETA|20260806`.
      */
-    private const CARD_DATES_SUFFIX = '/\s*\d{2}\/\d{2}\/\d{2}\|\d{8}$/';
+    private const CARD_DATES_SUFFIX = '/\s*(\d{2}\/\d{2}\/\d{2})?\|\d{8}$/';
 
     public function matches(string $description, ?string $bankName): bool
     {
@@ -39,8 +39,7 @@ class RemittanceTagFormatter implements BankFormatter
         $text = (string) preg_replace('/\s+/u', ' ', $text);
 
         // Internal marker on card charges and refunds ("#RECOBRO RECIBO VISA").
-        $text = ltrim(trim($text), '#');
-        $text = trim($text);
+        $text = trim(ltrim(trim($text), '#'));
 
         return $text === '' ? $description : $text;
     }

--- a/app/Services/Banking/Formatters/RemittanceTagFormatter.php
+++ b/app/Services/Banking/Formatters/RemittanceTagFormatter.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Services\Banking\Formatters;
+
+/**
+ * Strips the ISO 20022 `/TXT/` remittance tag some banks (Bankinter, Unicaja)
+ * leave in the unstructured remittance information, so the description is the
+ * merchant or counterparty instead of `/TXT/D|MERCHANT`. The tag identifies
+ * itself, so this formatter is keyed on the description rather than on a bank
+ * name and works for any bank that ships the same shape.
+ */
+class RemittanceTagFormatter implements BankFormatter
+{
+    private const TAG = '/TXT/';
+
+    /**
+     * Debit/credit marker the bank prepends to the text (`D|`, `H|`). It only
+     * repeats the sign of the amount.
+     */
+    private const CREDIT_DEBIT_MARKER = '/^[A-Z]\|/';
+
+    /**
+     * Card purchases carry the purchase date — often glued to a truncated
+     * merchant name — plus the settlement date after a pipe:
+     * `CONDIS SANT JUST DESV07/07/26|20260714`.
+     */
+    private const CARD_DATES_SUFFIX = '/\s*\d{2}\/\d{2}\/\d{2}\|\d{8}$/';
+
+    public function matches(string $description, ?string $bankName): bool
+    {
+        return str_starts_with($description, self::TAG);
+    }
+
+    public function format(string $description): string
+    {
+        $text = mb_substr($description, mb_strlen(self::TAG));
+        $text = (string) preg_replace(self::CREDIT_DEBIT_MARKER, '', $text);
+        $text = (string) preg_replace(self::CARD_DATES_SUFFIX, '', $text);
+        $text = (string) preg_replace('/\s+/u', ' ', $text);
+
+        // Internal marker on card charges and refunds ("#RECOBRO RECIBO VISA").
+        $text = ltrim(trim($text), '#');
+        $text = trim($text);
+
+        return $text === '' ? $description : $text;
+    }
+}

--- a/app/Services/Banking/TransactionDescriptionFormatter.php
+++ b/app/Services/Banking/TransactionDescriptionFormatter.php
@@ -4,6 +4,7 @@ namespace App\Services\Banking;
 
 use App\Services\Banking\Formatters\BankFormatter;
 use App\Services\Banking\Formatters\BbvaFormatter;
+use App\Services\Banking\Formatters\RemittanceTagFormatter;
 
 class TransactionDescriptionFormatter
 {
@@ -12,7 +13,10 @@ class TransactionDescriptionFormatter
 
     public function __construct()
     {
+        // Ordered most specific first: a formatter keyed on the description
+        // itself knows the shape it gets, a bank-keyed one only guesses.
         $this->formatters = [
+            new RemittanceTagFormatter,
             new BbvaFormatter,
         ];
     }
@@ -22,17 +26,17 @@ class TransactionDescriptionFormatter
      */
     public function format(string $description, ?string $bankName): array
     {
-        if ($bankName) {
-            foreach ($this->formatters as $formatter) {
-                if ($formatter->matches($bankName)) {
-                    $formatted = $formatter->format($description);
-
-                    return [
-                        'description' => $formatted,
-                        'original_description' => $formatted !== $description ? $description : null,
-                    ];
-                }
+        foreach ($this->formatters as $formatter) {
+            if (! $formatter->matches($description, $bankName)) {
+                continue;
             }
+
+            $formatted = $formatter->format($description);
+
+            return [
+                'description' => $formatted,
+                'original_description' => $formatted !== $description ? $description : null,
+            ];
         }
 
         return ['description' => $description, 'original_description' => null];

--- a/app/Services/Banking/TransactionDescriptionFormatter.php
+++ b/app/Services/Banking/TransactionDescriptionFormatter.php
@@ -13,8 +13,9 @@ class TransactionDescriptionFormatter
 
     public function __construct()
     {
-        // Ordered most specific first: a formatter keyed on the description
-        // itself knows the shape it gets, a bank-keyed one only guesses.
+        // First match wins, so a formatter keyed on the description — which
+        // knows the exact shape it gets — is tried before a bank-keyed one,
+        // which only guesses from the connection.
         $this->formatters = [
             new RemittanceTagFormatter,
             new BbvaFormatter,

--- a/tests/Feature/Console/BackfillTransactionDescriptionsCommandTest.php
+++ b/tests/Feature/Console/BackfillTransactionDescriptionsCommandTest.php
@@ -3,6 +3,7 @@
 use App\Models\AutomationRule;
 use App\Models\Transaction;
 use App\Models\User;
+use App\Services\AutomationRuleService;
 
 use function Pest\Laravel\artisan;
 
@@ -74,6 +75,25 @@ test('rewrites the tag in rules stored as a JSON string', function () {
 
     expect(json_decode($rule->refresh()->rules_json, true))
         ->toBe(['in' => ['BAR CONO', ['var' => 'description']]]);
+});
+
+test('a rule matching on the raw tag still matches its transaction afterwards', function () {
+    $user = User::factory()->create();
+    $transaction = taggedTransaction([
+        'user_id' => $user->id,
+        'description' => '/TXT/D|RECIBO VISA CLASICA',
+    ]);
+    $rule = AutomationRule::factory()->for($user)->create([
+        'rules_json' => ['in' => ['/TXT/D|RECIBO VISA CLASICA', ['var' => 'description']]],
+    ]);
+
+    $service = app(AutomationRuleService::class);
+
+    expect($service->ruleMatches($rule, $transaction))->toBeTrue();
+
+    artisan('banking:backfill-descriptions')->assertSuccessful();
+
+    expect($service->ruleMatches($rule->refresh(), $transaction->refresh()))->toBeTrue();
 });
 
 test('leaves untagged automation rules untouched', function () {

--- a/tests/Feature/Console/BackfillTransactionDescriptionsCommandTest.php
+++ b/tests/Feature/Console/BackfillTransactionDescriptionsCommandTest.php
@@ -1,18 +1,26 @@
 <?php
 
+use App\Models\AutomationRule;
 use App\Models\Transaction;
 use App\Models\User;
 
 use function Pest\Laravel\artisan;
 
-test('reformats already-imported descriptions that still carry the remittance tag', function () {
-    $transaction = Transaction::factory()->create([
+function taggedTransaction(array $attributes = []): Transaction
+{
+    return Transaction::factory()->create([
         'description' => '/TXT/D|BAR CONO',
         'original_description' => null,
+        'description_iv' => null,
+        ...$attributes,
     ]);
+}
+
+test('reformats already-imported descriptions that still carry the remittance tag', function () {
+    $transaction = taggedTransaction();
 
     artisan('banking:backfill-descriptions')
-        ->expectsOutputToContain('1 transaction(s) reformatted.')
+        ->expectsOutputToContain('1 transaction(s) and 0 automation rule(s) reformatted.')
         ->assertSuccessful();
 
     $transaction->refresh();
@@ -22,46 +30,93 @@ test('reformats already-imported descriptions that still carry the remittance ta
 });
 
 test('leaves untagged descriptions alone', function () {
-    $transaction = Transaction::factory()->create([
-        'description' => 'Cafe de la Plaza',
-        'original_description' => null,
-    ]);
+    $transaction = taggedTransaction(['description' => 'Cafe de la Plaza']);
 
     artisan('banking:backfill-descriptions')->assertSuccessful();
 
     expect($transaction->refresh()->description)->toBe('Cafe de la Plaza');
 });
 
-test('keeps an original description that was already stored', function () {
-    $transaction = Transaction::factory()->create([
-        'description' => '/TXT/D|BAR CONO',
-        'original_description' => 'SOMETHING THE USER RENAMED FROM',
-    ]);
+test('skips transactions the server cannot read', function () {
+    $transaction = taggedTransaction(['description_iv' => 'abcdefghijklmnop']);
 
     artisan('banking:backfill-descriptions')->assertSuccessful();
-
-    expect($transaction->refresh()->original_description)->toBe('SOMETHING THE USER RENAMED FROM');
-});
-
-test('does not save anything on a dry run', function () {
-    $transaction = Transaction::factory()->create(['description' => '/TXT/D|BAR CONO']);
-
-    artisan('banking:backfill-descriptions', ['--dry-run' => true])
-        ->expectsOutputToContain('1 transaction(s) would be reformatted.')
-        ->assertSuccessful();
 
     expect($transaction->refresh()->description)->toBe('/TXT/D|BAR CONO');
 });
 
+test('keeps an original description that was already stored', function () {
+    $transaction = taggedTransaction(['original_description' => '/TXT/D|BAR CONO  27/07/26|20260803']);
+
+    artisan('banking:backfill-descriptions')->assertSuccessful();
+
+    expect($transaction->refresh()->original_description)->toBe('/TXT/D|BAR CONO  27/07/26|20260803');
+});
+
+test('rewrites the automation rules that match on the raw tag', function () {
+    $rule = AutomationRule::factory()->for(User::factory())->create([
+        'rules_json' => ['in' => ['/TXT/D|BAR CONO', ['var' => 'description']]],
+    ]);
+
+    artisan('banking:backfill-descriptions')
+        ->expectsOutputToContain('0 transaction(s) and 1 automation rule(s) reformatted.')
+        ->assertSuccessful();
+
+    expect($rule->refresh()->rules_json)->toBe(['in' => ['BAR CONO', ['var' => 'description']]]);
+});
+
+test('rewrites the tag in rules stored as a JSON string', function () {
+    $rule = AutomationRule::factory()->for(User::factory())->create([
+        'rules_json' => json_encode(['in' => ['/TXT/D|BAR CONO', ['var' => 'description']]]),
+    ]);
+
+    artisan('banking:backfill-descriptions')->assertSuccessful();
+
+    expect(json_decode($rule->refresh()->rules_json, true))
+        ->toBe(['in' => ['BAR CONO', ['var' => 'description']]]);
+});
+
+test('leaves untagged automation rules untouched', function () {
+    $rule = AutomationRule::factory()->for(User::factory())->create([
+        'rules_json' => ['in' => ['grocery', ['var' => 'description']]],
+    ]);
+
+    artisan('banking:backfill-descriptions')->assertSuccessful();
+
+    expect($rule->refresh()->rules_json)->toBe(['in' => ['grocery', ['var' => 'description']]]);
+});
+
+test('does not save anything on a dry run', function () {
+    $transaction = taggedTransaction();
+    $rule = AutomationRule::factory()->for(User::factory())->create([
+        'rules_json' => ['in' => ['/TXT/D|BAR CONO', ['var' => 'description']]],
+    ]);
+
+    artisan('banking:backfill-descriptions', ['--dry-run' => true])
+        ->expectsOutputToContain('1 transaction(s) and 1 automation rule(s) would be reformatted.')
+        ->assertSuccessful();
+
+    expect($transaction->refresh()->description)->toBe('/TXT/D|BAR CONO');
+    expect($rule->refresh()->rules_json)->toBe(['in' => ['/TXT/D|BAR CONO', ['var' => 'description']]]);
+});
+
 test('only touches the given user when one is provided', function () {
     $user = User::factory()->create();
-    $mine = Transaction::factory()->for($user)->create(['description' => '/TXT/D|BAR CONO']);
-    $theirs = Transaction::factory()->create(['description' => '/TXT/D|BAR CONO']);
+    $mine = taggedTransaction(['user_id' => $user->id]);
+    $theirs = taggedTransaction();
+    $myRule = AutomationRule::factory()->for($user)->create([
+        'rules_json' => ['in' => ['/TXT/D|BAR CONO', ['var' => 'description']]],
+    ]);
+    $theirRule = AutomationRule::factory()->for(User::factory())->create([
+        'rules_json' => ['in' => ['/TXT/D|BAR CONO', ['var' => 'description']]],
+    ]);
 
     artisan('banking:backfill-descriptions', ['--user' => $user->email])->assertSuccessful();
 
     expect($mine->refresh()->description)->toBe('BAR CONO');
     expect($theirs->refresh()->description)->toBe('/TXT/D|BAR CONO');
+    expect($myRule->refresh()->rules_json)->toBe(['in' => ['BAR CONO', ['var' => 'description']]]);
+    expect($theirRule->refresh()->rules_json)->toBe(['in' => ['/TXT/D|BAR CONO', ['var' => 'description']]]);
 });
 
 test('fails when the given user does not exist', function () {

--- a/tests/Feature/Console/BackfillTransactionDescriptionsCommandTest.php
+++ b/tests/Feature/Console/BackfillTransactionDescriptionsCommandTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use App\Models\Transaction;
+use App\Models\User;
+
+use function Pest\Laravel\artisan;
+
+test('reformats already-imported descriptions that still carry the remittance tag', function () {
+    $transaction = Transaction::factory()->create([
+        'description' => '/TXT/D|BAR CONO',
+        'original_description' => null,
+    ]);
+
+    artisan('banking:backfill-descriptions')
+        ->expectsOutputToContain('1 transaction(s) reformatted.')
+        ->assertSuccessful();
+
+    $transaction->refresh();
+
+    expect($transaction->description)->toBe('BAR CONO');
+    expect($transaction->original_description)->toBe('/TXT/D|BAR CONO');
+});
+
+test('leaves untagged descriptions alone', function () {
+    $transaction = Transaction::factory()->create([
+        'description' => 'Cafe de la Plaza',
+        'original_description' => null,
+    ]);
+
+    artisan('banking:backfill-descriptions')->assertSuccessful();
+
+    expect($transaction->refresh()->description)->toBe('Cafe de la Plaza');
+});
+
+test('keeps an original description that was already stored', function () {
+    $transaction = Transaction::factory()->create([
+        'description' => '/TXT/D|BAR CONO',
+        'original_description' => 'SOMETHING THE USER RENAMED FROM',
+    ]);
+
+    artisan('banking:backfill-descriptions')->assertSuccessful();
+
+    expect($transaction->refresh()->original_description)->toBe('SOMETHING THE USER RENAMED FROM');
+});
+
+test('does not save anything on a dry run', function () {
+    $transaction = Transaction::factory()->create(['description' => '/TXT/D|BAR CONO']);
+
+    artisan('banking:backfill-descriptions', ['--dry-run' => true])
+        ->expectsOutputToContain('1 transaction(s) would be reformatted.')
+        ->assertSuccessful();
+
+    expect($transaction->refresh()->description)->toBe('/TXT/D|BAR CONO');
+});
+
+test('only touches the given user when one is provided', function () {
+    $user = User::factory()->create();
+    $mine = Transaction::factory()->for($user)->create(['description' => '/TXT/D|BAR CONO']);
+    $theirs = Transaction::factory()->create(['description' => '/TXT/D|BAR CONO']);
+
+    artisan('banking:backfill-descriptions', ['--user' => $user->email])->assertSuccessful();
+
+    expect($mine->refresh()->description)->toBe('BAR CONO');
+    expect($theirs->refresh()->description)->toBe('/TXT/D|BAR CONO');
+});
+
+test('fails when the given user does not exist', function () {
+    artisan('banking:backfill-descriptions', ['--user' => 'nobody@example.com'])
+        ->expectsOutputToContain("User with email 'nobody@example.com' not found.")
+        ->assertFailed();
+});

--- a/tests/Unit/Services/Banking/Formatters/BbvaFormatterTest.php
+++ b/tests/Unit/Services/Banking/Formatters/BbvaFormatterTest.php
@@ -7,14 +7,15 @@ beforeEach(function () {
 });
 
 test('matches BBVA bank name case-insensitively', function () {
-    expect($this->formatter->matches('BBVA'))->toBeTrue();
-    expect($this->formatter->matches('bbva'))->toBeTrue();
-    expect($this->formatter->matches('Bbva'))->toBeTrue();
+    expect($this->formatter->matches('ADEUDO', 'BBVA'))->toBeTrue();
+    expect($this->formatter->matches('ADEUDO', 'bbva'))->toBeTrue();
+    expect($this->formatter->matches('ADEUDO', 'Bbva'))->toBeTrue();
 });
 
 test('does not match other banks', function () {
-    expect($this->formatter->matches('ING'))->toBeFalse();
-    expect($this->formatter->matches('Santander'))->toBeFalse();
+    expect($this->formatter->matches('ADEUDO', 'ING'))->toBeFalse();
+    expect($this->formatter->matches('ADEUDO', 'Santander'))->toBeFalse();
+    expect($this->formatter->matches('ADEUDO', null))->toBeFalse();
 });
 
 test('formats ALL CAPS description with // separators to Title Case', function () {

--- a/tests/Unit/Services/Banking/Formatters/RemittanceTagFormatterTest.php
+++ b/tests/Unit/Services/Banking/Formatters/RemittanceTagFormatterTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Services\Banking\Formatters\RemittanceTagFormatter;
+
+beforeEach(function () {
+    $this->formatter = new RemittanceTagFormatter;
+});
+
+test('matches any bank whose description carries the remittance tag', function () {
+    expect($this->formatter->matches('/TXT/D|BAR CONO', 'Bankinter'))->toBeTrue();
+    expect($this->formatter->matches('/TXT/Amazon.es MP', 'Unicaja Banco'))->toBeTrue();
+    expect($this->formatter->matches('/TXT/BAR CONO', null))->toBeTrue();
+});
+
+test('does not match untagged descriptions', function () {
+    expect($this->formatter->matches('BAR CONO', 'Bankinter'))->toBeFalse();
+    expect($this->formatter->matches('PAGO BIZUM A /TXT/', 'Bankinter'))->toBeFalse();
+});
+
+test('strips the remittance tag and the credit/debit marker', function (string $input, string $expected) {
+    expect($this->formatter->format($input))->toBe($expected);
+})->with([
+    ['/TXT/D|SumUp *GELATERIA SALV', 'SumUp *GELATERIA SALV'],
+    ['/TXT/D|APARCA & GO S.L.', 'APARCA & GO S.L.'],
+    ['/TXT/H|PAGO BIZUM DE VICTORIA MOLLFU', 'PAGO BIZUM DE VICTORIA MOLLFU'],
+    ['/TXT/H|TRANSF NOMI /AIGUA DE RIGAT, S', 'TRANSF NOMI /AIGUA DE RIGAT, S'],
+    ['/TXT/Amazon.es MP', 'Amazon.es MP'],
+]);
+
+test('strips the purchase and settlement dates from card payments', function (string $input, string $expected) {
+    expect($this->formatter->format($input))->toBe($expected);
+})->with([
+    ['/TXT/EL CLANDESTI 27/07/26|20260803', 'EL CLANDESTI'],
+    ['/TXT/CONDIS SANT JUST DESV07/07/26|20260714', 'CONDIS SANT JUST DESV'],
+    ['/TXT/WWW.AMAZON 06/07/26|20260713', 'WWW.AMAZON'],
+]);
+
+test('strips the internal marker on card charges', function () {
+    expect($this->formatter->format('/TXT/D|#RECOBRO RECIBO VISA'))->toBe('RECOBRO RECIBO VISA');
+});
+
+test('collapses the padding banks leave inside the description', function () {
+    expect($this->formatter->format('/TXT/D|PAGO   BIZUM A  MARC ORTEGA  '))->toBe('PAGO BIZUM A MARC ORTEGA');
+});
+
+test('keeps the original description when nothing is left after stripping', function (string $input) {
+    expect($this->formatter->format($input))->toBe($input);
+})->with([
+    ['/TXT/'],
+    ['/TXT/D|'],
+    ['/TXT/ 27/07/26|20260803'],
+]);

--- a/tests/Unit/Services/Banking/Formatters/RemittanceTagFormatterTest.php
+++ b/tests/Unit/Services/Banking/Formatters/RemittanceTagFormatterTest.php
@@ -33,7 +33,13 @@ test('strips the purchase and settlement dates from card payments', function (st
     ['/TXT/EL CLANDESTI 27/07/26|20260803', 'EL CLANDESTI'],
     ['/TXT/CONDIS SANT JUST DESV07/07/26|20260714', 'CONDIS SANT JUST DESV'],
     ['/TXT/WWW.AMAZON 06/07/26|20260713', 'WWW.AMAZON'],
+    ['/TXT/RECIBO MES TARJETA|20260806', 'RECIBO MES TARJETA'],
+    ['/TXT/PROCESO DEL PROGRAMA: SATD066|20260720', 'PROCESO DEL PROGRAMA: SATD066'],
 ]);
+
+test('leaves a pipe that is not a date suffix alone', function () {
+    expect($this->formatter->format('/TXT/D|TRANS INM/ VICTORIA|MOLLFULLEDA'))->toBe('TRANS INM/ VICTORIA|MOLLFULLEDA');
+});
 
 test('strips the internal marker on card charges', function () {
     expect($this->formatter->format('/TXT/D|#RECOBRO RECIBO VISA'))->toBe('RECOBRO RECIBO VISA');

--- a/tests/Unit/Services/Banking/TransactionDescriptionFormatterTest.php
+++ b/tests/Unit/Services/Banking/TransactionDescriptionFormatterTest.php
@@ -20,6 +20,20 @@ test('does not set original_description when formatting produces no change', fun
     expect($result['original_description'])->toBeNull();
 });
 
+test('strips the remittance tag and stores the original, whatever the bank', function () {
+    $result = $this->formatter->format('/TXT/D|BAR CONO', 'Bankinter');
+
+    expect($result['description'])->toBe('BAR CONO');
+    expect($result['original_description'])->toBe('/TXT/D|BAR CONO');
+});
+
+test('strips the remittance tag even when the bank name is unknown', function () {
+    $result = $this->formatter->format('/TXT/D|BAR CONO', null);
+
+    expect($result['description'])->toBe('BAR CONO');
+    expect($result['original_description'])->toBe('/TXT/D|BAR CONO');
+});
+
 test('does not transform description for non-BBVA bank', function () {
     $result = $this->formatter->format('ADEUDO DE ENDESA', 'ING');
 

--- a/tests/Unit/Services/Banking/TransactionDescriptionFormatterTest.php
+++ b/tests/Unit/Services/Banking/TransactionDescriptionFormatterTest.php
@@ -34,6 +34,12 @@ test('strips the remittance tag even when the bank name is unknown', function ()
     expect($result['original_description'])->toBe('/TXT/D|BAR CONO');
 });
 
+test('a tagged description is handled by the remittance formatter, not the bank one', function () {
+    $result = $this->formatter->format('/TXT/D|ADEUDO DE ENDESA', 'BBVA');
+
+    expect($result['description'])->toBe('ADEUDO DE ENDESA');
+});
+
 test('does not transform description for non-BBVA bank', function () {
     $result = $this->formatter->format('ADEUDO DE ENDESA', 'ING');
 


### PR DESCRIPTION
## Why

A support ticket: Bankinter transactions arrive with the raw ISO 20022 remittance tag in front of the text, so AI categorization reads the tag instead of the merchant.

```
/TXT/D|SumUp *GELATERIA SALV
/TXT/H|TRANSF NOMI /AIGUA DE RIGAT, S      ← the payroll that got categorized as Fuel
/TXT/CONDIS SANT JUST DESV07/07/26|20260714
```

`/TXT/` is the unstructured remittance tag, `D|`/`H|` is the debe/haber marker (which only repeats the sign of the amount), and card payments append the purchase and settlement dates. None of it describes the transaction.

In production this hits **7297 transactions across 20 users** — Bankinter (6569) and Unicaja Banco (728), which ships the same shape.

## What

**`RemittanceTagFormatter`** strips the tag, the credit/debit marker, the card dates and the `#` marker on card charges. The tag identifies itself, so the formatter is keyed on the **description** rather than on a bank name — it works for any bank shipping the same shape instead of needing a new class per bank. `BankFormatter::matches()` now takes the description as well; `BbvaFormatter` keeps matching on the bank name.

**`banking:backfill-descriptions`** fixes the rows that are already imported. It also rewrites the automation rules that match on the raw text: **48 user-authored rules across 4 users** contain literals like `/TXT/D|RECIBO VISA CLASICA`, and rewriting descriptions without rewriting those rules would silently stop them from ever matching again. A test pins that a rule still matches its transaction after both are rewritten.

```
banking:backfill-descriptions [--user=email] [--dry-run] [-v]
```

## QA

Ran the formatter over **all 2755 distinct tagged descriptions in production**: 0 no-ops, 0 leftover tags/dates/markers, 0 degenerate output.

Ran the command against a database seeded with production-shaped rows and rules:

```
===== DRY RUN (-v) =====
DRY RUN — no changes will be saved.
  /TXT/D|SumUp *GELATERIA SALV            →  SumUp *GELATERIA SALV
  /TXT/H|TRANSF NOMI /AIGUA DE RIGAT, S   →  TRANSF NOMI /AIGUA DE RIGAT, S
  /TXT/EL CLANDESTI 27/07/26|20260803     →  EL CLANDESTI
  /TXT/CONDIS SANT JUST DESV07/07/26|20260714  →  CONDIS SANT JUST DESV
  /TXT/RECIBO MES TARJETA|20260806        →  RECIBO MES TARJETA
  /TXT/D|#RECOBRO RECIBO VISA             →  RECOBRO RECIBO VISA
  /TXT/OPENAI *CHATGPT SUBSCR MP          →  OPENAI *CHATGPT SUBSCR MP
  rule …080: {"in":["RECIBO VISA CLASICA",{"var":"description"}]}
8 transaction(s) and 2 automation rule(s) would be reformatted.

===== SECOND RUN =====
0 transaction(s) and 0 automation rule(s) reformatted.     ← idempotent
```

The raw text is kept in `original_description`; an already-stored original is never overwritten; untagged descriptions and rules are left alone; transactions the server cannot read (`description_iv`) are skipped.

## Not in this PR

**Already-categorized transactions keep their category.** The backfill fixes the text, not the past AI decisions — 4005 of the affected rows already have a category (1024 of them AI-sourced), and `ai:categorize-backfill` only picks up uncategorized ones. Rule-categorized rows are unaffected because the rules are migrated. If we want the AI ones re-run, that's a separate deliberate step: clear `category_source = 'ai'` on the affected rows, then run the existing backfill command.

## Rollout

```bash
php artisan banking:backfill-descriptions --dry-run -v     # inspect
php artisan banking:backfill-descriptions                  # apply
```
