### PR TITLE
fix(open-banking): unblock account mapping when the bank reports accounts without a uid

### DIFF
--- a/app/Http/Controllers/OpenBanking/AccountMappingController.php
+++ b/app/Http/Controllers/OpenBanking/AccountMappingController.php
@@ -42,6 +42,18 @@ class AccountMappingController extends Controller
                 ->with('success', 'Bank account connected successfully.');
         }
 
+        $mappableAccounts = $connection->mappablePendingAccounts();
+
+        // Nothing the bank gave us can be mapped, so there is no decision left for the
+        // user to make. Close the connection instead of leaving it awaiting a mapping
+        // that can never happen.
+        if ($mappableAccounts === []) {
+            $this->createAccountsFromPending($user, $connection, $accountUserCurrencyService);
+
+            return redirect()->route('settings.connections.index')
+                ->with('error', __('Your bank did not provide an identifier for any of its accounts, so they cannot be synced.'));
+        }
+
         $existingAccounts = $user
             ->accounts()
             ->whereNull('banking_connection_id')
@@ -50,8 +62,9 @@ class AccountMappingController extends Controller
 
         return Inertia::render('open-banking/map-accounts', [
             'connection' => $connection,
-            'bankAccounts' => $connection->mappablePendingAccounts(),
+            'bankAccounts' => $mappableAccounts,
             'existingAccounts' => $existingAccounts,
+            'unmappableAccountNames' => $connection->unmappablePendingAccountNames(),
         ]);
     }
 

--- a/app/Http/Controllers/OpenBanking/AccountMappingController.php
+++ b/app/Http/Controllers/OpenBanking/AccountMappingController.php
@@ -50,7 +50,7 @@ class AccountMappingController extends Controller
 
         return Inertia::render('open-banking/map-accounts', [
             'connection' => $connection,
-            'bankAccounts' => $connection->pending_accounts_data,
+            'bankAccounts' => $connection->mappablePendingAccounts(),
             'existingAccounts' => $existingAccounts,
         ]);
     }

--- a/app/Http/Controllers/OpenBanking/Concerns/CreatesAccountsFromPending.php
+++ b/app/Http/Controllers/OpenBanking/Concerns/CreatesAccountsFromPending.php
@@ -30,12 +30,8 @@ trait CreatesAccountsFromPending
 
         $accountType = $connection->provider->defaultAccountType();
 
-        foreach ($connection->pending_accounts_data ?? [] as $accountData) {
-            $uid = $accountData['uid'] ?? null;
-
-            if (! $uid) {
-                continue;
-            }
+        foreach ($connection->mappablePendingAccounts() as $accountData) {
+            $uid = $accountData['uid'];
 
             $currency = $accountUserCurrencyService->resolveImportedCurrency($accountData['currency'] ?? null, $user);
             $name = $accountData['name']

--- a/app/Http/Requests/OpenBanking/MapAccountsRequest.php
+++ b/app/Http/Requests/OpenBanking/MapAccountsRequest.php
@@ -31,4 +31,17 @@ class MapAccountsRequest extends FormRequest
             ],
         ];
     }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'mappings.required' => 'There are no accounts to map.',
+            'mappings.min' => 'There are no accounts to map.',
+            'mappings.*.bank_account_uid.required' => 'This account cannot be mapped because your bank did not provide an identifier for it.',
+            'mappings.*.existing_account_id.required_if' => 'Choose the account you want to link to.',
+        ];
+    }
 }

--- a/app/Http/Requests/Settings/StoreAutomationRuleRequest.php
+++ b/app/Http/Requests/Settings/StoreAutomationRuleRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Settings;
 
 use App\Http\Requests\Concerns\ValidatesUserOwnedResources;
+use App\Models\AutomationRule;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -26,7 +27,7 @@ class StoreAutomationRuleRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'title' => ['required', 'string', 'max:255'],
+            'title' => ['required', 'string', 'max:'.AutomationRule::MAX_TITLE_LENGTH],
             'priority' => ['required', 'integer', 'min:0'],
             'rules_json' => ['required', 'json', function ($attribute, $value, $fail) {
                 $decoded = json_decode($value, true);

--- a/app/Models/AutomationRule.php
+++ b/app/Models/AutomationRule.php
@@ -6,6 +6,7 @@ use App\Enums\RuleOrigin;
 use App\Models\Concerns\BelongsToSpace;
 use Database\Factories\AutomationRuleFactory;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -21,6 +22,8 @@ class AutomationRule extends Model
 {
     /** @use HasFactory<AutomationRuleFactory> */
     use BelongsToSpace, HasFactory, HasUuids, SoftDeletes;
+
+    public const MAX_TITLE_LENGTH = 255;
 
     protected $fillable = [
         'user_id',
@@ -46,6 +49,22 @@ class AutomationRule extends Model
             'priority' => 'integer',
             'origin' => RuleOrigin::class,
         ];
+    }
+
+    /**
+     * Generated titles are assembled from bank-supplied merchant names and AI
+     * tokens, neither of which the column bounds. Truncating here is the one
+     * place that covers every generator, so an oversized title can never abort
+     * the action that produced it. User-authored titles never reach this: the
+     * form request rejects anything over the same limit with a 422.
+     *
+     * @return Attribute<never, string|null>
+     */
+    protected function title(): Attribute
+    {
+        return Attribute::set(
+            fn (?string $value): ?string => $value === null ? null : mb_substr($value, 0, self::MAX_TITLE_LENGTH),
+        );
     }
 
     /**

--- a/app/Models/AutomationRule.php
+++ b/app/Models/AutomationRule.php
@@ -6,7 +6,6 @@ use App\Enums\RuleOrigin;
 use App\Models\Concerns\BelongsToSpace;
 use Database\Factories\AutomationRuleFactory;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -57,14 +56,12 @@ class AutomationRule extends Model
      * place that covers every generator, so an oversized title can never abort
      * the action that produced it. User-authored titles never reach this: the
      * form request rejects anything over the same limit with a 422.
-     *
-     * @return Attribute<never, string|null>
      */
-    protected function title(): Attribute
+    public function setTitleAttribute(?string $value): void
     {
-        return Attribute::set(
-            fn (?string $value): ?string => $value === null ? null : mb_substr($value, 0, self::MAX_TITLE_LENGTH),
-        );
+        $this->attributes['title'] = $value === null
+            ? null
+            : mb_substr($value, 0, self::MAX_TITLE_LENGTH);
     }
 
     /**

--- a/app/Models/BankingConnection.php
+++ b/app/Models/BankingConnection.php
@@ -24,7 +24,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property Carbon|null $bank_transactions_email_cutoff_at
  * @property Carbon|null $rate_limited_until
  * @property int $consecutive_sync_failures
- * @property array<int, mixed>|null $pending_accounts_data
+ * @property array<int, array<string, mixed>>|null $pending_accounts_data
  */
 class BankingConnection extends Model
 {
@@ -164,6 +164,23 @@ class BankingConnection extends Model
         return array_values(array_filter(
             $this->pending_accounts_data ?? [],
             fn (array $account): bool => ! empty($account['uid']),
+        ));
+    }
+
+    /**
+     * Names of the pending accounts left out of the mapping screen, so the user is told
+     * why an account they can see in their bank never shows up here.
+     *
+     * @return array<int, string>
+     */
+    public function unmappablePendingAccountNames(): array
+    {
+        return array_values(array_map(
+            fn (array $account): string => $account['name'] ?? $account['account_id']['iban'] ?? __('Bank Account'),
+            array_filter(
+                $this->pending_accounts_data ?? [],
+                fn (array $account): bool => empty($account['uid']),
+            ),
         ));
     }
 

--- a/app/Models/BankingConnection.php
+++ b/app/Models/BankingConnection.php
@@ -152,6 +152,21 @@ class BankingConnection extends Model
         return ! empty($this->pending_accounts_data);
     }
 
+    /**
+     * Pending accounts the user can actually map. Providers sometimes report accounts
+     * without a uid (EnableBanking does it for some French cards); those can never be
+     * synced, so offering them for mapping only produces a validation error.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function mappablePendingAccounts(): array
+    {
+        return array_values(array_filter(
+            $this->pending_accounts_data ?? [],
+            fn (array $account): bool => ! empty($account['uid']),
+        ));
+    }
+
     public function isExpired(): bool
     {
         return $this->status === BankingConnectionStatus::Expired

--- a/app/Services/Ai/AiRuleLearner.php
+++ b/app/Services/Ai/AiRuleLearner.php
@@ -37,6 +37,17 @@ class AiRuleLearner
     private const MIN_SOLE_TOKEN_LENGTH = 5;
 
     /**
+     * Rule titles are built from bank-supplied merchant names, and some banks
+     * stuff the whole statement line (dates, amounts, running balance) into
+     * them. Cap each token so the "→ Category" tail stays readable, and the
+     * whole title so it can never overflow the varchar(255) column — an
+     * oversized title used to abort the user's category change with a 500.
+     */
+    private const MAX_TOKEN_LABEL_LENGTH = 40;
+
+    private const MAX_TITLE_LENGTH = 255;
+
+    /**
      * Per-user document-frequency corpus, memoized for the lifetime of this
      * instance. A bulk correction runs learnFromCorrection once per transaction
      * for the same user, and the description corpus is immutable while only
@@ -513,16 +524,28 @@ class AiRuleLearner
         $categoryName = Category::query()->whereKey($categoryId)->value('name') ?? '';
 
         if ($tokens === []) {
-            return trim($categoryName.' (AI)');
+            return $this->fit(trim($categoryName.' (AI)'));
         }
 
-        $label = implode(', ', array_map(fn (string $token): string => Str::title($token), array_slice($tokens, 0, 3)));
+        $label = implode(', ', array_map(
+            fn (string $token): string => Str::limit(Str::title($token), self::MAX_TOKEN_LABEL_LENGTH),
+            array_slice($tokens, 0, 3),
+        ));
 
         if (count($tokens) > 3) {
             $label .= '…';
         }
 
-        return trim($label.' → '.$categoryName);
+        return $this->fit(trim($label.' → '.$categoryName));
+    }
+
+    /**
+     * Keep a generated title within the column, whatever the merchant and
+     * category names hold.
+     */
+    private function fit(string $title): string
+    {
+        return Str::limit($title, self::MAX_TITLE_LENGTH, '');
     }
 
     private function normalize(string $value): string

--- a/app/Services/Ai/AiRuleLearner.php
+++ b/app/Services/Ai/AiRuleLearner.php
@@ -39,13 +39,13 @@ class AiRuleLearner
     /**
      * Rule titles are built from bank-supplied merchant names, and some banks
      * stuff the whole statement line (dates, amounts, running balance) into
-     * them. Cap each token so the "→ Category" tail stays readable, and the
-     * whole title so it can never overflow the varchar(255) column — an
-     * oversized title used to abort the user's category change with a 500.
+     * them. Cap each part so the whole "Merchant, Merchant → Category" title
+     * stays readable and well inside the column, rather than being cut off at
+     * the end by the model's truncation backstop.
      */
     private const MAX_TOKEN_LABEL_LENGTH = 40;
 
-    private const MAX_TITLE_LENGTH = 255;
+    private const MAX_CATEGORY_LABEL_LENGTH = 60;
 
     /**
      * Per-user document-frequency corpus, memoized for the lifetime of this
@@ -521,14 +521,18 @@ class AiRuleLearner
      */
     private function title(string $categoryId, array $tokens): string
     {
-        $categoryName = Category::query()->whereKey($categoryId)->value('name') ?? '';
+        $categoryName = Str::limit(
+            Category::query()->whereKey($categoryId)->value('name') ?? '',
+            self::MAX_CATEGORY_LABEL_LENGTH,
+            '…',
+        );
 
         if ($tokens === []) {
-            return $this->fit(trim($categoryName.' (AI)'));
+            return trim($categoryName.' (AI)');
         }
 
         $label = implode(', ', array_map(
-            fn (string $token): string => Str::limit(Str::title($token), self::MAX_TOKEN_LABEL_LENGTH),
+            fn (string $token): string => Str::limit(Str::title($token), self::MAX_TOKEN_LABEL_LENGTH, '…'),
             array_slice($tokens, 0, 3),
         ));
 
@@ -536,16 +540,7 @@ class AiRuleLearner
             $label .= '…';
         }
 
-        return $this->fit(trim($label.' → '.$categoryName));
-    }
-
-    /**
-     * Keep a generated title within the column, whatever the merchant and
-     * category names hold.
-     */
-    private function fit(string $title): string
-    {
-        return Str::limit($title, self::MAX_TITLE_LENGTH, '');
+        return trim($label.' → '.$categoryName);
     }
 
     private function normalize(string $value): string

--- a/app/Services/Ai/CategoryOverrideHandler.php
+++ b/app/Services/Ai/CategoryOverrideHandler.php
@@ -7,6 +7,7 @@ use App\Enums\RuleOrigin;
 use App\Models\AutomationRule;
 use App\Models\CategoryCorrection;
 use App\Models\Transaction;
+use Throwable;
 
 /**
  * Runs when a user overrides a transaction's category. If the category being
@@ -44,6 +45,20 @@ class CategoryOverrideHandler
             return null;
         }
 
+        try {
+            return $this->learn($transaction, $newCategoryId, $aiDriven);
+        } catch (Throwable $e) {
+            // Learning is a side-effect of the correction, never the point of it.
+            // A failure here must not abort the category change the user asked
+            // for — nor, in a bulk correction, every transaction after it.
+            report($e);
+
+            return null;
+        }
+    }
+
+    private function learn(Transaction $transaction, ?string $newCategoryId, bool $aiDriven): ?AutomationRule
+    {
         // The correction signal calibrates AI accuracy, so only AI assignments
         // are logged — a correction rule overruling itself is not an AI miss.
         if ($aiDriven) {

--- a/lang/es.json
+++ b/lang/es.json
@@ -1150,7 +1150,7 @@
     "No balance records found.": "No se encontraron registros de balance.",
     "No bank connections yet. Connect a bank to automatically sync your transactions.": "Aún no hay conexiones bancarias. Conecta un banco para sincronizar automáticamente tus transacciones.",
     "No bank found.": "No se encontró ningún banco.",
-    "Not shown: :accounts. Your bank did not provide an identifier for them, so they cannot be synced.": "No se muestran: :accounts. Tu banco no proporcionó un identificador para ellas, así que no se pueden sincronizar.",
+    "Not shown: :accounts. Your bank did not provide an identifier, so syncing is not possible.": "No se muestran: :accounts. Tu banco no proporcionó un identificador, así que no es posible sincronizarlas.",
     "Your bank did not provide an identifier for any of its accounts, so they cannot be synced.": "Tu banco no proporcionó un identificador para ninguna de sus cuentas, así que no se pueden sincronizar.",
     "No banks found.": "No se encontraron bancos.",
     "No cashflow data for this period": "Sin datos de flujo de dinero para este período",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1150,6 +1150,8 @@
     "No balance records found.": "No se encontraron registros de balance.",
     "No bank connections yet. Connect a bank to automatically sync your transactions.": "Aún no hay conexiones bancarias. Conecta un banco para sincronizar automáticamente tus transacciones.",
     "No bank found.": "No se encontró ningún banco.",
+    "Not shown: :accounts. Your bank did not provide an identifier for them, so they cannot be synced.": "No se muestran: :accounts. Tu banco no proporcionó un identificador para ellas, así que no se pueden sincronizar.",
+    "Your bank did not provide an identifier for any of its accounts, so they cannot be synced.": "Tu banco no proporcionó un identificador para ninguna de sus cuentas, así que no se pueden sincronizar.",
     "No banks found.": "No se encontraron bancos.",
     "No cashflow data for this period": "Sin datos de flujo de dinero para este período",
     "No categories found.": "No se encontraron categorías.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1111,6 +1111,8 @@
     "No balance records found.": "Aucun enregistrement de solde trouvé.",
     "No bank connections yet. Connect a bank to automatically sync your transactions.": "Il n'y a pas encore de connexions bancaires. Connectez une banque pour synchroniser automatiquement vos transactions.",
     "No bank found.": "Aucun banc n'a été trouvé.",
+    "Not shown: :accounts. Your bank did not provide an identifier for them, so they cannot be synced.": "Non affichés : :accounts. Votre banque n'a pas fourni d'identifiant pour ces comptes, ils ne peuvent donc pas être synchronisés.",
+    "Your bank did not provide an identifier for any of its accounts, so they cannot be synced.": "Votre banque n'a fourni d'identifiant pour aucun de ses comptes, ils ne peuvent donc pas être synchronisés.",
     "No banks found.": "Aucun banc n'a été trouvé.",
     "No cashflow data for this period": "Aucune donnée sur les flux monétaires pour cette période",
     "No categories found.": "Aucune catégorie trouvée.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1111,7 +1111,7 @@
     "No balance records found.": "Aucun enregistrement de solde trouvé.",
     "No bank connections yet. Connect a bank to automatically sync your transactions.": "Il n'y a pas encore de connexions bancaires. Connectez une banque pour synchroniser automatiquement vos transactions.",
     "No bank found.": "Aucun banc n'a été trouvé.",
-    "Not shown: :accounts. Your bank did not provide an identifier for them, so they cannot be synced.": "Non affichés : :accounts. Votre banque n'a pas fourni d'identifiant pour ces comptes, ils ne peuvent donc pas être synchronisés.",
+    "Not shown: :accounts. Your bank did not provide an identifier, so syncing is not possible.": "Non affichés : :accounts. Votre banque n'a pas fourni d'identifiant, la synchronisation est donc impossible.",
     "Your bank did not provide an identifier for any of its accounts, so they cannot be synced.": "Votre banque n'a fourni d'identifiant pour aucun de ses comptes, ils ne peuvent donc pas être synchronisés.",
     "No banks found.": "Aucun banc n'a été trouvé.",
     "No cashflow data for this period": "Aucune donnée sur les flux monétaires pour cette période",

--- a/resources/js/pages/open-banking/map-accounts.tsx
+++ b/resources/js/pages/open-banking/map-accounts.tsx
@@ -21,6 +21,10 @@ import type { BankingConnection, PendingBankAccount } from '@/types/banking';
 import { __ } from '@/utils/i18n';
 import { Head, Link, router } from '@inertiajs/react';
 import { useState } from 'react';
+import { toast } from 'sonner';
+
+/** ISO 4217 code for "no currency" — some providers report it instead of a real one. */
+const NO_CURRENCY = 'XXX';
 
 interface Mapping {
     bank_account_uid: string;
@@ -56,7 +60,11 @@ export default function MapAccountsPage({
         );
     }
 
-    function getCompatibleAccounts(currency: string) {
+    function getCompatibleAccounts(currency: string | null) {
+        if (!currency) {
+            return existingAccounts;
+        }
+
         return existingAccounts.filter((a) => a.currency_code === currency);
     }
 
@@ -67,6 +75,11 @@ export default function MapAccountsPage({
             `/open-banking/connections/${connection.id}/map-accounts`,
             { mappings },
             {
+                onError: (errors) => {
+                    toast.error(
+                        Object.values(errors)[0] ?? __('Something went wrong.'),
+                    );
+                },
                 onFinish: () => setProcessing(false),
             },
         );
@@ -94,13 +107,22 @@ export default function MapAccountsPage({
                         const mapping = mappings.find(
                             (m) => m.bank_account_uid === bankAccount.uid,
                         );
-                        const compatibleAccounts = getCompatibleAccounts(
-                            bankAccount.currency,
-                        );
+                        const currency =
+                            bankAccount.currency === NO_CURRENCY
+                                ? null
+                                : bankAccount.currency;
+                        const compatibleAccounts =
+                            getCompatibleAccounts(currency);
                         const displayName =
                             bankAccount.name ||
                             bankAccount.account_id?.iban ||
                             __('Bank Account');
+                        const details = [
+                            currency,
+                            bankAccount.name
+                                ? bankAccount.account_id?.iban
+                                : null,
+                        ].filter(Boolean);
 
                         return (
                             <Card key={bankAccount.uid}>
@@ -109,10 +131,7 @@ export default function MapAccountsPage({
                                         {displayName}
                                     </CardTitle>
                                     <CardDescription>
-                                        {bankAccount.currency}
-                                        {bankAccount.account_id?.iban &&
-                                            bankAccount.name &&
-                                            ` \u00b7 ${bankAccount.account_id.iban}`}
+                                        {details.join(' \u00b7 ')}
                                     </CardDescription>
                                 </CardHeader>
                                 <CardContent>

--- a/resources/js/pages/open-banking/map-accounts.tsx
+++ b/resources/js/pages/open-banking/map-accounts.tsx
@@ -273,7 +273,7 @@ export default function MapAccountsPage({
                     {unmappableAccountNames.length > 0 && (
                         <p className="text-sm text-muted-foreground">
                             {__(
-                                'Not shown: :accounts. Your bank did not provide an identifier for them, so they cannot be synced.',
+                                'Not shown: :accounts. Your bank did not provide an identifier, so syncing is not possible.',
                                 { accounts: unmappableAccountNames.join(', ') },
                             )}
                         </p>

--- a/resources/js/pages/open-banking/map-accounts.tsx
+++ b/resources/js/pages/open-banking/map-accounts.tsx
@@ -23,8 +23,15 @@ import { Head, Link, router } from '@inertiajs/react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
-/** ISO 4217 code for "no currency" — some providers report it instead of a real one. */
-const NO_CURRENCY = 'XXX';
+/**
+ * Banks don't always report a usable currency: EnableBanking sends XXX, the ISO 4217
+ * code for "no currency". Treat that as unknown rather than as a real code.
+ */
+function usableCurrency(reported: string | null | undefined): string | null {
+    const currency = (reported ?? '').trim().toUpperCase();
+
+    return currency === '' || currency === 'XXX' ? null : currency;
+}
 
 interface Mapping {
     bank_account_uid: string;
@@ -36,12 +43,14 @@ interface Props {
     connection: BankingConnection;
     bankAccounts: PendingBankAccount[];
     existingAccounts: Account[];
+    unmappableAccountNames: string[];
 }
 
 export default function MapAccountsPage({
     connection,
     bankAccounts,
     existingAccounts,
+    unmappableAccountNames,
 }: Props) {
     const [mappings, setMappings] = useState<Mapping[]>(
         bankAccounts.map((ba) => ({
@@ -60,7 +69,8 @@ export default function MapAccountsPage({
         );
     }
 
-    function getCompatibleAccounts(currency: string | null) {
+    /** With no currency reported there is nothing to match on, so anything is linkable. */
+    function getLinkableAccounts(currency: string | null) {
         if (!currency) {
             return existingAccounts;
         }
@@ -107,21 +117,16 @@ export default function MapAccountsPage({
                         const mapping = mappings.find(
                             (m) => m.bank_account_uid === bankAccount.uid,
                         );
-                        const currency =
-                            bankAccount.currency === NO_CURRENCY
-                                ? null
-                                : bankAccount.currency;
+                        const currency = usableCurrency(bankAccount.currency);
                         const compatibleAccounts =
-                            getCompatibleAccounts(currency);
+                            getLinkableAccounts(currency);
+                        const iban = bankAccount.account_id?.iban;
                         const displayName =
-                            bankAccount.name ||
-                            bankAccount.account_id?.iban ||
-                            __('Bank Account');
+                            bankAccount.name || iban || __('Bank Account');
                         const details = [
                             currency,
-                            bankAccount.name
-                                ? bankAccount.account_id?.iban
-                                : null,
+                            // Don't repeat the IBAN when it is already the title.
+                            displayName === iban ? null : iban,
                         ].filter(Boolean);
 
                         return (
@@ -130,9 +135,11 @@ export default function MapAccountsPage({
                                     <CardTitle className="text-base">
                                         {displayName}
                                     </CardTitle>
-                                    <CardDescription>
-                                        {details.join(' \u00b7 ')}
-                                    </CardDescription>
+                                    {details.length > 0 && (
+                                        <CardDescription>
+                                            {details.join(' \u00b7 ')}
+                                        </CardDescription>
+                                    )}
                                 </CardHeader>
                                 <CardContent>
                                     <RadioGroup
@@ -262,6 +269,15 @@ export default function MapAccountsPage({
                             </Card>
                         );
                     })}
+
+                    {unmappableAccountNames.length > 0 && (
+                        <p className="text-sm text-muted-foreground">
+                            {__(
+                                'Not shown: :accounts. Your bank did not provide an identifier for them, so they cannot be synced.',
+                                { accounts: unmappableAccountNames.join(', ') },
+                            )}
+                        </p>
+                    )}
 
                     <div className="flex items-center justify-end gap-3">
                         <Link href="/settings/connections">

--- a/tests/Feature/Ai/AiRuleLearnerTest.php
+++ b/tests/Feature/Ai/AiRuleLearnerTest.php
@@ -288,8 +288,11 @@ it('keeps the generated title within the column when the bank stuffs the stateme
         );
     }
 
+    // Each merchant is shortened enough that the whole title stays well inside
+    // the column and the "→ Category" tail survives.
     expect($rule)->not->toBeNull()
-        ->and(mb_strlen($rule->refresh()->title))->toBeLessThanOrEqual(255)
+        ->and(mb_strlen($rule->refresh()->title))->toBeLessThan(AutomationRule::MAX_TITLE_LENGTH)
         ->and($rule->title)->toContain($target->name)
+        ->and($rule->title)->toStartWith('15/06 12/06 Pago Con Tarjeta En Discos,…, ')
         ->and($rule->rules_json['or'])->toHaveCount(2);
 });

--- a/tests/Feature/Ai/AiRuleLearnerTest.php
+++ b/tests/Feature/Ai/AiRuleLearnerTest.php
@@ -257,3 +257,39 @@ it('never reuses a user-owned rule, even for the same category', function () {
     expect($aiRule->id)->not->toBe($userRule->id)
         ->and($aiRule->origin)->toBe(RuleOrigin::Ai);
 });
+
+it('keeps the generated title within the column when the bank stuffs the statement line into the merchant name', function () {
+    $user = User::factory()->create();
+    $target = Category::factory()->for($user)->create([
+        'name' => 'Hobbies y otras actividades de ocio',
+        'type' => CategoryType::Expense,
+        'cashflow_direction' => CategoryCashflowDirection::Outflow,
+    ]);
+    $existing = expenseCategory($user);
+
+    // Real payload from PHP-LARAVEL-53: the bank sends the whole statement line
+    // (dates, concept, amount, running balance, card number) as the merchant, so
+    // two corrections alone already overflow the title column.
+    $statementLines = [
+        "15/06 12/06 Pago Con Tarjeta En Discos, Libros, Fotos Y Pc's -59,00 189,27 | 4940197152806468 Classpass* Monthly",
+        '01/06 31/05 Pago Con Tarjeta En Restaurantes Y Cafeterias -9,00 1.819,59 | 4940197152806468 Dirty Castelldefels Castelldefelses',
+    ];
+    $learner = app(AiRuleLearner::class);
+    $rule = null;
+
+    foreach ($statementLines as $statementLine) {
+        $rule = $learner->learnFromCorrection(
+            Transaction::factory()->plaintext()->create([
+                'user_id' => $user->id,
+                'category_id' => $existing->id,
+                'creditor_name' => $statementLine,
+            ]),
+            $target->id,
+        );
+    }
+
+    expect($rule)->not->toBeNull()
+        ->and(mb_strlen($rule->refresh()->title))->toBeLessThanOrEqual(255)
+        ->and($rule->title)->toContain($target->name)
+        ->and($rule->rules_json['or'])->toHaveCount(2);
+});

--- a/tests/Feature/Ai/CategoryOverrideHandlerTest.php
+++ b/tests/Feature/Ai/CategoryOverrideHandlerTest.php
@@ -13,6 +13,7 @@ use App\Services\Ai\AiRuleLearner;
 use App\Services\Ai\CategorizationOutcome;
 use App\Services\Ai\CategoryOverrideHandler;
 use App\Services\AutomationRuleService;
+use Illuminate\Support\Facades\Exceptions;
 
 function cohCategory(User $user): Category
 {
@@ -379,4 +380,22 @@ it('learns nothing from an encrypted-description transaction without a merchant'
 
     expect($learned)->toBeNull()
         ->and(AutomationRule::query()->origin(RuleOrigin::Correction)->count())->toBe(0);
+});
+
+it('still applies the correction when learning blows up', function () {
+    $user = User::factory()->create();
+    $target = cohCategory($user);
+    $transaction = cohMerchantTxn($user, 'Mercadona');
+    $transaction->update(['category_source' => CategorySource::Ai]);
+
+    $this->mock(AiRuleLearner::class)
+        ->shouldReceive('forgetFromAiRules')
+        ->andThrow(new RuntimeException('learning exploded'));
+
+    Exceptions::fake();
+
+    $rule = app(CategoryOverrideHandler::class)->record($transaction, $target->id);
+
+    Exceptions::assertReported(RuntimeException::class);
+    expect($rule)->toBeNull();
 });

--- a/tests/Feature/AutomationRuleTest.php
+++ b/tests/Feature/AutomationRuleTest.php
@@ -453,3 +453,12 @@ test('automation rules serialize full nested category and labels', function () {
     expect(array_keys($serialized['labels'][0]))
         ->toEqualCanonicalizing(['id', 'user_id', 'name', 'color', 'created_at', 'updated_at', 'deleted_at']);
 });
+
+test('a generated title is truncated to fit the column instead of failing the write', function () {
+    $rule = AutomationRule::factory()->create([
+        'user_id' => User::factory()->create()->id,
+        'title' => str_repeat('a', AutomationRule::MAX_TITLE_LENGTH + 50),
+    ]);
+
+    expect(mb_strlen($rule->refresh()->title))->toBe(AutomationRule::MAX_TITLE_LENGTH);
+});

--- a/tests/Feature/OpenBanking/AccountMappingTest.php
+++ b/tests/Feature/OpenBanking/AccountMappingTest.php
@@ -61,7 +61,37 @@ test('show hides pending accounts the provider reported without a uid', function
             ->component('open-banking/map-accounts')
             ->has('bankAccounts', 1)
             ->where('bankAccounts.0.uid', 'ext-1')
+            ->where('unmappableAccountNames', ['CB Visa'])
         );
+});
+
+test('show closes the connection when no pending account can be mapped', function () {
+    Queue::fake();
+
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->awaitingMapping()->create([
+        'user_id' => $user->id,
+        'pending_accounts_data' => [
+            [
+                'uid' => null,
+                'currency' => 'XXX',
+                'name' => 'CB Visa',
+                'account_id' => ['iban' => null],
+            ],
+        ],
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('open-banking.map-accounts', $connection))
+        ->assertRedirect(route('settings.connections.index'));
+
+    $connection->refresh();
+    expect($connection->status)->toBe(BankingConnectionStatus::Active);
+    expect($connection->pending_accounts_data)->toBeNull();
+
+    $this->assertDatabaseMissing('accounts', [
+        'banking_connection_id' => $connection->id,
+    ]);
 });
 
 test('show redirects if no pending accounts', function () {

--- a/tests/Feature/OpenBanking/AccountMappingTest.php
+++ b/tests/Feature/OpenBanking/AccountMappingTest.php
@@ -34,6 +34,36 @@ test('show returns mapping page with correct props', function () {
     );
 });
 
+test('show hides pending accounts the provider reported without a uid', function () {
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->awaitingMapping()->create([
+        'user_id' => $user->id,
+        'pending_accounts_data' => [
+            [
+                'uid' => 'ext-1',
+                'currency' => 'EUR',
+                'name' => 'Compte Bancaire',
+                'account_id' => ['iban' => 'FR1234567890'],
+            ],
+            [
+                'uid' => null,
+                'currency' => 'XXX',
+                'name' => 'CB Visa',
+                'account_id' => ['iban' => null],
+            ],
+        ],
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('open-banking.map-accounts', $connection))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('open-banking/map-accounts')
+            ->has('bankAccounts', 1)
+            ->where('bankAccounts.0.uid', 'ext-1')
+        );
+});
+
 test('show redirects if no pending accounts', function () {
     $user = User::factory()->onboarded()->create();
     $connection = BankingConnection::factory()->create([


### PR DESCRIPTION
## Problem

A paying user reported that "Save & Sync" on the account mapping screen did nothing — no error, no navigation, nothing.

EnableBanking returned their Société Générale card (`CB Visa`) with `uid: null`:

```json
{"uid": null, "name": "CB Visa", "cash_account_type": "CARD", "account_id": {"iban": null, "other": {"scheme_name": "CPAN", "identification": "************8210"}}}
```

The page renders one mapping row per pending account, so the form posted `bank_account_uid: null`. `MapAccountsRequest` requires it, the request 422'd, and since the page never rendered validation errors the button looked dead. The user retried the connection six times.

A second problem kept them from doing what they actually wanted: both accounts reported `currency: "XXX"` — ISO 4217 for "no currency". `getCompatibleAccounts` filtered their existing EUR accounts against `"XXX"`, matched nothing, and the "Link to existing account" option was never rendered. The backend already knew `XXX` isn't a currency (`AccountUserCurrencyService::resolveImportedCurrency`); the frontend didn't.

## Fix

- Accounts without a uid are filtered out of the mapping screen. They can never be synced anyway — every sync service early-returns on an empty `external_account_id` — and `CreatesAccountsFromPending` already skipped them during onboarding. That rule now lives in one place, `BankingConnection::mappablePendingAccounts()`.
- The skipped accounts are named on the page, so users don't go hunting for an account they can see in their bank app.
- A connection where *no* account has a uid is closed out instead of parking on a mapping page that could only ever 422.
- Validation errors surface as a toast, with app-authored messages in `MapAccountsRequest::messages()` instead of raw field paths.
- `XXX` (and a blank/lowercase variant) is treated as "unknown currency": the code isn't displayed, and it no longer filters out every linkable account.

## Scope

One user affected in production (the reporter). Their connection has one valid account alongside the card, so this fix unblocks them on deploy — no data change needed.

## Testing

- `tests/Feature/OpenBanking` — 315 passed, including two new cases: uid-less accounts are hidden and named, and an all-uid-less connection is closed rather than left awaiting mapping.
- Browser QA against a local reproduction of the exact production payload: only `Compte Bancaire` is offered, `CB Visa` is named as skipped, "Link to existing account" appears despite the `XXX` currency, submitting without picking an account toasts the error, and picking `Dany SG` links it (`external_account_id` set, connection `active`).

## Demo

https://github.com/user-attachments/assets/6275834a-a518-47b9-9015-a698e5926d71
<!-- PLACEHOLDER: drag account-mapping-fix-qa.mp4 here -->

## Not in this PR

`AuthorizationController::refreshAccountIds()` consumes the raw pending list on reconnect; its positional fallback can pair a legacy account with a uid-less entry. Not reachable for any account in production today, it belongs to a different flow, and it deserves its own test — filed separately rather than smuggled in here.
