### PR TITLE
feat(mcp): budget tools — read, create, edit and delete

### DIFF
--- a/app/Http/Controllers/BudgetController.php
+++ b/app/Http/Controllers/BudgetController.php
@@ -4,17 +4,16 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\StoreBudgetRequest;
 use App\Http\Requests\UpdateBudgetRequest;
-use App\Jobs\AssignHistoricalTransactionsToBudget;
 use App\Models\Account;
 use App\Models\Bank;
 use App\Models\Budget;
 use App\Models\Category;
 use App\Models\Label;
 use App\Services\BudgetPeriodService;
+use App\Services\BudgetService;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -22,7 +21,10 @@ class BudgetController extends Controller
 {
     use AuthorizesRequests;
 
-    public function __construct(protected BudgetPeriodService $budgetPeriodService) {}
+    public function __construct(
+        protected BudgetPeriodService $budgetPeriodService,
+        protected BudgetService $budgetService,
+    ) {}
 
     public function index(Request $request): Response
     {
@@ -119,55 +121,32 @@ class BudgetController extends Controller
 
     public function store(StoreBudgetRequest $request): RedirectResponse
     {
-        $result = DB::transaction(function () use ($request) {
-            $setting = $request->user()->setting;
-
-            $budget = $request->user()->budgets()->create([
+        $budget = $this->budgetService->create(
+            $request->user(),
+            [
                 'name' => $request->name,
                 'period_type' => $request->period_type,
                 'period_start_day' => $request->period_start_day,
                 'rollover_type' => $request->rollover_type,
                 'is_catch_all' => $request->boolean('is_catch_all'),
-                'notify_on_new_transaction' => $setting->budget_notify_on_new_transaction ?? false,
-                'notify_on_close_to_limit' => $setting->budget_notify_on_close_to_limit ?? true,
-                'notify_on_over_limit' => $setting->budget_notify_on_over_limit ?? true,
-            ]);
+            ],
+            (int) $request->allocated_amount,
+            $request->category_ids ?? [],
+            $request->label_ids ?? [],
+        );
 
-            $budget->categories()->sync($request->category_ids ?? []);
-            $budget->labels()->sync($request->label_ids ?? []);
-
-            $period = $this->budgetPeriodService->generatePeriod($budget, $request->allocated_amount, null, true);
-            $previousPeriod = $this->budgetPeriodService->generatePreviousPeriod($budget, $period, $request->allocated_amount, true);
-
-            return ['budget' => $budget, 'period' => $period, 'previousPeriod' => $previousPeriod];
-        });
-
-        // Dispatch jobs to assign historical transactions for the current and previous periods
-        AssignHistoricalTransactionsToBudget::dispatch($result['budget'], $result['period']);
-        AssignHistoricalTransactionsToBudget::dispatch($result['budget'], $result['previousPeriod']);
-
-        return redirect()->route('budgets.show', $result['budget']);
+        return redirect()->route('budgets.show', $budget);
     }
 
     public function update(UpdateBudgetRequest $request, Budget $budget): RedirectResponse
     {
         $this->authorize('update', $budget);
 
-        DB::transaction(function () use ($request, $budget) {
-            $budget->update($request->only([
-                'name',
-                'period_type',
-                'period_start_day',
-                'rollover_type',
-            ]));
-
-            // If allocated_amount is provided, update current and future periods
-            if ($request->has('allocated_amount')) {
-                $budget->periods()
-                    ->where('start_date', '>=', now()->startOfDay())
-                    ->update(['allocated_amount' => $request->allocated_amount]);
-            }
-        });
+        $this->budgetService->update(
+            $budget,
+            $request->only(['name', 'period_type', 'period_start_day', 'rollover_type']),
+            $request->has('allocated_amount') ? (int) $request->allocated_amount : null,
+        );
 
         return redirect()->route('budgets.show', $budget);
     }

--- a/app/Mcp/Servers/WhisperMoneyServer.php
+++ b/app/Mcp/Servers/WhisperMoneyServer.php
@@ -5,6 +5,7 @@ namespace App\Mcp\Servers;
 use App\Mcp\Tools\CategorizeTransaction;
 use App\Mcp\Tools\CreateAutomationRule;
 use App\Mcp\Tools\CreateBalance;
+use App\Mcp\Tools\CreateBudget;
 use App\Mcp\Tools\CreateCategory;
 use App\Mcp\Tools\CreateLabel;
 use App\Mcp\Tools\CreateTransaction;
@@ -16,12 +17,14 @@ use App\Mcp\Tools\GetCashflow;
 use App\Mcp\Tools\GetNetWorth;
 use App\Mcp\Tools\LabelTransaction;
 use App\Mcp\Tools\ListAccounts;
+use App\Mcp\Tools\ListBudgets;
 use App\Mcp\Tools\ListCategories;
 use App\Mcp\Tools\ListLabels;
 use App\Mcp\Tools\ListSpaces;
 use App\Mcp\Tools\SearchTransactions;
 use App\Mcp\Tools\SpendingByCategory;
 use App\Mcp\Tools\UpdateAutomationRule;
+use App\Mcp\Tools\UpdateBudget;
 use App\Mcp\Tools\UpdateCategory;
 use App\Mcp\Tools\UpdateLabel;
 use App\Mcp\Tools\UpdateTransaction;
@@ -42,13 +45,19 @@ data.
 - Data is organised into "spaces" (the personal space and any shared spaces).
   Transaction, account, category and label tools accept an optional `space` id and
   default to the personal space; call `list_spaces` to discover ids. The cashflow,
-  net-worth and spending tools cover the user's whole account.
+  net-worth, spending and budget tools cover the user's whole account.
+- A budget is a per-period spending limit over a set of categories and/or labels;
+  tracking a parent category also tracks its children. `list_budgets` reports the
+  period in progress (allocated, carried over, spent and remaining). Matching
+  transactions are attached automatically, so a freshly created budget may take a
+  moment to report its spending.
 - To find recurring charges (subscriptions), use `search_transactions` and group
   the results by merchant and cadence yourself.
 
 Write tools (create_transaction, update_transaction, delete_transaction,
-categorize_transaction, label_transaction, create_balance and full CRUD for
-categories, labels and automation rules) require a read & write token; a
+categorize_transaction, label_transaction, create_balance, create_budget,
+update_budget and full CRUD for categories, labels and automation rules) require
+a read & write token; a
 read-only token can analyse data but never change it. Manual transactions can be
 created on any account, bank-connected ones included — a sync never removes them.
 Bank/imported transactions themselves are protected: only manually-created ones
@@ -68,6 +77,7 @@ class WhisperMoneyServer extends Server
         ListAccounts::class,
         ListCategories::class,
         ListLabels::class,
+        ListBudgets::class,
         ListSpaces::class,
 
         // Write
@@ -86,5 +96,7 @@ class WhisperMoneyServer extends Server
         CreateAutomationRule::class,
         UpdateAutomationRule::class,
         DeleteAutomationRule::class,
+        CreateBudget::class,
+        UpdateBudget::class,
     ];
 }

--- a/app/Mcp/Servers/WhisperMoneyServer.php
+++ b/app/Mcp/Servers/WhisperMoneyServer.php
@@ -10,6 +10,7 @@ use App\Mcp\Tools\CreateCategory;
 use App\Mcp\Tools\CreateLabel;
 use App\Mcp\Tools\CreateTransaction;
 use App\Mcp\Tools\DeleteAutomationRule;
+use App\Mcp\Tools\DeleteBudget;
 use App\Mcp\Tools\DeleteCategory;
 use App\Mcp\Tools\DeleteLabel;
 use App\Mcp\Tools\DeleteTransaction;
@@ -46,19 +47,21 @@ data.
   Transaction, account, category and label tools accept an optional `space` id and
   default to the personal space; call `list_spaces` to discover ids. The cashflow,
   net-worth, spending and budget tools cover the user's whole account.
-- A budget is a per-period spending limit over a set of categories and/or labels;
-  tracking a parent category also tracks its children. `list_budgets` reports the
-  period in progress (allocated, carried over, spent and remaining). Matching
-  transactions are attached automatically, so a freshly created budget may take a
-  moment to report its spending.
+- A budget is a per-period spending limit over the user's own categories and/or
+  labels; tracking a parent category also tracks its children. `list_budgets`
+  reports the period in progress, or `current_period: null` when no period covers
+  today. `remaining_amount` is the allocated amount minus what was spent, matching
+  the figure the app shows. Matching transactions are attached in the background,
+  so treat `spent_amount` as provisional while `processing_historical` is true.
+  A budget's period length, start day, rollover and tracked categories are fixed
+  once created: to change those, delete the budget and create it again.
 - To find recurring charges (subscriptions), use `search_transactions` and group
   the results by merchant and cadence yourself.
 
 Write tools (create_transaction, update_transaction, delete_transaction,
-categorize_transaction, label_transaction, create_balance, create_budget,
-update_budget and full CRUD for categories, labels and automation rules) require
-a read & write token; a
-read-only token can analyse data but never change it. Manual transactions can be
+categorize_transaction, label_transaction, create_balance and full CRUD for
+budgets, categories, labels and automation rules) require a read & write token;
+a read-only token can analyse data but never change it. Manual transactions can be
 created on any account, bank-connected ones included — a sync never removes them.
 Bank/imported transactions themselves are protected: only manually-created ones
 can be edited or deleted, though you can categorize and label any transaction.
@@ -98,5 +101,6 @@ class WhisperMoneyServer extends Server
         DeleteAutomationRule::class,
         CreateBudget::class,
         UpdateBudget::class,
+        DeleteBudget::class,
     ];
 }

--- a/app/Mcp/Tools/Concerns/PresentsBudgets.php
+++ b/app/Mcp/Tools/Concerns/PresentsBudgets.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Mcp\Tools\Concerns;
+
+use App\Models\Budget;
+use App\Models\BudgetPeriod;
+use App\Models\Category;
+use App\Models\Label;
+
+/**
+ * The budget shape every budget tool returns, so list_budgets, create_budget and
+ * update_budget all hand the agent the same row. Amounts are in minor units.
+ */
+trait PresentsBudgets
+{
+    /**
+     * @return array<string, mixed>
+     */
+    protected function presentBudget(Budget $budget): array
+    {
+        $budget->loadMissing(['categories:id,name', 'labels:id,name']);
+
+        $period = $budget->getCurrentPeriod();
+
+        return [
+            'id' => $budget->id,
+            'name' => $budget->name,
+            'period_type' => $budget->period_type->value,
+            'period_start_day' => $budget->period_start_day,
+            'rollover_type' => $budget->rollover_type->value,
+            'is_catch_all' => $budget->is_catch_all,
+            'categories' => $budget->categories->map(fn (Category $category): array => ['id' => $category->id, 'name' => $category->name])->all(),
+            'labels' => $budget->labels->map(fn (Label $label): array => ['id' => $label->id, 'name' => $label->name])->all(),
+            'current_period' => $period === null ? null : $this->presentBudgetPeriod($period),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function presentBudgetPeriod(BudgetPeriod $period): array
+    {
+        $spent = $period->spentAmount();
+
+        return [
+            'id' => $period->id,
+            'start_date' => $period->start_date->toDateString(),
+            'end_date' => $period->end_date->toDateString(),
+            'allocated_amount' => $period->allocated_amount,
+            'carried_over_amount' => $period->carried_over_amount,
+            'spent_amount' => $spent,
+            'remaining_amount' => $period->allocated_amount + $period->carried_over_amount - $spent,
+        ];
+    }
+}

--- a/app/Mcp/Tools/Concerns/PresentsBudgets.php
+++ b/app/Mcp/Tools/Concerns/PresentsBudgets.php
@@ -40,16 +40,18 @@ trait PresentsBudgets
      */
     private function presentBudgetPeriod(BudgetPeriod $period): array
     {
-        $spent = $period->spentAmount();
-
         return [
             'id' => $period->id,
             'start_date' => $period->start_date->toDateString(),
             'end_date' => $period->end_date->toDateString(),
             'allocated_amount' => $period->allocated_amount,
             'carried_over_amount' => $period->carried_over_amount,
-            'spent_amount' => $spent,
-            'remaining_amount' => $period->allocated_amount + $period->carried_over_amount - $spent,
+            'spent_amount' => $period->spentAmount(),
+            'remaining_amount' => $period->remainingAmount(),
+            // True while the queued backfill is still attaching the transactions
+            // that were already in range, so an agent can tell "nothing spent
+            // yet" apart from "not counted yet" and poll again.
+            'processing_historical' => $period->processing_historical,
         ];
     }
 }

--- a/app/Mcp/Tools/CreateBudget.php
+++ b/app/Mcp/Tools/CreateBudget.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Enums\BudgetPeriodType;
+use App\Enums\RolloverType;
+use App\Mcp\Tools\Concerns\PresentsBudgets;
+use App\Models\Category;
+use App\Models\Label;
+use App\Models\User;
+use App\Services\BudgetService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+
+#[Description('Create a budget: a spending limit per period over a set of categories and/or labels. The transactions already inside the current and previous period are attached in the background, so spent_amount may still be filling in right after the call.')]
+class CreateBudget extends WriteTool
+{
+    use PresentsBudgets;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'name' => $schema->string()->description('Budget name.')->required(),
+            'allocated_amount' => $schema->integer()->description('Limit for each period, in minor units (50000 = 500.00).')->required(),
+            'period_type' => $schema->string()->enum(array_column(BudgetPeriodType::cases(), 'value'))->description('How often the budget starts over.')->required(),
+            'rollover_type' => $schema->string()->enum(array_column(RolloverType::cases(), 'value'))->description('"carry_over" adds what is left to the next period, "reset" starts every period at the limit.')->required(),
+            'period_start_day' => $schema->integer()->min(0)->max(31)->description('Day the period starts: day of the month (1-31) when monthly, day of the week (0 = Sunday) when weekly or biweekly. Ignored when yearly.'),
+            'category_ids' => $schema->array()->items($schema->string())->description('Categories to track. Tracking a parent also tracks its children. Call list_categories to see valid ids.'),
+            'label_ids' => $schema->array()->items($schema->string())->description('Labels to track. Call list_labels to see valid ids.'),
+            'is_catch_all' => $schema->boolean()->description('Track every expense category no other budget tracks. Needs no categories or labels, and only one catch-all budget is allowed.'),
+        ];
+    }
+
+    protected function write(Request $request, User $user): Response
+    {
+        $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'allocated_amount' => ['required', 'integer', 'min:0'],
+            'period_type' => ['required', Rule::enum(BudgetPeriodType::class)],
+            'rollover_type' => ['required', Rule::enum(RolloverType::class)],
+            'period_start_day' => ['sometimes', 'nullable', 'integer', 'min:0', 'max:31'],
+            'is_catch_all' => ['sometimes', 'boolean'],
+        ]);
+
+        $categoryIds = $this->ownedIds($request, 'category_ids', Category::query()->where('user_id', $user->id), 'Call list_categories to see valid ids.');
+        $labelIds = $this->ownedIds($request, 'label_ids', Label::query()->where('user_id', $user->id), 'Call list_labels to see valid ids.');
+        $isCatchAll = $request->boolean('is_catch_all');
+
+        $this->assertBudgetTracksSomething($user, $isCatchAll, $categoryIds, $labelIds);
+
+        $budget = (new BudgetService)->create(
+            $user,
+            [
+                'name' => $request->string('name')->toString(),
+                'period_type' => $request->string('period_type')->toString(),
+                'period_start_day' => $request->filled('period_start_day') ? $request->integer('period_start_day') : null,
+                'rollover_type' => $request->string('rollover_type')->toString(),
+                'is_catch_all' => $isCatchAll,
+            ],
+            $request->integer('allocated_amount'),
+            $categoryIds,
+            $labelIds,
+        );
+
+        return $this->json(['budget' => $this->presentBudget($budget)]);
+    }
+
+    /**
+     * A budget needs something to watch: either explicit categories/labels, or
+     * the single catch-all budget that absorbs whatever the others leave behind.
+     *
+     * @param  array<int, string>  $categoryIds
+     * @param  array<int, string>  $labelIds
+     */
+    private function assertBudgetTracksSomething(User $user, bool $isCatchAll, array $categoryIds, array $labelIds): void
+    {
+        if (! $isCatchAll && $categoryIds === [] && $labelIds === []) {
+            throw ValidationException::withMessages([
+                'category_ids' => 'Pass at least one category or label to track, or set is_catch_all to true.',
+            ]);
+        }
+
+        if ($isCatchAll && $user->budgets()->where('is_catch_all', true)->exists()) {
+            throw ValidationException::withMessages([
+                'is_catch_all' => 'This account already has a catch-all budget.',
+            ]);
+        }
+    }
+
+    /**
+     * The ids passed under $key, every one asserted to be reachable through
+     * $query so a typo is reported instead of silently dropped.
+     *
+     * @param  Builder<covariant Model>  $query
+     * @return array<int, string>
+     */
+    private function ownedIds(Request $request, string $key, Builder $query, string $hint): array
+    {
+        $ids = collect($request->get($key, []))
+            ->map(fn (mixed $id): string => (string) $id)
+            ->filter()
+            ->unique()
+            ->values();
+
+        $found = $ids->isEmpty() ? collect() : $query->whereIn('id', $ids)->pluck('id');
+
+        if ($found->count() !== $ids->count()) {
+            throw ValidationException::withMessages([$key => "One or more ids in {$key} do not exist. {$hint}"]);
+        }
+
+        return $found->all();
+    }
+}

--- a/app/Mcp/Tools/CreateBudget.php
+++ b/app/Mcp/Tools/CreateBudget.php
@@ -18,7 +18,7 @@ use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Attributes\Description;
 
-#[Description('Create a budget: a spending limit per period over a set of categories and/or labels. The transactions already inside the current and previous period are attached in the background, so spent_amount may still be filling in right after the call.')]
+#[Description('Create a budget: a spending limit per period over a set of categories and/or labels. Transactions already in range are attached in the background, so spent_amount may still be filling in.')]
 class CreateBudget extends WriteTool
 {
     use PresentsBudgets;
@@ -33,7 +33,7 @@ class CreateBudget extends WriteTool
             'allocated_amount' => $schema->integer()->description('Limit for each period, in minor units (50000 = 500.00).')->required(),
             'period_type' => $schema->string()->enum(array_column(BudgetPeriodType::cases(), 'value'))->description('How often the budget starts over.')->required(),
             'rollover_type' => $schema->string()->enum(array_column(RolloverType::cases(), 'value'))->description('"carry_over" adds what is left to the next period, "reset" starts every period at the limit.')->required(),
-            'period_start_day' => $schema->integer()->min(0)->max(31)->description('Day the period starts: day of the month (1-31) when monthly, day of the week (0 = Sunday) when weekly or biweekly. Ignored when yearly.'),
+            'period_start_day' => $schema->integer()->min(0)->max(31)->description('Day the period starts: day of the month (1-31) when monthly, day of the week (0 = Sunday, 6 = Saturday) when weekly or biweekly. Ignored when yearly.'),
             'category_ids' => $schema->array()->items($schema->string())->description('Categories to track. Tracking a parent also tracks its children. Call list_categories to see valid ids.'),
             'label_ids' => $schema->array()->items($schema->string())->description('Labels to track. Call list_labels to see valid ids.'),
             'is_catch_all' => $schema->boolean()->description('Track every expense category no other budget tracks. Needs no categories or labels, and only one catch-all budget is allowed.'),
@@ -42,22 +42,29 @@ class CreateBudget extends WriteTool
 
     protected function write(Request $request, User $user): Response
     {
+        $periodType = $request->string('period_type')->toString();
+
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
             'allocated_amount' => ['required', 'integer', 'min:0'],
             'period_type' => ['required', Rule::enum(BudgetPeriodType::class)],
             'rollover_type' => ['required', Rule::enum(RolloverType::class)],
-            'period_start_day' => ['sometimes', 'nullable', 'integer', 'min:0', 'max:31'],
+            // The field means a day of the week for weekly periods and a day of
+            // the month for monthly ones, so its range depends on period_type.
+            'period_start_day' => ['sometimes', 'nullable', 'integer', 'min:'.($periodType === 'monthly' ? 1 : 0), 'max:'.(in_array($periodType, ['weekly', 'biweekly'], true) ? 6 : 31)],
             'is_catch_all' => ['sometimes', 'boolean'],
         ]);
 
-        $categoryIds = $this->ownedIds($request, 'category_ids', Category::query()->where('user_id', $user->id), 'Call list_categories to see valid ids.');
-        $labelIds = $this->ownedIds($request, 'label_ids', Label::query()->where('user_id', $user->id), 'Call list_labels to see valid ids.');
+        // Budgets track their owner's own categories and labels, so an id
+        // belonging to a co-member of a shared space is rejected even though
+        // list_categories, being space-scoped, does return it.
+        $categoryIds = $this->ownedIds($request, 'category_ids', Category::query()->where('user_id', $user->id), 'One or more category_ids are not categories you own. Only your own categories can be budgeted.');
+        $labelIds = $this->ownedIds($request, 'label_ids', Label::query()->where('user_id', $user->id), 'One or more label_ids are not labels you own. Only your own labels can be budgeted.');
         $isCatchAll = $request->boolean('is_catch_all');
 
         $this->assertBudgetTracksSomething($user, $isCatchAll, $categoryIds, $labelIds);
 
-        $budget = (new BudgetService)->create(
+        $budget = app(BudgetService::class)->create(
             $user,
             [
                 'name' => $request->string('name')->toString(),
@@ -78,6 +85,10 @@ class CreateBudget extends WriteTool
      * A budget needs something to watch: either explicit categories/labels, or
      * the single catch-all budget that absorbs whatever the others leave behind.
      *
+     * The web form checks the same two rules (StoreBudgetRequest), with wording
+     * aimed at someone looking at the create dialog rather than at an agent
+     * deciding what to send next.
+     *
      * @param  array<int, string>  $categoryIds
      * @param  array<int, string>  $labelIds
      */
@@ -97,26 +108,20 @@ class CreateBudget extends WriteTool
     }
 
     /**
-     * The ids passed under $key, every one asserted to be reachable through
-     * $query so a typo is reported instead of silently dropped.
+     * The ids passed under $key, asserted to all be reachable through $query so
+     * an unusable one is reported instead of silently dropped.
      *
      * @param  Builder<covariant Model>  $query
-     * @return array<int, string>
+     * @return list<string>
      */
-    private function ownedIds(Request $request, string $key, Builder $query, string $hint): array
+    private function ownedIds(Request $request, string $key, Builder $query, string $failure): array
     {
-        $ids = collect($request->get($key, []))
-            ->map(fn (mixed $id): string => (string) $id)
-            ->filter()
-            ->unique()
-            ->values();
+        $ids = $this->requestedIds($request, $key);
 
-        $found = $ids->isEmpty() ? collect() : $query->whereIn('id', $ids)->pluck('id');
-
-        if ($found->count() !== $ids->count()) {
-            throw ValidationException::withMessages([$key => "One or more ids in {$key} do not exist. {$hint}"]);
+        if ($query->whereIn('id', $ids)->count() !== count($ids)) {
+            throw ValidationException::withMessages([$key => $failure]);
         }
 
-        return $found->all();
+        return $ids;
     }
 }

--- a/app/Mcp/Tools/DeleteBudget.php
+++ b/app/Mcp/Tools/DeleteBudget.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+
+#[IsDestructive]
+#[Description('Delete a budget, with its periods and their spending history. The transactions themselves are untouched — only the budget that was watching them goes away.')]
+class DeleteBudget extends WriteTool
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'budget_id' => $schema->string()->description('Id of the budget to delete. Call list_budgets to see valid ids.')->required(),
+        ];
+    }
+
+    protected function write(Request $request, User $user): Response
+    {
+        $budget = $this->budgetOfUser($request, $user);
+
+        $budget->delete();
+
+        return $this->json(['deleted' => true, 'id' => $budget->id]);
+    }
+}

--- a/app/Mcp/Tools/ListBudgets.php
+++ b/app/Mcp/Tools/ListBudgets.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Mcp\Tools\Concerns\PresentsBudgets;
+use App\Models\Budget;
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[Description('List the user\'s budgets with the current period\'s allocated, spent and remaining amounts, plus the categories and labels each one tracks. Covers the whole account.')]
+class ListBudgets extends McpTool
+{
+    use PresentsBudgets;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+
+    protected function respond(Request $request, User $user): Response
+    {
+        // ponytail: two extra queries per budget (its current period, and that
+        // period's spend). Fine for the handful of budgets a user keeps; eager
+        // load the current period with a sum if anyone ever runs dozens.
+        $budgets = $user->budgets()
+            ->with(['categories:id,name', 'labels:id,name'])
+            ->orderBy('name')
+            ->get()
+            ->map(fn (Budget $budget): array => $this->presentBudget($budget))
+            ->all();
+
+        return $this->json([
+            'currency' => $user->currency_code ?? 'USD',
+            'budgets' => $budgets,
+        ]);
+    }
+}

--- a/app/Mcp/Tools/McpTool.php
+++ b/app/Mcp/Tools/McpTool.php
@@ -144,27 +144,37 @@ abstract class McpTool extends Tool
      */
     protected function labelsInSpace(Request $request, Space $space, string $key): Collection
     {
-        $ids = collect($request->get($key, []))
-            ->map(fn (mixed $id): string => (string) $id)
-            ->filter()
-            ->unique()
-            ->values();
+        $ids = $this->requestedIds($request, $key);
 
-        if ($ids->isEmpty()) {
-            /** @var Collection<int, Label> $empty */
-            $empty = Label::query()->whereRaw('1 = 0')->get();
-
-            return $empty;
+        if ($ids === []) {
+            /** @var Collection<int, Label> */
+            return new Collection;
         }
 
         $labels = Label::query()->forSpace($space)->whereIn('id', $ids)->get();
 
-        if ($labels->count() !== $ids->count()) {
+        if ($labels->count() !== count($ids)) {
             throw ValidationException::withMessages([
                 $key => "One or more label ids do not exist in space {$space->id}. Call list_labels to see valid ids.",
             ]);
         }
 
         return $labels;
+    }
+
+    /**
+     * The ids passed under $key, cast to strings and de-duplicated. Empty when
+     * the argument is absent.
+     *
+     * @return list<string>
+     */
+    protected function requestedIds(Request $request, string $key): array
+    {
+        return collect($request->get($key, []))
+            ->map(fn (mixed $id): string => (string) $id)
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
     }
 }

--- a/app/Mcp/Tools/UpdateBudget.php
+++ b/app/Mcp/Tools/UpdateBudget.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Enums\BudgetPeriodType;
+use App\Enums\RolloverType;
+use App\Mcp\Tools\Concerns\PresentsBudgets;
+use App\Models\Budget;
+use App\Models\User;
+use App\Services\BudgetService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+
+#[Description('Edit a budget. Only the fields you pass are changed. A new allocated_amount applies to the period in progress and every future one. The categories and labels a budget tracks cannot be changed here — create a new budget for a different selection.')]
+class UpdateBudget extends WriteTool
+{
+    use PresentsBudgets;
+
+    /**
+     * The editable fields, in the order the schema declares them.
+     *
+     * @var array<int, string>
+     */
+    private const FIELDS = ['name', 'period_type', 'period_start_day', 'rollover_type'];
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'budget_id' => $schema->string()->description('Id of the budget to edit. Call list_budgets to see valid ids.')->required(),
+            'name' => $schema->string()->description('New budget name.'),
+            'allocated_amount' => $schema->integer()->description('New limit per period, in minor units (50000 = 500.00). Applies to the current and future periods.'),
+            'period_type' => $schema->string()->enum(array_column(BudgetPeriodType::cases(), 'value'))->description('New period length. Takes effect on the next period.'),
+            'rollover_type' => $schema->string()->enum(array_column(RolloverType::cases(), 'value'))->description('New rollover behaviour.'),
+            'period_start_day' => $schema->integer()->min(0)->max(31)->description('New day the period starts. Takes effect on the next period.'),
+        ];
+    }
+
+    protected function write(Request $request, User $user): Response
+    {
+        $request->validate([
+            'name' => ['sometimes', 'string', 'max:255'],
+            'allocated_amount' => ['sometimes', 'integer', 'min:0'],
+            'period_type' => ['sometimes', Rule::enum(BudgetPeriodType::class)],
+            'rollover_type' => ['sometimes', Rule::enum(RolloverType::class)],
+            'period_start_day' => ['sometimes', 'nullable', 'integer', 'min:0', 'max:31'],
+        ]);
+
+        $budget = $this->budgetOf($request, $user);
+
+        $attributes = [];
+
+        foreach (self::FIELDS as $field) {
+            if ($request->has($field)) {
+                $attributes[$field] = $request->get($field);
+            }
+        }
+
+        (new BudgetService)->update(
+            $budget,
+            $attributes,
+            $request->has('allocated_amount') ? $request->integer('allocated_amount') : null,
+        );
+
+        return $this->json(['budget' => $this->presentBudget($budget->refresh())]);
+    }
+
+    /**
+     * Budgets are owned by the user rather than scoped to a space, matching how
+     * the app assigns transactions to them.
+     */
+    private function budgetOf(Request $request, User $user): Budget
+    {
+        $id = $request->string('budget_id')->toString();
+
+        $budget = $user->budgets()->whereKey($id)->first();
+
+        if ($budget === null) {
+            throw ValidationException::withMessages([
+                'budget_id' => "No budget with id {$id}. Call list_budgets to see valid ids.",
+            ]);
+        }
+
+        return $budget;
+    }
+}

--- a/app/Mcp/Tools/UpdateBudget.php
+++ b/app/Mcp/Tools/UpdateBudget.php
@@ -2,30 +2,18 @@
 
 namespace App\Mcp\Tools;
 
-use App\Enums\BudgetPeriodType;
-use App\Enums\RolloverType;
 use App\Mcp\Tools\Concerns\PresentsBudgets;
-use App\Models\Budget;
 use App\Models\User;
 use App\Services\BudgetService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
-use Illuminate\Validation\Rule;
-use Illuminate\Validation\ValidationException;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Attributes\Description;
 
-#[Description('Edit a budget. Only the fields you pass are changed. A new allocated_amount applies to the period in progress and every future one. The categories and labels a budget tracks cannot be changed here — create a new budget for a different selection.')]
+#[Description('Rename a budget or change its limit; only the fields you pass are changed. Its period length, start day, rollover and tracked categories are fixed — delete and recreate it to change those.')]
 class UpdateBudget extends WriteTool
 {
     use PresentsBudgets;
-
-    /**
-     * The editable fields, in the order the schema declares them.
-     *
-     * @var array<int, string>
-     */
-    private const FIELDS = ['name', 'period_type', 'period_start_day', 'rollover_type'];
 
     /**
      * @return array<string, mixed>
@@ -35,10 +23,7 @@ class UpdateBudget extends WriteTool
         return [
             'budget_id' => $schema->string()->description('Id of the budget to edit. Call list_budgets to see valid ids.')->required(),
             'name' => $schema->string()->description('New budget name.'),
-            'allocated_amount' => $schema->integer()->description('New limit per period, in minor units (50000 = 500.00). Applies to the current and future periods.'),
-            'period_type' => $schema->string()->enum(array_column(BudgetPeriodType::cases(), 'value'))->description('New period length. Takes effect on the next period.'),
-            'rollover_type' => $schema->string()->enum(array_column(RolloverType::cases(), 'value'))->description('New rollover behaviour.'),
-            'period_start_day' => $schema->integer()->min(0)->max(31)->description('New day the period starts. Takes effect on the next period.'),
+            'allocated_amount' => $schema->integer()->description('New limit per period, in minor units (50000 = 500.00). Applies to the period in progress and every future one.'),
         ];
     }
 
@@ -47,46 +32,20 @@ class UpdateBudget extends WriteTool
         $request->validate([
             'name' => ['sometimes', 'string', 'max:255'],
             'allocated_amount' => ['sometimes', 'integer', 'min:0'],
-            'period_type' => ['sometimes', Rule::enum(BudgetPeriodType::class)],
-            'rollover_type' => ['sometimes', Rule::enum(RolloverType::class)],
-            'period_start_day' => ['sometimes', 'nullable', 'integer', 'min:0', 'max:31'],
         ]);
 
-        $budget = $this->budgetOf($request, $user);
+        $budget = $this->budgetOfUser($request, $user);
 
-        $attributes = [];
-
-        foreach (self::FIELDS as $field) {
-            if ($request->has($field)) {
-                $attributes[$field] = $request->get($field);
-            }
-        }
-
-        (new BudgetService)->update(
+        // The period length, start day and rollover stay as created: budgets are
+        // calculated historically, so reshaping their periods afterwards would
+        // leave overlapping ones counting the same transaction twice. The web
+        // edit dialog locks these fields for the same reason.
+        app(BudgetService::class)->update(
             $budget,
-            $attributes,
+            $request->has('name') ? ['name' => $request->string('name')->toString()] : [],
             $request->has('allocated_amount') ? $request->integer('allocated_amount') : null,
         );
 
         return $this->json(['budget' => $this->presentBudget($budget->refresh())]);
-    }
-
-    /**
-     * Budgets are owned by the user rather than scoped to a space, matching how
-     * the app assigns transactions to them.
-     */
-    private function budgetOf(Request $request, User $user): Budget
-    {
-        $id = $request->string('budget_id')->toString();
-
-        $budget = $user->budgets()->whereKey($id)->first();
-
-        if ($budget === null) {
-            throw ValidationException::withMessages([
-                'budget_id' => "No budget with id {$id}. Call list_budgets to see valid ids.",
-            ]);
-        }
-
-        return $budget;
     }
 }

--- a/app/Mcp/Tools/WriteTool.php
+++ b/app/Mcp/Tools/WriteTool.php
@@ -4,6 +4,7 @@ namespace App\Mcp\Tools;
 
 use App\Models\Account;
 use App\Models\AutomationRule;
+use App\Models\Budget;
 use App\Models\Category;
 use App\Models\Label;
 use App\Models\Space;
@@ -144,6 +145,25 @@ abstract class WriteTool extends McpTool
     protected function ruleInSpace(Request $request, Space $space, string $key = 'automation_rule_id'): AutomationRule
     {
         return $this->modelInSpace($request, $space, AutomationRule::query()->forSpace($space), $key, 'automation rule');
+    }
+
+    /**
+     * Resolve a budget. Budgets hang off the user rather than off a space,
+     * matching how the app decides which budgets a transaction feeds.
+     */
+    protected function budgetOfUser(Request $request, User $user, string $key = 'budget_id'): Budget
+    {
+        $id = $request->string($key)->toString();
+
+        $budget = $user->budgets()->whereKey($id)->first();
+
+        if ($budget === null) {
+            throw ValidationException::withMessages([
+                $key => "No budget with id {$id}. Call list_budgets to see valid ids.",
+            ]);
+        }
+
+        return $budget;
     }
 
     /**

--- a/app/Models/BudgetPeriod.php
+++ b/app/Models/BudgetPeriod.php
@@ -56,6 +56,17 @@ class BudgetPeriod extends Model
         return (int) $this->budgetTransactions()->sum('amount');
     }
 
+    /**
+     * What is left of this period's limit, in cents. Deliberately ignores
+     * `carried_over_amount`: the budget cards, the spending chart and the
+     * limit alerts all judge a period against its allocated amount alone, so a
+     * second definition of "remaining" would contradict them.
+     */
+    public function remainingAmount(): int
+    {
+        return $this->allocated_amount - $this->spentAmount();
+    }
+
     /** @return HasMany<BudgetTransaction, $this> */
     public function budgetTransactions(): HasMany
     {

--- a/app/Services/BudgetPeriodService.php
+++ b/app/Services/BudgetPeriodService.php
@@ -56,8 +56,7 @@ class BudgetPeriodService
         $carriedOverAmount = 0;
 
         if ($budget->rollover_type->value === 'carry_over') {
-            $totalSpent = $period->budgetTransactions()->sum('amount');
-            $remaining = $period->allocated_amount - $totalSpent;
+            $remaining = $period->remainingAmount();
 
             if ($remaining > 0) {
                 $carriedOverAmount = $remaining;
@@ -82,18 +81,12 @@ class BudgetPeriodService
                 break;
 
             case BudgetPeriodType::Weekly:
-                $dayOfWeek = $budget->period_start_day ?? 0;
-                while ($startDate->dayOfWeek !== $dayOfWeek) {
-                    $startDate->subDay();
-                }
+                $startDate = $this->rewindToDayOfWeek($startDate, $budget->period_start_day);
                 $endDate = $startDate->copy()->addWeek()->subDay();
                 break;
 
             case BudgetPeriodType::Biweekly:
-                $dayOfWeek = $budget->period_start_day ?? 0;
-                while ($startDate->dayOfWeek !== $dayOfWeek) {
-                    $startDate->subDay();
-                }
+                $startDate = $this->rewindToDayOfWeek($startDate, $budget->period_start_day);
                 $endDate = $startDate->copy()->addWeeks(2)->subDay();
                 break;
 
@@ -104,6 +97,23 @@ class BudgetPeriodService
         }
 
         return [$startDate, $endDate];
+    }
+
+    /**
+     * Step back to the most recent $dayOfWeek. Taken modulo 7 because
+     * `period_start_day` holds a day of the month for monthly budgets, so a
+     * budget switched to a weekly period can carry a value above 6 — which
+     * `Carbon::dayOfWeek` would never match, spinning forever.
+     */
+    private function rewindToDayOfWeek(Carbon $date, ?int $dayOfWeek): Carbon
+    {
+        $target = ($dayOfWeek ?? 0) % 7;
+
+        while ($date->dayOfWeek !== $target) {
+            $date->subDay();
+        }
+
+        return $date;
     }
 
     protected function calculateNextPeriodStartDate(Budget $budget): Carbon

--- a/app/Services/BudgetService.php
+++ b/app/Services/BudgetService.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Services;
+
+use App\Jobs\AssignHistoricalTransactionsToBudget;
+use App\Models\Budget;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Creating and editing a budget, shared by the web controller and the MCP tools
+ * so both surfaces seed periods, backfill history and move the allocated amount
+ * the same way.
+ */
+class BudgetService
+{
+    public function __construct(private readonly BudgetPeriodService $periods = new BudgetPeriodService) {}
+
+    /**
+     * Create a budget with its current and previous period, then backfill both
+     * with the transactions already in range.
+     *
+     * @param  array<string, mixed>  $attributes  name, period_type, period_start_day, rollover_type, is_catch_all
+     * @param  array<int, string>  $categoryIds
+     * @param  array<int, string>  $labelIds
+     */
+    public function create(User $user, array $attributes, int $allocatedAmount, array $categoryIds = [], array $labelIds = []): Budget
+    {
+        [$budget, $period, $previousPeriod] = DB::transaction(function () use ($user, $attributes, $allocatedAmount, $categoryIds, $labelIds): array {
+            $setting = $user->setting;
+
+            $budget = $user->budgets()->create([
+                ...$attributes,
+                'notify_on_new_transaction' => $setting->budget_notify_on_new_transaction ?? false,
+                'notify_on_close_to_limit' => $setting->budget_notify_on_close_to_limit ?? true,
+                'notify_on_over_limit' => $setting->budget_notify_on_over_limit ?? true,
+            ]);
+
+            $budget->categories()->sync($categoryIds);
+            $budget->labels()->sync($labelIds);
+
+            $period = $this->periods->generatePeriod($budget, $allocatedAmount, null, true);
+
+            return [$budget, $period, $this->periods->generatePreviousPeriod($budget, $period, $allocatedAmount, true)];
+        });
+
+        AssignHistoricalTransactionsToBudget::dispatch($budget, $period);
+        AssignHistoricalTransactionsToBudget::dispatch($budget, $previousPeriod);
+
+        return $budget;
+    }
+
+    /**
+     * Edit a budget. A new allocated amount applies to the period in progress and
+     * to every future one — editing the limit is meant to change what is left to
+     * spend now, not only what the next period gets.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function update(Budget $budget, array $attributes, ?int $allocatedAmount = null): Budget
+    {
+        DB::transaction(function () use ($budget, $attributes, $allocatedAmount): void {
+            $budget->update($attributes);
+
+            if ($allocatedAmount !== null) {
+                $budget->periods()
+                    ->where('end_date', '>=', today())
+                    ->update(['allocated_amount' => $allocatedAmount]);
+            }
+        });
+
+        return $budget;
+    }
+}

--- a/app/Services/BudgetService.php
+++ b/app/Services/BudgetService.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Facades\DB;
  */
 class BudgetService
 {
-    public function __construct(private readonly BudgetPeriodService $periods = new BudgetPeriodService) {}
+    public function __construct(private readonly BudgetPeriodService $periods) {}
 
     /**
      * Create a budget with its current and previous period, then backfill both

--- a/chatgpt-app-submission.json
+++ b/chatgpt-app-submission.json
@@ -4,7 +4,7 @@
   "app_info": {
     "display_name": "Whisper Money",
     "subtitle": "Chat with your own finances",
-    "description": "Whisper Money is a privacy-first personal finance app: your financial data is yours, and it is never shared with third parties. This app connects ChatGPT to your own Whisper Money account so you can analyse your money in plain language instead of clicking through dashboards.\n\nAsk questions like \"how much did I spend on groceries last month\", \"what's my net worth trend this year\", \"which subscriptions are draining me\" or \"break down Q2 by category\" — the app reads your transactions, accounts, categories, labels, cashflow and net worth and answers with your real numbers. You can also keep your books tidy from the conversation: log manual transactions, recategorize and label existing ones, record balances for manual accounts, and manage categories, labels and automation rules.\n\nYour synced bank data is protected: transactions imported from a bank connection can be categorized and labelled, but never edited or deleted, and balances can only be recorded on manual accounts. You can still add your own manual transactions to a bank-connected account — a sync never removes them. Data is scoped to the account you sign in with, including any shared spaces you belong to. The app reads and writes bookkeeping records only — it can never move money, make payments or reach any account outside Whisper Money.\n\nRequires a Whisper Money account on a paid (Pro) plan. Sign in happens through Whisper Money's own OAuth flow — ChatGPT never sees your password, and access can be revoked at any time from your account settings.",
+    "description": "Whisper Money is a privacy-first personal finance app: your financial data is yours, and it is never shared with third parties. This app connects ChatGPT to your own Whisper Money account so you can analyse your money in plain language instead of clicking through dashboards.\n\nAsk questions like \"how much did I spend on groceries last month\", \"what's my net worth trend this year\", \"which subscriptions are draining me\" or \"break down Q2 by category\" — the app reads your transactions, accounts, categories, labels, budgets, cashflow and net worth and answers with your real numbers. You can also keep your books tidy from the conversation: log manual transactions, recategorize and label existing ones, record balances for manual accounts, and manage budgets, categories, labels and automation rules.\n\nYour synced bank data is protected: transactions imported from a bank connection can be categorized and labelled, but never edited or deleted, and balances can only be recorded on manual accounts. You can still add your own manual transactions to a bank-connected account — a sync never removes them. Data is scoped to the account you sign in with, including any shared spaces you belong to. The app reads and writes bookkeeping records only — it can never move money, make payments or reach any account outside Whisper Money.\n\nRequires a Whisper Money account on a paid (Pro) plan. Sign in happens through Whisper Money's own OAuth flow — ChatGPT never sees your password, and access can be revoked at any time from your account settings.",
     "category": "FINANCE"
   },
   "tools": {
@@ -61,6 +61,14 @@
       "justifications": {
         "read_only_justification": "Lists the user's own labels so later calls can reference label ids. It writes nothing.",
         "open_world_justification": "Lists only labels inside the authenticated user's own Whisper Money workspace, a closed system.",
+        "destructive_justification": "Read-only, so nothing can be changed or lost."
+      }
+    },
+    "list_budgets": {
+      "annotations": { "readOnlyHint": true, "openWorldHint": false, "destructiveHint": false },
+      "justifications": {
+        "read_only_justification": "Lists the user's own budgets with what the period in progress has allocated, spent and left. It writes nothing.",
+        "open_world_justification": "Lists only budgets inside the authenticated user's own Whisper Money workspace, a closed system.",
         "destructive_justification": "Read-only, so nothing can be changed or lost."
       }
     },
@@ -191,6 +199,30 @@
         "open_world_justification": "Deletes a rule inside the user's own Whisper Money workspace, a closed system.",
         "destructive_justification": "Irreversible: the rule definition is deleted and cannot be restored, so the model must confirm with the user first. Transactions it already categorized are left untouched."
       }
+    },
+    "create_budget": {
+      "annotations": { "readOnlyHint": false, "openWorldHint": false, "destructiveHint": false },
+      "justifications": {
+        "read_only_justification": "Writes: it creates a budget, its first periods, and attaches the transactions already inside them.",
+        "open_world_justification": "Creates a budget inside the user's own Whisper Money workspace, a closed system. It cannot move money or reach any external service.",
+        "destructive_justification": "Additive and reversible: no existing record is altered, and the budget can be edited or deleted afterwards."
+      }
+    },
+    "update_budget": {
+      "annotations": { "readOnlyHint": false, "openWorldHint": false, "destructiveHint": false },
+      "justifications": {
+        "read_only_justification": "Writes: it renames the user's own budget or changes the amount allocated to its current and future periods.",
+        "open_world_justification": "Edits a budget inside the user's own Whisper Money workspace, a closed system.",
+        "destructive_justification": "Reversible: only the name and the limit can be changed, both can be set straight back, and no transaction is touched."
+      }
+    },
+    "delete_budget": {
+      "annotations": { "readOnlyHint": false, "openWorldHint": false, "destructiveHint": true },
+      "justifications": {
+        "read_only_justification": "Writes: it removes a budget from the user's own workspace.",
+        "open_world_justification": "Deletes a budget inside the user's own Whisper Money workspace, a closed system.",
+        "destructive_justification": "Irreversible for the user: the budget disappears from their account along with the spending history of its periods, and nothing in the app brings it back, so the model must confirm first. The transactions themselves are left untouched."
+      }
     }
   },
   "test_cases": [
@@ -223,6 +255,12 @@
       "user_prompt": "My Uber charges are filed as Shopping — move them to Transport.",
       "tools_triggered": "search_transactions, list_categories, categorize_transaction",
       "expected_output": "The matching transactions listed for confirmation, then each one reassigned to the Transport category, including bank-imported ones (categorizing is always allowed)."
+    },
+    {
+      "description": "Budget check and adjustment. The app reads the budgets with the figures of the period in progress, and can raise a limit when the user asks.",
+      "user_prompt": "Am I still inside my food budget this month? Raise it to 600 if I am not.",
+      "tools_triggered": "list_budgets, update_budget",
+      "expected_output": "The food budget's allocated, spent and remaining amounts for the current period, and, when it is over, the limit raised to 600 for this period and the ones after it."
     }
   ],
   "negative_test_cases": [

--- a/lang/es.json
+++ b/lang/es.json
@@ -2251,7 +2251,7 @@
     "Read only": "Solo lectura",
     "Read & write": "Lectura y escritura",
     "Access": "Acceso",
-    "Read-only tokens can analyse your data. Read & write tokens can also create, edit and delete transactions, categories, labels and automation rules.": "Los tokens de solo lectura pueden analizar tus datos. Los tokens de lectura y escritura también pueden crear, editar y eliminar transacciones, categorías, etiquetas y reglas de automatización.",
+    "Read-only tokens can analyse your data. Read & write tokens can also create, edit and delete transactions, categories, labels, budgets and automation rules.": "Los tokens de solo lectura pueden analizar tus datos. Los tokens de lectura y escritura también pueden crear, editar y eliminar transacciones, categorías, etiquetas, presupuestos y reglas de automatización.",
     "Create token": "Crear token",
     "Your tokens": "Tus tokens",
     "Rotate a token to replace a leaked secret, or revoke it to cut off access.": "Rota un token para reemplazar un secreto filtrado, o revócalo para cortar el acceso.",

--- a/resources/js/pages/settings/mcp.tsx
+++ b/resources/js/pages/settings/mcp.tsx
@@ -362,7 +362,7 @@ export default function Mcp() {
                                             </h3>
                                             <p className="text-sm text-muted-foreground">
                                                 {__(
-                                                    'Read-only tokens can analyse your data. Read & write tokens can also create, edit and delete transactions, categories, labels and automation rules.',
+                                                    'Read-only tokens can analyse your data. Read & write tokens can also create, edit and delete transactions, categories, labels, budgets and automation rules.',
                                                 )}
                                             </p>
                                         </div>

--- a/tests/Feature/BudgetTest.php
+++ b/tests/Feature/BudgetTest.php
@@ -119,6 +119,37 @@ test('user can update their budget', function () {
     ]);
 });
 
+test('a new budget amount applies to the period in progress', function () {
+    $user = User::factory()->create(['onboarded_at' => now()]);
+
+    $budget = Budget::factory()->create([
+        'user_id' => $user->id,
+        'period_type' => 'monthly',
+        'period_start_day' => 1,
+    ]);
+
+    $current = $budget->periods()->create([
+        'start_date' => today()->startOfMonth(),
+        'end_date' => today()->endOfMonth(),
+        'allocated_amount' => 50000,
+        'carried_over_amount' => 0,
+    ]);
+
+    $past = $budget->periods()->create([
+        'start_date' => today()->subMonthNoOverflow()->startOfMonth(),
+        'end_date' => today()->subMonthNoOverflow()->endOfMonth(),
+        'allocated_amount' => 50000,
+        'carried_over_amount' => 0,
+    ]);
+
+    $this->actingAs($user)
+        ->patch("/budgets/{$budget->id}", ['allocated_amount' => 60000])
+        ->assertRedirect();
+
+    expect($current->fresh()->allocated_amount)->toBe(60000);
+    expect($past->fresh()->allocated_amount)->toBe(50000);
+});
+
 test('user can delete their budget', function () {
     $user = User::factory()->create(['onboarded_at' => now()]);
 

--- a/tests/Feature/Mcp/McpToolsTest.php
+++ b/tests/Feature/Mcp/McpToolsTest.php
@@ -174,6 +174,42 @@ it('lists budgets with what the current period has spent and has left', function
         ->assertSee('"remaining_amount":38000');
 });
 
+it('reports the remaining amount the app shows, ignoring carry-over', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->create(['user_id' => $user->id]);
+    $category = Category::factory()->create(['user_id' => $user->id]);
+
+    $budget = Budget::factory()->forCategories($category)->create([
+        'user_id' => $user->id,
+        'period_type' => 'monthly',
+        'period_start_day' => 1,
+        'rollover_type' => 'carry_over',
+    ]);
+
+    $budget->periods()->create([
+        'start_date' => today()->startOfMonth(),
+        'end_date' => today()->endOfMonth(),
+        'allocated_amount' => 50_000,
+        'carried_over_amount' => 10_000,
+    ]);
+
+    Transaction::factory()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'category_id' => $category->id,
+        'transaction_date' => today(),
+        'amount' => -12_000,
+    ]);
+
+    // The budget cards, the spending chart and the limit emails all measure
+    // against the allocated amount alone, so the agent must not add carry-over.
+    WhisperMoneyServer::actingAs($user)
+        ->tool(ListBudgets::class)
+        ->assertOk()
+        ->assertSee('"carried_over_amount":10000')
+        ->assertSee('"remaining_amount":38000');
+});
+
 it('never exposes another user\'s budgets', function () {
     $user = User::factory()->create();
     Budget::factory()->create(['user_id' => User::factory()->create()->id, 'name' => 'Secret Budget']);

--- a/tests/Feature/Mcp/McpToolsTest.php
+++ b/tests/Feature/Mcp/McpToolsTest.php
@@ -2,10 +2,12 @@
 
 use App\Mcp\Servers\WhisperMoneyServer;
 use App\Mcp\Tools\ListAccounts;
+use App\Mcp\Tools\ListBudgets;
 use App\Mcp\Tools\ListCategories;
 use App\Mcp\Tools\ListSpaces;
 use App\Mcp\Tools\SearchTransactions;
 use App\Models\Account;
+use App\Models\Budget;
 use App\Models\Category;
 use App\Models\Label;
 use App\Models\Transaction;
@@ -132,4 +134,52 @@ it('lists the user\'s categories for the space', function () {
         ->tool(ListCategories::class, [])
         ->assertOk()
         ->assertSee('Groceries');
+});
+
+it('lists budgets with what the current period has spent and has left', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->create(['user_id' => $user->id]);
+    $category = Category::factory()->create(['user_id' => $user->id, 'name' => 'Groceries']);
+
+    $budget = Budget::factory()->forCategories($category)->create([
+        'user_id' => $user->id,
+        'name' => 'Food Budget',
+        'period_type' => 'monthly',
+        'period_start_day' => 1,
+    ]);
+
+    $budget->periods()->create([
+        'start_date' => today()->startOfMonth(),
+        'end_date' => today()->endOfMonth(),
+        'allocated_amount' => 50_000,
+        'carried_over_amount' => 0,
+    ]);
+
+    // Assigned to the period by the TransactionCreated listener.
+    Transaction::factory()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'category_id' => $category->id,
+        'transaction_date' => today(),
+        'amount' => -12_000,
+    ]);
+
+    WhisperMoneyServer::actingAs($user)
+        ->tool(ListBudgets::class)
+        ->assertOk()
+        ->assertSee('Food Budget')
+        ->assertSee('Groceries')
+        ->assertSee('"allocated_amount":50000')
+        ->assertSee('"spent_amount":12000')
+        ->assertSee('"remaining_amount":38000');
+});
+
+it('never exposes another user\'s budgets', function () {
+    $user = User::factory()->create();
+    Budget::factory()->create(['user_id' => User::factory()->create()->id, 'name' => 'Secret Budget']);
+
+    WhisperMoneyServer::actingAs($user)
+        ->tool(ListBudgets::class)
+        ->assertOk()
+        ->assertDontSee('Secret Budget');
 });

--- a/tests/Feature/Mcp/McpWriteToolsTest.php
+++ b/tests/Feature/Mcp/McpWriteToolsTest.php
@@ -5,6 +5,7 @@ use App\Mcp\Servers\WhisperMoneyServer;
 use App\Mcp\Tools\CategorizeTransaction;
 use App\Mcp\Tools\CreateAutomationRule;
 use App\Mcp\Tools\CreateBalance;
+use App\Mcp\Tools\CreateBudget;
 use App\Mcp\Tools\CreateCategory;
 use App\Mcp\Tools\CreateLabel;
 use App\Mcp\Tools\CreateTransaction;
@@ -14,11 +15,13 @@ use App\Mcp\Tools\DeleteLabel;
 use App\Mcp\Tools\DeleteTransaction;
 use App\Mcp\Tools\LabelTransaction;
 use App\Mcp\Tools\UpdateAutomationRule;
+use App\Mcp\Tools\UpdateBudget;
 use App\Mcp\Tools\UpdateCategory;
 use App\Mcp\Tools\UpdateLabel;
 use App\Mcp\Tools\UpdateTransaction;
 use App\Models\Account;
 use App\Models\AutomationRule;
+use App\Models\Budget;
 use App\Models\Category;
 use App\Models\Label;
 use App\Models\Transaction;
@@ -316,6 +319,157 @@ it('requires an automation rule to have at least one action', function () {
     ])->assertHasErrors(['action']);
 
     expect($user->automationRules()->count())->toBe(0);
+});
+
+it('creates a budget with its periods and backfills the transactions already in range', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->create(['user_id' => $user->id]);
+    $category = Category::factory()->create(['user_id' => $user->id, 'name' => 'Groceries']);
+
+    Transaction::factory()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'category_id' => $category->id,
+        'transaction_date' => today(),
+        'amount' => -7_500,
+    ]);
+
+    callWriteTool($user, CreateBudget::class, [
+        'name' => 'Food Budget',
+        'allocated_amount' => 50_000,
+        'period_type' => 'monthly',
+        'rollover_type' => 'reset',
+        'period_start_day' => 1,
+        'category_ids' => [$category->id],
+    ])->assertOk()->assertSee('Food Budget');
+
+    $budget = $user->budgets()->first();
+
+    expect($budget)->not->toBeNull();
+    expect($budget->categories->pluck('id')->all())->toBe([$category->id]);
+    // The current period and the previous one, for period-over-period comparison.
+    expect($budget->periods()->count())->toBe(2);
+    expect($budget->getCurrentPeriod()->allocated_amount)->toBe(50_000);
+    expect($budget->getCurrentPeriod()->spentAmount())->toBe(7_500);
+});
+
+it('creates a catch-all budget without categories, but only one', function () {
+    $user = User::factory()->create();
+
+    callWriteTool($user, CreateBudget::class, [
+        'name' => 'Everything Else',
+        'allocated_amount' => 100_000,
+        'period_type' => 'monthly',
+        'rollover_type' => 'carry_over',
+        'is_catch_all' => true,
+    ])->assertOk();
+
+    callWriteTool($user, CreateBudget::class, [
+        'name' => 'Everything Else Again',
+        'allocated_amount' => 100_000,
+        'period_type' => 'monthly',
+        'rollover_type' => 'carry_over',
+        'is_catch_all' => true,
+    ])->assertHasErrors(['catch-all']);
+
+    expect($user->budgets()->count())->toBe(1);
+});
+
+it('refuses a budget that tracks nothing', function () {
+    $user = User::factory()->create();
+
+    callWriteTool($user, CreateBudget::class, [
+        'name' => 'Tracks nothing',
+        'allocated_amount' => 10_000,
+        'period_type' => 'monthly',
+        'rollover_type' => 'reset',
+    ])->assertHasErrors(['at least one category or label']);
+
+    expect($user->budgets()->count())->toBe(0);
+});
+
+it('refuses a budget tracking another user\'s category', function () {
+    $user = User::factory()->create();
+    $foreignCategory = Category::factory()->create(['user_id' => User::factory()->create()->id]);
+
+    callWriteTool($user, CreateBudget::class, [
+        'name' => 'Sneaky',
+        'allocated_amount' => 10_000,
+        'period_type' => 'monthly',
+        'rollover_type' => 'reset',
+        'category_ids' => [$foreignCategory->id],
+    ])->assertHasErrors(['list_categories']);
+
+    expect($user->budgets()->count())->toBe(0);
+});
+
+it('edits a budget and moves the new amount onto the period in progress', function () {
+    $user = User::factory()->create();
+    $budget = Budget::factory()->create([
+        'user_id' => $user->id,
+        'name' => 'Food Budget',
+        'period_type' => 'monthly',
+        'period_start_day' => 1,
+    ]);
+
+    $current = $budget->periods()->create([
+        'start_date' => today()->startOfMonth(),
+        'end_date' => today()->endOfMonth(),
+        'allocated_amount' => 50_000,
+        'carried_over_amount' => 0,
+    ]);
+
+    $past = $budget->periods()->create([
+        'start_date' => today()->subMonthNoOverflow()->startOfMonth(),
+        'end_date' => today()->subMonthNoOverflow()->endOfMonth(),
+        'allocated_amount' => 50_000,
+        'carried_over_amount' => 0,
+    ]);
+
+    callWriteTool($user, UpdateBudget::class, [
+        'budget_id' => $budget->id,
+        'name' => 'Groceries Budget',
+        'allocated_amount' => 60_000,
+    ])->assertOk()->assertSee('Groceries Budget');
+
+    expect($budget->fresh()->name)->toBe('Groceries Budget');
+    expect($current->fresh()->allocated_amount)->toBe(60_000);
+    // A period that is already over keeps the amount it was judged against.
+    expect($past->fresh()->allocated_amount)->toBe(50_000);
+});
+
+it('leaves the fields the agent did not pass alone', function () {
+    $user = User::factory()->create();
+    $budget = Budget::factory()->create([
+        'user_id' => $user->id,
+        'name' => 'Food Budget',
+        'period_type' => 'monthly',
+        'period_start_day' => 4,
+        'rollover_type' => 'reset',
+    ]);
+
+    callWriteTool($user, UpdateBudget::class, [
+        'budget_id' => $budget->id,
+        'name' => 'Renamed',
+    ])->assertOk();
+
+    $budget->refresh();
+
+    expect($budget->name)->toBe('Renamed');
+    expect($budget->period_start_day)->toBe(4);
+    expect($budget->rollover_type->value)->toBe('reset');
+});
+
+it('refuses to edit another user\'s budget', function () {
+    $user = User::factory()->create();
+    $foreignBudget = Budget::factory()->create(['user_id' => User::factory()->create()->id, 'name' => 'Not Yours']);
+
+    callWriteTool($user, UpdateBudget::class, [
+        'budget_id' => $foreignBudget->id,
+        'name' => 'Hijacked',
+    ])->assertHasErrors(['list_budgets']);
+
+    expect($foreignBudget->fresh()->name)->toBe('Not Yours');
 });
 
 it('rejects a write tool called with a read-only token', function () {

--- a/tests/Feature/Mcp/McpWriteToolsTest.php
+++ b/tests/Feature/Mcp/McpWriteToolsTest.php
@@ -10,6 +10,7 @@ use App\Mcp\Tools\CreateCategory;
 use App\Mcp\Tools\CreateLabel;
 use App\Mcp\Tools\CreateTransaction;
 use App\Mcp\Tools\DeleteAutomationRule;
+use App\Mcp\Tools\DeleteBudget;
 use App\Mcp\Tools\DeleteCategory;
 use App\Mcp\Tools\DeleteLabel;
 use App\Mcp\Tools\DeleteTransaction;
@@ -398,7 +399,25 @@ it('refuses a budget tracking another user\'s category', function () {
         'period_type' => 'monthly',
         'rollover_type' => 'reset',
         'category_ids' => [$foreignCategory->id],
-    ])->assertHasErrors(['list_categories']);
+    ])->assertHasErrors(['not categories you own']);
+
+    expect($user->budgets()->count())->toBe(0);
+});
+
+it('rejects a period start day that cannot mean anything for the period type', function () {
+    $user = User::factory()->create();
+    $category = Category::factory()->create(['user_id' => $user->id]);
+
+    // 15 is a valid day of the month but not a day of the week, and the period
+    // generator would otherwise walk backwards forever looking for it.
+    callWriteTool($user, CreateBudget::class, [
+        'name' => 'Weekly',
+        'allocated_amount' => 10_000,
+        'period_type' => 'weekly',
+        'period_start_day' => 15,
+        'category_ids' => [$category->id],
+        'rollover_type' => 'reset',
+    ])->assertHasErrors(['period start day']);
 
     expect($user->budgets()->count())->toBe(0);
 });
@@ -426,6 +445,13 @@ it('edits a budget and moves the new amount onto the period in progress', functi
         'carried_over_amount' => 0,
     ]);
 
+    $future = $budget->periods()->create([
+        'start_date' => today()->addMonthNoOverflow()->startOfMonth(),
+        'end_date' => today()->addMonthNoOverflow()->endOfMonth(),
+        'allocated_amount' => 50_000,
+        'carried_over_amount' => 0,
+    ]);
+
     callWriteTool($user, UpdateBudget::class, [
         'budget_id' => $budget->id,
         'name' => 'Groceries Budget',
@@ -434,6 +460,7 @@ it('edits a budget and moves the new amount onto the period in progress', functi
 
     expect($budget->fresh()->name)->toBe('Groceries Budget');
     expect($current->fresh()->allocated_amount)->toBe(60_000);
+    expect($future->fresh()->allocated_amount)->toBe(60_000);
     // A period that is already over keeps the amount it was judged against.
     expect($past->fresh()->allocated_amount)->toBe(50_000);
 });
@@ -448,6 +475,13 @@ it('leaves the fields the agent did not pass alone', function () {
         'rollover_type' => 'reset',
     ]);
 
+    $period = $budget->periods()->create([
+        'start_date' => today()->startOfMonth(),
+        'end_date' => today()->endOfMonth(),
+        'allocated_amount' => 50_000,
+        'carried_over_amount' => 0,
+    ]);
+
     callWriteTool($user, UpdateBudget::class, [
         'budget_id' => $budget->id,
         'name' => 'Renamed',
@@ -458,6 +492,30 @@ it('leaves the fields the agent did not pass alone', function () {
     expect($budget->name)->toBe('Renamed');
     expect($budget->period_start_day)->toBe(4);
     expect($budget->rollover_type->value)->toBe('reset');
+    expect($period->fresh()->allocated_amount)->toBe(50_000);
+});
+
+it('will not reshape the periods of an existing budget', function () {
+    $user = User::factory()->create();
+    $budget = Budget::factory()->create([
+        'user_id' => $user->id,
+        'period_type' => 'monthly',
+        'period_start_day' => 1,
+    ]);
+
+    // Period settings are fixed once a budget exists — changing them would let
+    // the next generated period overlap the current one and count the same
+    // transaction twice, so the tool does not accept them at all.
+    callWriteTool($user, UpdateBudget::class, [
+        'budget_id' => $budget->id,
+        'period_type' => 'weekly',
+        'period_start_day' => 15,
+    ])->assertOk();
+
+    $budget->refresh();
+
+    expect($budget->period_type->value)->toBe('monthly');
+    expect($budget->period_start_day)->toBe(1);
 });
 
 it('refuses to edit another user\'s budget', function () {
@@ -470,6 +528,46 @@ it('refuses to edit another user\'s budget', function () {
     ])->assertHasErrors(['list_budgets']);
 
     expect($foreignBudget->fresh()->name)->toBe('Not Yours');
+});
+
+it('deletes a budget and leaves its transactions alone', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->create(['user_id' => $user->id]);
+    $category = Category::factory()->create(['user_id' => $user->id]);
+
+    $transaction = Transaction::factory()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'category_id' => $category->id,
+        'transaction_date' => today(),
+        'amount' => -3_000,
+    ]);
+
+    callWriteTool($user, CreateBudget::class, [
+        'name' => 'Food Budget',
+        'allocated_amount' => 50_000,
+        'period_type' => 'monthly',
+        'rollover_type' => 'reset',
+        'category_ids' => [$category->id],
+    ])->assertOk();
+
+    $budget = $user->budgets()->firstOrFail();
+
+    callWriteTool($user, DeleteBudget::class, ['budget_id' => $budget->id])->assertOk();
+
+    expect($user->budgets()->count())->toBe(0);
+    expect(Transaction::query()->find($transaction->id))->not->toBeNull();
+});
+
+it('refuses to delete another user\'s budget', function () {
+    $user = User::factory()->create();
+    $foreignBudget = Budget::factory()->create(['user_id' => User::factory()->create()->id]);
+
+    callWriteTool($user, DeleteBudget::class, [
+        'budget_id' => $foreignBudget->id,
+    ])->assertHasErrors(['list_budgets']);
+
+    expect(Budget::query()->find($foreignBudget->id))->not->toBeNull();
 });
 
 it('rejects a write tool called with a read-only token', function () {

--- a/tests/Unit/Mcp/ToolAnnotationsTest.php
+++ b/tests/Unit/Mcp/ToolAnnotationsTest.php
@@ -15,6 +15,7 @@ $readOnly = [
     'list_accounts',
     'list_categories',
     'list_labels',
+    'list_budgets',
     'list_spaces',
 ];
 
@@ -23,6 +24,7 @@ $destructive = [
     'delete_category',
     'delete_label',
     'delete_automation_rule',
+    'delete_budget',
 ];
 
 /**
@@ -46,7 +48,7 @@ it('declares all three MCP hints on every tool', function () use ($readOnly, $de
     /** @var array<int, class-string<Tool>> $tools */
     $tools = (new ReflectionClass(WhisperMoneyServer::class))->getDefaultProperties()['tools'];
 
-    expect($tools)->toHaveCount(count($readOnly) + 15);
+    expect($tools)->toHaveCount(count($readOnly) + 18);
 
     foreach ($tools as $class) {
         $tool = new $class;


### PR DESCRIPTION
Budgets were the one part of the app a connected agent could not see. It could
list transactions, categories and labels, but "am I still inside my food budget
this month" had no answer, and setting a budget up meant leaving the
conversation. This adds the four tools that close that gap.

## Tools

| Tool | What it does |
| --- | --- |
| `list_budgets` | Every budget with the period in progress: allocated, carried over, spent, remaining, plus the categories and labels it tracks |
| `create_budget` | A limit per period over categories and/or labels, or the single catch-all budget |
| `update_budget` | Rename, or change the limit |
| `delete_budget` | Remove a budget; the transactions it was watching are untouched |

Budgets hang off the user rather than off a space — that is how the app already
decides which budgets a transaction feeds — so these tools take no `space`
argument and cover the whole account, like the cashflow and net-worth ones.

`update_budget` deliberately only takes `name` and `allocated_amount`. The web
edit dialog locks the period length, start day and rollover behind an explicit
message ("budgets are calculated historically"), and for good reason: changing
them afterwards lets the next generated period overlap the one in progress, so
the same transaction gets counted twice. To change those, or the tracked
categories, the agent deletes the budget and creates it again.

## Shared service, and one web behaviour change

Creating a budget seeds two periods and dispatches the historical backfill for
both; that logic now lives in `BudgetService`, called by `BudgetController` and
by the tools, instead of being copied into the MCP layer.

**This changes one thing on the web:** editing a budget's amount now applies to
the period in progress as well as future ones. The old filter was
`start_date >= today`, which skipped a period that had already started — so on
any day but the first of the period, saving a new amount appeared to do nothing.
The edit dialog already promised the new behaviour ("This will update the
allocated amount for the current and future periods") and prefills the current
period's amount, so the code was the side that was wrong. Covered by a new test
in `BudgetTest`.

## Fix: a start day that could hang period generation

`period_start_day` means a day of the month for monthly budgets and a day of the
week for weekly ones. A weekly budget carrying a value above 6 sent
`calculatePeriodDates()` into `while ($date->dayOfWeek !== $dayOfWeek)`, walking
backwards forever looking for a day that cannot exist. The web form caps the
input at 6, but the server-side rule never did, so the tools were the first
surface that could reach it — and once such a row exists, the daily
`budgets:generate-periods` command hits it and stops generating periods **for
every user**.

Two changes: the tools validate the range against `period_type`, and the
generator takes the value modulo 7 so no caller can spin. Verified against a row
doctored to `weekly` + `15`: it now resolves to a normal week instead of hanging.

## Reviews

Both review passes ran; the notable ones applied beyond the two above:

- `remaining_amount` no longer adds the carried-over amount. The budget cards,
  the spending chart and the limit emails all measure against the allocated
  amount alone, so the old formula meant an agent quoting a number no screen
  shows. `carried_over_amount` is still reported as its own field.
- The period reports `processing_historical`, so an agent can tell "nothing
  spent" from "backfill still running" instead of trusting a prose caveat.
- The category/label hints say the ids must be ones the user owns —
  `list_categories` is space-scoped and can return a co-member's, which a budget
  cannot track.
- Request id normalisation moved onto `McpTool` as `requestedIds()`, shared with
  `labelsInSpace`, which no longer runs a query just to build an empty result.

Deliberately not applied: the "at least one category or label" and "only one
catch-all" rules stay duplicated between `StoreBudgetRequest` and
`create_budget`. Unifying them would change the web error key `selection`, which
the create dialog renders, and the two audiences want different wording — the
agent gets told what to send next.

## QA

Driven over the real `/mcp` endpoint with a Sanctum token, since there is no UI
surface:

- `tools/list` advertises all four with the right annotations and schemas
  (`delete_budget` destructive, `list_budgets` read-only).
- `create_budget` → the response comes back with `processing_historical: true`;
  after draining the queue, the €120 transaction already on the account is
  attached and `spent_amount` reads 12000, `remaining_amount` 38000.
- `update_budget` to 60000 → the August period moves to 60000, the closed July
  period keeps 50000.
- `delete_budget` → gone from `list_budgets`, transaction still there.
- Refused as expected: a read-only token, a weekly budget with `period_start_day`
  15, a budget tracking nothing, and an unknown budget id.
- `mcp_tool_calls` recorded only the four calls that did something, not the
  rejections.

`chatgpt-app-submission.json` gains the four tools with their hint
justifications, plus a budget test case, so the submitted manifest keeps matching
what the server serves (`ToolAnnotationsTest` enforces the count).
