### PR TITLE
fix(coinbase): stop one unlisted stablecoin from unpricing the whole portfolio

### DIFF
--- a/app/Services/Banking/CoinbaseBalanceSyncService.php
+++ b/app/Services/Banking/CoinbaseBalanceSyncService.php
@@ -4,12 +4,12 @@ namespace App\Services\Banking;
 
 use App\Models\Account;
 use App\Services\CurrencyConversionService;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Log;
 
 class CoinbaseBalanceSyncService
 {
-    /** @var array<int, string> Stablecoins pegged 1:1 to USD */
     /**
      * Stablecoins settle at their peg instead of being quoted, so Coinbase is
      * never asked for a product id that does not exist. EURC is the one that
@@ -288,12 +288,29 @@ class CoinbaseBalanceSyncService
             // does not list, which would leave every other holding unpriced.
             // Asking one at a time costs more calls but contains the damage to
             // the asset that is actually unquotable.
-            return count($assets) > 1
+            //
+            // Only worth it when the batch itself was refused. A 429 or a 5xx
+            // says the endpoint is unhappy with us rather than with one id, and
+            // CoinbaseClient already spends up to ~100s of backoff per call -
+            // fanning that out across every holding would blow the sync job's
+            // 120s timeout instead of returning a wrong-but-quick answer.
+            return count($assets) > 1 && $this->isRejectedBatch($e)
                 ? $this->fetchBestBidAskPricesIndividually($client, $assets, $quoteCurrency)
                 : [];
         }
 
         return $this->mapPricebooks($response);
+    }
+
+    /**
+     * A client error other than a rate limit means Coinbase read the request
+     * and refused it - for best_bid_ask that is an unlisted product id.
+     */
+    private function isRejectedBatch(\Throwable $e): bool
+    {
+        return $e instanceof RequestException
+            && $e->response->clientError()
+            && $e->response->status() !== 429;
     }
 
     /**

--- a/app/Services/Banking/CoinbaseBalanceSyncService.php
+++ b/app/Services/Banking/CoinbaseBalanceSyncService.php
@@ -284,10 +284,31 @@ class CoinbaseBalanceSyncService
                 'error' => $e->getMessage(),
             ]);
 
-            return [];
+            // Coinbase rejects the whole request over a single product id it
+            // does not list, which would leave every other holding unpriced.
+            // Asking one at a time costs more calls but contains the damage to
+            // the asset that is actually unquotable.
+            return count($assets) > 1
+                ? $this->fetchBestBidAskPricesIndividually($client, $assets, $quoteCurrency)
+                : [];
         }
 
         return $this->mapPricebooks($response);
+    }
+
+    /**
+     * @param  array<int, string>  $assets
+     * @return array<string, float>
+     */
+    private function fetchBestBidAskPricesIndividually(CoinbaseClient $client, array $assets, string $quoteCurrency): array
+    {
+        $map = [];
+
+        foreach ($assets as $asset) {
+            $map += $this->fetchBestBidAskPrices($client, [$asset], $quoteCurrency);
+        }
+
+        return $map;
     }
 
     /**

--- a/app/Services/Banking/CoinbaseBalanceSyncService.php
+++ b/app/Services/Banking/CoinbaseBalanceSyncService.php
@@ -10,7 +10,20 @@ use Illuminate\Support\Facades\Log;
 class CoinbaseBalanceSyncService
 {
     /** @var array<int, string> Stablecoins pegged 1:1 to USD */
-    private const USD_STABLECOINS = ['USDT', 'USDC', 'DAI', 'PYUSD', 'GUSD'];
+    /**
+     * Stablecoins settle at their peg instead of being quoted, so Coinbase is
+     * never asked for a product id that does not exist. EURC is the one that
+     * bit us: pegged to EUR, not USD, and not an ISO 4217 code either, so it
+     * reached the pricebook as a crypto id and 400'd the whole batch.
+     */
+    private const STABLECOIN_PEGS = [
+        'USDT' => 'USD',
+        'USDC' => 'USD',
+        'DAI' => 'USD',
+        'PYUSD' => 'USD',
+        'GUSD' => 'USD',
+        'EURC' => 'EUR',
+    ];
 
     private const USD_CURRENCY = 'USD';
 
@@ -212,10 +225,10 @@ class CoinbaseBalanceSyncService
      */
     private function fetchPriceMap(CoinbaseClient $client, array $assets, string $targetCurrency): array
     {
-        // convertCryptoAssets settles stablecoins at 1 USD before it ever reads
-        // the map, so quoting them is two wasted round trips. The historical
-        // path skips them for the same reason.
-        $assets = array_values(array_diff($assets, self::USD_STABLECOINS));
+        // convertCryptoAssets settles stablecoins at their peg before it ever
+        // reads the map, so quoting them is two wasted round trips. The
+        // historical path skips them for the same reason.
+        $assets = array_values(array_diff($assets, array_keys(self::STABLECOIN_PEGS)));
 
         if ($assets === []) {
             return [];
@@ -274,6 +287,15 @@ class CoinbaseBalanceSyncService
             return [];
         }
 
+        return $this->mapPricebooks($response);
+    }
+
+    /**
+     * @param  array<string, mixed>  $response
+     * @return array<string, float>
+     */
+    private function mapPricebooks(array $response): array
+    {
         $map = [];
 
         foreach ($response['pricebooks'] ?? [] as $pricebook) {
@@ -310,7 +332,7 @@ class CoinbaseBalanceSyncService
         $priceHistory = [];
 
         foreach ($assets as $asset) {
-            if (in_array($asset, self::USD_STABLECOINS, true)) {
+            if (isset(self::STABLECOIN_PEGS[$asset])) {
                 continue;
             }
 
@@ -436,8 +458,8 @@ class CoinbaseBalanceSyncService
         $total = 0.0;
 
         foreach ($cryptoAssets as $asset => $quantity) {
-            if (in_array($asset, self::USD_STABLECOINS, true)) {
-                $total += $this->convertFiatOnDate(self::USD_CURRENCY, $quantity, $targetCurrency, $date);
+            if (isset(self::STABLECOIN_PEGS[$asset])) {
+                $total += $this->convertFiatOnDate(self::STABLECOIN_PEGS[$asset], $quantity, $targetCurrency, $date);
 
                 continue;
             }
@@ -467,8 +489,8 @@ class CoinbaseBalanceSyncService
         $total = 0.0;
 
         foreach ($cryptoAssets as $asset => $quantity) {
-            if (in_array($asset, self::USD_STABLECOINS, true)) {
-                $total += $this->convertFiat(self::USD_CURRENCY, $quantity, $targetCurrency);
+            if (isset(self::STABLECOIN_PEGS[$asset])) {
+                $total += $this->convertFiat(self::STABLECOIN_PEGS[$asset], $quantity, $targetCurrency);
 
                 continue;
             }

--- a/tests/Feature/OpenBanking/CoinbaseBalanceSyncTest.php
+++ b/tests/Feature/OpenBanking/CoinbaseBalanceSyncTest.php
@@ -8,8 +8,12 @@ use App\Services\Banking\CoinbaseClient;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Sleep;
 
-afterEach(fn () => Carbon::setTestNow());
+afterEach(function () {
+    Carbon::setTestNow();
+    Sleep::fake(false);
+});
 
 function ecPrivateKeyForCoinbase(): string
 {
@@ -382,6 +386,68 @@ test('prices the rest of the portfolio when Coinbase rejects one product id', fu
     Http::assertSent(fn (Request $request) => str_contains($request->url(), 'best_bid_ask')
         && str_contains($request->url(), 'BTC-EUR')
         && ! str_contains($request->url(), 'NOPE'));
+});
+
+test('gives up on a rate-limited price batch rather than retrying every asset', function () {
+    // CoinbaseClient backs off 10s/30s/60s on a 429; without this the test
+    // spends over three minutes sleeping for real.
+    Sleep::fake();
+
+    $user = User::factory()->onboarded()->create(['currency_code' => 'EUR']);
+    $connection = BankingConnection::factory()->coinbase()->create(['user_id' => $user->id]);
+    $account = Account::factory()->connected()->create([
+        'user_id' => $user->id,
+        'banking_connection_id' => $connection->id,
+        'external_account_id' => 'coinbase-portfolio',
+        'currency_code' => 'EUR',
+    ]);
+
+    Http::fake(function (Request $request) {
+        $url = $request->url();
+
+        if (str_contains($url, '/api/v3/brokerage/accounts')) {
+            return Http::response([
+                'accounts' => [
+                    [
+                        'uuid' => 'cb-1',
+                        'name' => 'BTC',
+                        'currency' => 'BTC',
+                        'available_balance' => ['value' => '1.0', 'currency' => 'BTC'],
+                        'hold' => ['value' => '0', 'currency' => 'BTC'],
+                        'active' => true,
+                        'type' => 'ACCOUNT_TYPE_CRYPTO',
+                    ],
+                    [
+                        'uuid' => 'cb-2',
+                        'name' => 'ETH',
+                        'currency' => 'ETH',
+                        'available_balance' => ['value' => '1.0', 'currency' => 'ETH'],
+                        'hold' => ['value' => '0', 'currency' => 'ETH'],
+                        'active' => true,
+                        'type' => 'ACCOUNT_TYPE_CRYPTO',
+                    ],
+                ],
+                'has_next' => false,
+                'cursor' => '',
+                'size' => 2,
+            ]);
+        }
+
+        if (str_contains($url, '/api/v3/brokerage/best_bid_ask')) {
+            return Http::response(['error' => 'rate limit'], 429);
+        }
+
+        return Http::response([], 404);
+    });
+
+    $client = new CoinbaseClient('organizations/org/apiKeys/key', ecPrivateKeyForCoinbase());
+    app(CoinbaseBalanceSyncService::class)->sync($account, $client);
+
+    // A rate limit is not one bad product id, and CoinbaseClient already burns
+    // up to ~100s of backoff per call - fanning out would blow the job timeout.
+    Http::assertNotSent(fn (Request $request) => str_contains($request->url(), 'best_bid_ask')
+        && str_contains($request->url(), 'BTC-EUR')
+        && ! str_contains($request->url(), 'ETH-EUR'));
 });
 
 test('first sync creates twelve monthly coinbase historical balances', function () {

--- a/tests/Feature/OpenBanking/CoinbaseBalanceSyncTest.php
+++ b/tests/Feature/OpenBanking/CoinbaseBalanceSyncTest.php
@@ -311,6 +311,79 @@ test('settles EURC at its euro peg instead of asking Coinbase to quote it', func
     Http::assertNotSent(fn (Request $request) => str_contains($request->url(), 'EURC'));
 });
 
+test('prices the rest of the portfolio when Coinbase rejects one product id', function () {
+    $user = User::factory()->onboarded()->create(['currency_code' => 'EUR']);
+    $connection = BankingConnection::factory()->coinbase()->create(['user_id' => $user->id]);
+    $account = Account::factory()->connected()->create([
+        'user_id' => $user->id,
+        'banking_connection_id' => $connection->id,
+        'external_account_id' => 'coinbase-portfolio',
+        'currency_code' => 'EUR',
+    ]);
+
+    Http::fake(function (Request $request) {
+        $url = $request->url();
+
+        if (str_contains($url, '/api/v3/brokerage/accounts')) {
+            return Http::response([
+                'accounts' => [
+                    [
+                        'uuid' => 'cb-1',
+                        'name' => 'BTC',
+                        'currency' => 'BTC',
+                        'available_balance' => ['value' => '1.0', 'currency' => 'BTC'],
+                        'hold' => ['value' => '0', 'currency' => 'BTC'],
+                        'active' => true,
+                        'type' => 'ACCOUNT_TYPE_CRYPTO',
+                    ],
+                    [
+                        'uuid' => 'cb-2',
+                        'name' => 'NOPE',
+                        'currency' => 'NOPE',
+                        'available_balance' => ['value' => '5.0', 'currency' => 'NOPE'],
+                        'hold' => ['value' => '0', 'currency' => 'NOPE'],
+                        'active' => true,
+                        'type' => 'ACCOUNT_TYPE_CRYPTO',
+                    ],
+                ],
+                'has_next' => false,
+                'cursor' => '',
+                'size' => 2,
+            ]);
+        }
+
+        if (str_contains($url, '/api/v3/brokerage/best_bid_ask')) {
+            // Anything asking for NOPE is refused, batch or not.
+            if (str_contains($url, 'NOPE')) {
+                return Http::response(['error' => 'invalid product_id provided: "NOPE-EUR"'], 400);
+            }
+
+            return Http::response([
+                'pricebooks' => [
+                    [
+                        'product_id' => 'BTC-EUR',
+                        'bids' => [['price' => '50000.00', 'size' => '1']],
+                        'asks' => [['price' => '50000.00', 'size' => '1']],
+                    ],
+                ],
+            ]);
+        }
+
+        return Http::response([], 404);
+    });
+
+    $client = new CoinbaseClient('organizations/org/apiKeys/key', ecPrivateKeyForCoinbase());
+    app(CoinbaseBalanceSyncService::class)->sync($account, $client);
+
+    // BTC survives the rejected batch: only the unquotable asset is lost.
+    expect($account->balances()->first()->balance)->toBe(5_000_000);
+
+    // The retry asked for BTC on its own rather than giving up on the batch.
+    Http::assertSent(fn (Request $request) => str_contains($request->url(), 'best_bid_ask')
+        && str_contains($request->url(), 'BTC-EUR')
+        && ! str_contains($request->url(), 'NOPE'));
+});
+
 test('first sync creates twelve monthly coinbase historical balances', function () {
     Carbon::setTestNow('2026-05-14 12:00:00');
 

--- a/tests/Feature/OpenBanking/CoinbaseBalanceSyncTest.php
+++ b/tests/Feature/OpenBanking/CoinbaseBalanceSyncTest.php
@@ -241,6 +241,76 @@ test('mixes fiat-quoted and USD-only assets in one balance', function () {
         && ! str_contains($request->url(), 'BTC-USD'));
 });
 
+test('settles EURC at its euro peg instead of asking Coinbase to quote it', function () {
+    $user = User::factory()->onboarded()->create(['currency_code' => 'EUR']);
+    $connection = BankingConnection::factory()->coinbase()->create(['user_id' => $user->id]);
+    $account = Account::factory()->connected()->create([
+        'user_id' => $user->id,
+        'banking_connection_id' => $connection->id,
+        'external_account_id' => 'coinbase-portfolio',
+        'currency_code' => 'EUR',
+    ]);
+
+    Http::fake(function (Request $request) {
+        $url = $request->url();
+
+        if (str_contains($url, '/api/v3/brokerage/accounts')) {
+            return Http::response([
+                'accounts' => [
+                    [
+                        'uuid' => 'cb-1',
+                        'name' => 'BTC',
+                        'currency' => 'BTC',
+                        'available_balance' => ['value' => '1.0', 'currency' => 'BTC'],
+                        'hold' => ['value' => '0', 'currency' => 'BTC'],
+                        'active' => true,
+                        'type' => 'ACCOUNT_TYPE_CRYPTO',
+                    ],
+                    [
+                        'uuid' => 'cb-2',
+                        'name' => 'EURC',
+                        'currency' => 'EURC',
+                        'available_balance' => ['value' => '100.0', 'currency' => 'EURC'],
+                        'hold' => ['value' => '0', 'currency' => 'EURC'],
+                        'active' => true,
+                        'type' => 'ACCOUNT_TYPE_CRYPTO',
+                    ],
+                ],
+                'has_next' => false,
+                'cursor' => '',
+                'size' => 2,
+            ]);
+        }
+
+        if (str_contains($url, '/api/v3/brokerage/best_bid_ask')) {
+            // Coinbase does not list EURC-EUR; asking for it 400s the batch.
+            if (str_contains($url, 'EURC')) {
+                return Http::response(['error' => 'invalid product_id provided: "EURC-EUR"'], 400);
+            }
+
+            return Http::response([
+                'pricebooks' => [
+                    [
+                        'product_id' => 'BTC-EUR',
+                        'bids' => [['price' => '50000.00', 'size' => '1']],
+                        'asks' => [['price' => '50000.00', 'size' => '1']],
+                    ],
+                ],
+            ]);
+        }
+
+        return Http::response([], 404);
+    });
+
+    $client = new CoinbaseClient('organizations/org/apiKeys/key', ecPrivateKeyForCoinbase());
+    app(CoinbaseBalanceSyncService::class)->sync($account, $client);
+
+    // 1 BTC * 50000 EUR + 100 EURC at par = 50100 EUR.
+    expect($account->balances()->first()->balance)->toBe(5_010_000);
+
+    Http::assertNotSent(fn (Request $request) => str_contains($request->url(), 'EURC'));
+});
+
 test('first sync creates twelve monthly coinbase historical balances', function () {
     Carbon::setTestNow('2026-05-14 12:00:00');
 


### PR DESCRIPTION
Follow-up to #759, which turned out to be **inert in production**. Confirmed from the logs after it deployed.

## What is actually happening

`fetchPriceMap` builds `{ASSET}-{QUOTE}` product ids for a batched `best_bid_ask` call. **EURC** — Circle's euro stablecoin — is not an ISO 4217 code, so `isFiatCurrency()` rejects it, and the stablecoin list was USD-only, so it went out as an ordinary crypto product id.

Coinbase does not list `EURC-EUR`, and it refuses the **entire** request over one unknown id:

```
invalid product_id provided: "EURC-EUR"
```

Since #759 that happens twice per run — once for the fiat pass, once for the new USD retry (`invalid product_id provided: "EURC-USD"`). So `fetchPriceMap` has been returning an empty map on **every** sync, #759's USD hop never contributed anything, and every holding fell through to the per-asset `CurrencyConversionService`, which prices almost no crypto. The post-#759 log signature is 2× `Coinbase API error` (400) + 2× `Coinbase best_bid_ask failed` per run, and `Could not price Coinbase asset` never dropped.

The balance is still written, so net worth and the chart have been showing a badly understated number.

## Three commits

1. **EURC settles at its euro peg.** The USD-only list became a peg map (`asset => peg currency`), which also collapses three duplicated `in_array` branches into one lookup that carries the peg. USDT/USDC/DAI/PYUSD/GUSD are byte-for-byte unchanged.
2. **A rejected batch retries one asset at a time.** Fixing EURC removes today's bad id, but not the shape of the failure: one unlisted holding takes the price of every other holding with it, and the next unlisted token would do it again. The batch is now an optimisation rather than a single point of failure.
3. **Fan out only when the batch itself was refused.** Both reviews caught this independently, and it was a real bug I introduced in commit 2: retrying on *any* throwable multiplies `CoinbaseClient`'s own 429 backoff (10s/30s/60s ≈ 100s per call) by the number of holdings, against `SyncBankingConnectionJob`'s 120s timeout — trading a fast wrong answer for a sync that hangs and dies. The fan-out now requires a 4xx that is not 429.

## Tests

Three new, each verified to fail without its fix:

| test | without the fix |
|---|---|
| `settles EURC at its euro peg instead of asking Coinbase to quote it` | 5 000 000 instead of 5 010 000 — the EURC vanishes |
| `prices the rest of the portfolio when Coinbase rejects one product id` | **0** — the entire portfolio unpriced, which is what production does today |
| `gives up on a rate-limited price batch rather than retrying every asset` | fans out and sends the per-asset requests |

The 429 test fakes `Sleep`; without it the real backoff makes the file take 209s instead of 10s.

`tests/Feature/OpenBanking` is green at 341/341 locally.

## Deliberately not here

- **Already-written rows stay understated.** `needsHistoricalBackfill` is already satisfied by the wrong rows, so the next sync only heals today's. The chart will show a discontinuity on deploy day. No new code needed to repair it — `SyncBankingConnectionJob` already has a `fullSync` flag that forces the historical pass, reachable as `php artisan banking:sync --full`. Replaying a year of pricing on real accounts is your call, not something this loop should do unattended. Blast radius: 2 Coinbase connections, both EUR.
- **A USD-currency user's EURC** used to be quoted against the real `EURC-USD` pair and now goes peg + FX instead. Inert today (all crypto connections in production are EUR) and consistent with how USDT/USDC are already handled, but it is a silent pricing change for a future USD holder.
- **Anything not in the peg map and not quotable is still silently zero.** This fixes EURC by name; the general "report an incomplete balance as if it were complete" behaviour needs a product decision.
- **`BinanceBalanceSyncService`'s historical path** still hands a raw crypto ticker to the fiat converter with no USD hop (its live path is fine). Same class, own PR — I started on it this cycle and dropped it when the logs showed this was live and Binance's was not.
