### PR TITLE
feat(feedback): move feedback and roadmap links from Canny to UserJot

### DIFF
--- a/resources/js/components/user-menu-content.test.tsx
+++ b/resources/js/components/user-menu-content.test.tsx
@@ -103,6 +103,25 @@ describe('UserMenuContent', () => {
         );
     });
 
+    it('links feedback and roadmap to UserJot', () => {
+        render(
+            <UserMenuContent
+                user={user}
+                onOpenSupport={vi.fn()}
+                onOpenIntegrationRequests={vi.fn()}
+            />,
+        );
+
+        expect(
+            screen
+                .getByRole('link', { name: /feedback/i })
+                .getAttribute('href'),
+        ).toBe('https://whispermoney.userjot.com/');
+        expect(
+            screen.getByRole('link', { name: /roadmap/i }).getAttribute('href'),
+        ).toBe('https://whispermoney.userjot.com/roadmap');
+    });
+
     it('triggers the support callback when the support item is clicked', () => {
         const onOpenSupport = vi.fn();
 

--- a/resources/js/components/user-menu-content.tsx
+++ b/resources/js/components/user-menu-content.tsx
@@ -116,7 +116,7 @@ export function UserMenuContent({
                 <DropdownMenuItem asChild>
                     <a
                         className="block w-full cursor-pointer"
-                        href="https://whisper-money.canny.io/feature-requests"
+                        href="https://whispermoney.userjot.com/"
                         target="_blank"
                         rel="noopener noreferrer"
                         onClick={cleanup}
@@ -128,7 +128,7 @@ export function UserMenuContent({
                 <DropdownMenuItem asChild>
                     <a
                         className="block w-full cursor-pointer"
-                        href="https://whisper-money.canny.io/"
+                        href="https://whispermoney.userjot.com/roadmap"
                         target="_blank"
                         rel="noopener noreferrer"
                         onClick={cleanup}

--- a/resources/views/mail/updates/first-update-jan-2026.blade.php
+++ b/resources/views/mail/updates/first-update-jan-2026.blade.php
@@ -19,10 +19,10 @@ Whisper Money is a small project built by one person (me!), but it can become so
 **Join our Discord community** – Share ideas, report bugs, or just chat about privacy-first finance. [Join our comminity](https://discord.gg/m8hUhx6D9D).
 
 **Check our Roadmap** – See what's coming next and vote on features you care about:
-[whisper-money.canny.io](https://whisper-money.canny.io/)
+[whispermoney.userjot.com/roadmap](https://whispermoney.userjot.com/roadmap)
 
 **Request Features** – Have an idea? I want to hear it:
-[whisper-money.canny.io/feature-requests](https://whisper-money.canny.io/feature-requests)
+[whispermoney.userjot.com](https://whispermoney.userjot.com/)
 </x-mail::panel>
 
 ## Why This Matters


### PR DESCRIPTION
## What

Replaces Canny (`whisper-money.canny.io`) with UserJot (`whispermoney.userjot.com`) everywhere it is linked in the app.

| Surface | Before | After |
| --- | --- | --- |
| User dropdown → **Feedback** | `whisper-money.canny.io/feature-requests` | `whispermoney.userjot.com/` |
| User dropdown → **Roadmap** | `whisper-money.canny.io/` | `whispermoney.userjot.com/roadmap` |
| Jan 2026 update email | both Canny URLs | `/roadmap` + root |

Canny's board root was the feedback list and `/feature-requests` the submission board; UserJot inverts that. The root is the cross-board "All Feedback" feed — it covers both the Features and Bugs boards and carries the *Give Feedback* button, so it is a superset of the old `/feature-requests` destination. `/roadmap` is a real dedicated page, which Canny never had.

A repo-wide grep confirms no `canny` reference remains. Nothing else linked it — not the README, the landing page, the privacy/terms pages, or the drip emails.

The new vitest case pins both hrefs, so an accidental revert fails the build.

## Testing

- `user-menu-content.test.tsx` — 3/3 green.
- Browser QA on the running app: logged in, opened the dropdown, clicked **Feedback** and **Roadmap**, and confirmed each opens the right UserJot page in a new tab (`rel="noopener noreferrer"` intact). Repeated at a 390×844 mobile viewport. See the demo below.

## Demo

<!-- PLACEHOLDER: drag the video here -->

## Follow-ups (outside this repo)

- **The UserJot workspace still has demo seed posts.** "Shared access for family accounts" (Emily Roberts) is the only card under **In Progress**, so every user clicking Roadmap sees a fake item presented as actively being built — and it duplicates the real imported post "Multi-tenant support for families or companies". "Custom tags for transactions" (Sam Wilson) is in the feed too. Worth deleting before this ships.
- **Canny is still live** and still serves its 17 posts. It has no URL redirect feature, so already-sent emails, Discord pins and search results will keep landing there. Close or rename the boards with a pointer to UserJot, and reconcile the import (Canny 17 vs UserJot Planned 5 / In Progress 1 / Done 11) before decommissioning.
- **The Bugs board has no entry point.** The Support dialog still routes bug reports to Discord/email, so `/board/bugs` sits empty. Either point Support at it or drop the board.
- **No SSO.** UserJot supports JWT identification; without it users need a second account to vote. Same as Canny, but the migration is the natural moment to add it.