### PR TITLE
feat(accounts): count shared accounts at the owner's percentage

### DIFF
--- a/app/Http/Controllers/Api/Concerns/ConvertsTransactionCurrency.php
+++ b/app/Http/Controllers/Api/Concerns/ConvertsTransactionCurrency.php
@@ -13,14 +13,20 @@ use Illuminate\Support\Collection;
  */
 trait ConvertsTransactionCurrency
 {
+    /**
+     * The transaction amount in the user's currency, reduced to their share of
+     * the account. Requires the `account` relation to be eager loaded.
+     */
     protected function convertTransactionAmount(Transaction $transaction, string $currency): int
     {
-        return $this->exchangeRateService->convert(
+        $converted = $this->exchangeRateService->convert(
             $transaction->currency_code ?: $transaction->account?->currency_code ?: $currency,
             $currency,
             $transaction->amount,
             $transaction->transaction_date->toDateString(),
         );
+
+        return $transaction->account?->shareOfAmount($converted) ?? $converted;
     }
 
     /**

--- a/app/Http/Controllers/Api/DashboardAnalyticsController.php
+++ b/app/Http/Controllers/Api/DashboardAnalyticsController.php
@@ -274,12 +274,13 @@ class DashboardAnalyticsController extends Controller
         return (int) Transaction::query()
             ->where('transactions.user_id', request()->user()->id)
             ->whereBetween('transactions.transaction_date', [$from, $to])
+            ->joinOwningAccount()
             ->join('categories', function ($join) use ($type) {
                 $join->on('transactions.category_id', '=', 'categories.id')
                     ->where('categories.type', '=', $type)
                     ->whereNull('categories.deleted_at');
             })
-            ->sum('transactions.amount');
+            ->sum(Transaction::ownedAmount());
     }
 
     /**

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -110,9 +110,10 @@ class DashboardController extends Controller
 
     private function getTransactionSum(string $userId, Carbon $from, Carbon $to, CategoryType $type): int
     {
-        return Transaction::query()
+        return (int) Transaction::query()
             ->where('transactions.user_id', $userId)
             ->whereBetween('transactions.transaction_date', [$from, $to])
+            ->joinOwningAccount()
             ->where(function ($q) use ($type) {
                 $q->whereExists(function ($sub) use ($type) {
                     $sub->select(DB::raw(1))
@@ -125,6 +126,6 @@ class DashboardController extends Controller
                             ->where('transactions.amount', $type === CategoryType::Income ? '>' : '<', 0);
                     });
             })
-            ->sum('transactions.amount');
+            ->sum(Transaction::ownedAmount());
     }
 }

--- a/app/Http/Controllers/Settings/AccountController.php
+++ b/app/Http/Controllers/Settings/AccountController.php
@@ -214,48 +214,66 @@ class AccountController extends Controller
             }
         }
 
-        // Update or create loan detail if account type is loan
         if ($account->type === AccountType::Loan) {
-            $loanData = collect($validated)->only([
-                'annual_interest_rate', 'loan_term_months', 'original_amount',
-            ])->filter(fn ($value) => $value !== null)->toArray();
+            $incompleteLoan = $this->syncLoanDetail($account, $validated);
 
-            $loanStartDate = $validated['loan_start_date'] ?? null;
-            if ($loanStartDate) {
-                $loanData['start_date'] = $loanStartDate;
-            }
-
-            if (! empty($loanData)) {
-                $existingLoanDetail = $account->loanDetail;
-
-                if ($existingLoanDetail) {
-                    $existingLoanDetail->update($loanData);
-                } elseif (isset($loanData['annual_interest_rate'], $loanData['loan_term_months'], $loanData['original_amount'])) {
-                    if (! isset($loanData['start_date'])) {
-                        $loanData['start_date'] = now()->toDateString();
-                    }
-
-                    $account->loanDetail()->create($loanData);
-                } else {
-                    $errors = [];
-                    $requiredFields = [
-                        'annual_interest_rate' => 'annual_interest_rate',
-                        'loan_term_months' => 'loan_term_months',
-                        'original_amount' => 'original_amount',
-                    ];
-
-                    foreach ($requiredFields as $field => $errorKey) {
-                        if (! isset($loanData[$field])) {
-                            $errors[$errorKey] = __('This field is required.');
-                        }
-                    }
-
-                    return to_route('accounts.index')->withErrors($errors);
-                }
+            if ($incompleteLoan !== null) {
+                return $incompleteLoan;
             }
         }
 
         return to_route('accounts.index');
+    }
+
+    /**
+     * Update or create the account's loan detail from the validated payload.
+     *
+     * Returns a redirect carrying the missing-field errors when a loan detail
+     * has to be created but the payload is incomplete, and null otherwise.
+     *
+     * @param  array<string, mixed>  $validated
+     */
+    private function syncLoanDetail(Account $account, array $validated): ?RedirectResponse
+    {
+        $loanData = collect($validated)->only([
+            'annual_interest_rate', 'loan_term_months', 'original_amount',
+        ])->filter(fn ($value) => $value !== null)->toArray();
+
+        $loanStartDate = $validated['loan_start_date'] ?? null;
+        if ($loanStartDate) {
+            $loanData['start_date'] = $loanStartDate;
+        }
+
+        if (empty($loanData)) {
+            return null;
+        }
+
+        $existingLoanDetail = $account->loanDetail;
+
+        if ($existingLoanDetail) {
+            $existingLoanDetail->update($loanData);
+
+            return null;
+        }
+
+        if (isset($loanData['annual_interest_rate'], $loanData['loan_term_months'], $loanData['original_amount'])) {
+            $loanData['start_date'] ??= now()->toDateString();
+
+            $account->loanDetail()->create($loanData);
+
+            return null;
+        }
+
+        $required = ['annual_interest_rate', 'loan_term_months', 'original_amount'];
+        $errors = [];
+
+        foreach ($required as $field) {
+            if (! isset($loanData[$field])) {
+                $errors[$field] = __('This field is required.');
+            }
+        }
+
+        return to_route('accounts.index')->withErrors($errors);
     }
 
     /**

--- a/app/Http/Controllers/Settings/AccountController.php
+++ b/app/Http/Controllers/Settings/AccountController.php
@@ -189,6 +189,7 @@ class AccountController extends Controller
 
         $accountData = collect($validated)->only([
             'name', 'bank_id', 'currency_code', 'type',
+            'ownership_percentage', 'ownership_applies_to_balance',
         ])->toArray();
 
         $account->update([

--- a/app/Http/Requests/Settings/UpdateAccountRequest.php
+++ b/app/Http/Requests/Settings/UpdateAccountRequest.php
@@ -45,6 +45,8 @@ class UpdateAccountRequest extends FormRequest
                 'string',
                 Rule::in(array_map(fn ($type) => $type->value, AccountType::cases())),
             ],
+            'ownership_percentage' => ['sometimes', 'integer', 'min:1', 'max:100'],
+            'ownership_applies_to_balance' => ['sometimes', 'boolean'],
         ];
 
         if ($isRealEstate) {

--- a/app/Mcp/Tools/ListAccounts.php
+++ b/app/Mcp/Tools/ListAccounts.php
@@ -40,6 +40,7 @@ class ListAccounts extends McpTool
                 'currency' => $account->currency_code,
                 'bank' => $account->bank?->name,
                 'is_connected' => $account->isConnected(),
+                'ownership_percentage' => $account->ownership_percentage,
             ]);
 
         return $this->json([

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -37,6 +37,8 @@ class Account extends Model
         'linked_at',
         'position',
         'hidden_on_dashboard',
+        'ownership_percentage',
+        'ownership_applies_to_balance',
     ];
 
     /** @var list<string> */
@@ -65,7 +67,23 @@ class Account extends Model
             'linked_at' => 'datetime',
             'position' => 'integer',
             'hidden_on_dashboard' => 'boolean',
+            'ownership_percentage' => 'integer',
+            'ownership_applies_to_balance' => 'boolean',
         ];
+    }
+
+    /**
+     * The owner's share of an amount held in this account, in the same minor
+     * units. A shared account (say 50% with a partner) only contributes that
+     * slice of every transaction to the user's own figures.
+     */
+    public function shareOfAmount(int $amount): int
+    {
+        if ($this->ownership_percentage >= 100) {
+            return $amount;
+        }
+
+        return (int) round($amount * $this->ownership_percentage / 100);
     }
 
     /**

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -79,11 +79,16 @@ class Account extends Model
      */
     public function shareOfAmount(int $amount): int
     {
-        if ($this->ownership_percentage >= 100) {
+        // Defaults to full ownership so a model built without the column (a
+        // partial select, a fresh factory instance) reads at face value
+        // instead of silently zeroing every amount.
+        $percentage = $this->ownership_percentage ?? 100;
+
+        if ($percentage >= 100) {
             return $amount;
         }
 
-        return (int) round($amount * $this->ownership_percentage / 100);
+        return (int) round($amount * $percentage / 100);
     }
 
     /**

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -250,7 +250,8 @@ class Transaction extends Model
 
     /**
      * A transaction amount reduced to the owner's share of its account, for
-     * SQL-side aggregates. Rounds per row, matching {@see Account::shareOfAmount()}.
+     * SQL-side aggregates. Rounds per row, matching {@see Account::shareOfAmount()}
+     * (MySQL and PHP both round half away from zero).
      * Only valid on queries that ran {@see self::scopeJoinOwningAccount()}.
      */
     public const OWNED_AMOUNT_SQL = 'round(transactions.amount * accounts.ownership_percentage / 100)';
@@ -258,6 +259,10 @@ class Transaction extends Model
     /**
      * Join the owning account so aggregates can weigh each amount by the
      * account's ownership percentage. Pair it with {@see self::ownedAmount()}.
+     *
+     * `account_id` is NOT NULL and the join deliberately ignores the account's
+     * soft-delete scope, so the row set is exactly what it was before the
+     * ownership weighting existed.
      *
      * @param  Builder<Transaction>  $query
      * @return Builder<Transaction>

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -13,6 +13,7 @@ use App\Models\Concerns\BelongsToSpace;
 use App\Services\CategoryTree;
 use Carbon\Carbon;
 use Database\Factories\TransactionFactory;
+use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -22,6 +23,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\DB;
 
 /**
  * @property Carbon $transaction_date
@@ -244,6 +246,33 @@ class Transaction extends Model
     public function scopePendingAiCategorization(Builder $query): Builder
     {
         return $query->whereNull('category_id')->whereNull('description_iv');
+    }
+
+    /**
+     * A transaction amount reduced to the owner's share of its account, for
+     * SQL-side aggregates. Rounds per row, matching {@see Account::shareOfAmount()}.
+     * Only valid on queries that ran {@see self::scopeJoinOwningAccount()}.
+     */
+    public const OWNED_AMOUNT_SQL = 'round(transactions.amount * accounts.ownership_percentage / 100)';
+
+    /**
+     * Join the owning account so aggregates can weigh each amount by the
+     * account's ownership percentage. Pair it with {@see self::ownedAmount()}.
+     *
+     * @param  Builder<Transaction>  $query
+     * @return Builder<Transaction>
+     */
+    public function scopeJoinOwningAccount(Builder $query): Builder
+    {
+        return $query->join('accounts', 'accounts.id', '=', 'transactions.account_id');
+    }
+
+    /**
+     * {@see self::OWNED_AMOUNT_SQL} as an expression, for `sum()` and friends.
+     */
+    public static function ownedAmount(): Expression
+    {
+        return DB::raw(self::OWNED_AMOUNT_SQL);
     }
 
     /**

--- a/app/Services/BalanceLookup.php
+++ b/app/Services/BalanceLookup.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Models\Account;
 use App\Models\AccountBalance;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
@@ -31,6 +32,10 @@ class BalanceLookup
      * 1. A derived-table join to find the latest balance record before the range start per account.
      * 2. A derived-table join to find the latest non-null invested_amount before the range start per account.
      * 3. All balance records within the range.
+     *
+     * Accounts configured to apply their ownership percentage to balances get
+     * every figure scaled down to the owner's share here, so every reader
+     * (net worth, evolution charts, account metrics) stays consistent.
      *
      * @param  Collection<int, string>|array<string>  $accountIds
      */
@@ -89,18 +94,30 @@ class BalanceLookup
             ->orderBy('balance_date')
             ->get(['account_id', 'balance_date', 'balance', 'invested_amount']);
 
+        // The accounts that only count towards the user's figures as a share of
+        // their balance; everything else is read at face value.
+        $sharedAccounts = Account::query()
+            ->whereIn('id', $accountIdList)
+            ->where('ownership_applies_to_balance', true)
+            ->get()
+            ->keyBy('id');
+
         // Build the per-account sorted arrays
         foreach ($accountIdList as $accountId) {
             $entries = [];
             $investedEntries = [];
+            $account = $sharedAccounts->get($accountId);
+            $share = static fn (?int $amount): ?int => $amount === null || $account === null
+                ? $amount
+                : $account->shareOfAmount($amount);
 
             // Add carry-forward seed
             $seed = $carryForwardRecords->firstWhere('account_id', $accountId);
             if ($seed) {
                 $entries[] = [
                     'date' => $seed->balance_date->toDateString(),
-                    'balance' => $seed->balance,
-                    'invested_amount' => $seed->invested_amount,
+                    'balance' => $share($seed->balance),
+                    'invested_amount' => $share($seed->invested_amount),
                 ];
             }
 
@@ -109,7 +126,7 @@ class BalanceLookup
             if ($investedSeed) {
                 $investedEntries[] = [
                     'date' => $investedSeed->balance_date->toDateString(),
-                    'invested_amount' => $investedSeed->invested_amount,
+                    'invested_amount' => $share($investedSeed->invested_amount),
                 ];
             }
 
@@ -118,14 +135,14 @@ class BalanceLookup
                 $dateStr = $record->balance_date->toDateString();
                 $entries[] = [
                     'date' => $dateStr,
-                    'balance' => $record->balance,
-                    'invested_amount' => $record->invested_amount,
+                    'balance' => $share($record->balance),
+                    'invested_amount' => $share($record->invested_amount),
                 ];
 
                 if ($record->invested_amount !== null) {
                     $investedEntries[] = [
                         'date' => $dateStr,
-                        'invested_amount' => $record->invested_amount,
+                        'invested_amount' => $share($record->invested_amount),
                     ];
                 }
             }

--- a/app/Services/BalanceLookup.php
+++ b/app/Services/BalanceLookup.php
@@ -28,14 +28,16 @@ class BalanceLookup
     /**
      * Preload all balance data for a set of accounts covering the given date range.
      *
-     * Executes exactly 3 efficient queries (no correlated subqueries):
+     * Executes exactly 4 efficient queries (no correlated subqueries):
      * 1. A derived-table join to find the latest balance record before the range start per account.
      * 2. A derived-table join to find the latest non-null invested_amount before the range start per account.
      * 3. All balance records within the range.
+     * 4. The accounts that only count as a share of their balance.
      *
-     * Accounts configured to apply their ownership percentage to balances get
-     * every figure scaled down to the owner's share here, so every reader
-     * (net worth, evolution charts, account metrics) stays consistent.
+     * Those accounts get every figure scaled down to the owner's share here,
+     * so every reader (net worth, evolution charts, account metrics) stays
+     * consistent. Callers that need the real bank balance — the balance editor,
+     * imports, bank sync — read `account_balances` directly and are unaffected.
      *
      * @param  Collection<int, string>|array<string>  $accountIds
      */

--- a/app/Services/CategorySpendingService.php
+++ b/app/Services/CategorySpendingService.php
@@ -25,12 +25,13 @@ class CategorySpendingService
         $perCategory = Transaction::query()
             ->where('transactions.user_id', $userId)
             ->whereBetween('transactions.transaction_date', [$from, $to])
+            ->joinOwningAccount()
             ->join('categories', function ($join) {
                 $join->on('transactions.category_id', '=', 'categories.id')
                     ->where('categories.type', '=', CategoryType::Expense)
                     ->whereNull('categories.deleted_at');
             })
-            ->select('transactions.category_id', DB::raw('sum(transactions.amount) as total_amount'))
+            ->select('transactions.category_id', DB::raw('sum('.Transaction::OWNED_AMOUNT_SQL.') as total_amount'))
             ->groupBy('transactions.category_id')
             ->get()
             ->map(fn ($item): array => [

--- a/database/migrations/2026_08_10_090000_add_ownership_to_accounts_table.php
+++ b/database/migrations/2026_08_10_090000_add_ownership_to_accounts_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('accounts', function (Blueprint $table) {
+            // Signed on purpose: MySQL promotes `signed * unsigned` to BIGINT
+            // UNSIGNED, which overflows on the negative amounts of an expense.
+            $table->tinyInteger('ownership_percentage')->default(100)->after('hidden_on_dashboard');
+            $table->boolean('ownership_applies_to_balance')->default(false)->after('ownership_percentage');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('accounts', function (Blueprint $table) {
+            $table->dropColumn(['ownership_percentage', 'ownership_applies_to_balance']);
+        });
+    }
+};

--- a/lang/es.json
+++ b/lang/es.json
@@ -1,4 +1,7 @@
 {
+    "Apply it to the balance too, so only my share counts towards net worth": "Aplicarlo también al saldo, para que solo mi parte cuente en el patrimonio neto",
+    "For accounts you share with someone else. Income and expenses only count towards your figures by this percentage.": "Para cuentas que compartes con otra persona. Los ingresos y gastos solo cuentan en tus cifras en ese porcentaje.",
+    "My share of this account (%)": "Mi parte de esta cuenta (%)",
     "Set this up on a computer": "Configúralo desde un ordenador",
     "Signing in and approving works fine in a desktop browser, but usually breaks in a phone's in-app browser. Once it's connected, you can chat with Whisper Money from Claude or ChatGPT on your phone as usual.": "El inicio de sesión y la aprobación funcionan bien en un navegador de escritorio, pero suelen fallar en el navegador interno del móvil. Una vez conectado, puedes chatear con Whisper Money desde Claude o ChatGPT en el móvil con normalidad.",
     "Learned: similar transactions will be categorized automatically.": "Aprendido: las transacciones similares se categorizarán automáticamente.",
@@ -81,7 +84,6 @@
     "You have reached your monthly limit of :count integration actions. Try again next month.": "Has alcanzado tu límite mensual de :count acciones de integración. Inténtalo de nuevo el mes que viene.",
     "Remove one vote": "Quitar un voto",
     "Categorized by AI": "Categorizado por IA",
-    "Let AI categorize your transactions": "Deja que la IA categorice tus transacciones",
     "Categorized by AI with :confidence% confident": "Categorizado por IA con un :confidence % de confianza",
     "Only show AI guesses": "Mostrar solo sugerencias de IA",
     "Created by AI": "Creado por IA",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1,5 +1,6 @@
 {
     "Apply it to the balance too, so only my share counts towards net worth": "Aplicarlo también al saldo, para que solo mi parte cuente en el patrimonio neto",
+    "Enter the full amount held in the account. You own :percentage% of it, and that is the share shown everywhere else.": "Introduce el importe total que hay en la cuenta. Tú tienes el :percentage % y esa es la parte que se muestra en el resto de pantallas.",
     "For accounts you share with someone else. Income and expenses only count towards your figures by this percentage.": "Para cuentas que compartes con otra persona. Los ingresos y gastos solo cuentan en tus cifras en ese porcentaje.",
     "My share of this account (%)": "Mi parte de esta cuenta (%)",
     "Set this up on a computer": "Configúralo desde un ordenador",

--- a/resources/js/components/accounts/edit-account-dialog.tsx
+++ b/resources/js/components/accounts/edit-account-dialog.tsx
@@ -155,10 +155,14 @@ export function EditAccountDialog({
         formDataRef.current = data;
     }, []);
 
-    // An empty field reads as full ownership; anything else goes to the server
-    // as typed so an out-of-range value comes back as a validation error.
-    const parsedShare = parseInt(ownershipPercentage, 10);
-    const sharePercentage = Number.isNaN(parsedShare) ? 100 : parsedShare;
+    // An empty field means "leave it as it is" rather than a silent reset to
+    // full ownership. Anything else is sent as the number typed, so a decimal
+    // or out-of-range value comes back as a validation error instead of being
+    // quietly truncated.
+    const shareIsBlank = ownershipPercentage.trim() === '';
+    const sharePercentage = shareIsBlank
+        ? (account.ownership_percentage ?? 100)
+        : Number(ownershipPercentage);
 
     useEffect(() => {
         if (open) {
@@ -359,6 +363,7 @@ export function EditAccountDialog({
                                     max={100}
                                     step={1}
                                     value={ownershipPercentage}
+                                    aria-describedby="ownership-percentage-hint"
                                     onChange={(event) =>
                                         setOwnershipPercentage(
                                             event.target.value,
@@ -366,7 +371,10 @@ export function EditAccountDialog({
                                     }
                                     disabled={isSubmitting}
                                 />
-                                <p className="text-xs text-muted-foreground">
+                                <p
+                                    id="ownership-percentage-hint"
+                                    className="text-xs text-muted-foreground"
+                                >
                                     {__(
                                         'For accounts you share with someone else. Income and expenses only count towards your figures by this percentage.',
                                     )}

--- a/resources/js/components/accounts/edit-account-dialog.tsx
+++ b/resources/js/components/accounts/edit-account-dialog.tsx
@@ -1,6 +1,8 @@
 import { update } from '@/actions/App/Http/Controllers/Settings/AccountController';
 import { store as storeBank } from '@/actions/App/Http/Controllers/Settings/BankController';
+import InputError from '@/components/input-error';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
     Dialog,
     DialogContent,
@@ -8,6 +10,8 @@ import {
     DialogHeader,
     DialogTitle,
 } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { decrypt, importKey } from '@/lib/crypto';
 import { getCsrfToken } from '@/lib/csrf';
 import { getStoredKey } from '@/lib/key-storage';
@@ -49,6 +53,12 @@ export function EditAccountDialog({
     const [deleteOpen, setDeleteOpen] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [errors, setErrors] = useState<Record<string, string>>({});
+    const [ownershipPercentage, setOwnershipPercentage] = useState(
+        String(account.ownership_percentage ?? 100),
+    );
+    const [ownershipAppliesToBalance, setOwnershipAppliesToBalance] = useState(
+        account.ownership_applies_to_balance ?? false,
+    );
     const formDataRef = useRef<AccountFormData>({
         displayName: '',
         bankId: account.bank?.id ?? null,
@@ -145,11 +155,24 @@ export function EditAccountDialog({
         formDataRef.current = data;
     }, []);
 
+    // An empty field reads as full ownership; anything else goes to the server
+    // as typed so an out-of-range value comes back as a validation error.
+    const parsedShare = parseInt(ownershipPercentage, 10);
+    const sharePercentage = Number.isNaN(parsedShare) ? 100 : parsedShare;
+
     useEffect(() => {
         if (open) {
             setErrors({});
+            setOwnershipPercentage(String(account.ownership_percentage ?? 100));
+            setOwnershipAppliesToBalance(
+                account.ownership_applies_to_balance ?? false,
+            );
         }
-    }, [open]);
+    }, [
+        open,
+        account.ownership_percentage,
+        account.ownership_applies_to_balance,
+    ]);
 
     async function createBankAndGetId(): Promise<string | null> {
         const customBank = formDataRef.current.customBank;
@@ -231,6 +254,9 @@ export function EditAccountDialog({
                     ...(finalBankId ? { bank_id: finalBankId } : {}),
                     type: type,
                     currency_code: currencyCode,
+                    ownership_percentage: sharePercentage,
+                    ownership_applies_to_balance:
+                        sharePercentage < 100 && ownershipAppliesToBalance,
                     ...(formDataRef.current.loan
                         ? {
                               annual_interest_rate:
@@ -315,11 +341,64 @@ export function EditAccountDialog({
                 </DialogHeader>
                 <form onSubmit={handleSubmit} className="space-y-2">
                     {initialValues ? (
-                        <AccountForm
-                            initialValues={initialValues}
-                            onChange={handleFormChange}
-                            errors={errors}
-                        />
+                        <>
+                            <AccountForm
+                                initialValues={initialValues}
+                                onChange={handleFormChange}
+                                errors={errors}
+                            />
+
+                            <div className="grid gap-2 pt-2">
+                                <Label htmlFor="ownership-percentage">
+                                    {__('My share of this account (%)')}
+                                </Label>
+                                <Input
+                                    id="ownership-percentage"
+                                    type="number"
+                                    min={1}
+                                    max={100}
+                                    step={1}
+                                    value={ownershipPercentage}
+                                    onChange={(event) =>
+                                        setOwnershipPercentage(
+                                            event.target.value,
+                                        )
+                                    }
+                                    disabled={isSubmitting}
+                                />
+                                <p className="text-xs text-muted-foreground">
+                                    {__(
+                                        'For accounts you share with someone else. Income and expenses only count towards your figures by this percentage.',
+                                    )}
+                                </p>
+                                <InputError
+                                    message={errors.ownership_percentage}
+                                />
+
+                                {sharePercentage < 100 && (
+                                    <div className="flex items-start gap-2 pt-1">
+                                        <Checkbox
+                                            id="ownership-applies-to-balance"
+                                            checked={ownershipAppliesToBalance}
+                                            onCheckedChange={(checked) =>
+                                                setOwnershipAppliesToBalance(
+                                                    checked === true,
+                                                )
+                                            }
+                                            disabled={isSubmitting}
+                                        />
+                                        <Label
+                                            htmlFor="ownership-applies-to-balance"
+                                            className="cursor-pointer font-normal"
+                                        >
+                                            {__(
+                                                'Apply it to the balance too, so only my share counts towards net worth',
+                                            )}
+                                        </Label>
+                                    </div>
+                                )}
+                            </div>
+                        </>
                     ) : (
                         <div className="space-y-4">
                             <div className="h-10 animate-pulse rounded bg-muted" />

--- a/resources/js/components/accounts/update-balance-dialog.tsx
+++ b/resources/js/components/accounts/update-balance-dialog.tsx
@@ -57,6 +57,12 @@ export function UpdateBalanceDialog({
     const inputRef = useRef<HTMLInputElement>(null);
     const showInvestedAmount = supportsInvestedAmount(account);
     const isLoan = account.type === 'loan';
+    // This dialog always writes the real amount held in the account, while a
+    // shared account shows only the owner's slice elsewhere. Say so, or the
+    // mismatch reads as a bug and invites typing the halved figure back in.
+    const countsPartially =
+        (account.ownership_applies_to_balance ?? false) &&
+        (account.ownership_percentage ?? 100) < 100;
     const userCurrencyCode =
         usePage<SharedData>().props.auth.user.currency_code;
 
@@ -178,6 +184,18 @@ export function UpdateBalanceDialog({
                                   'Set the balance for this account on a specific date.',
                               )}
                     </DialogDescription>
+                    {countsPartially && (
+                        <p className="text-xs text-muted-foreground">
+                            {__(
+                                'Enter the full amount held in the account. You own :percentage% of it, and that is the share shown everywhere else.',
+                                {
+                                    percentage: String(
+                                        account.ownership_percentage,
+                                    ),
+                                },
+                            )}
+                        </p>
+                    )}
                 </DialogHeader>
 
                 <form onSubmit={handleSubmit} className="space-y-4">

--- a/resources/js/types/account.ts
+++ b/resources/js/types/account.ts
@@ -52,6 +52,8 @@ export interface Account {
     external_account_id: string | null;
     linked_at: string | null;
     linked_loan_account_id?: UUID | null;
+    ownership_percentage?: number;
+    ownership_applies_to_balance?: boolean;
 }
 
 export interface AccountBalance {

--- a/tests/Feature/AccountControllerTest.php
+++ b/tests/Feature/AccountControllerTest.php
@@ -660,6 +660,7 @@ test('accounts index serializes the standard account field set without sensitive
         'id', 'name', 'name_iv', 'encrypted', 'type', 'currency_code',
         'banking_connection_id', 'external_account_id', 'linked_at',
         'bank', 'linked_loan_account_id',
+        'ownership_percentage', 'ownership_applies_to_balance',
     ]);
     expect($account)->not->toHaveKeys(['user_id', 'bank_id', 'iban', 'created_at', 'updated_at', 'deleted_at']);
 });

--- a/tests/Feature/SharedAccountOwnershipTest.php
+++ b/tests/Feature/SharedAccountOwnershipTest.php
@@ -132,6 +132,60 @@ test('the dashboard top categories endpoint counts only the owner share of a sha
     expect($response->json('0.amount'))->toBe(40000);
 });
 
+test('the dashboard page cashflow summary counts only the owner share of a shared account', function () {
+    sharedAccountWithTransactions($this->user, 50);
+
+    $response = $this->withoutVite()->get(route('dashboard'), [
+        'X-Inertia' => 'true',
+        'X-Inertia-Partial-Component' => 'dashboard',
+        'X-Inertia-Partial-Data' => 'cashflowSummary',
+    ]);
+
+    $response->assertOk();
+    expect($response->json('props.cashflowSummary.current.income'))->toBe(100000)
+        ->and($response->json('props.cashflowSummary.current.expense'))->toBe(40000);
+});
+
+/**
+ * The share is computed twice — in PHP for the row-by-row cashflow paths and in
+ * SQL for the dashboard aggregates. An amount that does not divide evenly is the
+ * only thing that catches the two rounding rules drifting apart.
+ */
+test('the PHP and SQL paths round an uneven share identically', function () {
+    $account = Account::factory()->create([
+        'user_id' => $this->user->id,
+        'type' => AccountType::Checking,
+        'currency_code' => 'USD',
+        'ownership_percentage' => 33,
+    ]);
+
+    $expense = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'type' => CategoryType::Expense,
+    ]);
+
+    // 33% of 3333 is 1099.89, which has to land on the same side in both paths.
+    Transaction::factory()->create([
+        'user_id' => $this->user->id,
+        'account_id' => $account->id,
+        'category_id' => $expense->id,
+        'amount' => -3333,
+        'currency_code' => 'USD',
+        'transaction_date' => now(),
+    ]);
+
+    $query = http_build_query([
+        'from' => now()->startOfMonth()->toDateString(),
+        'to' => now()->endOfMonth()->toDateString(),
+    ]);
+
+    $php = $this->getJson('/api/cashflow/summary?'.$query);
+    $sql = $this->getJson('/api/dashboard/monthly-spending?'.$query);
+
+    expect($php->json('current.expense'))->toBe(1100)
+        ->and($sql->json('current'))->toBe(1100);
+});
+
 test('fully owned accounts are unaffected', function () {
     sharedAccountWithTransactions($this->user, 100);
 

--- a/tests/Feature/SharedAccountOwnershipTest.php
+++ b/tests/Feature/SharedAccountOwnershipTest.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\Http;
 beforeEach(function () {
     Http::fake();
 
-    $this->user = User::factory()->create(['currency_code' => 'USD']);
+    $this->user = User::factory()->onboarded()->create(['currency_code' => 'USD']);
     $this->actingAs($this->user);
 });
 

--- a/tests/Feature/SharedAccountOwnershipTest.php
+++ b/tests/Feature/SharedAccountOwnershipTest.php
@@ -1,0 +1,222 @@
+<?php
+
+use App\Enums\AccountType;
+use App\Enums\CategoryType;
+use App\Models\Account;
+use App\Models\AccountBalance;
+use App\Models\Bank;
+use App\Models\Category;
+use App\Models\Transaction;
+use App\Models\User;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    Http::fake();
+
+    $this->user = User::factory()->create(['currency_code' => 'USD']);
+    $this->actingAs($this->user);
+});
+
+/**
+ * A checking account owned at the given percentage, with one income and one
+ * expense transaction dated today.
+ */
+function sharedAccountWithTransactions(User $user, int $percentage, bool $appliesToBalance = false): Account
+{
+    $account = Account::factory()->create([
+        'user_id' => $user->id,
+        'type' => AccountType::Checking,
+        'currency_code' => 'USD',
+        'ownership_percentage' => $percentage,
+        'ownership_applies_to_balance' => $appliesToBalance,
+    ]);
+
+    $income = Category::factory()->create([
+        'user_id' => $user->id,
+        'type' => CategoryType::Income,
+    ]);
+    $expense = Category::factory()->create([
+        'user_id' => $user->id,
+        'type' => CategoryType::Expense,
+    ]);
+
+    Transaction::factory()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'category_id' => $income->id,
+        'amount' => 200000,
+        'currency_code' => 'USD',
+        'transaction_date' => now(),
+    ]);
+
+    Transaction::factory()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'category_id' => $expense->id,
+        'amount' => -80000,
+        'currency_code' => 'USD',
+        'transaction_date' => now(),
+    ]);
+
+    return $account;
+}
+
+test('accounts are fully owned by default', function () {
+    $account = Account::factory()->create(['user_id' => $this->user->id]);
+
+    expect($account->fresh()->ownership_percentage)->toBe(100)
+        ->and($account->fresh()->ownership_applies_to_balance)->toBeFalse();
+});
+
+test('the cashflow summary endpoint counts only the owner share of a shared account', function () {
+    sharedAccountWithTransactions($this->user, 50);
+
+    $response = $this->getJson('/api/cashflow/summary?'.http_build_query([
+        'from' => now()->startOfMonth()->toDateString(),
+        'to' => now()->endOfMonth()->toDateString(),
+    ]));
+
+    $response->assertOk();
+    expect($response->json('current.income'))->toBe(100000)
+        ->and($response->json('current.expense'))->toBe(40000)
+        ->and($response->json('current.net'))->toBe(60000);
+});
+
+test('the cashflow breakdown endpoint counts only the owner share of a shared account', function () {
+    sharedAccountWithTransactions($this->user, 50);
+
+    $response = $this->getJson('/api/cashflow/breakdown?'.http_build_query([
+        'from' => now()->startOfMonth()->toDateString(),
+        'to' => now()->endOfMonth()->toDateString(),
+        'type' => 'expense',
+    ]));
+
+    $response->assertOk();
+    expect($response->json('total'))->toBe(40000);
+});
+
+test('the dashboard cashflow endpoint counts only the owner share of a shared account', function () {
+    sharedAccountWithTransactions($this->user, 50);
+
+    $response = $this->getJson('/api/dashboard/cash-flow?'.http_build_query([
+        'from' => now()->startOfMonth()->toDateString(),
+        'to' => now()->endOfMonth()->toDateString(),
+    ]));
+
+    $response->assertOk();
+    expect($response->json('current.income'))->toBe(100000)
+        ->and($response->json('current.expense'))->toBe(40000);
+});
+
+test('the dashboard monthly spending endpoint counts only the owner share of a shared account', function () {
+    sharedAccountWithTransactions($this->user, 50);
+
+    $response = $this->getJson('/api/dashboard/monthly-spending?'.http_build_query([
+        'from' => now()->startOfMonth()->toDateString(),
+        'to' => now()->endOfMonth()->toDateString(),
+    ]));
+
+    $response->assertOk();
+    expect($response->json('current'))->toBe(40000);
+});
+
+test('the dashboard top categories endpoint counts only the owner share of a shared account', function () {
+    sharedAccountWithTransactions($this->user, 50);
+
+    $response = $this->getJson('/api/dashboard/top-categories?'.http_build_query([
+        'from' => now()->startOfMonth()->toDateString(),
+        'to' => now()->endOfMonth()->toDateString(),
+    ]));
+
+    $response->assertOk();
+    expect($response->json('0.amount'))->toBe(40000);
+});
+
+test('fully owned accounts are unaffected', function () {
+    sharedAccountWithTransactions($this->user, 100);
+
+    $response = $this->getJson('/api/cashflow/summary?'.http_build_query([
+        'from' => now()->startOfMonth()->toDateString(),
+        'to' => now()->endOfMonth()->toDateString(),
+    ]));
+
+    $response->assertOk();
+    expect($response->json('current.income'))->toBe(200000)
+        ->and($response->json('current.expense'))->toBe(80000);
+});
+
+test('net worth keeps the full balance when the share is limited to transactions', function () {
+    $account = sharedAccountWithTransactions($this->user, 50);
+    AccountBalance::factory()->create([
+        'account_id' => $account->id,
+        'balance_date' => now(),
+        'balance' => 300000,
+    ]);
+
+    $response = $this->getJson('/api/dashboard/net-worth?'.http_build_query([
+        'from' => now()->startOfMonth()->toDateString(),
+        'to' => now()->endOfMonth()->toDateString(),
+    ]));
+
+    $response->assertOk();
+    expect($response->json('current'))->toBe(300000);
+});
+
+test('net worth counts only the owner share when the account applies it to the balance', function () {
+    $account = sharedAccountWithTransactions($this->user, 50, appliesToBalance: true);
+    AccountBalance::factory()->create([
+        'account_id' => $account->id,
+        'balance_date' => now(),
+        'balance' => 300000,
+    ]);
+
+    $response = $this->getJson('/api/dashboard/net-worth?'.http_build_query([
+        'from' => now()->startOfMonth()->toDateString(),
+        'to' => now()->endOfMonth()->toDateString(),
+    ]));
+
+    $response->assertOk();
+    expect($response->json('current'))->toBe(150000);
+});
+
+test('updating an account persists its ownership settings', function () {
+    $bank = Bank::factory()->create();
+    $account = Account::factory()->create([
+        'user_id' => $this->user->id,
+        'bank_id' => $bank->id,
+        'type' => AccountType::Checking,
+        'currency_code' => 'USD',
+    ]);
+
+    $this->patch(route('accounts.update', $account), [
+        'name' => 'Joint account',
+        'bank_id' => $bank->id,
+        'type' => AccountType::Checking->value,
+        'currency_code' => 'USD',
+        'ownership_percentage' => 50,
+        'ownership_applies_to_balance' => true,
+    ])->assertRedirect();
+
+    expect($account->fresh()->ownership_percentage)->toBe(50)
+        ->and($account->fresh()->ownership_applies_to_balance)->toBeTrue();
+});
+
+test('the ownership percentage must stay between 1 and 100', function () {
+    $bank = Bank::factory()->create();
+    $account = Account::factory()->create([
+        'user_id' => $this->user->id,
+        'bank_id' => $bank->id,
+        'type' => AccountType::Checking,
+        'currency_code' => 'USD',
+    ]);
+
+    $this->patch(route('accounts.update', $account), [
+        'name' => 'Joint account',
+        'bank_id' => $bank->id,
+        'type' => AccountType::Checking->value,
+        'currency_code' => 'USD',
+        'ownership_percentage' => 120,
+    ])->assertSessionHasErrors('ownership_percentage');
+
+    expect($account->fresh()->ownership_percentage)->toBe(100);
+});


### PR DESCRIPTION
## Why

Some accounts are shared. A joint account funded 50/50 with a partner holds money that is only half yours, so its expenses and income should only count towards your figures by half — otherwise the dashboard and the cashflow screen overstate both sides of every month.

## What

An account can now be configured with **the share of it you actually own**, in Settings → Accounts → Edit account.

- **Transactions are always weighted** by that percentage. This covers the cashflow screen (summary, sankey, trend, category breakdown) and the dashboard (cashflow summary, monthly spending, top categories).
- **Balances stay at face value by default**, so an account keeps matching what the bank shows. An opt-in checkbox — only offered below 100% — applies the same percentage to the balance as well, which then flows through net worth, its evolution, and the account cards.

Defaults are 100% / opt-in off, so existing users see no change at all.

## How

The share is computed at exactly two choke points, one per code path:

- **PHP** — `ConvertsTransactionCurrency::convertTransactionAmount()` applies `Account::shareOfAmount()` after the currency conversion, covering every row-by-row analytics consumer.
- **SQL** — `Transaction::OWNED_AMOUNT_SQL` plus the `joinOwningAccount()` scope weigh the four aggregate queries that never hydrate models.

Balances go through `BalanceLookup::forAccounts()`, the single point every net-worth, evolution and account-metrics reader already shares — so they all stay consistent for free, while the surfaces that must show the real bank figure (the balance editor, imports, bank sync) read `account_balances` directly and are untouched.

`ownership_percentage` is a **signed** `tinyInteger` on purpose: MySQL promotes `signed * unsigned` to `BIGINT UNSIGNED`, which overflows on the negative amount of an expense. A test caught this.

## Deliberate boundaries

- **Transaction rows keep showing the real amount.** A row should say what the bank actually charged; only totals are your share.
- **The balance editor writes the full amount**, and now says so when the account is shared — that is what stops a shared balance being halved again on every correction.
- **Percentages are whole numbers, 1–100.** A three-way split (33.33%) is not expressible yet.
- **Configurable on edit only.** `StoreAccountRequest` and the create form are unchanged, so a new joint account counts at 100% until you edit it.

## Known gap (follow-up)

**Budgets are not weighted.** `budget_transactions.amount` is a snapshot written at assignment time, so a 50% account still counts at 100% in budget spend, carry-over and threshold alerts. Fixing it properly needs the write path weighted, a re-snapshot when the percentage changes, and a backfill of existing rows — a separate PR rather than a line in this one. Until then a shared account can read €400 on the dashboard and €800 in Budgets for the same category.

Loan/mortgage *projections* also seed off the raw latest balance, so a shared **loan** with the balance opt-in on draws a step at today's date. Narrow, and follow-up material.

## Testing

`tests/Feature/SharedAccountOwnershipTest.php` covers every weighted endpoint, net worth with and without the balance opt-in, the 1–100 validation, and pins the PHP and SQL rounding to the same answer on an uneven share (33% of an odd amount).

Manual QA on real local data (June 2026, account "Daily" set to 50%):

| | Before | After |
|---|---|---|
| Cashflow income | €4,460 | €4,057 (−€403 = half of the account's €805.80) |
| Cashflow expenses | €4,122 | €3,217 (−€905 = half of the account's €1,809.85) |
| Net worth (opt-in off) | 30,516,453 | 30,516,453 — unchanged |
| Net worth (opt-in on) | 30,516,453 | 30,470,797 (−45,656 = half of the €913.12 balance) |

Also verified: the balance editor still prefills the real €244,310.08 and shows the shared-account notice; an empty percentage field leaves the setting untouched instead of resetting to 100%; out-of-range values are rejected.

## Demo

https://github.com/user-attachments/assets/de47e41a-ff72-4b2b-8e5b-51076e048504


<!-- PLACEHOLDER: drag the QA video here -->
