### PR TITLE
feat(demo): seed named accounts with demo:reset --email

### DIFF
--- a/app/Console/Commands/ResetDemoAccountCommand.php
+++ b/app/Console/Commands/ResetDemoAccountCommand.php
@@ -6,6 +6,7 @@ use App\Actions\CreateDefaultCategories;
 use App\Enums\AccountType;
 use App\Enums\BudgetPeriodType;
 use App\Enums\RolloverType;
+use App\Enums\TransactionSource;
 use App\Models\Account;
 use App\Models\Bank;
 use App\Models\Budget;
@@ -22,7 +23,10 @@ use Illuminate\Support\Collection;
 
 class ResetDemoAccountCommand extends Command
 {
-    protected $signature = 'demo:reset';
+    protected $signature = 'demo:reset
+        {--email= : Create or reset this account instead of the configured demo user}
+        {--password= : Password for --email}
+        {--imported : Mark one account\'s transactions as bank-imported, so the read-only protections can be demonstrated}';
 
     protected $description = 'Reset the demo account with fresh data';
 
@@ -40,19 +44,24 @@ class ResetDemoAccountCommand extends Command
 
     public function handle(): int
     {
-        $demoEnabled = config('app.demo.enabled');
+        /** An explicit --email is a named account (e.g. an app-store reviewer), not the public demo. */
+        $explicitEmail = (string) $this->option('email');
 
-        if (! $demoEnabled) {
+        if ($explicitEmail === '' && ! config('app.demo.enabled')) {
             $this->info('Demo account is not enabled');
 
             return self::SUCCESS;
         }
 
-        $demoEmail = config('app.demo.email');
-        $demoPassword = config('app.demo.password');
+        $demoEmail = $explicitEmail !== '' ? $explicitEmail : config('app.demo.email');
+        $demoPassword = $explicitEmail !== ''
+            ? (string) $this->option('password')
+            : config('app.demo.password');
 
         if (! $demoEmail || ! $demoPassword) {
-            $this->error('Demo configuration not set. Please set DEMO_EMAIL and DEMO_PASSWORD in .env');
+            $this->error($explicitEmail !== ''
+                ? 'Pass --password together with --email.'
+                : 'Demo configuration not set. Please set DEMO_EMAIL and DEMO_PASSWORD in .env');
 
             return self::FAILURE;
         }
@@ -76,6 +85,10 @@ class ResetDemoAccountCommand extends Command
         $this->assignTransactionsToBudgets($user);
 
         $this->createSubscription($user);
+
+        if ($this->option('imported')) {
+            $this->markTransactionsAsImported($user);
+        }
 
         $this->info('✓ Demo account reset successfully!');
 
@@ -506,6 +519,24 @@ class ResetDemoAccountCommand extends Command
         foreach ($budgetAssignments as $budgetName => $count) {
             $this->info("    - {$budgetName}: {$count} transactions");
         }
+    }
+
+    /**
+     * Mark one account's transactions as bank-imported so a reviewer can see
+     * update_transaction and delete_transaction refuse to touch synced data.
+     * The account keeps no banking connection, so no sync ever runs on it.
+     */
+    private function markTransactionsAsImported(User $user): void
+    {
+        $account = $user->accounts()->whereHas('transactions')->first();
+
+        if ($account === null) {
+            return;
+        }
+
+        $count = $account->transactions()->update(['source' => TransactionSource::EnableBanking]);
+
+        $this->info("  Marked {$count} transactions on '{$account->name}' as bank-imported");
     }
 
     private function createSubscription(User $user): void

--- a/tests/Feature/Console/ResetDemoAccountCommandTest.php
+++ b/tests/Feature/Console/ResetDemoAccountCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Enums\PlanFeature;
+use App\Enums\TransactionSource;
 use App\Models\User;
 
 beforeEach(function () {
@@ -48,4 +50,27 @@ test('demo:reset verifies existing unverified demo user', function () {
     $user = User::where('email', 'demo@whisper.money')->first();
 
     expect($user->email_verified_at)->not->toBeNull();
+})->group('slow');
+
+test('demo:reset fails if a password is not passed alongside an explicit email', function () {
+    $this->artisan('demo:reset', ['--email' => 'openai-review@whisper.money'])->assertFailed();
+
+    expect(User::where('email', 'openai-review@whisper.money')->exists())->toBeFalse();
+});
+
+test('demo:reset seeds a named reviewer account on the Pro plan with imported transactions', function () {
+    config(['subscriptions.enabled' => true]);
+
+    $this->artisan('demo:reset', [
+        '--email' => 'openai-review@whisper.money',
+        '--password' => 'secret-review-password',
+        '--imported' => true,
+    ])->assertSuccessful();
+
+    $user = User::where('email', 'openai-review@whisper.money')->sole();
+
+    expect($user->canUseFeature(PlanFeature::McpAccess))->toBeTrue()
+        ->and($user->isDemoAccount())->toBeFalse()
+        ->and($user->transactions()->where('source', TransactionSource::ManuallyCreated)->exists())->toBeTrue()
+        ->and($user->transactions()->where('source', '!=', TransactionSource::ManuallyCreated)->exists())->toBeTrue();
 })->group('slow');


### PR DESCRIPTION
## Why

The ChatGPT app directory review needs a reviewer account: fully featured, pre-loaded with sample data, reachable with an email and password, no 2FA, and on the Pro plan our MCP tools require. `demo:reset` already builds that dataset — 6 accounts, ~2k transactions, 12 months of balances, categories, labels, rules, budgets — and attaches an active subscription, so it only needed to target an email other than the public demo user.

## What

- `--email` / `--password` create or reset an arbitrary account instead of the configured demo user. An explicit `--email` skips the `app.demo.enabled` gate, since a named account is not the public demo.
- The account keeps `isDemoAccount() === false` (that check compares against `app.demo.email`), so none of the demo UI restrictions apply to it.
- `--imported` marks one account's transactions as bank-imported, so a reviewer can verify that `update_transaction` and `delete_transaction` refuse to touch synced data — one of the negative test cases in the submission. That account gets no banking connection, so no sync ever runs on it.
- The public `demo:reset` path is unchanged: same config, same gate, same data.

Usage:

```
php artisan demo:reset --email=openai-review@whisper.money --password='...' --imported
```

## Testing

`tests/Feature/Console/ResetDemoAccountCommandTest.php` adds two cases on top of the existing ones: a named account comes out on the Pro plan, not flagged as the demo account, and holding both manual and imported transactions; and `--email` without `--password` fails without creating anything.