### PR TITLE
feat(mcp): record MCP tool usage and report it with stats:mcp-usage

### DIFF
--- a/app/Console/Commands/McpUsageStatsCommand.php
+++ b/app/Console/Commands/McpUsageStatsCommand.php
@@ -6,6 +6,7 @@ use App\Models\McpToolCall;
 use Illuminate\Console\Command;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
 
 class McpUsageStatsCommand extends Command
 {
@@ -20,8 +21,10 @@ class McpUsageStatsCommand extends Command
 
         $total = $this->callsSince($since)->count();
 
+        $window = $days.' '.Str::plural('day', $days);
+
         if ($total === 0) {
-            $this->warn("No MCP tool calls in the last {$days} days.");
+            $this->warn("No MCP tool calls in the last {$window}.");
 
             return self::SUCCESS;
         }
@@ -29,7 +32,7 @@ class McpUsageStatsCommand extends Command
         $users = $this->callsSince($since)->distinct()->count('user_id');
 
         $this->newLine();
-        $this->line("<options=bold>MCP usage — last {$days} days</> (since {$since->toDateString()})");
+        $this->line("<options=bold>MCP usage — last {$window}</> (since {$since->toDateString()})");
         $this->line("  Calls: <fg=cyan>{$total}</>   Users: <fg=cyan>{$users}</>");
 
         $this->renderTools($since, $total);

--- a/app/Console/Commands/McpUsageStatsCommand.php
+++ b/app/Console/Commands/McpUsageStatsCommand.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\McpToolCall;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
+
+class McpUsageStatsCommand extends Command
+{
+    protected $signature = 'stats:mcp-usage {--days=30 : Days of history to report on} {--top=20 : Users listed in the per-user table}';
+
+    protected $description = 'Show MCP usage: calls per tool, calls per user and daily totals';
+
+    public function handle(): int
+    {
+        $days = max(1, (int) $this->option('days'));
+        $since = Carbon::now()->subDays($days)->startOfDay();
+
+        $total = $this->scope($since)->count();
+
+        if ($total === 0) {
+            $this->warn("No MCP tool calls in the last {$days} days.");
+
+            return self::SUCCESS;
+        }
+
+        $users = $this->scope($since)->distinct()->count('user_id');
+
+        $this->newLine();
+        $this->line("<options=bold>MCP usage — last {$days} days</> (since {$since->toDateString()})");
+        $this->line("  Calls: <fg=cyan>{$total}</>   Users: <fg=cyan>{$users}</>");
+
+        $this->renderTools($since, $total);
+        $this->renderUsers($since);
+        $this->renderDays($since);
+
+        return self::SUCCESS;
+    }
+
+    /** @return Builder<McpToolCall> */
+    private function scope(Carbon $since): Builder
+    {
+        return McpToolCall::query()->where('created_at', '>=', $since);
+    }
+
+    private function renderTools(Carbon $since, int $total): void
+    {
+        $rows = $this->scope($since)
+            ->selectRaw('tool, count(*) as calls, count(distinct user_id) as users')
+            ->groupBy('tool')
+            ->orderByDesc('calls')
+            ->get();
+
+        $this->newLine();
+        $this->line('<options=bold>By tool</>');
+        $this->table(
+            ['Tool', 'Calls', '%', 'Users'],
+            $rows->map(fn (McpToolCall $row): array => [
+                $row->tool,
+                $row->getAttribute('calls'),
+                sprintf('%.1f%%', $row->getAttribute('calls') / $total * 100),
+                $row->getAttribute('users'),
+            ])->all()
+        );
+    }
+
+    private function renderUsers(Carbon $since): void
+    {
+        $top = max(1, (int) $this->option('top'));
+
+        $rows = $this->scope($since)
+            ->selectRaw('user_id, count(*) as calls, count(distinct tool) as tools, max(created_at) as last_call')
+            ->groupBy('user_id')
+            ->orderByDesc('calls')
+            ->limit($top)
+            ->with('user:id,email')
+            ->get();
+
+        $this->newLine();
+        $this->line("<options=bold>By user</> (top {$top})");
+        $this->table(
+            ['User', 'Calls', 'Tools', 'Last call'],
+            $rows->map(fn (McpToolCall $row): array => [
+                $row->user->email,
+                $row->getAttribute('calls'),
+                $row->getAttribute('tools'),
+                (string) $row->getAttribute('last_call'),
+            ])->all()
+        );
+    }
+
+    private function renderDays(Carbon $since): void
+    {
+        $rows = $this->scope($since)
+            ->selectRaw('date(created_at) as day, count(*) as calls, count(distinct user_id) as users')
+            ->groupBy('day')
+            ->orderBy('day')
+            ->get();
+
+        $this->newLine();
+        $this->line('<options=bold>By day</>');
+        $this->table(
+            ['Day', 'Calls', 'Users'],
+            $rows->map(fn (McpToolCall $row): array => [
+                (string) $row->getAttribute('day'),
+                $row->getAttribute('calls'),
+                $row->getAttribute('users'),
+            ])->all()
+        );
+    }
+}

--- a/app/Console/Commands/McpUsageStatsCommand.php
+++ b/app/Console/Commands/McpUsageStatsCommand.php
@@ -4,7 +4,7 @@ namespace App\Console\Commands;
 
 use App\Models\McpToolCall;
 use Illuminate\Console\Command;
-use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Carbon;
 
 class McpUsageStatsCommand extends Command
@@ -16,9 +16,9 @@ class McpUsageStatsCommand extends Command
     public function handle(): int
     {
         $days = max(1, (int) $this->option('days'));
-        $since = Carbon::now()->subDays($days)->startOfDay();
+        $since = Carbon::now()->subDays($days - 1)->startOfDay();
 
-        $total = $this->scope($since)->count();
+        $total = $this->callsSince($since)->count();
 
         if ($total === 0) {
             $this->warn("No MCP tool calls in the last {$days} days.");
@@ -26,7 +26,7 @@ class McpUsageStatsCommand extends Command
             return self::SUCCESS;
         }
 
-        $users = $this->scope($since)->distinct()->count('user_id');
+        $users = $this->callsSince($since)->distinct()->count('user_id');
 
         $this->newLine();
         $this->line("<options=bold>MCP usage — last {$days} days</> (since {$since->toDateString()})");
@@ -39,15 +39,18 @@ class McpUsageStatsCommand extends Command
         return self::SUCCESS;
     }
 
-    /** @return Builder<McpToolCall> */
-    private function scope(Carbon $since): Builder
+    /**
+     * Every call in the window, as a plain query builder: the report only ever
+     * reads aggregates, so it has no use for hydrated models.
+     */
+    private function callsSince(Carbon $since): Builder
     {
-        return McpToolCall::query()->where('created_at', '>=', $since);
+        return McpToolCall::query()->toBase()->where('mcp_tool_calls.created_at', '>=', $since);
     }
 
     private function renderTools(Carbon $since, int $total): void
     {
-        $rows = $this->scope($since)
+        $rows = $this->callsSince($since)
             ->selectRaw('tool, count(*) as calls, count(distinct user_id) as users')
             ->groupBy('tool')
             ->orderByDesc('calls')
@@ -57,44 +60,49 @@ class McpUsageStatsCommand extends Command
         $this->line('<options=bold>By tool</>');
         $this->table(
             ['Tool', 'Calls', '%', 'Users'],
-            $rows->map(fn (McpToolCall $row): array => [
+            $rows->map(fn (object $row): array => [
                 $row->tool,
-                $row->getAttribute('calls'),
-                sprintf('%.1f%%', $row->getAttribute('calls') / $total * 100),
-                $row->getAttribute('users'),
+                $row->calls,
+                sprintf('%.1f%%', $row->calls / $total * 100),
+                $row->users,
             ])->all()
         );
     }
 
+    /**
+     * Joined rather than eager-loaded so users who deleted their account still
+     * show up: `user:delete` soft-deletes, so the cascade never fires and the
+     * relation (with its `deleted_at is null` scope) would come back empty.
+     */
     private function renderUsers(Carbon $since): void
     {
         $top = max(1, (int) $this->option('top'));
 
-        $rows = $this->scope($since)
-            ->selectRaw('user_id, count(*) as calls, count(distinct tool) as tools, max(created_at) as last_call')
-            ->groupBy('user_id')
+        $rows = $this->callsSince($since)
+            ->join('users', 'users.id', '=', 'mcp_tool_calls.user_id')
+            ->selectRaw('users.email, users.deleted_at, count(*) as calls, count(distinct tool) as tools, max(mcp_tool_calls.created_at) as last_call')
+            ->groupBy('users.id', 'users.email', 'users.deleted_at')
             ->orderByDesc('calls')
             ->limit($top)
-            ->with('user:id,email')
             ->get();
 
         $this->newLine();
         $this->line("<options=bold>By user</> (top {$top})");
         $this->table(
             ['User', 'Calls', 'Tools', 'Last call'],
-            $rows->map(fn (McpToolCall $row): array => [
-                $row->user->email,
-                $row->getAttribute('calls'),
-                $row->getAttribute('tools'),
-                (string) $row->getAttribute('last_call'),
+            $rows->map(fn (object $row): array => [
+                $row->email.($row->deleted_at === null ? '' : ' (deleted)'),
+                $row->calls,
+                $row->tools,
+                (string) $row->last_call,
             ])->all()
         );
     }
 
     private function renderDays(Carbon $since): void
     {
-        $rows = $this->scope($since)
-            ->selectRaw('date(created_at) as day, count(*) as calls, count(distinct user_id) as users')
+        $rows = $this->callsSince($since)
+            ->selectRaw('date(mcp_tool_calls.created_at) as day, count(*) as calls, count(distinct user_id) as users')
             ->groupBy('day')
             ->orderBy('day')
             ->get();
@@ -103,10 +111,10 @@ class McpUsageStatsCommand extends Command
         $this->line('<options=bold>By day</>');
         $this->table(
             ['Day', 'Calls', 'Users'],
-            $rows->map(fn (McpToolCall $row): array => [
-                (string) $row->getAttribute('day'),
-                $row->getAttribute('calls'),
-                $row->getAttribute('users'),
+            $rows->map(fn (object $row): array => [
+                (string) $row->day,
+                $row->calls,
+                $row->users,
             ])->all()
         );
     }

--- a/app/Mcp/Tools/McpTool.php
+++ b/app/Mcp/Tools/McpTool.php
@@ -62,14 +62,20 @@ abstract class McpTool extends Tool
             );
         }
 
-        // Usage metric (see `stats:mcp-usage`). Rescued so a failed insert can
-        // never break a working tool call.
-        rescue(fn (): McpToolCall => McpToolCall::create([
-            'user_id' => $user->id,
-            'tool' => $this->name(),
-        ]));
+        $response = $this->respond($request, $user);
 
-        return $this->respond($request, $user);
+        // Usage metric (see `stats:mcp-usage`), recorded only for calls that did
+        // something: an error response (a read-only token, an id the user cannot
+        // reach) or a thrown ValidationException is a rejected attempt, not
+        // usage. Rescued so a failed insert can never break a working call.
+        if (! $response->isError()) {
+            rescue(fn (): McpToolCall => McpToolCall::create([
+                'user_id' => $user->id,
+                'tool' => $this->name(),
+            ]));
+        }
+
+        return $response;
     }
 
     abstract protected function respond(Request $request, User $user): Response;

--- a/app/Mcp/Tools/McpTool.php
+++ b/app/Mcp/Tools/McpTool.php
@@ -4,6 +4,7 @@ namespace App\Mcp\Tools;
 
 use App\Enums\PlanFeature;
 use App\Models\Label;
+use App\Models\McpToolCall;
 use App\Models\Space;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Collection;
@@ -60,6 +61,13 @@ abstract class McpTool extends Tool
                 'A paid (Pro) plan is required to use the Whisper Money MCP. Upgrade your account at '.route('subscribe')
             );
         }
+
+        // Usage metric (see `stats:mcp-usage`). Rescued so a failed insert can
+        // never break a working tool call.
+        rescue(fn (): McpToolCall => McpToolCall::create([
+            'user_id' => $user->id,
+            'tool' => $this->name(),
+        ]));
 
         return $this->respond($request, $user);
     }

--- a/app/Models/McpToolCall.php
+++ b/app/Models/McpToolCall.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\McpToolCallFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * A single MCP tool invocation, recorded by McpTool once the plan gate passes.
+ */
+class McpToolCall extends Model
+{
+    /** @use HasFactory<McpToolCallFactory> */
+    use HasFactory, HasUuids;
+
+    protected $fillable = [
+        'user_id',
+        'tool',
+    ];
+
+    /** @return BelongsTo<User, $this> */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/McpToolCall.php
+++ b/app/Models/McpToolCall.php
@@ -16,6 +16,9 @@ class McpToolCall extends Model
     /** @use HasFactory<McpToolCallFactory> */
     use HasFactory, HasUuids;
 
+    /** Append-only: a call is never updated, so there is no `updated_at`. */
+    const UPDATED_AT = null;
+
     protected $fillable = [
         'user_id',
         'tool',

--- a/database/factories/McpToolCallFactory.php
+++ b/database/factories/McpToolCallFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\McpToolCall;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<McpToolCall>
+ */
+class McpToolCallFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'tool' => $this->faker->randomElement(['search_transactions', 'list_accounts', 'get_net_worth']),
+        ];
+    }
+}

--- a/database/migrations/2026_08_10_144811_create_mcp_tool_calls_table.php
+++ b/database/migrations/2026_08_10_144811_create_mcp_tool_calls_table.php
@@ -21,9 +21,8 @@ return new class extends Migration
             $table->uuid('id')->primary();
             $table->foreignUuid('user_id')->constrained()->cascadeOnDelete();
             $table->string('tool');
-            $table->timestamps();
+            $table->timestamp('created_at');
 
-            $table->index(['tool', 'created_at']);
             $table->index('created_at');
         });
     }

--- a/database/migrations/2026_08_10_144811_create_mcp_tool_calls_table.php
+++ b/database/migrations/2026_08_10_144811_create_mcp_tool_calls_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * One append-only row per MCP tool call, so we can answer which tools get
+     * used, by whom and how often.
+     *
+     * ponytail: raw rows instead of pre-aggregated counters — the volume is a
+     * handful of calls per Pro user per day, so GROUP BY answers every question
+     * we might ask later. Add a prune command (or roll up into daily counters)
+     * if the table ever grows past a few million rows.
+     */
+    public function up(): void
+    {
+        Schema::create('mcp_tool_calls', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('user_id')->constrained()->cascadeOnDelete();
+            $table->string('tool');
+            $table->timestamps();
+
+            $table->index(['tool', 'created_at']);
+            $table->index('created_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('mcp_tool_calls');
+    }
+};

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -64,6 +64,9 @@ parameters:
           path: app/Models/*
         - identifier: public.property.unused
           path: app/Models/*
+        # Eloquent reads model constants (CREATED_AT, UPDATED_AT, …) itself
+        - identifier: public.classConstant.unused
+          path: app/Models/*
         # Enum label/description methods used in Blade/frontend
         - identifier: public.method.unused
           path: app/Enums/*

--- a/tests/Feature/Mcp/McpUsageMetricsTest.php
+++ b/tests/Feature/Mcp/McpUsageMetricsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Mcp\Servers\WhisperMoneyServer;
+use App\Mcp\Tools\CreateLabel;
 use App\Mcp\Tools\ListAccounts;
 use App\Mcp\Tools\ListSpaces;
 use App\Models\McpToolCall;
@@ -13,8 +14,8 @@ it('records a row per tool call, named after the tool', function () {
     WhisperMoneyServer::actingAs($user)->tool(ListSpaces::class)->assertOk();
     WhisperMoneyServer::actingAs($user)->tool(ListAccounts::class)->assertOk();
 
-    expect(McpToolCall::query()->where('user_id', $user->id)->pluck('tool')->all())
-        ->toBe(['list_spaces', 'list_spaces', 'list_accounts']);
+    expect(McpToolCall::query()->where('user_id', $user->id)->pluck('tool')->countBy()->all())
+        ->toBe(['list_spaces' => 2, 'list_accounts' => 1]);
 });
 
 it('does not record calls rejected by the plan gate', function () {
@@ -22,6 +23,17 @@ it('does not record calls rejected by the plan gate', function () {
     $user = User::factory()->create();
 
     WhisperMoneyServer::actingAs($user)->tool(ListSpaces::class)->assertHasErrors();
+
+    expect(McpToolCall::query()->count())->toBe(0);
+});
+
+it('does not record a write rejected because the token is read-only', function () {
+    $user = User::factory()->create();
+    $user->withAccessToken($user->createToken('mcp', ['mcp:read'])->accessToken);
+
+    WhisperMoneyServer::actingAs($user)
+        ->tool(CreateLabel::class, ['name' => 'Trips', 'color' => 'blue'])
+        ->assertHasErrors();
 
     expect(McpToolCall::query()->count())->toBe(0);
 });
@@ -43,6 +55,18 @@ it('reports usage per tool, per user and per day', function () {
         ->expectsOutputToContain('search_transactions')
         ->expectsOutputToContain('heavy@example.com')
         ->expectsOutputToContain('light@example.com')
+        ->assertSuccessful();
+});
+
+it('still attributes calls made by a user who deleted their account', function () {
+    $user = User::factory()->create(['email' => 'churned@example.com']);
+    McpToolCall::factory()->create(['user_id' => $user->id, 'tool' => 'get_net_worth']);
+    $user->delete();
+
+    // One substring per output line: two expectations matching the same line
+    // would only consume the first (Mockery matches an expectation once).
+    $this->artisan('stats:mcp-usage')
+        ->expectsOutputToContain('churned@example.com (deleted)')
         ->assertSuccessful();
 });
 

--- a/tests/Feature/Mcp/McpUsageMetricsTest.php
+++ b/tests/Feature/Mcp/McpUsageMetricsTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use App\Mcp\Servers\WhisperMoneyServer;
+use App\Mcp\Tools\ListAccounts;
+use App\Mcp\Tools\ListSpaces;
+use App\Models\McpToolCall;
+use App\Models\User;
+
+it('records a row per tool call, named after the tool', function () {
+    $user = User::factory()->create();
+
+    WhisperMoneyServer::actingAs($user)->tool(ListSpaces::class)->assertOk();
+    WhisperMoneyServer::actingAs($user)->tool(ListSpaces::class)->assertOk();
+    WhisperMoneyServer::actingAs($user)->tool(ListAccounts::class)->assertOk();
+
+    expect(McpToolCall::query()->where('user_id', $user->id)->pluck('tool')->all())
+        ->toBe(['list_spaces', 'list_spaces', 'list_accounts']);
+});
+
+it('does not record calls rejected by the plan gate', function () {
+    config(['subscriptions.enabled' => true]);
+    $user = User::factory()->create();
+
+    WhisperMoneyServer::actingAs($user)->tool(ListSpaces::class)->assertHasErrors();
+
+    expect(McpToolCall::query()->count())->toBe(0);
+});
+
+it('reports usage per tool, per user and per day', function () {
+    $heavy = User::factory()->create(['email' => 'heavy@example.com']);
+    $light = User::factory()->create(['email' => 'light@example.com']);
+
+    McpToolCall::factory()->count(3)->create(['user_id' => $heavy->id, 'tool' => 'search_transactions']);
+    McpToolCall::factory()->create(['user_id' => $light->id, 'tool' => 'get_net_worth']);
+    McpToolCall::factory()->create([
+        'user_id' => $light->id,
+        'tool' => 'search_transactions',
+        'created_at' => now()->subDays(90),
+    ]);
+
+    $this->artisan('stats:mcp-usage', ['--days' => 30])
+        ->expectsOutputToContain('Calls: 4')
+        ->expectsOutputToContain('search_transactions')
+        ->expectsOutputToContain('heavy@example.com')
+        ->expectsOutputToContain('light@example.com')
+        ->assertSuccessful();
+});
+
+it('reports nothing when there is no usage in the window', function () {
+    $this->artisan('stats:mcp-usage')
+        ->expectsOutputToContain('No MCP tool calls')
+        ->assertSuccessful();
+});


### PR DESCRIPTION
## What

We had no idea whether anyone actually uses the MCP server. This records one row per tool call and adds a report to read it back: which tools get used, by which users, and how much.

**Storage** — `mcp_tool_calls`: `user_id`, `tool`, `created_at`. Raw rows rather than pre-aggregated counters, because the volume is a handful of calls per Pro user per day and a `GROUP BY` then answers whatever we want to ask later. No arguments and no financial content are stored.

**Recording** — one `rescue()`d insert in `McpTool::handle()`, the base class all 24 tools inherit with no overrides, so coverage is complete by construction. It sits *after* `respond()` and skips error responses, so the number means "calls that did something": a plan-gate rejection, a read-only token rejected on a write, or a `ValidationException` for an unreachable id is an attempt, not usage. `rescue()` keeps a failed insert from ever breaking a working tool call while still reporting to Sentry.

**Reading** — `php artisan stats:mcp-usage [--days=30] [--top=20]`:

```
MCP usage — last 30 days (since 2026-07-13)
  Calls: 15   Users: 2

By tool
+---------------------+-------+-------+-------+
| Tool                | Calls | %     | Users |
+---------------------+-------+-------+-------+
| search_transactions | 10    | 66.7% | 2     |
| get_cashflow        | 2     | 13.3% | 1     |
| get_net_worth       | 2     | 13.3% | 1     |
| create_transaction  | 1     | 6.7%  | 1     |
+---------------------+-------+-------+-------+

By user (top 20)
+--------------------------------------------+-------+-------+---------------------+
| User                                       | Calls | Tools | Last call           |
+--------------------------------------------+-------+-------+---------------------+
| ana@example.com                            | 12    | 4     | 2026-08-11 08:06:59 |
| 20260811080659_bruno@example.com (deleted)  | 3     | 1     | 2026-08-11 08:06:59 |
+--------------------------------------------+-------+-------+---------------------+

By day
+------------+-------+-------+
| Day        | Calls | Users |
+------------+-------+-------+
| 2026-08-08 | 2     | 1     |
| 2026-08-11 | 13    | 2     |
+------------+-------+-------+
```

The per-user table joins `users` instead of eager-loading the relation: `user:delete` soft-deletes, so the FK cascade never fires and the relation's `deleted_at is null` scope would silently blank out exactly the users we most want to see — the ones who churned. They render with a `(deleted)` marker.

## QA

Driven through the real `/mcp` HTTP endpoint with real Sanctum bearer tokens, against MySQL:

- 5 successful calls by a read+write user → 5 rows, right user, right tool names.
- `get_net_worth` with missing arguments and `search_transactions` on an unreachable space → both rejected, neither recorded.
- A read-only token: `list_accounts` recorded; `create_label` rejected with "This token is read-only" and not recorded.
- Report checked at `--days` 1 / 30 / 200, with `--top 1` truncation, with a churned (`markAsDeleted()`) user, and with no data at all.

48 MCP tests green, `pint` and `phpstan` clean.

## Deliberately left out

- **No Discord post or schedule.** The other `stats:*` commands post weekly; whether MCP usage is worth that noise is a product call, and it's one `Schedule::command()` line whenever we want it.
- **No client column.** `Auth::getDefaultDriver()` would tell us OAuth (Claude Desktop / ChatGPT) vs personal token (Claude Code) at the insert. It's not recoverable after the fact, so it's worth knowing we skipped it — but it wasn't asked for.
- **No pruning.** Noted in the migration; add it if the table ever gets big.
- **No collector service.** The sibling report commands extract one because they feed both the console and Discord. This has one consumer.
