### PR TITLE
feat(mcp): serve the ChatGPT app directory domain challenge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -127,6 +127,10 @@ FORWARD_MAILHOG_DASHBOARD_PORT=8025
 # Dev Mode (set to false for full Docker deployment via setup.sh)
 DEV_MODE=true
 
+# ChatGPT app directory domain verification token, served at
+# /.well-known/openai-apps-challenge (only needed on the public host)
+OPENAI_APPS_CHALLENGE=
+
 # EnableBanking (Open Banking)
 ENABLEBANKING_APP_ID=
 ENABLEBANKING_PRIVATE_KEY_PATH=

--- a/config/services.php
+++ b/config/services.php
@@ -42,6 +42,14 @@ return [
         'redirect_url' => env('ENABLEBANKING_REDIRECT_URL'),
     ],
 
+    'openai' => [
+        /**
+         * Domain-ownership token for the ChatGPT app directory submission,
+         * served at /.well-known/openai-apps-challenge.
+         */
+        'apps_challenge' => env('OPENAI_APPS_CHALLENGE'),
+    ],
+
     'discord' => [
         'webhook_url' => env('DISCORD_WEBHOOK_URL'),
         'ai_cohort_webhook_url' => env('DISCORD_AI_COHORT_WEBHOOK_URL'),

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,6 +28,7 @@ use App\Http\Controllers\SitemapController;
 use App\Http\Controllers\SubscriptionController;
 use App\Http\Controllers\TransactionController;
 use App\Models\Bank;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -66,6 +67,19 @@ Route::get('/', function () {
 
 Route::get('sitemap.xml', [SitemapController::class, 'index'])->name('sitemap');
 Route::get('robots.txt', [RobotsController::class, 'index'])->name('robots');
+
+/**
+ * Domain ownership check for the ChatGPT app directory. It must return the bare
+ * token and nothing else, so an unconfigured deploy 404s rather than serving an
+ * empty body the verifier would read as a mismatched token.
+ */
+Route::get('.well-known/openai-apps-challenge', function (): Response {
+    $token = (string) config('services.openai.apps_challenge');
+
+    abort_if($token === '', 404);
+
+    return response($token)->header('Content-Type', 'text/plain');
+})->name('openai.apps-challenge');
 
 Route::get('verify-email/{id}/{hash}', VerifyEmailController::class)
     ->middleware(['signed', 'throttle:6,1'])

--- a/tests/Feature/OpenAiAppsChallengeTest.php
+++ b/tests/Feature/OpenAiAppsChallengeTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use function Pest\Laravel\get;
+
+it('serves the bare verification token when one is configured', function () {
+    config(['services.openai.apps_challenge' => 'token-123']);
+
+    get('/.well-known/openai-apps-challenge')
+        ->assertOk()
+        ->assertHeader('Content-Type', 'text/plain; charset=UTF-8')
+        ->assertContent('token-123');
+});
+
+it('404s when no verification token is configured', function () {
+    config(['services.openai.apps_challenge' => null]);
+
+    get('/.well-known/openai-apps-challenge')->assertNotFound();
+});


### PR DESCRIPTION
## Why

Publishing the MCP server to the ChatGPT app directory requires proving we own the host that serves it. The submission portal issues a token and fetches `https://whisper.money/.well-known/openai-apps-challenge`, expecting the bare token back. That path currently 404s.

## What

- `GET /.well-known/openai-apps-challenge` returns `OPENAI_APPS_CHALLENGE` as `text/plain`, nothing else — no JSON envelope, no extra tokens.
- Aborts with 404 when the token is unset, so a host without the variable configured cannot answer with an empty body that the verifier would read as a mismatched token.
- Token lives in config/env rather than the repo: it is per-plugin and rotates independently of the code.

## Testing

`tests/Feature/OpenAiAppsChallengeTest.php` covers both branches: the token is served verbatim when configured, and the route 404s when it is not.

The production env var is already set, so the endpoint answers once this deploys.