### PR TITLE
fix(banking): stop Wise outages from silently parking a bank connection

### DIFF
--- a/app/Jobs/SyncBankingConnectionJob.php
+++ b/app/Jobs/SyncBankingConnectionJob.php
@@ -222,16 +222,31 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
 
     /**
      * Handle temporary errors that may resolve on retry.
+     *
+     * A provider outage must not spend the connection's budget of scheduled
+     * retries: MAX_SCHEDULED_RETRIES failures drop it out of every future
+     * scheduled sync, silently and with no way back other than reconnecting.
+     * Reaching that state because the bank was down for three cycles is the
+     * wrong trade, so a classified-transient failure surfaces on the
+     * connection without moving the counter.
+     *
+     * ponytail: a provider that is down forever is then retried forever. That
+     * costs one job per cycle and shows up as a repeating warning; add a cap
+     * if the retries ever become expensive.
      */
     private function handleTemporaryError(BankingConnection $connection, \Throwable $e): void
     {
         $isFinalAttempt = $this->attempts() >= $this->tries;
 
         if ($isFinalAttempt) {
+            $isTransient = $e instanceof TransientBankingProviderException;
+
             $connection->update([
                 'status' => BankingConnectionStatus::Error,
                 'error_message' => $this->friendlyErrorMessage($e),
-                'consecutive_sync_failures' => $connection->consecutive_sync_failures + 1,
+                'consecutive_sync_failures' => $isTransient
+                    ? $connection->consecutive_sync_failures
+                    : $connection->consecutive_sync_failures + 1,
             ]);
         }
 

--- a/app/Services/Banking/WiseClient.php
+++ b/app/Services/Banking/WiseClient.php
@@ -90,7 +90,8 @@ class WiseClient
             );
         }
 
-        return $response->json();
+        /** A 200 with an empty body used to degrade to an empty result, not a TypeError. */
+        return $response->json() ?? [];
     }
 
     private function client(): PendingRequest

--- a/app/Services/Banking/WiseClient.php
+++ b/app/Services/Banking/WiseClient.php
@@ -2,6 +2,8 @@
 
 namespace App\Services\Banking;
 
+use App\Exceptions\Banking\TransientBankingProviderException;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
@@ -18,11 +20,7 @@ class WiseClient
      */
     public function getProfiles(): array
     {
-        $response = $this->client()->get('/v1/profiles');
-
-        $response->throw();
-
-        return $response->json();
+        return $this->get('/v1/profiles');
     }
 
     /**
@@ -32,13 +30,7 @@ class WiseClient
      */
     public function getBorderlessAccount(int $profileId): array
     {
-        $response = $this->client()->get('/v2/borderless-accounts', [
-            'profileId' => $profileId,
-        ]);
-
-        $response->throw();
-
-        $accounts = $response->json();
+        $accounts = $this->get('/v2/borderless-accounts', ['profileId' => $profileId]);
 
         return $accounts[0] ?? [];
     }
@@ -61,9 +53,42 @@ class WiseClient
             $params['cursor'] = $cursor;
         }
 
-        $response = $this->client()->get("/v1/profiles/{$profileId}/activities", $params);
+        return $this->get("/v1/profiles/{$profileId}/activities", $params);
+    }
 
-        $response->throw();
+    /**
+     * An unattended sync cannot do anything about Wise being down or slow, so a
+     * timeout or a 5xx is reclassified as transient: the job logs it as a
+     * warning, keeps it out of Sentry and retries later. Statuses the caller
+     * acts on - 401/403 auth failures, 429 rate limits - stay as they are.
+     *
+     * @param  array<string, mixed>  $params
+     * @return array<mixed>
+     */
+    private function get(string $url, array $params = []): array
+    {
+        try {
+            $response = $this->client()->get($url, $params);
+
+            $response->throw();
+        } catch (ConnectionException $e) {
+            throw new TransientBankingProviderException(
+                'Wise did not respond in time.',
+                provider: 'wise',
+                previous: $e,
+            );
+        } catch (RequestException $e) {
+            if (! $e->response->serverError()) {
+                throw $e;
+            }
+
+            throw new TransientBankingProviderException(
+                'Wise could not serve the request right now.',
+                provider: 'wise',
+                statusCode: $e->response->status(),
+                previous: $e,
+            );
+        }
 
         return $response->json();
     }
@@ -74,7 +99,7 @@ class WiseClient
             ->withToken($this->apiToken)
             ->acceptJson()
             ->throw(function ($response, RequestException $exception) {
-                Log::error('Wise API error', [
+                Log::log($response->serverError() ? 'warning' : 'error', 'Wise API error', [
                     'status' => $response->status(),
                     'body' => $response->json(),
                 ]);

--- a/tests/Feature/OpenBanking/SyncRetryAndLoggingTest.php
+++ b/tests/Feature/OpenBanking/SyncRetryAndLoggingTest.php
@@ -196,6 +196,7 @@ test('transient banking provider error on final attempt uses retry later message
     $connection = BankingConnection::factory()->create([
         'user_id' => $user->id,
         'last_synced_at' => now()->subDay(),
+        'consecutive_sync_failures' => 2,
     ]);
     Account::factory()->connected()->create([
         'user_id' => $user->id,
@@ -235,7 +236,46 @@ test('transient banking provider error on final attempt uses retry later message
     $connection->refresh();
     expect($connection->status)->toBe(BankingConnectionStatus::Error);
     expect($connection->error_message)->toContain('bank provider is temporarily unavailable');
-    expect($connection->consecutive_sync_failures)->toBe(1);
+
+    // A provider outage must not spend the retry budget: at MAX_SCHEDULED_RETRIES
+    // the connection drops out of every scheduled sync for good.
+    expect($connection->consecutive_sync_failures)->toBe(2)
+        ->toBeLessThan(SyncBankingConnectionJob::MAX_SCHEDULED_RETRIES);
+});
+
+test('a non-transient error on final attempt still spends a scheduled retry', function () {
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->create([
+        'user_id' => $user->id,
+        'last_synced_at' => now()->subDay(),
+        'consecutive_sync_failures' => 2,
+    ]);
+    Account::factory()->connected()->create([
+        'user_id' => $user->id,
+        'banking_connection_id' => $connection->id,
+        'external_account_id' => 'ext-123',
+    ]);
+
+    $transactionSync = Mockery::mock(TransactionSyncService::class);
+    $transactionSync->shouldReceive('sync')->andThrow(new RuntimeException('something we did not classify'));
+
+    $balanceSync = Mockery::mock(BalanceSyncService::class);
+
+    $job = new SyncBankingConnectionJob($connection);
+    $job->job = Mockery::mock(Job::class);
+    $job->job->shouldReceive('attempts')->andReturn(3);
+    $job->job->shouldReceive('isReleased')->andReturn(false);
+    $job->job->shouldReceive('isDeletedOrReleased')->andReturn(false);
+    $job->job->shouldReceive('hasFailed')->andReturn(false);
+
+    try {
+        runSync($job, $transactionSync, $balanceSync);
+    } catch (RuntimeException) {
+        // expected
+    }
+
+    $connection->refresh();
+    expect($connection->consecutive_sync_failures)->toBe(3);
 });
 
 test('expired session marks the connection expired and emails the user instead of reporting an error', function () {

--- a/tests/Feature/OpenBanking/WiseTransientErrorTest.php
+++ b/tests/Feature/OpenBanking/WiseTransientErrorTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Exceptions\Banking\TransientBankingProviderException;
+use App\Services\Banking\WiseClient;
+use Illuminate\Contracts\Debug\ShouldntReport;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+
+test('a wise 500 while paginating activities is reclassified as transient', function () {
+    Http::fake([
+        'api.wise.com/v1/profiles/*/activities*' => Http::response(['error' => 'oops'], 500),
+    ]);
+
+    expect(fn () => (new WiseClient('test-token'))->getActivities(
+        35242290,
+        '2025-08-10T00:00:00Z',
+        '2026-08-10T23:59:59Z',
+        'cursor-token',
+    ))->toThrow(TransientBankingProviderException::class);
+});
+
+test('a wise timeout is reclassified as transient', function () {
+    Http::fake(fn () => throw new ConnectionException('cURL error 28: Operation timed out'));
+
+    expect(fn () => (new WiseClient('test-token'))->getProfiles())
+        ->toThrow(TransientBankingProviderException::class);
+});
+
+test('wise auth and rate-limit responses stay raw so the sync job can act on them', function (int $status) {
+    Http::fake(['api.wise.com/v1/profiles' => Http::response(['error' => 'nope'], $status)]);
+
+    expect(fn () => (new WiseClient('test-token'))->getProfiles())
+        ->toThrow(RequestException::class);
+})->with([401, 403, 429]);
+
+test('the transient wise exception is not reported to sentry', function () {
+    expect(new TransientBankingProviderException('down', provider: 'wise'))
+        ->toBeInstanceOf(ShouldntReport::class);
+});

--- a/tests/Feature/OpenBanking/WiseTransientErrorTest.php
+++ b/tests/Feature/OpenBanking/WiseTransientErrorTest.php
@@ -2,7 +2,6 @@
 
 use App\Exceptions\Banking\TransientBankingProviderException;
 use App\Services\Banking\WiseClient;
-use Illuminate\Contracts\Debug\ShouldntReport;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
@@ -34,7 +33,8 @@ test('wise auth and rate-limit responses stay raw so the sync job can act on the
         ->toThrow(RequestException::class);
 })->with([401, 403, 429]);
 
-test('the transient wise exception is not reported to sentry', function () {
-    expect(new TransientBankingProviderException('down', provider: 'wise'))
-        ->toBeInstanceOf(ShouldntReport::class);
+test('an empty wise response body still degrades to an empty result', function () {
+    Http::fake(['api.wise.com/v2/borderless-accounts*' => Http::response('', 200)]);
+
+    expect((new WiseClient('test-token'))->getBorderlessAccount(35242290))->toBe([]);
 });


### PR DESCRIPTION
Fixes [PHP-LARAVEL-58](https://whisper-money.sentry.io/issues/PHP-LARAVEL-58).

## What production looks like

There is exactly one Wise connection in production and it has **never synced** — `last_synced_at` is null. Its entire history is three failed attempts:

| when | error |
|---|---|
| 2026-07-29 | `ConnectionException` — cURL error 28, timed out after 30s |
| 2026-08-03 | `ConnectionException` — cURL error 28, timed out after 30s |
| 2026-08-10 | `RequestException` — HTTP 500 from `/v1/profiles/{id}/activities`, mid-cursor |

All three are upstream. All three were charged to `consecutive_sync_failures`, now at **2**. At `MAX_SCHEDULED_RETRIES = 3` both `SyncAllBankingConnectionsJob` and `sync:banking` stop dispatching the connection — permanently, with no email and no reconnect notice in the UI. The next Wise outage would have been the last sync this user ever got.

## Three commits

**1. Classify Wise timeouts and 5xx as transient.** `WiseClient` rethrew everything raw, so an outage looked like an application bug: reported to Sentry at error level and logged as `Wise API error`. Timeouts and 5xx now raise `TransientBankingProviderException`, matching `EnableBankingProvider` (PR #678). The job already understands that type — warning instead of error, `ShouldntReport`, and a "temporarily unavailable" message for the user. **401/403 and 429 deliberately stay raw**: `isAuthError` and `isRateLimitError` match on `RequestException`, and `resolveRateLimitBackoffUntil` reads `Retry-After` off `$e->response`. The three request methods now share one private `get()`, which is where the classification lives.

**2. Keep an empty body from becoming a TypeError.** Introduced by commit 1: routing everything through `get(): array` turned a 200 with an empty body into a `TypeError` — neither transient nor suppressed, i.e. exactly the noise this branch removes. It used to degrade to `[]` via `$accounts[0] ?? []`. Caught by review.

**3. Stop provider outages from parking a connection for good.** Without this the branch is only a log-level change: `handleTemporaryError` incremented the counter for any non-auth throwable, so the classification never reached the user. A transient failure now surfaces on the connection (status and message unchanged) without spending a scheduled retry. Unclassified failures still count, so a genuine defect still parks the connection.

No data migration needed — the connection is at 2, still under the cap, so it stays eligible and the counter resets on its first success.

## Trade-off, stated plainly

A provider that is down forever is now retried forever: one job per cycle, surfacing as a repeating `Banking sync failed` warning. That is cheap and visible, and strictly better than silently never syncing a user's bank. Marked with a `ponytail:` comment naming the ceiling.

The flip side is that a **persistent** Wise breakage (an API contract change, say) now produces no Sentry issue — only warn-level logs and `banking_sync_logs` rows. Worth knowing before assuming silence means health.

## Tests

- `WiseTransientErrorTest`: 500 mid-cursor and a cURL 28 timeout both become `TransientBankingProviderException`; 401/403/429 (dataset) stay `RequestException`; an empty body still degrades to `[]`.
- `SyncRetryAndLoggingTest`: a transient failure at `consecutive_sync_failures = 2` leaves it at 2 and below the cap; a **non**-transient one still takes it to 3.

Local: 490/490 across `tests/Feature/OpenBanking`, `tests/Feature/Jobs`, `tests/Unit`.

## Follow-ups (found in review, deliberately not here)

- `WiseClient` sets no timeouts; `EnableBankingProvider` uses `timeout(20)->connectTimeout(5)`, IB uses 5/15. Two of the three prod failures were 30s timeouts, so bounding them is worth a look — but shortening the window on a 12-month first sync needs its own thinking.
- `EnableBankingProvider` logs its 5xx at `error` while raising the same transient exception. Wise is the consistent one here; EB should follow.
- The `ConnectionException` + 5xx catch skeleton now exists three times. Rule of three is reached — a shared trait would also let Binance/Coinbase/Bitpanda/IndexaCapital adopt it.
- Both credential-validation call sites catch `\Throwable`, so connecting Wise during an outage still tells the user "Invalid API token". Now cheaply fixable by catching the transient type first.
