### PR TITLE
feat(roadmap): add a public roadmap page mirrored from UserJot

### DIFF
--- a/app/Http/Controllers/RoadmapController.php
+++ b/app/Http/Controllers/RoadmapController.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Client\Pool;
+use Illuminate\Http\Client\Response as ClientResponse;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Inertia\Inertia;
+use Inertia\Response;
+use Throwable;
+
+/**
+ * Public roadmap, mirrored from the UserJot board. UserJot has no public API,
+ * so we read the same tRPC endpoints its own frontend calls and cache the
+ * result for a day.
+ */
+class RoadmapController extends Controller
+{
+    private const CACHE_KEY = 'roadmap-items';
+
+    private const HOST = 'whispermoney.userjot.com';
+
+    private const ROADMAP_ENDPOINT = 'https://api.userjot.com/trpc/x1.roadmap.getPage';
+
+    private const SUBMISSION_ENDPOINT = 'https://api.userjot.com/trpc/x1.submission.getPage';
+
+    /**
+     * UserJot statuses, in the order they are rendered.
+     */
+    private const STATUSES = [
+        'PLANNED' => 'planned',
+        'PROGRESS' => 'in_progress',
+        'COMPLETED' => 'shipped',
+    ];
+
+    public function index(): Response
+    {
+        return Inertia::render('roadmap', [
+            'canRegister' => config('auth.registration_enabled'),
+            'items' => $this->items(),
+        ]);
+    }
+
+    /**
+     * @return array<int, array{title: string, body: string, status: string, date: string, url: string}>
+     */
+    private function items(): array
+    {
+        try {
+            return Cache::remember(self::CACHE_KEY, now()->addDay(), fn (): array => $this->fetch());
+        } catch (Throwable) {
+            // ponytail: an unreachable UserJot renders the empty state, not a 500
+            return [];
+        }
+    }
+
+    /**
+     * @return array<int, array{title: string, body: string, status: string, date: string, url: string}>
+     */
+    private function fetch(): array
+    {
+        $items = [];
+
+        foreach (self::STATUSES as $userJotStatus => $status) {
+            $submissions = Http::withHeader('x-host', self::HOST)
+                ->get(self::ROADMAP_ENDPOINT, [
+                    'input' => $this->input(['limit' => 50, 'status' => [$userJotStatus]]),
+                ])
+                ->throw()
+                ->json('result.data.json.submissions', []);
+
+            foreach ($submissions as $submission) {
+                $items[] = [
+                    'title' => (string) $submission['title'],
+                    'body' => $this->toPlainText((string) ($submission['body'] ?? '')),
+                    'status' => $status,
+                    'date' => (string) $submission['createdAt'],
+                    'url' => 'https://'.self::HOST.'/board/p/'.$submission['slug'],
+                    'slug' => (string) $submission['slug'],
+                ];
+            }
+        }
+
+        return $this->sortByStatusThenDate($this->withStatusDates($items));
+    }
+
+    /**
+     * Statuses keep the order they are declared in; within a status the most
+     * recently moved submission comes first.
+     *
+     * @param  array<int, array<string, string>>  $items
+     * @return array<int, array<string, string>>
+     */
+    private function sortByStatusThenDate(array $items): array
+    {
+        $order = array_values(self::STATUSES);
+
+        usort($items, fn (array $first, array $second): int => [
+            array_search($first['status'], $order, strict: true), $second['date'],
+        ] <=> [
+            array_search($second['status'], $order, strict: true), $first['date'],
+        ]);
+
+        return $items;
+    }
+
+    /**
+     * The roadmap listing only knows when a submission was opened, which for
+     * shipped work is months before it moved. The date each submission last
+     * changed status lives on its detail endpoint, so those are fetched
+     * concurrently and fall back to the creation date.
+     *
+     * @param  array<int, array<string, string>>  $items
+     * @return array<int, array<string, string>>
+     */
+    private function withStatusDates(array $items): array
+    {
+        $responses = Http::pool(fn (Pool $pool) => array_map(
+            fn (array $item) => $pool->withHeader('x-host', self::HOST)
+                ->get(self::SUBMISSION_ENDPOINT, ['input' => $this->input(['slug' => $item['slug']])]),
+            $items,
+        ));
+
+        foreach ($items as $index => $item) {
+            $items[$index]['date'] = $this->lastStatusChange($responses[$index] ?? null) ?? $item['date'];
+            unset($items[$index]['slug']);
+        }
+
+        return $items;
+    }
+
+    /**
+     * ISO-8601 timestamps sort lexicographically, so the newest status change
+     * is simply the largest one.
+     */
+    private function lastStatusChange(mixed $response): ?string
+    {
+        if (! $response instanceof ClientResponse || $response->failed()) {
+            return null;
+        }
+
+        $dates = collect($response->json('result.data.json.events', []))
+            ->where('type', 'STATUS_CHANGED')
+            ->pluck('createdAt')
+            ->filter();
+
+        return $dates->max();
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function input(array $payload): string
+    {
+        return (string) json_encode(['json' => $payload]);
+    }
+
+    /**
+     * Submissions are written in Markdown by whoever opened them, and the
+     * roadmap shows them as a single paragraph of running text.
+     *
+     * ponytail: drops the emphasis markers instead of rendering Markdown; a
+     * renderer is only worth it if we ever show the full submission.
+     */
+    private function toPlainText(string $body): string
+    {
+        return trim((string) preg_replace('/\s+/u', ' ', str_replace(['**', '__'], '', $body)));
+    }
+}

--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -18,6 +18,12 @@ class SitemapController extends Controller
                 'lastmod' => now()->toW3cString(),
             ],
             [
+                'loc' => "{$baseUrl}/roadmap",
+                'changefreq' => 'daily',
+                'priority' => '0.7',
+                'lastmod' => now()->toW3cString(),
+            ],
+            [
                 'loc' => "{$baseUrl}/privacy",
                 'changefreq' => 'monthly',
                 'priority' => '0.5',

--- a/lang/es.json
+++ b/lang/es.json
@@ -2337,5 +2337,13 @@
     "Your :provider connection has expired, so we cannot sync new transactions until you reconnect it.": "Tu conexión con :provider ha dejado de ser válida, así que no podemos sincronizar nuevos movimientos hasta que vuelvas a conectarla.",
     "Reconnect Account": "Volver a conectar",
     "If the button does not work, open your connection settings and reconnect :provider from there.": "Si el botón no funciona, abre los ajustes de tus conexiones y vuelve a conectar :provider desde ahí.",
-    "This account's balance comes from your bank, so it won't change.": "El saldo de esta cuenta lo trae tu banco, así que no cambiará."
+    "This account's balance comes from your bank, so it won't change.": "El saldo de esta cuenta lo trae tu banco, así que no cambiará.",
+    "Planned": "Planificado",
+    "Shipped": "Publicado",
+    "Roadmap.": "Hoja de Ruta.",
+    "Roadmap - Whisper Money": "Hoja de Ruta - Whisper Money",
+    "See what's shipped, what we're building, and what's coming next in Whisper Money.": "Descubre qué hemos publicado, qué estamos construyendo y qué viene después en Whisper Money.",
+    "What's shipped. What's coming.": "Lo publicado. Lo que viene.",
+    "Request a feature": "Pedir una función",
+    "The roadmap is temporarily unavailable. Check it out on our feedback board.": "La hoja de ruta no está disponible ahora mismo. Puedes consultarla en nuestro tablón de sugerencias."
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2172,5 +2172,14 @@
     "vs. average": "vs. moyenne",
     "Income & expenses per month": "Revenus et dépenses par mois",
     "Monthly trend needs at least one whole calendar month.": "La tendance mensuelle nécessite au moins un mois calendaire complet.",
-    "This account's balance comes from your bank, so it won't change.": "Le solde de ce compte provient de votre banque, il ne changera donc pas."
+    "This account's balance comes from your bank, so it won't change.": "Le solde de ce compte provient de votre banque, il ne changera donc pas.",
+    "Planned": "Prévu",
+    "In progress": "En cours",
+    "Shipped": "Livré",
+    "Roadmap.": "Feuille de route.",
+    "Roadmap - Whisper Money": "Feuille de route - Whisper Money",
+    "See what's shipped, what we're building, and what's coming next in Whisper Money.": "Découvrez ce qui est livré, ce que nous construisons et ce qui arrive ensuite dans Whisper Money.",
+    "What's shipped. What's coming.": "Ce qui est livré. Ce qui arrive.",
+    "Request a feature": "Proposer une fonctionnalité",
+    "The roadmap is temporarily unavailable. Check it out on our feedback board.": "La feuille de route est momentanément indisponible. Consultez-la sur notre tableau de suggestions."
 }

--- a/resources/js/components/partials/header.tsx
+++ b/resources/js/components/partials/header.tsx
@@ -1,8 +1,8 @@
-import { dashboard, login } from '@/routes';
+import { dashboard, login, roadmap } from '@/routes';
 import { type SharedData } from '@/types';
 import { __ } from '@/utils/i18n';
 import { Link, usePage } from '@inertiajs/react';
-import { BirdIcon, Github, LogIn, StarIcon } from 'lucide-react';
+import { BirdIcon, Github, LogIn, MapIcon, StarIcon } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import DiscordIcon from '../icons/DiscordIcon';
 import { Button } from '../ui/button';
@@ -142,6 +142,17 @@ export default function Header({
                     <nav className="flex items-center gap-4">
                         {!hideExternalButtons && (
                             <>
+                                <Link href={roadmap()}>
+                                    <Button
+                                        variant={'ghost'}
+                                        className="hidden cursor-pointer opacity-70 transition-all duration-200 hover:opacity-100 sm:flex"
+                                    >
+                                        <MapIcon className="size-5" />
+                                        <span className="hidden sm:inline">
+                                            {__('Roadmap')}
+                                        </span>
+                                    </Button>
+                                </Link>
                                 <a
                                     href="https://github.com/whisper-money/whisper-money"
                                     target="_blank"

--- a/resources/js/pages/roadmap.tsx
+++ b/resources/js/pages/roadmap.tsx
@@ -1,0 +1,175 @@
+import Header from '@/components/partials/header';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { type SharedData } from '@/types';
+import { formatDateMedium } from '@/utils/date';
+import { __ } from '@/utils/i18n';
+import { Head, Link, usePage } from '@inertiajs/react';
+import { ExternalLinkIcon } from 'lucide-react';
+
+const FEEDBACK_URL = 'https://whispermoney.userjot.com/';
+
+type RoadmapStatus = 'planned' | 'in_progress' | 'shipped';
+
+type RoadmapItem = {
+    title: string;
+    body: string;
+    status: RoadmapStatus;
+    date: string;
+    url: string;
+};
+
+const STATUS_STYLES: Record<RoadmapStatus, { dot: string; label: string }> = {
+    planned: {
+        dot: 'bg-[#c9c8c3] dark:bg-[#5a5a55]',
+        label: 'text-[#a3a29d] dark:text-[#7a7975]',
+    },
+    in_progress: {
+        dot: 'bg-amber-500',
+        label: 'text-amber-600 dark:text-amber-500',
+    },
+    shipped: {
+        dot: 'bg-emerald-600 dark:bg-emerald-500',
+        label: 'text-emerald-700 dark:text-emerald-500',
+    },
+};
+
+function statusLabel(status: RoadmapStatus): string {
+    if (status === 'planned') {
+        return __('Planned');
+    }
+
+    if (status === 'in_progress') {
+        return __('In progress');
+    }
+
+    return __('Shipped');
+}
+
+export default function Roadmap({
+    canRegister = false,
+    items,
+}: {
+    canRegister?: boolean;
+    items: RoadmapItem[];
+}) {
+    const { appUrl, locale } = usePage<SharedData>().props;
+    const description = __(
+        "See what's shipped, what we're building, and what's coming next in Whisper Money.",
+    );
+
+    return (
+        <>
+            {/* The Inertia title callback already appends " - Whisper Money". */}
+            <Head title={__('Roadmap')}>
+                <meta name="description" content={description} />
+                <link rel="canonical" href={`${appUrl}/roadmap`} />
+                <meta name="robots" content="index, follow" />
+                <meta
+                    property="og:title"
+                    content={__('Roadmap - Whisper Money')}
+                />
+                <meta property="og:description" content={description} />
+                <meta property="og:type" content="website" />
+                <meta property="og:url" content={`${appUrl}/roadmap`} />
+            </Head>
+
+            <div className="flex min-h-screen flex-col bg-[#FDFDFC] text-[#1b1b18] dark:bg-[#0a0a0a] dark:text-[#EDEDEC]">
+                <Header canRegister={canRegister} />
+
+                <main className="flex flex-1 flex-col px-6 py-28 sm:py-32">
+                    <div className="mx-auto flex w-full max-w-3xl flex-col gap-12">
+                        <div className="flex flex-col items-center gap-4 text-center">
+                            <h1 className="font-heading text-4xl font-semibold sm:text-5xl">
+                                {__('Roadmap.')}
+                            </h1>
+                            <p className="text-lg text-[#706f6c] dark:text-[#A1A09A]">
+                                {__("What's shipped. What's coming.")}
+                            </p>
+                            <a
+                                href={FEEDBACK_URL}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                <Button
+                                    variant="outline"
+                                    className="cursor-pointer rounded-full"
+                                >
+                                    {__('Request a feature')}
+                                    <ExternalLinkIcon className="size-4 opacity-60" />
+                                </Button>
+                            </a>
+                        </div>
+
+                        {items.length === 0 ? (
+                            <p className="text-center text-[#706f6c] dark:text-[#A1A09A]">
+                                {__(
+                                    'The roadmap is temporarily unavailable. Check it out on our feedback board.',
+                                )}
+                            </p>
+                        ) : (
+                            <ol className="relative flex flex-col gap-10 border-l border-[#e3e3e0] pl-8 dark:border-[#3E3E3A]">
+                                {items.map((item) => (
+                                    <li
+                                        key={item.title}
+                                        className="relative flex flex-col gap-2"
+                                    >
+                                        <span
+                                            className={cn(
+                                                'absolute top-1.5 -left-[2.125rem] size-2.5 rounded-full ring-4 ring-[#FDFDFC] dark:ring-[#0a0a0a]',
+                                                STATUS_STYLES[item.status].dot,
+                                            )}
+                                        />
+                                        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                                            <h2 className="font-mono text-lg font-medium">
+                                                <a
+                                                    href={item.url}
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    className="decoration-[#c9c8c3] underline-offset-4 hover:underline dark:decoration-[#5a5a55]"
+                                                >
+                                                    {item.title}
+                                                </a>
+                                            </h2>
+                                            <span
+                                                className={cn(
+                                                    'font-mono text-xs tracking-wider uppercase',
+                                                    STATUS_STYLES[item.status]
+                                                        .label,
+                                                )}
+                                            >
+                                                {statusLabel(item.status)}
+                                            </span>
+                                            <span className="font-mono text-xs text-[#a3a29d] dark:text-[#7a7975]">
+                                                {formatDateMedium(
+                                                    item.date,
+                                                    locale,
+                                                )}
+                                            </span>
+                                        </div>
+                                        {item.body && (
+                                            <p className="line-clamp-3 text-[#706f6c] dark:text-[#A1A09A]">
+                                                {item.body}
+                                            </p>
+                                        )}
+                                    </li>
+                                ))}
+                            </ol>
+                        )}
+                    </div>
+                </main>
+
+                <footer className="py-8">
+                    <div className="mx-auto max-w-3xl px-6 text-sm text-[#706f6c] dark:text-[#A1A09A]">
+                        <Link
+                            href="/"
+                            className="hover:text-[#1b1b18] dark:hover:text-[#EDEDEC]"
+                        >
+                            {__('← Back to home')}
+                        </Link>
+                    </div>
+                </footer>
+            </div>
+        </>
+    );
+}

--- a/resources/js/pages/welcome.tsx
+++ b/resources/js/pages/welcome.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/hooks/use-scroll-progress';
 import { readStoredValue, writeStoredValue } from '@/lib/safe-storage';
 import { cn } from '@/lib/utils';
-import { dashboard } from '@/routes';
+import { dashboard, roadmap } from '@/routes';
 import { type SharedData } from '@/types';
 import { type CategoryColor, getCategoryColorClasses } from '@/types/category';
 import { LANGUAGE_OPTIONS } from '@/types/language';
@@ -2639,7 +2639,13 @@ export default function Welcome({
                                 'Whisper Money. All\n                            rights reserved.',
                             )}
                         </p>
-                        <div className="flex gap-6">
+                        <div className="flex flex-wrap justify-center gap-x-6 gap-y-2">
+                            <Link
+                                href={roadmap()}
+                                className="hover:text-[#1b1b18] dark:hover:text-[#EDEDEC]"
+                            >
+                                {__('Roadmap')}
+                            </Link>
                             <Link
                                 href="/privacy"
                                 className="hover:text-[#1b1b18] dark:hover:text-[#EDEDEC]"

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,7 @@ use App\Http\Controllers\OpenBanking\InteractiveBrokersController;
 use App\Http\Controllers\OpenBanking\WiseController;
 use App\Http\Controllers\RealEstateDetailController;
 use App\Http\Controllers\ReEvaluateTransactionRulesController;
+use App\Http\Controllers\RoadmapController;
 use App\Http\Controllers\RobotsController;
 use App\Http\Controllers\SitemapController;
 use App\Http\Controllers\SubscriptionController;
@@ -92,6 +93,8 @@ Route::get('privacy', function () {
 Route::get('terms', function () {
     return Inertia::render('terms');
 })->name('terms');
+
+Route::get('roadmap', [RoadmapController::class, 'index'])->name('roadmap');
 
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('subscribe', [SubscriptionController::class, 'index'])->name('subscribe');

--- a/tests/Feature/RoadmapTest.php
+++ b/tests/Feature/RoadmapTest.php
@@ -1,0 +1,149 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Inertia\Testing\AssertableInertia;
+
+/**
+ * Fakes both UserJot endpoints: the roadmap listing returns one submission per
+ * status, and each submission detail reports two status changes.
+ */
+function fakeUserJot(): void
+{
+    Http::fake(function (Request $request) {
+        $url = urldecode($request->url());
+
+        if (str_contains($url, 'x1.submission.getPage')) {
+            return Http::response(['result' => ['data' => ['json' => [
+                'events' => [
+                    ['type' => 'STATUS_CHANGED', 'createdAt' => '2026-04-02T10:00:00.000Z'],
+                    ['type' => 'COMMENT', 'createdAt' => '2026-09-09T10:00:00.000Z'],
+                    ['type' => 'STATUS_CHANGED', 'createdAt' => '2026-07-01T10:00:00.000Z'],
+                ],
+            ]]]]);
+        }
+
+        preg_match('/(PLANNED|PROGRESS|COMPLETED)/', $url, $matches);
+        $status = $matches[1] ?? 'PLANNED';
+
+        return Http::response(['result' => ['data' => ['json' => [
+            'submissions' => [
+                [
+                    'title' => "{$status} item",
+                    'body' => "**{$status}**\n\nbody",
+                    'slug' => mb_strtolower($status).'-item',
+                    'createdAt' => '2026-01-15T10:00:00.000Z',
+                ],
+            ],
+            'nextPage' => null,
+        ]]]]);
+    });
+}
+
+/**
+ * @return array<string, string>
+ */
+function expectedRoadmapItem(string $status, string $mappedStatus): array
+{
+    return [
+        'title' => "{$status} item",
+        'body' => "{$status} body",
+        'status' => $mappedStatus,
+        // The latest status change wins over the creation date.
+        'date' => '2026-07-01T10:00:00.000Z',
+        'url' => 'https://whispermoney.userjot.com/board/p/'.mb_strtolower($status).'-item',
+    ];
+}
+
+beforeEach(function () {
+    Cache::forget('roadmap-items');
+});
+
+test('guests see the roadmap ordered by status, as plain text, linked to its ticket', function () {
+    fakeUserJot();
+
+    $this->get(route('roadmap'))
+        ->assertOk()
+        ->assertInertia(
+            fn (AssertableInertia $page) => $page
+                ->component('roadmap')
+                ->where('items', [
+                    expectedRoadmapItem('PLANNED', 'planned'),
+                    expectedRoadmapItem('PROGRESS', 'in_progress'),
+                    expectedRoadmapItem('COMPLETED', 'shipped'),
+                ])
+        );
+});
+
+test('a submission that never changed status keeps its creation date', function () {
+    Http::fake(function (Request $request) {
+        if (str_contains(urldecode($request->url()), 'x1.submission.getPage')) {
+            return Http::response(['result' => ['data' => ['json' => ['events' => []]]]]);
+        }
+
+        return Http::response(['result' => ['data' => ['json' => [
+            'submissions' => [[
+                'title' => 'Fresh idea',
+                'body' => 'Body',
+                'slug' => 'fresh-idea',
+                'createdAt' => '2026-01-15T10:00:00.000Z',
+            ]],
+            'nextPage' => null,
+        ]]]]);
+    });
+
+    $this->get(route('roadmap'))
+        ->assertOk()
+        ->assertInertia(
+            fn (AssertableInertia $page) => $page->where('items.0.date', '2026-01-15T10:00:00.000Z')
+        );
+});
+
+test('submissions sharing a status are ordered by their most recent move', function () {
+    Http::fake(function (Request $request) {
+        $url = urldecode($request->url());
+
+        if (str_contains($url, 'x1.submission.getPage')) {
+            return Http::response(['result' => ['data' => ['json' => ['events' => []]]]]);
+        }
+
+        return Http::response(['result' => ['data' => ['json' => [
+            'submissions' => str_contains($url, 'COMPLETED') ? [
+                ['title' => 'Older', 'body' => '', 'slug' => 'older', 'createdAt' => '2026-02-01T10:00:00.000Z'],
+                ['title' => 'Newer', 'body' => '', 'slug' => 'newer', 'createdAt' => '2026-05-01T10:00:00.000Z'],
+            ] : [],
+            'nextPage' => null,
+        ]]]]);
+    });
+
+    $this->get(route('roadmap'))
+        ->assertOk()
+        ->assertInertia(
+            fn (AssertableInertia $page) => $page
+                ->where('items.0.title', 'Newer')
+                ->where('items.1.title', 'Older')
+        );
+});
+
+test('the roadmap is fetched once and served from cache afterwards', function () {
+    fakeUserJot();
+
+    $this->get(route('roadmap'))->assertOk();
+    $this->get(route('roadmap'))->assertOk();
+
+    // Three listing calls plus one detail call per submission, once in total.
+    // Inertia's SSR request goes through the same fake, so it is filtered out.
+    expect(Http::recorded(fn (Request $request) => str_contains($request->url(), 'api.userjot.com')))
+        ->toHaveCount(6);
+});
+
+test('an unreachable UserJot renders an empty roadmap instead of failing', function () {
+    Http::fake(fn () => Http::response(status: 500));
+
+    $this->get(route('roadmap'))
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page->where('items', []));
+
+    expect(Cache::has('roadmap-items'))->toBeFalse();
+});


### PR DESCRIPTION
## What

A public `/roadmap` page in the landing's own style, listing the UserJot board so visitors can see what is being built, and links to it from the landing header (before GitHub and Discord) and footer.

<!-- Drop pr-roadmap-light.png and pr-roadmap-dark.png here -->

## How

UserJot has no public API, so the page reads the same tRPC endpoints its own frontend calls (`x1.roadmap.getPage`, `x1.submission.getPage`, both keyed by an `x-host` header) and caches the whole result for a day.

- **Dates.** The roadmap listing only knows when a submission was *opened*, which for shipped work is months before it moved — nearly every item would read "Jan 2026". The date a submission last changed status lives on its detail endpoint, so those are fetched concurrently with `Http::pool` and fall back to the creation date when a submission has never moved.
- **Order.** Planned → in progress → shipped, and within a status the most recently moved item first.
- **Bodies.** Submissions are written in Markdown by whoever opened them. Rather than pull in a renderer for text we only show three lines of, the emphasis markers are stripped and the body is collapsed into a single paragraph, clamped with `line-clamp-3`. Each title links to its ticket (new tab), so the full text is one click away.
- **Failure.** An unreachable UserJot renders the empty state with a link to the board, not a 500, and the failure is not cached.

The page is also in `sitemap.xml`.

## Notes

- The mobile pill header hides its GitHub and Discord buttons (`hidden sm:flex` inside an `sm:hidden` container), so a link there would never be visible. The footer link is how mobile visitors reach the page; its row got `flex-wrap` since it now holds five items.
- No pagination: there are 20 submissions and the request limit is 50.

## Testing
<img width="1280" height="1100" alt="pr-roadmap-dark" src="https://github.com/user-attachments/assets/db07cb16-7e0f-4de8-960b-464bf0419d59" />
<img width="1280" height="1100" alt="pr-roadmap-light" src="https://github.com/user-attachments/assets/a107e5bb-2deb-4f37-b511-7c188552c1e1" />

- `tests/Feature/RoadmapTest.php` covers status grouping, the status-change date and its fallback, the ordering, the one-fetch-per-day cache, and the unreachable-UserJot empty state.
- QA'd in Chrome: desktop light and dark, and mobile.
- `pint`, `prettier`, `eslint`, `jscpd` and `crap` all clean.
