### PR TITLE
fix(banking): stop crypto holdings quoted only in USD from vanishing from the balance

### DIFF
--- a/app/Services/Banking/BitpandaBalanceSyncService.php
+++ b/app/Services/Banking/BitpandaBalanceSyncService.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\Log;
 
 class BitpandaBalanceSyncService
 {
+    private const USD_CURRENCY = 'USD';
+
     public function __construct(private CurrencyConversionService $currencyConverter) {}
 
     /**
@@ -121,17 +123,38 @@ class BitpandaBalanceSyncService
     /**
      * Get the ticker price for an asset in the target currency.
      *
+     * Bitpanda's ticker only quotes a handful of fiats, so anyone outside that
+     * set would otherwise have every crypto wallet dropped from their balance.
+     * Routing through USD keeps the holding priced instead of silently zeroed.
+     *
      * @param  array<string, array<string, string>>  $ticker
      */
     private function getTickerPrice(array $ticker, string $symbol, string $targetCurrency): ?float
     {
         $price = $ticker[$symbol][$targetCurrency] ?? null;
 
-        if ($price === null) {
+        if ($price !== null) {
+            return (float) $price;
+        }
+
+        if ($targetCurrency === self::USD_CURRENCY) {
             return null;
         }
 
-        return (float) $price;
+        $usdPrice = $ticker[$symbol][self::USD_CURRENCY] ?? null;
+
+        if ($usdPrice === null) {
+            return null;
+        }
+
+        $converted = $this->currencyConverter->convert(
+            self::USD_CURRENCY,
+            $targetCurrency,
+            (float) $usdPrice,
+            now()->toDateString(),
+        );
+
+        return $converted > 0 ? $converted : null;
     }
 
     /**

--- a/app/Services/Banking/CoinbaseBalanceSyncService.php
+++ b/app/Services/Banking/CoinbaseBalanceSyncService.php
@@ -212,6 +212,11 @@ class CoinbaseBalanceSyncService
      */
     private function fetchPriceMap(CoinbaseClient $client, array $assets, string $targetCurrency): array
     {
+        // convertCryptoAssets settles stablecoins at 1 USD before it ever reads
+        // the map, so quoting them is two wasted round trips. The historical
+        // path skips them for the same reason.
+        $assets = array_values(array_diff($assets, self::USD_STABLECOINS));
+
         if ($assets === []) {
             return [];
         }
@@ -252,12 +257,16 @@ class CoinbaseBalanceSyncService
      */
     private function fetchBestBidAskPrices(CoinbaseClient $client, array $assets, string $quoteCurrency): array
     {
+        if ($assets === []) {
+            return [];
+        }
+
         $productIds = array_map(fn (string $asset) => "{$asset}-{$quoteCurrency}", $assets);
 
         try {
             $response = $client->getBestBidAsk($productIds);
         } catch (\Throwable $e) {
-            Log::warning('Coinbase best_bid_ask failed, falling back to per-asset USD conversion', [
+            Log::warning('Coinbase best_bid_ask failed', [
                 'quote_currency' => $quoteCurrency,
                 'error' => $e->getMessage(),
             ]);

--- a/app/Services/Banking/CoinbaseBalanceSyncService.php
+++ b/app/Services/Banking/CoinbaseBalanceSyncService.php
@@ -212,16 +212,53 @@ class CoinbaseBalanceSyncService
      */
     private function fetchPriceMap(CoinbaseClient $client, array $assets, string $targetCurrency): array
     {
-        $productIds = array_map(fn (string $asset) => "{$asset}-{$targetCurrency}", $assets);
-
-        if (empty($productIds)) {
+        if ($assets === []) {
             return [];
         }
+
+        $map = $this->fetchBestBidAskPrices($client, $assets, $targetCurrency);
+
+        if ($targetCurrency === self::USD_CURRENCY) {
+            return $map;
+        }
+
+        // Coinbase lists most assets only against USD, so being absent from the
+        // fiat pricebook is normal rather than unpriceable. The historical
+        // backfill already routes those through USD (fetchHistoricalPricesForAsset);
+        // without the same hop here the holding falls through to a fiat-only
+        // converter that knows no crypto ticker, and lands in the balance as zero.
+        $missing = array_values(array_diff($assets, array_keys($map)));
+
+        if ($missing === []) {
+            return $map;
+        }
+
+        $date = now()->toDateString();
+
+        foreach ($this->fetchBestBidAskPrices($client, $missing, self::USD_CURRENCY) as $asset => $usdPrice) {
+            $targetPrice = $this->currencyConverter->convert(self::USD_CURRENCY, $targetCurrency, $usdPrice, $date);
+
+            if ($targetPrice > 0) {
+                $map[$asset] = $targetPrice;
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param  array<int, string>  $assets
+     * @return array<string, float>
+     */
+    private function fetchBestBidAskPrices(CoinbaseClient $client, array $assets, string $quoteCurrency): array
+    {
+        $productIds = array_map(fn (string $asset) => "{$asset}-{$quoteCurrency}", $assets);
 
         try {
             $response = $client->getBestBidAsk($productIds);
         } catch (\Throwable $e) {
             Log::warning('Coinbase best_bid_ask failed, falling back to per-asset USD conversion', [
+                'quote_currency' => $quoteCurrency,
                 'error' => $e->getMessage(),
             ]);
 

--- a/tests/Feature/OpenBanking/BitpandaBalanceSyncTest.php
+++ b/tests/Feature/OpenBanking/BitpandaBalanceSyncTest.php
@@ -72,6 +72,58 @@ test('syncs bitpanda balance with crypto and fiat wallets', function () {
     expect($balance->balance_date->toDateString())->toBe(now()->toDateString());
 });
 
+test('prices a wallet Bitpanda does not quote in the user currency via USD', function () {
+    $user = User::factory()->onboarded()->create(['currency_code' => 'DKK']);
+    $connection = BankingConnection::factory()->bitpanda()->create([
+        'user_id' => $user->id,
+    ]);
+    $account = Account::factory()->connected()->create([
+        'user_id' => $user->id,
+        'banking_connection_id' => $connection->id,
+        'external_account_id' => 'bitpanda-portfolio',
+        'currency_code' => 'DKK',
+    ]);
+
+    Http::fake([
+        // Bitpanda's ticker only quotes EUR/USD/CHF/GBP/TRY.
+        'api.bitpanda.com/v1/ticker' => Http::response([
+            'BTC' => ['EUR' => '50000.00', 'USD' => '55000.00'],
+        ]),
+        'api.bitpanda.com/v1/wallets' => Http::response([
+            'data' => [
+                [
+                    'type' => 'wallet',
+                    'attributes' => [
+                        'cryptocoin_id' => '1',
+                        'cryptocoin_symbol' => 'BTC',
+                        'balance' => '1.00000000',
+                        'is_default' => true,
+                        'name' => 'BTC wallet',
+                        'deleted' => false,
+                    ],
+                    'id' => 'wallet-uuid-1',
+                ],
+            ],
+        ]),
+        'api.bitpanda.com/v1/fiatwallets/transactions*' => Http::response([
+            'data' => [],
+            'meta' => ['next_cursor' => null],
+            'links' => [],
+        ]),
+        'api.bitpanda.com/v1/fiatwallets' => Http::response(['data' => []]),
+        'cdn.jsdelivr.net/*' => Http::response(['dkk' => ['usd' => 0.5]]),
+        'currency-api.pages.dev/*' => Http::response(['dkk' => ['usd' => 0.5]]),
+    ]);
+
+    $client = new BitpandaClient('test-key');
+    $service = app(BitpandaBalanceSyncService::class);
+    $service->sync($account, $client);
+
+    // 1 BTC * 55000 USD, at dkk.usd = 0.5 → 110000 DKK. Without the USD hop the
+    // wallet is dropped and the balance reads zero.
+    expect($account->balances()->first()->balance)->toBe(11_000_000);
+});
+
 test('syncs bitpanda balance with crypto only', function () {
     $user = User::factory()->onboarded()->create(['currency_code' => 'EUR']);
     $connection = BankingConnection::factory()->bitpanda()->create([

--- a/tests/Feature/OpenBanking/CoinbaseBalanceSyncTest.php
+++ b/tests/Feature/OpenBanking/CoinbaseBalanceSyncTest.php
@@ -84,6 +84,73 @@ test('syncs coinbase balance with crypto and fiat wallets', function () {
     expect($balance->balance_date->toDateString())->toBe(now()->toDateString());
 });
 
+test('prices an asset Coinbase only quotes in USD instead of dropping it from the balance', function () {
+    $user = User::factory()->onboarded()->create(['currency_code' => 'EUR']);
+    $connection = BankingConnection::factory()->coinbase()->create([
+        'user_id' => $user->id,
+    ]);
+    $account = Account::factory()->connected()->create([
+        'user_id' => $user->id,
+        'banking_connection_id' => $connection->id,
+        'external_account_id' => 'coinbase-portfolio',
+        'currency_code' => 'EUR',
+    ]);
+
+    Http::fake(function (Request $request) {
+        $url = $request->url();
+
+        if (str_contains($url, '/api/v3/brokerage/accounts')) {
+            return Http::response([
+                'accounts' => [
+                    [
+                        'uuid' => 'cb-1',
+                        'name' => 'SOL',
+                        'currency' => 'SOL',
+                        'available_balance' => ['value' => '2.0', 'currency' => 'SOL'],
+                        'hold' => ['value' => '0', 'currency' => 'SOL'],
+                        'active' => true,
+                        'type' => 'ACCOUNT_TYPE_CRYPTO',
+                    ],
+                ],
+                'has_next' => false,
+                'cursor' => '',
+                'size' => 1,
+            ]);
+        }
+
+        if (str_contains($url, 'cdn.jsdelivr.net') || str_contains($url, 'currency-api.pages.dev')) {
+            return Http::response(['eur' => ['usd' => 2.0]]);
+        }
+
+        if (str_contains($url, '/api/v3/brokerage/best_bid_ask')) {
+            // Coinbase has no SOL-EUR book, only SOL-USD.
+            if (! str_contains($url, 'SOL-USD')) {
+                return Http::response(['pricebooks' => []]);
+            }
+
+            return Http::response([
+                'pricebooks' => [
+                    [
+                        'product_id' => 'SOL-USD',
+                        'bids' => [['price' => '100.00', 'size' => '1']],
+                        'asks' => [['price' => '100.00', 'size' => '1']],
+                    ],
+                ],
+            ]);
+        }
+
+        return Http::response([], 404);
+    });
+
+    $client = new CoinbaseClient('organizations/org/apiKeys/key', ecPrivateKeyForCoinbase());
+    $service = app(CoinbaseBalanceSyncService::class);
+    $service->sync($account, $client);
+
+    // 2 SOL * 100 USD, at eur.usd = 2.0 → 100 EUR. Without the USD hop the
+    // fiat-only converter returns 0 for SOL and the holding vanishes.
+    expect($account->balances()->first()->balance)->toBe(10_000);
+});
+
 test('first sync creates twelve monthly coinbase historical balances', function () {
     Carbon::setTestNow('2026-05-14 12:00:00');
 

--- a/tests/Feature/OpenBanking/CoinbaseBalanceSyncTest.php
+++ b/tests/Feature/OpenBanking/CoinbaseBalanceSyncTest.php
@@ -151,6 +151,96 @@ test('prices an asset Coinbase only quotes in USD instead of dropping it from th
     expect($account->balances()->first()->balance)->toBe(10_000);
 });
 
+test('mixes fiat-quoted and USD-only assets in one balance', function () {
+    $user = User::factory()->onboarded()->create(['currency_code' => 'EUR']);
+    $connection = BankingConnection::factory()->coinbase()->create([
+        'user_id' => $user->id,
+    ]);
+    $account = Account::factory()->connected()->create([
+        'user_id' => $user->id,
+        'banking_connection_id' => $connection->id,
+        'external_account_id' => 'coinbase-portfolio',
+        'currency_code' => 'EUR',
+    ]);
+
+    Http::fake(function (Request $request) {
+        $url = $request->url();
+
+        if (str_contains($url, '/api/v3/brokerage/accounts')) {
+            return Http::response([
+                'accounts' => [
+                    [
+                        'uuid' => 'cb-1',
+                        'name' => 'BTC',
+                        'currency' => 'BTC',
+                        'available_balance' => ['value' => '1.0', 'currency' => 'BTC'],
+                        'hold' => ['value' => '0', 'currency' => 'BTC'],
+                        'active' => true,
+                        'type' => 'ACCOUNT_TYPE_CRYPTO',
+                    ],
+                    [
+                        'uuid' => 'cb-2',
+                        'name' => 'SOL',
+                        'currency' => 'SOL',
+                        'available_balance' => ['value' => '2.0', 'currency' => 'SOL'],
+                        'hold' => ['value' => '0', 'currency' => 'SOL'],
+                        'active' => true,
+                        'type' => 'ACCOUNT_TYPE_CRYPTO',
+                    ],
+                ],
+                'has_next' => false,
+                'cursor' => '',
+                'size' => 2,
+            ]);
+        }
+
+        if (str_contains($url, 'cdn.jsdelivr.net') || str_contains($url, 'currency-api.pages.dev')) {
+            return Http::response(['eur' => ['usd' => 2.0]]);
+        }
+
+        if (str_contains($url, '/api/v3/brokerage/best_bid_ask')) {
+            // BTC has a EUR book, SOL only a USD one, so the second pass must
+            // ask for SOL alone and leave the already-priced BTC untouched.
+            if (str_contains($url, 'SOL-USD')) {
+                return Http::response([
+                    'pricebooks' => [
+                        [
+                            'product_id' => 'SOL-USD',
+                            'bids' => [['price' => '100.00', 'size' => '1']],
+                            'asks' => [['price' => '100.00', 'size' => '1']],
+                        ],
+                    ],
+                ]);
+            }
+
+            return Http::response([
+                'pricebooks' => [
+                    [
+                        'product_id' => 'BTC-EUR',
+                        'bids' => [['price' => '50000.00', 'size' => '1']],
+                        'asks' => [['price' => '50000.00', 'size' => '1']],
+                    ],
+                ],
+            ]);
+        }
+
+        return Http::response([], 404);
+    });
+
+    $client = new CoinbaseClient('organizations/org/apiKeys/key', ecPrivateKeyForCoinbase());
+    $service = app(CoinbaseBalanceSyncService::class);
+    $service->sync($account, $client);
+
+    // 1 BTC * 50000 EUR + 2 SOL * (100 USD / 2.0) = 50100 EUR.
+    expect($account->balances()->first()->balance)->toBe(5_010_000);
+
+    // The USD pass asks only for what the EUR book missed. An expectation
+    // inside the fake would be swallowed by fetchBestBidAskPrices' catch.
+    Http::assertSent(fn (Request $request) => str_contains($request->url(), 'best_bid_ask')
+        && str_contains($request->url(), 'SOL-USD')
+        && ! str_contains($request->url(), 'BTC-USD'));
+});
+
 test('first sync creates twelve monthly coinbase historical balances', function () {
     Carbon::setTestNow('2026-05-14 12:00:00');
 


### PR DESCRIPTION
Found in the Sentry **logs**, not the issues queue — this class of bug never throws, it just quietly reports the wrong number. `Could not price Coinbase asset` has been firing steadily, 24 times in the last 7 days.

## What happens

`CoinbaseBalanceSyncService::fetchPriceMap` only ever asked Coinbase for `{ASSET}-{USER_CURRENCY}` price books. Coinbase lists most assets against USD alone, so for a EUR user those come back empty. `convertCryptoAssets` then falls through to `CurrencyConversionService::convert('SOL', 'EUR', …)` — a **fiat** FX service that has no rate for a crypto ticker and returns `0.0`.

The holding contributes nothing. The balance is still written to `account_balances`, so it feeds net worth and the balance chart as a confidently wrong, lower number — indistinguishable from the user genuinely holding less.

The historical backfill never had this problem: `fetchHistoricalPricesForAsset` already retries against USD and converts. So the same wallet is priced correctly for every past month and collapses on today's balance — a cliff at the right-hand edge of the chart rather than an obviously broken figure.

**All three Coinbase/Bitpanda/Binance users in production are on EUR**, so the Coinbase half of this is live for both Coinbase connections.

## The commits

1. **Coinbase**: the live path takes the same USD hop the historical path already takes, for whatever the fiat pricebook did not cover — one extra batched request, and only when something is actually missing.
2. **Bitpanda**: same defect one service over. `getTickerPrice` read `$ticker[$symbol][$targetCurrency]` and gave up on a miss, and the caller logs and `continue`s, dropping the wallet entirely. Bitpanda's ticker only quotes EUR, USD, CHF, GBP and TRY — so every other supported currency reads **zero for every crypto wallet**, which now includes DKK (added in #754). No user is on such a currency with a Bitpanda connection today, so this one is a landmine rather than a live bug; I fixed it because it is the same one-line shape and it silently misreports money.
3. **Review follow-ups** (no behaviour change): stop quoting stablecoins that `convertCryptoAssets` settles at 1 USD before it ever reads the map; guard the empty batch inside `fetchBestBidAskPrices` rather than relying on the caller; drop the now-untrue "falling back to per-asset USD conversion" tail from the catch message.
4. **Mixed-batch test** — the single-asset test never exercises the `array_diff` that decides what the USD pass asks for.

## Safety

- USD users short-circuit before any USD hop. Assets that already have a fiat book are excluded from the retry and never touch the new path. Stablecoins are intercepted before the map is consulted.
- If the second request throws, or the FX rate for the date is missing, the `$targetPrice > 0` guard drops it and the asset falls through to exactly today's behaviour. The change can only add a price, never replace a good one.
- Money math verified against `CurrencyConversionService::convert`, which **divides** by a rate keyed to the target currency as base: 100 USD ÷ 2.0 = 50 EUR per unit, then multiplied by quantity.

## Two things this does NOT do

**Already-written rows stay wrong.** The next sync overwrites only today's `balance_date` row. `needsHistoricalBackfill` re-runs the historical pass only once, so every daily row written since the account was connected keeps its understated value — 102 rows on one Coinbase account, 16 on the other. The existing `php artisan banking:sync --full` re-runs the historical pass and would repair them; I did not run it, since replaying a year of pricing for real accounts is an ops call, not something an autonomous loop should do unattended.

**An asset Coinbase does not quote in USD either still vanishes silently.** It logs and contributes zero, with nothing surfaced to the user. Pricing an unquotable asset is not solvable here, but reporting a balance we know is incomplete as if it were complete is a product decision worth taking: flagging the account as partially priced would be the honest behaviour.

## Follow-up found in review, deliberately not here

`BinanceBalanceSyncService`'s **historical** path (`:145`) also hands a raw ticker to the fiat converter with no USD hop, dropping zeros into a `skipped_assets` log. Its live path is correct, so today's balance is right and only the one-time historical anchors are affected — a smaller, different blast radius that deserves its own change.

## Tests

`prices an asset Coinbase only quotes in USD instead of dropping it from the balance`, `mixes fiat-quoted and USD-only assets in one balance` (asserts the second request carries `SOL-USD` and does not re-quote `BTC`), and `prices a wallet Bitpanda does not quote in the user currency via USD` (a DKK user).

**I could not run the PHP suite locally — the local Docker daemon is wedged, so the MySQL testcontainer never starts. Relying on CI.** Pint and `php -l` are clean.
