### PR TITLE
fix(demo): stop demo:reset from colliding on the fake Stripe subscription id

### DIFF
--- a/app/Console/Commands/ResetDemoAccountCommand.php
+++ b/app/Console/Commands/ResetDemoAccountCommand.php
@@ -539,13 +539,18 @@ class ResetDemoAccountCommand extends Command
         $this->info("  Marked {$count} transactions on '{$account->name}' as bank-imported");
     }
 
+    /**
+     * `subscriptions.stripe_id` is unique, so the fake id has to be derived from
+     * the user: --email lets several demo accounts coexist, and a shared literal
+     * would collide with whichever account was seeded first.
+     */
     private function createSubscription(User $user): void
     {
         $user->subscriptions()->delete();
 
         $user->subscriptions()->create([
             'type' => 'default',
-            'stripe_id' => 'sub_demo_free_forever',
+            'stripe_id' => "sub_demo_{$user->id}",
             'stripe_status' => 'active',
             'stripe_price' => 'price_demo_free',
         ]);

--- a/app/Http/Controllers/SubscriptionController.php
+++ b/app/Http/Controllers/SubscriptionController.php
@@ -242,7 +242,7 @@ class SubscriptionController extends Controller
 
     public function billingPortal(Request $request): RedirectResponse
     {
-        if ($request->user()->isDemoAccount()) {
+        if ($request->user()->isDemoAccount() || $request->user()->hasSeededSubscription()) {
             return redirect()->route('settings.billing')
                 ->withErrors(['demo' => 'Billing management is not available on the demo account.']);
         }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -366,6 +366,18 @@ class User extends Authenticatable implements HasLocalePreference, MustVerifyEma
     }
 
     /**
+     * Demo and end-to-end fixture accounts are seeded with a made-up Stripe
+     * subscription, so every path that would hand that id back to Stripe has to
+     * bail out first or the call 404s.
+     */
+    public function hasSeededSubscription(): bool
+    {
+        $stripeId = (string) $this->subscription('default')?->stripe_id;
+
+        return str_starts_with($stripeId, 'sub_demo_') || str_starts_with($stripeId, 'sub_e2e_');
+    }
+
+    /**
      * Whether the user can access the given feature on their current plan.
      */
     public function canUseFeature(PlanFeature $feature): bool

--- a/app/Services/Subscriptions/ExperimentOffer.php
+++ b/app/Services/Subscriptions/ExperimentOffer.php
@@ -83,6 +83,10 @@ class ExperimentOffer
             return false;
         }
 
+        if ($user->hasSeededSubscription()) {
+            return false;
+        }
+
         return $this->refundDeadlineFor($subscription)->isFuture();
     }
 

--- a/tests/Feature/Console/ResetDemoAccountCommandTest.php
+++ b/tests/Feature/Console/ResetDemoAccountCommandTest.php
@@ -74,3 +74,21 @@ test('demo:reset seeds a named reviewer account on the Pro plan with imported tr
         ->and($user->transactions()->where('source', TransactionSource::ManuallyCreated)->exists())->toBeTrue()
         ->and($user->transactions()->where('source', '!=', TransactionSource::ManuallyCreated)->exists())->toBeTrue();
 })->group('slow');
+
+test('demo:reset subscribes a named account even when the public demo account already exists', function () {
+    config(['subscriptions.enabled' => true]);
+
+    $this->artisan('demo:reset')->assertSuccessful();
+
+    $this->artisan('demo:reset', [
+        '--email' => 'openai-review@whisper.money',
+        '--password' => 'secret-review-password',
+    ])->assertSuccessful();
+
+    $demo = User::where('email', 'demo@whisper.money')->sole();
+    $reviewer = User::where('email', 'openai-review@whisper.money')->sole();
+
+    expect($demo->subscriptions()->count())->toBe(1)
+        ->and($reviewer->subscriptions()->count())->toBe(1)
+        ->and($reviewer->canUseFeature(PlanFeature::McpAccess))->toBeTrue();
+})->group('slow');

--- a/tests/Feature/Console/ResetDemoAccountCommandTest.php
+++ b/tests/Feature/Console/ResetDemoAccountCommandTest.php
@@ -90,5 +90,7 @@ test('demo:reset subscribes a named account even when the public demo account al
 
     expect($demo->subscriptions()->count())->toBe(1)
         ->and($reviewer->subscriptions()->count())->toBe(1)
+        ->and($reviewer->subscription('default')->stripe_id)
+        ->not->toBe($demo->subscription('default')->stripe_id)
         ->and($reviewer->canUseFeature(PlanFeature::McpAccess))->toBeTrue();
 })->group('slow');

--- a/tests/Feature/DemoAccountRestrictionsTest.php
+++ b/tests/Feature/DemoAccountRestrictionsTest.php
@@ -88,6 +88,28 @@ test('regular user can log in when demo is disabled', function () {
     $this->assertAuthenticated();
 });
 
+test('a seeded reviewer account cannot reach the billing portal', function () {
+    config(['app.demo.email' => 'demo@whisper.money']);
+    config(['subscriptions.enabled' => true]);
+
+    $reviewer = User::factory()->create(['email' => 'openai-review@whisper.money']);
+    $reviewer->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => "sub_demo_{$reviewer->id}",
+        'stripe_status' => 'active',
+        'stripe_price' => 'price_demo_free',
+    ]);
+
+    $this->actingAs($reviewer);
+
+    $this->get(route('settings.billing.portal'))
+        ->assertRedirect(route('settings.billing'))
+        ->assertSessionHasErrors('demo');
+
+    expect($reviewer->isDemoAccount())->toBeFalse()
+        ->and($reviewer->hasSeededSubscription())->toBeTrue();
+});
+
 test('regular user is not restricted', function () {
     $user = User::factory()->create([
         'password' => 'password123',

--- a/tests/Feature/SelfServeRefundTest.php
+++ b/tests/Feature/SelfServeRefundTest.php
@@ -58,6 +58,12 @@ it('blocks a self-refund once already refunded', function () {
     expect(app(ExperimentOffer::class)->canSelfRefund($user))->toBeFalse();
 });
 
+it('blocks a self-refund on a seeded demo subscription', function () {
+    $user = payNowSubscriber(['stripe_id' => 'sub_demo_'.fake()->uuid()]);
+
+    expect(app(ExperimentOffer::class)->canSelfRefund($user))->toBeFalse();
+});
+
 it('blocks a self-refund for non pay-now variants', function () {
     $user = payNowSubscriber();
     Feature::for($user)->activate(SubscriptionExperiment::class, SubscriptionExperiment::CONTROL);


### PR DESCRIPTION
Fixes [PHP-LARAVEL-5B](https://whisper-money.sentry.io/issues/PHP-LARAVEL-5B).

## What broke

`demo:reset` seeds a fabricated Stripe subscription so the demo account gets Pro access without touching Stripe. The id was the hardcoded literal `sub_demo_free_forever`, and `subscriptions.stripe_id` is unique.

`--email` (#753, shipped this morning) made a second seeded account possible. `createSubscription()` deletes only the *current* user's subscriptions before inserting, so the first `demo:reset --email` run after the public demo account existed died on:

```
SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry
'sub_demo_free_forever' for key 'subscriptions.subscriptions_stripe_id_unique'
```

`createSubscription()` is the last step of `handle()`, so the reviewer account was left fully seeded but with **no subscription at all** — an app-store reviewer signing in lands on the paywall instead of the Pro app.

## The fix

Derive the fake id from the user: `sub_demo_{$user->id}`. Matches what `E2eBankingFixtureCommand` already does (`sub_e2e_.$user->id`). Nothing reads the old literal — entitlement goes through Cashier's `subscribed('default')`, which only looks at `stripe_status`. Production is self-healing: the next run replaces the old row, and the demo account keeps working until then.

## Second commit: seeded accounts and the Stripe billing paths

Fixing the collision means reviewer accounts now genuinely have `hasProPlan() === true`, which switches on paths that were unreachable while they were paywalled. `isDemoAccount()` is equality against `config('app.demo.email')`, so an `--email` account is **not** a demo account and skipped every existing guard:

- `SubscriptionController::billingPortal` would call `createAsStripeCustomer()` — creating a real Stripe customer in production — and drop the reviewer on an empty portal.
- Bucketed into `PAY_NOW`, `canSelfRefund()` returns true, so the refund box renders; `RefundSelfServe::handle` then calls `$subscription->latestPayment()` on `sub_demo_<uuid>` → Stripe 404, thrown above the `try`, 500 plus a false `🔴 Self-service refund FAILED — the user may have been charged without a refund` Discord alert.

`User::hasSeededSubscription()` keys off the fabricated id prefix rather than one hardcoded email, so it also covers the e2e fixture account. Real Stripe ids are `sub_` + alphanumerics with no further underscore, so no paying user can match it.

## Tests

- `demo:reset subscribes a named account even when the public demo account already exists` — seeds the public demo account, then a named one. Verified it fails on the pre-fix code with the **identical** SQLSTATE 1062 message from the Sentry event, and asserts the two ids differ so a regression back to a shared literal is caught.
- `a seeded reviewer account cannot reach the billing portal`, `blocks a self-refund on a seeded demo subscription`.

Local: `ResetDemoAccountCommandTest` 7/7, `SelfServeRefundTest` + `DemoAccountRestrictionsTest` + `SubscriptionTest` 59/59.

## Not fixed here (found during review, out of scope)

- `ResetDemoAccountCommand` falls back to `Bank::factory()->create(['user_id' => null])` when a named bank is missing, permanently adding randomly-named **global** banks visible to every user. `firstOrCreate(['name' => …, 'user_id' => null])` would fix it.
- Seeded accounts count as paid in `SubscriptionFunnelCollector` / `ExperimentFunnelCollector` unless their email is in `AI_SUGGESTIONS_REPORT_EXCLUDED_EMAILS`.
- `handle()` runs without a transaction, so a failure mid-reseed still leaves a half-seeded account.
