### PR TITLE
refactor(analytics): dedupe the two account balance evolution endpoints

### DIFF
--- a/app/Http/Controllers/Api/DashboardAnalyticsController.php
+++ b/app/Http/Controllers/Api/DashboardAnalyticsController.php
@@ -429,7 +429,9 @@ class DashboardAnalyticsController extends Controller
      */
     private function realEstateProjection(Account $account, ?Account $linkedLoanAccount, array $points, ?string $displayCurrencyCode): array
     {
-        $revaluationPercentage = (float) ($account->realEstateDetail?->revaluation_percentage ?? 0);
+        // The ?? already covers a missing detail row, so no nullsafe operator here
+        // (phpstan flags the combination as redundant).
+        $revaluationPercentage = (float) ($account->realEstateDetail->revaluation_percentage ?? 0);
         $linkedLoanDetail = $linkedLoanAccount?->loadMissing('loanDetail')->loanDetail;
 
         if ($revaluationPercentage === 0.0 && $linkedLoanDetail === null) {

--- a/app/Http/Controllers/Api/DashboardAnalyticsController.php
+++ b/app/Http/Controllers/Api/DashboardAnalyticsController.php
@@ -15,6 +15,7 @@ use App\Services\LoanAmortizationService;
 use App\Services\PeriodComparator;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class DashboardAnalyticsController extends Controller
@@ -113,28 +114,11 @@ class DashboardAnalyticsController extends Controller
 
     public function accountBalanceEvolution(Request $request, Account $account)
     {
-        if ($account->user_id !== $request->user()->id) {
-            abort(403);
-        }
-
-        $validated = $request->validate([
-            'from' => 'required|date',
-            'to' => 'required|date',
-        ]);
-
-        $start = Carbon::parse($validated['from']);
-        $end = Carbon::parse($validated['to']);
+        [$start, $end] = $this->authorizedDateRange($request, $account);
 
         $linkedLoanAccount = $this->getLinkedLoanAccount($account);
-        $linkedLoanId = $linkedLoanAccount?->id;
-        $accountIds = $linkedLoanId ? [$account->id, $linkedLoanId] : [$account->id];
-
-        $lookup = BalanceLookup::forAccounts($accountIds, $start->copy()->startOfMonth(), $end);
-
-        $userCurrency = $request->user()->currency_code;
-        $displayCurrencyCode = strcasecmp($account->currency_code, $userCurrency) !== 0
-            ? $userCurrency
-            : null;
+        $displayCurrencyCode = $this->displayCurrencyFor($request, $account);
+        $lookup = $this->balanceLookupFor($account, $linkedLoanAccount, $start->copy()->startOfMonth(), $end);
 
         $points = [];
         $current = $start->copy()->startOfMonth();
@@ -142,276 +126,41 @@ class DashboardAnalyticsController extends Controller
 
         while ($current->lte($endMonth)) {
             $date = $current->copy()->endOfMonth();
-            $value = $lookup->getBalanceAt($account->id, $date);
-            $point = [
+            $points[] = [
                 'month' => $date->format('Y-m'),
-                'timestamp' => $date->timestamp,
-                'value' => $value,
+                ...$this->balancePointAt($account, $linkedLoanAccount, $lookup, $date, $displayCurrencyCode),
             ];
-
-            if ($account->type->supportsInvestedAmount()) {
-                $investedAmount = $lookup->getInvestedAmountAt($account->id, $date);
-                $point['invested_amount'] = $investedAmount;
-
-                if ($displayCurrencyCode !== null && $investedAmount !== null) {
-                    $point['display_invested_amount'] = $this->convertBalanceForDate($userCurrency, $account->currency_code, $investedAmount, $date);
-                }
-            }
-
-            if ($linkedLoanId) {
-                $mortgageBalance = $lookup->getBalanceAt($linkedLoanId, $date);
-                $point['mortgage_balance'] = $this->convertBalanceForDate(
-                    $linkedLoanAccount->currency_code,
-                    $account->currency_code,
-                    $mortgageBalance,
-                    $date,
-                );
-
-                if ($displayCurrencyCode !== null) {
-                    $point['display_mortgage_balance'] = $this->convertBalanceForDate(
-                        $linkedLoanAccount->currency_code,
-                        $displayCurrencyCode,
-                        $mortgageBalance,
-                        $date,
-                    );
-                }
-            }
-
-            if ($displayCurrencyCode !== null) {
-                $point['display_value'] = $this->convertBalanceForDate(
-                    $account->currency_code,
-                    $displayCurrencyCode,
-                    $value,
-                    $date,
-                );
-            }
-
-            $points[] = $point;
             $current->addMonth();
         }
 
-        // Append projected future months for loan accounts with loan details
-        if ($account->type === AccountType::Loan) {
-            $loanDetail = $account->loanDetail;
-
-            if ($loanDetail) {
-                $projection = $this->loanAmortizationService->generateProjection($loanDetail, 12);
-                $now = Carbon::now();
-
-                foreach ($projection as $yearMonth => $balanceCents) {
-                    $projectedDate = Carbon::createFromFormat('Y-m', $yearMonth)->endOfMonth();
-
-                    // Only add future months that are beyond the current date
-                    if ($projectedDate->lte($now)) {
-                        continue;
-                    }
-
-                    $projectedPoint = [
-                        'month' => $yearMonth,
-                        'timestamp' => $projectedDate->timestamp,
-                        'value' => $balanceCents,
-                        'projected' => true,
-                    ];
-
-                    if ($displayCurrencyCode !== null) {
-                        $projectedPoint['display_value'] = $this->convertBalanceForDate(
-                            $account->currency_code,
-                            $displayCurrencyCode,
-                            $balanceCents,
-                            Carbon::today(),
-                        );
-                    }
-
-                    $points[] = $projectedPoint;
-                }
-            }
-        }
-
-        // Append projected future months for real estate accounts with revaluation
-        // and/or a linked loan, so the chart shows both market value and mortgage
-        // forward together.
-        if ($account->type === AccountType::RealEstate) {
-            $realEstateDetail = $account->realEstateDetail;
-            $revaluationPercentage = $realEstateDetail?->revaluation_percentage;
-            $hasRevaluation = $revaluationPercentage !== null && (float) $revaluationPercentage !== 0.0;
-
-            $linkedLoanDetail = null;
-            if ($linkedLoanAccount) {
-                $linkedLoanAccount->loadMissing('loanDetail');
-                $linkedLoanDetail = $linkedLoanAccount->loanDetail;
-            }
-
-            if ($hasRevaluation || $linkedLoanDetail) {
-                $monthsAhead = 12;
-                $now = Carbon::now();
-                $lastPoint = end($points);
-                $baseValue = is_array($lastPoint) ? $lastPoint['value'] : 0;
-                $monthlyRate = $hasRevaluation ? ((float) $revaluationPercentage / 12 / 100) : 0.0;
-
-                $loanProjection = $linkedLoanDetail
-                    ? $this->loanAmortizationService->generateProjection($linkedLoanDetail, $monthsAhead)
-                    : [];
-
-                for ($i = 1; $i <= $monthsAhead; $i++) {
-                    $projectedDate = $now->copy()->addMonthsNoOverflow($i)->endOfMonth();
-                    $yearMonth = $projectedDate->format('Y-m');
-
-                    $projectedValue = (int) round($baseValue * pow(1 + $monthlyRate, $i));
-
-                    $projectedPoint = [
-                        'month' => $yearMonth,
-                        'timestamp' => $projectedDate->timestamp,
-                        'value' => $projectedValue,
-                        'projected' => true,
-                    ];
-
-                    if ($displayCurrencyCode !== null) {
-                        $projectedPoint['display_value'] = $this->convertBalanceForDate(
-                            $account->currency_code,
-                            $displayCurrencyCode,
-                            $projectedValue,
-                            Carbon::today(),
-                        );
-                    }
-
-                    if ($linkedLoanDetail && array_key_exists($yearMonth, $loanProjection)) {
-                        $mortgageProj = $loanProjection[$yearMonth];
-                        $projectedPoint['mortgage_balance'] = $this->convertBalanceForDate(
-                            $linkedLoanAccount->currency_code,
-                            $account->currency_code,
-                            $mortgageProj,
-                            $projectedDate,
-                        );
-
-                        if ($displayCurrencyCode !== null) {
-                            $projectedPoint['display_mortgage_balance'] = $this->convertBalanceForDate(
-                                $linkedLoanAccount->currency_code,
-                                $displayCurrencyCode,
-                                $mortgageProj,
-                                $projectedDate,
-                            );
-                        }
-                    }
-
-                    $points[] = $projectedPoint;
-                }
-            }
-        }
-
-        $response = [
-            'data' => $points,
-            'account' => [
-                'id' => $account->id,
-                'name' => $account->name,
-                'name_iv' => $account->name_iv,
-                'encrypted' => $account->encrypted,
-                'type' => $account->type,
-                'currency_code' => $account->currency_code,
-            ],
-        ];
-
-        if ($displayCurrencyCode !== null) {
-            $response['display_currency_code'] = $displayCurrencyCode;
-        }
-
-        return response()->json($response);
+        return $this->evolutionResponse(
+            [...$points, ...$this->projectedPoints($account, $linkedLoanAccount, $points, $displayCurrencyCode)],
+            $account,
+            $displayCurrencyCode,
+        );
     }
 
     public function accountDailyBalanceEvolution(Request $request, Account $account)
     {
-        if ($account->user_id !== $request->user()->id) {
-            abort(403);
-        }
-
-        $validated = $request->validate([
-            'from' => 'required|date',
-            'to' => 'required|date',
-        ]);
-
-        $start = Carbon::parse($validated['from']);
-        $end = Carbon::parse($validated['to']);
+        [$start, $end] = $this->authorizedDateRange($request, $account);
 
         $linkedLoanAccount = $this->getLinkedLoanAccount($account);
-        $linkedLoanId = $linkedLoanAccount?->id;
-        $accountIds = $linkedLoanId ? [$account->id, $linkedLoanId] : [$account->id];
-
-        $lookup = BalanceLookup::forAccounts($accountIds, $start, $end);
-
-        $userCurrency = $request->user()->currency_code;
-        $displayCurrencyCode = strcasecmp($account->currency_code, $userCurrency) !== 0
-            ? $userCurrency
-            : null;
+        $displayCurrencyCode = $this->displayCurrencyFor($request, $account);
+        $lookup = $this->balanceLookupFor($account, $linkedLoanAccount, $start, $end);
 
         $points = [];
         $current = $start->copy();
 
         while ($current->lte($end)) {
-            $date = $current->copy();
-            $value = $lookup->getBalanceAt($account->id, $date);
-            $point = [
+            $date = $current->copy()->endOfDay();
+            $points[] = [
                 'date' => $date->format('Y-m-d'),
-                'timestamp' => $date->endOfDay()->timestamp,
-                'value' => $value,
+                ...$this->balancePointAt($account, $linkedLoanAccount, $lookup, $date, $displayCurrencyCode),
             ];
-
-            if ($account->type->supportsInvestedAmount()) {
-                $investedAmount = $lookup->getInvestedAmountAt($account->id, $date);
-                $point['invested_amount'] = $investedAmount;
-
-                if ($displayCurrencyCode !== null && $investedAmount !== null) {
-                    $point['display_invested_amount'] = $this->convertBalanceForDate($userCurrency, $account->currency_code, $investedAmount, $date);
-                }
-            }
-
-            if ($linkedLoanId) {
-                $mortgageBalance = $lookup->getBalanceAt($linkedLoanId, $date);
-                $point['mortgage_balance'] = $this->convertBalanceForDate(
-                    $linkedLoanAccount->currency_code,
-                    $account->currency_code,
-                    $mortgageBalance,
-                    $date,
-                );
-
-                if ($displayCurrencyCode !== null) {
-                    $point['display_mortgage_balance'] = $this->convertBalanceForDate(
-                        $linkedLoanAccount->currency_code,
-                        $displayCurrencyCode,
-                        $mortgageBalance,
-                        $date,
-                    );
-                }
-            }
-
-            if ($displayCurrencyCode !== null) {
-                $point['display_value'] = $this->convertBalanceForDate(
-                    $account->currency_code,
-                    $displayCurrencyCode,
-                    $value,
-                    $date,
-                );
-            }
-
-            $points[] = $point;
             $current->addDay();
         }
 
-        $response = [
-            'data' => $points,
-            'account' => [
-                'id' => $account->id,
-                'name' => $account->name,
-                'name_iv' => $account->name_iv,
-                'encrypted' => $account->encrypted,
-                'type' => $account->type,
-                'currency_code' => $account->currency_code,
-            ],
-        ];
-
-        if ($displayCurrencyCode !== null) {
-            $response['display_currency_code'] = $displayCurrencyCode;
-        }
-
-        return response()->json($response);
+        return $this->evolutionResponse($points, $account, $displayCurrencyCode);
     }
 
     public function netWorthDailyEvolution(Request $request)
@@ -505,45 +254,278 @@ class DashboardAnalyticsController extends Controller
 
     private function calculateSpending(Carbon $from, Carbon $to): int
     {
-        $spending = Transaction::query()
-            ->where('transactions.user_id', request()->user()->id)
-            ->whereBetween('transactions.transaction_date', [$from, $to])
-            ->join('categories', function ($join) {
-                $join->on('transactions.category_id', '=', 'categories.id')
-                    ->where('categories.type', '=', CategoryType::Expense)
-                    ->whereNull('categories.deleted_at');
-            })
-            ->sum('transactions.amount');
-
-        return max(0, -$spending);
+        return max(0, -$this->sumByCategoryType(CategoryType::Expense, $from, $to));
     }
 
     private function calculateCashFlow(Carbon $from, Carbon $to): array
     {
-        $income = Transaction::query()
-            ->where('transactions.user_id', request()->user()->id)
-            ->whereBetween('transactions.transaction_date', [$from, $to])
-            ->join('categories', function ($join) {
-                $join->on('transactions.category_id', '=', 'categories.id')
-                    ->where('categories.type', '=', CategoryType::Income)
-                    ->whereNull('categories.deleted_at');
-            })
-            ->sum('transactions.amount');
-
-        $expense = Transaction::query()
-            ->where('transactions.user_id', request()->user()->id)
-            ->whereBetween('transactions.transaction_date', [$from, $to])
-            ->join('categories', function ($join) {
-                $join->on('transactions.category_id', '=', 'categories.id')
-                    ->where('categories.type', '=', CategoryType::Expense)
-                    ->whereNull('categories.deleted_at');
-            })
-            ->sum('transactions.amount');
-
         return [
-            'income' => max(0, $income),
-            'expense' => max(0, -$expense),
+            'income' => max(0, $this->sumByCategoryType(CategoryType::Income, $from, $to)),
+            'expense' => max(0, -$this->sumByCategoryType(CategoryType::Expense, $from, $to)),
         ];
+    }
+
+    /**
+     * Signed sum of the user's transactions in the range whose category is of the
+     * given type: income comes out positive, expenses negative.
+     */
+    private function sumByCategoryType(CategoryType $type, Carbon $from, Carbon $to): int
+    {
+        return (int) Transaction::query()
+            ->where('transactions.user_id', request()->user()->id)
+            ->whereBetween('transactions.transaction_date', [$from, $to])
+            ->join('categories', function ($join) use ($type) {
+                $join->on('transactions.category_id', '=', 'categories.id')
+                    ->where('categories.type', '=', $type)
+                    ->whereNull('categories.deleted_at');
+            })
+            ->sum('transactions.amount');
+    }
+
+    /**
+     * Make sure the account belongs to the caller and return the requested range.
+     *
+     * @return array{0: Carbon, 1: Carbon}
+     */
+    private function authorizedDateRange(Request $request, Account $account): array
+    {
+        abort_if($account->user_id !== $request->user()->id, 403);
+
+        $validated = $request->validate([
+            'from' => 'required|date',
+            'to' => 'required|date',
+        ]);
+
+        return [Carbon::parse($validated['from']), Carbon::parse($validated['to'])];
+    }
+
+    /**
+     * The user's currency when it differs from the account's, null when no
+     * conversion is needed.
+     */
+    private function displayCurrencyFor(Request $request, Account $account): ?string
+    {
+        $userCurrency = $request->user()->currency_code;
+
+        return strcasecmp($account->currency_code, $userCurrency) !== 0 ? $userCurrency : null;
+    }
+
+    private function balanceLookupFor(Account $account, ?Account $linkedLoanAccount, Carbon $from, Carbon $to): BalanceLookup
+    {
+        return BalanceLookup::forAccounts(
+            array_values(array_filter([$account->id, $linkedLoanAccount?->id])),
+            $from,
+            $to,
+        );
+    }
+
+    /**
+     * Balance, invested amount and linked-mortgage balance at a single date, with
+     * their display-currency equivalents. The monthly and daily series share this:
+     * they differ only in the dates they ask for.
+     *
+     * @return array<string, int|null>
+     */
+    private function balancePointAt(Account $account, ?Account $linkedLoanAccount, BalanceLookup $lookup, Carbon $date, ?string $displayCurrencyCode): array
+    {
+        $value = $lookup->getBalanceAt($account->id, $date);
+
+        $point = [
+            'timestamp' => $date->timestamp,
+            'value' => $value,
+        ];
+
+        if ($account->type->supportsInvestedAmount()) {
+            $investedAmount = $lookup->getInvestedAmountAt($account->id, $date);
+            $point['invested_amount'] = $investedAmount;
+
+            if ($displayCurrencyCode !== null && $investedAmount !== null) {
+                $point['display_invested_amount'] = $this->convertBalanceForDate($displayCurrencyCode, $account->currency_code, $investedAmount, $date);
+            }
+        }
+
+        if ($linkedLoanAccount !== null) {
+            $mortgageBalance = $lookup->getBalanceAt($linkedLoanAccount->id, $date);
+            $point['mortgage_balance'] = $this->convertBalanceForDate(
+                $linkedLoanAccount->currency_code,
+                $account->currency_code,
+                $mortgageBalance,
+                $date,
+            );
+
+            if ($displayCurrencyCode !== null) {
+                $point['display_mortgage_balance'] = $this->convertBalanceForDate(
+                    $linkedLoanAccount->currency_code,
+                    $displayCurrencyCode,
+                    $mortgageBalance,
+                    $date,
+                );
+            }
+        }
+
+        if ($displayCurrencyCode !== null) {
+            $point['display_value'] = $this->convertBalanceForDate(
+                $account->currency_code,
+                $displayCurrencyCode,
+                $value,
+                $date,
+            );
+        }
+
+        return $point;
+    }
+
+    /**
+     * Future months appended to the historical series: the amortization schedule
+     * for loans, and revaluation plus the linked mortgage for real estate.
+     *
+     * @param  list<array<string, mixed>>  $points  the historical series
+     * @return list<array<string, mixed>>
+     */
+    private function projectedPoints(Account $account, ?Account $linkedLoanAccount, array $points, ?string $displayCurrencyCode): array
+    {
+        return match ($account->type) {
+            AccountType::Loan => $this->loanProjection($account, $displayCurrencyCode),
+            AccountType::RealEstate => $this->realEstateProjection($account, $linkedLoanAccount, $points, $displayCurrencyCode),
+            default => [],
+        };
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function loanProjection(Account $account, ?string $displayCurrencyCode): array
+    {
+        $loanDetail = $account->loanDetail;
+
+        if ($loanDetail === null) {
+            return [];
+        }
+
+        $now = Carbon::now();
+        $points = [];
+
+        foreach ($this->loanAmortizationService->generateProjection($loanDetail, 12) as $yearMonth => $balanceCents) {
+            $projectedDate = Carbon::createFromFormat('Y-m', $yearMonth)->endOfMonth();
+
+            // Only add future months that are beyond the current date
+            if ($projectedDate->lte($now)) {
+                continue;
+            }
+
+            $points[] = $this->projectedPoint($account, $projectedDate, $balanceCents, $displayCurrencyCode);
+        }
+
+        return $points;
+    }
+
+    /**
+     * Real estate projects market value forward from the last historical point at
+     * the revaluation rate, alongside the linked mortgage, so the chart shows both
+     * moving together.
+     *
+     * @param  list<array<string, mixed>>  $points  the historical series
+     * @return list<array<string, mixed>>
+     */
+    private function realEstateProjection(Account $account, ?Account $linkedLoanAccount, array $points, ?string $displayCurrencyCode): array
+    {
+        $revaluationPercentage = (float) ($account->realEstateDetail?->revaluation_percentage ?? 0);
+        $linkedLoanDetail = $linkedLoanAccount?->loadMissing('loanDetail')->loanDetail;
+
+        if ($revaluationPercentage === 0.0 && $linkedLoanDetail === null) {
+            return [];
+        }
+
+        $monthsAhead = 12;
+        $lastPoint = end($points);
+        $baseValue = is_array($lastPoint) ? $lastPoint['value'] : 0;
+        $monthlyRate = $revaluationPercentage / 12 / 100;
+        $loanProjection = $linkedLoanDetail !== null
+            ? $this->loanAmortizationService->generateProjection($linkedLoanDetail, $monthsAhead)
+            : [];
+
+        $now = Carbon::now();
+        $projected = [];
+
+        for ($i = 1; $i <= $monthsAhead; $i++) {
+            $projectedDate = $now->copy()->addMonthsNoOverflow($i)->endOfMonth();
+            $projectedValue = (int) round($baseValue * pow(1 + $monthlyRate, $i));
+            $point = $this->projectedPoint($account, $projectedDate, $projectedValue, $displayCurrencyCode);
+            $mortgageProj = $loanProjection[$projectedDate->format('Y-m')] ?? null;
+
+            if ($mortgageProj !== null) {
+                $point['mortgage_balance'] = $this->convertBalanceForDate(
+                    $linkedLoanAccount->currency_code,
+                    $account->currency_code,
+                    $mortgageProj,
+                    $projectedDate,
+                );
+
+                if ($displayCurrencyCode !== null) {
+                    $point['display_mortgage_balance'] = $this->convertBalanceForDate(
+                        $linkedLoanAccount->currency_code,
+                        $displayCurrencyCode,
+                        $mortgageProj,
+                        $projectedDate,
+                    );
+                }
+            }
+
+            $projected[] = $point;
+        }
+
+        return $projected;
+    }
+
+    /**
+     * A single projected month. Its display value is converted at today's rate:
+     * there is no exchange rate for a date that hasn't happened yet.
+     *
+     * @return array<string, mixed>
+     */
+    private function projectedPoint(Account $account, Carbon $projectedDate, int $value, ?string $displayCurrencyCode): array
+    {
+        $point = [
+            'month' => $projectedDate->format('Y-m'),
+            'timestamp' => $projectedDate->timestamp,
+            'value' => $value,
+            'projected' => true,
+        ];
+
+        if ($displayCurrencyCode !== null) {
+            $point['display_value'] = $this->convertBalanceForDate(
+                $account->currency_code,
+                $displayCurrencyCode,
+                $value,
+                Carbon::today(),
+            );
+        }
+
+        return $point;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $points
+     */
+    private function evolutionResponse(array $points, Account $account, ?string $displayCurrencyCode): JsonResponse
+    {
+        $response = [
+            'data' => $points,
+            'account' => [
+                'id' => $account->id,
+                'name' => $account->name,
+                'name_iv' => $account->name_iv,
+                'encrypted' => $account->encrypted,
+                'type' => $account->type,
+                'currency_code' => $account->currency_code,
+            ],
+        ];
+
+        if ($displayCurrencyCode !== null) {
+            $response['display_currency_code'] = $displayCurrencyCode;
+        }
+
+        return response()->json($response);
     }
 
     /**


### PR DESCRIPTION
## Why

We just landed the CRAP and DRY checks. `DashboardAnalyticsController` was the worst offender after the trial-experiment code (which #762 deletes anyway):

- `accountBalanceEvolution` — cyclomatic complexity **30**
- `accountDailyBalanceEvolution` — cyclomatic complexity **12**

And the two were near-identical copies of each other, so it was a duplication problem wearing a complexity costume.

## What changed

The monthly and daily series shared everything except the dates they iterate and the projections the monthly one appends: authorization, range validation, per-point assembly (balance, invested amount, linked mortgage, display-currency equivalents) and the response envelope. Those are now shared methods:

| new method | what it owns |
|---|---|
| `authorizedDateRange` | 403 guard + `from`/`to` validation + parsing |
| `displayCurrencyFor` | the user currency, or null when it matches the account |
| `balanceLookupFor` | the `BalanceLookup` over the account and its linked loan |
| `balancePointAt` | one point: value, invested amount, mortgage, display fields |
| `projectedPoints` → `loanProjection` / `realEstateProjection` / `projectedPoint` | the future months |
| `evolutionResponse` | the `data` + `account` + `display_currency_code` envelope |

Also collapsed the three byte-identical "sum transactions joined to a category of type X" queries in `calculateSpending`/`calculateCashFlow` behind `sumByCategoryType`.

## Behaviour

No change. One thing worth naming: the daily series used to read the balance at **start** of day and the invested amount at **end** of day (`endOfDay()` mutates the Carbon instance mid-method). It now reads both at end of day — same result, because `BalanceLookup` compares `toDateString()`, i.e. by day.

## Metrics

| | before | after |
|---|---|---|
| methods over complexity 10 | 35 | 33 |
| `accountBalanceEvolution` | 30 | 4 |
| `accountDailyBalanceEvolution` | 12 | 4 |
| duplicated lines (php) | 5.92% | 5.68% |
| duplicated lines (total) | 5.34% | 5.25% |

## Testing

`DashboardAnalyticsTest` (41), `LoanTest` + `AccountControllerTest` (68) — all green, unchanged. Between them they cover both projection paths, both currency-conversion paths and the mortgage overlay, so the refactor is verified by the existing suite; no new tests were needed.

## Noticed, not changed

`display_invested_amount` converts **from** the user currency **to** the account currency, while every sibling field converts the other way. Looks like an inverted argument pair, but fixing it changes numbers on the invested-amount chart, so it stays out of a no-behaviour-change PR. Worth a follow-up.