### PR TITLE
refactor(mcp): dedupe record resolution and field updates in the write tools

### DIFF
--- a/app/Mcp/Tools/DeleteAutomationRule.php
+++ b/app/Mcp/Tools/DeleteAutomationRule.php
@@ -2,10 +2,8 @@
 
 namespace App\Mcp\Tools;
 
-use App\Models\AutomationRule;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
-use Illuminate\Validation\ValidationException;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Attributes\Description;
@@ -29,16 +27,7 @@ class DeleteAutomationRule extends WriteTool
     protected function write(Request $request, User $user): Response
     {
         $space = $this->resolveSpace($request, $user);
-
-        $id = $request->string('automation_rule_id')->toString();
-
-        $rule = AutomationRule::query()->forSpace($space)->whereKey($id)->first();
-
-        if ($rule === null) {
-            throw ValidationException::withMessages([
-                'automation_rule_id' => "No automation rule with id {$id} in space {$space->id}.",
-            ]);
-        }
+        $rule = $this->ruleInSpace($request, $space);
 
         $rule->delete();
 

--- a/app/Mcp/Tools/UpdateAutomationRule.php
+++ b/app/Mcp/Tools/UpdateAutomationRule.php
@@ -3,8 +3,6 @@
 namespace App\Mcp\Tools;
 
 use App\Mcp\Tools\Concerns\DecodesRulesJson;
-use App\Models\AutomationRule;
-use App\Models\Space;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Validation\ValidationException;
@@ -45,23 +43,15 @@ class UpdateAutomationRule extends WriteTool
         $space = $this->resolveSpace($request, $user);
         $rule = $this->ruleInSpace($request, $space);
 
-        if ($request->has('title')) {
-            $rule->title = $request->string('title')->toString();
-        }
-        if ($request->has('priority')) {
-            $rule->priority = $request->integer('priority');
-        }
-        if ($request->has('rules_json')) {
-            $rule->rules_json = $this->rulesJson($request);
-        }
-        if ($request->has('action_category_id')) {
-            $rule->action_category_id = $request->filled('action_category_id')
+        $this->applyFields($request, $rule, [
+            'title' => fn () => $request->string('title')->toString(),
+            'priority' => fn () => $request->integer('priority'),
+            'rules_json' => fn () => $this->rulesJson($request),
+            'action_category_id' => fn () => $request->filled('action_category_id')
                 ? $this->categoryInSpace($request, $space, 'action_category_id')->id
-                : null;
-        }
-        if ($request->has('action_note')) {
-            $rule->action_note = $request->filled('action_note') ? $request->string('action_note')->toString() : null;
-        }
+                : null,
+            'action_note' => fn () => $this->nullableString($request, 'action_note'),
+        ]);
 
         $newLabels = $request->has('action_label_ids')
             ? $this->labelsInSpace($request, $space, 'action_label_ids')
@@ -86,20 +76,5 @@ class UpdateAutomationRule extends WriteTool
         $rule->touch();
 
         return $this->json(['automation_rule' => $this->presentAutomationRule($rule->refresh())]);
-    }
-
-    private function ruleInSpace(Request $request, Space $space): AutomationRule
-    {
-        $id = $request->string('automation_rule_id')->toString();
-
-        $rule = AutomationRule::query()->forSpace($space)->whereKey($id)->first();
-
-        if ($rule === null) {
-            throw ValidationException::withMessages([
-                'automation_rule_id' => "No automation rule with id {$id} in space {$space->id}.",
-            ]);
-        }
-
-        return $rule;
     }
 }

--- a/app/Mcp/Tools/UpdateTransaction.php
+++ b/app/Mcp/Tools/UpdateTransaction.php
@@ -59,30 +59,16 @@ class UpdateTransaction extends WriteTool
         // moved off the old values if the edit changes them.
         $originalSnapshot = clone $transaction;
 
-        if ($request->has('description')) {
-            $transaction->description = $request->string('description')->toString();
-        }
-        if ($request->has('amount')) {
-            $transaction->amount = $request->integer('amount');
-        }
-        if ($request->has('transaction_date')) {
-            $transaction->transaction_date = Carbon::parse($request->string('transaction_date')->toString());
-        }
-        if ($request->has('currency_code')) {
-            $transaction->currency_code = mb_strtoupper($request->string('currency_code')->toString());
-        }
-        if ($request->has('account_id')) {
-            $transaction->account_id = $this->accountInSpace($request, $space)->id;
-        }
-        if ($request->has('notes')) {
-            $transaction->notes = $request->filled('notes') ? $request->string('notes')->toString() : null;
-        }
-        if ($request->has('creditor_name')) {
-            $transaction->creditor_name = $request->filled('creditor_name') ? $request->string('creditor_name')->toString() : null;
-        }
-        if ($request->has('debtor_name')) {
-            $transaction->debtor_name = $request->filled('debtor_name') ? $request->string('debtor_name')->toString() : null;
-        }
+        $this->applyFields($request, $transaction, [
+            'description' => fn () => $request->string('description')->toString(),
+            'amount' => fn () => $request->integer('amount'),
+            'transaction_date' => fn () => Carbon::parse($request->string('transaction_date')->toString()),
+            'currency_code' => fn () => mb_strtoupper($request->string('currency_code')->toString()),
+            'account_id' => fn () => $this->accountInSpace($request, $space)->id,
+            'notes' => fn () => $this->nullableString($request, 'notes'),
+            'creditor_name' => fn () => $this->nullableString($request, 'creditor_name'),
+            'debtor_name' => fn () => $this->nullableString($request, 'debtor_name'),
+        ]);
 
         // A new category is always a manual assignment: reset any AI/rule
         // provenance so the row is not later treated as machine-categorized.

--- a/app/Mcp/Tools/WriteTool.php
+++ b/app/Mcp/Tools/WriteTool.php
@@ -9,6 +9,7 @@ use App\Models\Label;
 use App\Models\Space;
 use App\Models\Transaction;
 use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;
@@ -46,21 +47,22 @@ abstract class WriteTool extends McpTool
     abstract protected function write(Request $request, User $user): Response;
 
     /**
-     * Resolve a model of the given class inside the space, failing with a message
-     * that tells the agent which tool lists the valid ids.
+     * Resolve the record the request points at, failing with a message that tells
+     * the agent which tool lists the valid ids. Callers pass the space-scoped
+     * query so each keeps its own model type.
      *
      * @template TModel of Model
      *
-     * @param  class-string<TModel>  $model
-     * @param  string  $noun  how the model is named in the failure message
+     * @param  Builder<TModel>  $query
+     * @param  string  $noun  how the record is named in the failure message
      * @param  string  $hint  appended to the failure message
      * @return TModel
      */
-    protected function modelInSpace(Request $request, Space $space, string $model, string $key, string $noun, string $hint = ''): Model
+    protected function modelInSpace(Request $request, Space $space, Builder $query, string $key, string $noun, string $hint = ''): Model
     {
         $id = $request->string($key)->toString();
 
-        $found = $model::query()->forSpace($space)->whereKey($id)->first();
+        $found = $query->whereKey($id)->first();
 
         if ($found === null) {
             throw ValidationException::withMessages([
@@ -103,7 +105,7 @@ abstract class WriteTool extends McpTool
      */
     protected function accountInSpace(Request $request, Space $space, string $key = 'account_id'): Account
     {
-        return $this->modelInSpace($request, $space, Account::class, $key, 'account', 'Call list_accounts to see valid ids.');
+        return $this->modelInSpace($request, $space, Account::query()->forSpace($space), $key, 'account', 'Call list_accounts to see valid ids.');
     }
 
     /**
@@ -126,22 +128,22 @@ abstract class WriteTool extends McpTool
 
     protected function transactionInSpace(Request $request, Space $space, string $key = 'transaction_id'): Transaction
     {
-        return $this->modelInSpace($request, $space, Transaction::class, $key, 'transaction', 'Call search_transactions to find ids.');
+        return $this->modelInSpace($request, $space, Transaction::query()->forSpace($space), $key, 'transaction', 'Call search_transactions to find ids.');
     }
 
     protected function categoryInSpace(Request $request, Space $space, string $key = 'category_id'): Category
     {
-        return $this->modelInSpace($request, $space, Category::class, $key, 'category', 'Call list_categories to see valid ids.');
+        return $this->modelInSpace($request, $space, Category::query()->forSpace($space), $key, 'category', 'Call list_categories to see valid ids.');
     }
 
     protected function labelInSpace(Request $request, Space $space, string $key = 'label_id'): Label
     {
-        return $this->modelInSpace($request, $space, Label::class, $key, 'label', 'Call list_labels to see valid ids.');
+        return $this->modelInSpace($request, $space, Label::query()->forSpace($space), $key, 'label', 'Call list_labels to see valid ids.');
     }
 
     protected function ruleInSpace(Request $request, Space $space, string $key = 'automation_rule_id'): AutomationRule
     {
-        return $this->modelInSpace($request, $space, AutomationRule::class, $key, 'automation rule');
+        return $this->modelInSpace($request, $space, AutomationRule::query()->forSpace($space), $key, 'automation rule');
     }
 
     /**

--- a/app/Mcp/Tools/WriteTool.php
+++ b/app/Mcp/Tools/WriteTool.php
@@ -9,6 +9,7 @@ use App\Models\Label;
 use App\Models\Space;
 use App\Models\Transaction;
 use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;
 use Laravel\Mcp\Request;
@@ -45,23 +46,64 @@ abstract class WriteTool extends McpTool
     abstract protected function write(Request $request, User $user): Response;
 
     /**
+     * Resolve a model of the given class inside the space, failing with a message
+     * that tells the agent which tool lists the valid ids.
+     *
+     * @template TModel of Model
+     *
+     * @param  class-string<TModel>  $model
+     * @param  string  $noun  how the model is named in the failure message
+     * @param  string  $hint  appended to the failure message
+     * @return TModel
+     */
+    protected function modelInSpace(Request $request, Space $space, string $model, string $key, string $noun, string $hint = ''): Model
+    {
+        $id = $request->string($key)->toString();
+
+        $found = $model::query()->forSpace($space)->whereKey($id)->first();
+
+        if ($found === null) {
+            throw ValidationException::withMessages([
+                $key => trim("No {$noun} with id {$id} in space {$space->id}. {$hint}"),
+            ]);
+        }
+
+        return $found;
+    }
+
+    /**
+     * Assign only the fields the request actually carries — the "only what you
+     * pass changes" contract every update tool promises. Values are closures so
+     * that resolving a related model (which may fail validation) happens only
+     * when the field is present.
+     *
+     * @param  array<string, callable(): mixed>  $fields
+     */
+    protected function applyFields(Request $request, Model $model, array $fields): void
+    {
+        foreach ($fields as $attribute => $value) {
+            if ($request->has($attribute)) {
+                $model->{$attribute} = $value();
+            }
+        }
+    }
+
+    /**
+     * A string field, or null when the agent passed an empty value to clear it.
+     */
+    protected function nullableString(Request $request, string $key): ?string
+    {
+        return $request->filled($key) ? $request->string($key)->toString() : null;
+    }
+
+    /**
      * Resolve an account in the space. Bank-connected accounts are allowed:
      * a sync only inserts rows it has not seen before, so a manual transaction
      * added to a connected account survives every later sync.
      */
     protected function accountInSpace(Request $request, Space $space, string $key = 'account_id'): Account
     {
-        $id = $request->string($key)->toString();
-
-        $account = Account::query()->forSpace($space)->whereKey($id)->first();
-
-        if ($account === null) {
-            throw ValidationException::withMessages([
-                $key => "No account with id {$id} in space {$space->id}. Call list_accounts to see valid ids.",
-            ]);
-        }
-
-        return $account;
+        return $this->modelInSpace($request, $space, Account::class, $key, 'account', 'Call list_accounts to see valid ids.');
     }
 
     /**
@@ -84,47 +126,22 @@ abstract class WriteTool extends McpTool
 
     protected function transactionInSpace(Request $request, Space $space, string $key = 'transaction_id'): Transaction
     {
-        $id = $request->string($key)->toString();
-
-        $transaction = Transaction::query()->forSpace($space)->whereKey($id)->first();
-
-        if ($transaction === null) {
-            throw ValidationException::withMessages([
-                $key => "No transaction with id {$id} in space {$space->id}. Call search_transactions to find ids.",
-            ]);
-        }
-
-        return $transaction;
+        return $this->modelInSpace($request, $space, Transaction::class, $key, 'transaction', 'Call search_transactions to find ids.');
     }
 
     protected function categoryInSpace(Request $request, Space $space, string $key = 'category_id'): Category
     {
-        $id = $request->string($key)->toString();
-
-        $category = Category::query()->forSpace($space)->whereKey($id)->first();
-
-        if ($category === null) {
-            throw ValidationException::withMessages([
-                $key => "No category with id {$id} in space {$space->id}. Call list_categories to see valid ids.",
-            ]);
-        }
-
-        return $category;
+        return $this->modelInSpace($request, $space, Category::class, $key, 'category', 'Call list_categories to see valid ids.');
     }
 
     protected function labelInSpace(Request $request, Space $space, string $key = 'label_id'): Label
     {
-        $id = $request->string($key)->toString();
+        return $this->modelInSpace($request, $space, Label::class, $key, 'label', 'Call list_labels to see valid ids.');
+    }
 
-        $label = Label::query()->forSpace($space)->whereKey($id)->first();
-
-        if ($label === null) {
-            throw ValidationException::withMessages([
-                $key => "No label with id {$id} in space {$space->id}. Call list_labels to see valid ids.",
-            ]);
-        }
-
-        return $label;
+    protected function ruleInSpace(Request $request, Space $space, string $key = 'automation_rule_id'): AutomationRule
+    {
+        return $this->modelInSpace($request, $space, AutomationRule::class, $key, 'automation rule');
     }
 
     /**

--- a/tests/Feature/Mcp/McpWriteToolsTest.php
+++ b/tests/Feature/Mcp/McpWriteToolsTest.php
@@ -356,3 +356,22 @@ it('never lets a write tool touch another user\'s data', function () {
 
     expect(Transaction::query()->find($otherTransaction->id))->not->toBeNull();
 });
+
+it('tells the agent which id was missing and where to find valid ones', function () {
+    $user = User::factory()->create();
+
+    // Records that have a listing tool point the agent at it.
+    callWriteTool($user, UpdateTransaction::class, [
+        'transaction_id' => 'no-such-transaction',
+        'description' => 'Nope',
+    ])->assertHasErrors([
+        'No transaction with id no-such-transaction in space '.$user->personalSpace->id.'. Call search_transactions to find ids.',
+    ]);
+
+    // Those without one end at the sentence, with no dangling hint.
+    callWriteTool($user, DeleteAutomationRule::class, [
+        'automation_rule_id' => 'no-such-rule',
+    ])->assertHasErrors([
+        'No automation rule with id no-such-rule in space '.$user->personalSpace->id.'.',
+    ]);
+});


### PR DESCRIPTION
## Why

Second pass at the complexity report. After the trial-experiment code (deleted by #762) and the analytics controller (#766), the worst offenders were the MCP write tools:

- `UpdateTransaction::write` — cyclomatic complexity **20**
- `UpdateAutomationRule::write` — cyclomatic complexity **13**

Both for the same reason: a long wall of `if ($request->has('x')) { $model->x = ...; }` blocks, one per optional field.

## What changed

Two shapes moved into `WriteTool`:

**`modelInSpace()`** — resolving a record in the space was written five times (account, transaction, category, label, plus a rule resolver that existed twice, once in `UpdateAutomationRule` and once in `DeleteAutomationRule`), each a copy of the same query + null check + message. The four public helpers are now one-liners over it, and `ruleInSpace()` is shared instead of duplicated.

**`applyFields()`** — assigns only the fields the request actually carries, which is the "only what you pass changes" contract these tools document. Values are closures, so resolving a related model (`accountInSpace`, `categoryInSpace` — either can throw a validation error) still happens only when its field is present.

## Metrics

| | before | after |
|---|---|---|
| methods over complexity 10 | 35 | 33 |
| `UpdateTransaction::write` | 20 | 7 |
| `UpdateAutomationRule::write` | 13 | 6 |
| duplicated lines | 5.34% | 5.34% |

Duplication does not move, and it's worth being straight about why: what jscpd still flags across `app/Mcp/Tools` is **file headers** — the `use` block, the `#[Description]` attribute, the class line and the opening of `schema()`. Nine near-identical lines per tool that no extraction can remove. Deleting the duplicated `ruleInSpace` shortened `DeleteAutomationRule` enough that its header became a clone pair with another tool's, so the counter stayed flat while the real duplication went away.

## Testing

`tests/Feature/Mcp` — 46 tests green, plus a new one. Nothing asserted the resolver failure messages before, and this PR changes how they are built (a shared template plus an optional hint), so the new test pins both branches: the message that points at a listing tool (`Call search_transactions to find ids.`) and the one that has no hint to append.