### PR TITLE
refactor(open-banking): bring the authorization callback back under the complexity threshold

### DIFF
--- a/app/Http/Controllers/OpenBanking/AuthorizationController.php
+++ b/app/Http/Controllers/OpenBanking/AuthorizationController.php
@@ -165,44 +165,14 @@ class AuthorizationController extends Controller
                 ->with('error', __('Please log back in to finish connecting your bank account.'));
         }
 
-        $errorRedirectRoute = $user->isOnboarded() ? 'settings.connections.index' : 'onboarding';
-        $errorRedirectParams = $user->isOnboarded() ? [] : ['step' => 'create-account'];
-
         if ($request->has('error')) {
-            $errorDescription = $request->query('error_description');
-            $errorMessage = is_string($errorDescription) && $errorDescription !== ''
-                ? $errorDescription
-                : 'Authorization was denied or cancelled.';
-
-            Log::warning('EnableBanking authorization error', [
-                'error' => $request->query('error'),
-                'description' => $errorDescription,
-            ]);
-
-            $pendingConnection = $connection ?? $user->bankingConnections()
-                ->where('status', BankingConnectionStatus::Pending)
-                ->latest()
-                ->first();
-
-            if ($pendingConnection) {
-                if ($pendingConnection->accounts()->exists()) {
-                    $pendingConnection->update([
-                        'status' => BankingConnectionStatus::Error,
-                        'error_message' => $errorMessage,
-                        'state_token' => null,
-                    ]);
-                } else {
-                    $pendingConnection->delete();
-                }
-            }
-
-            return $this->finishRedirect($errorRedirectRoute, $errorRedirectParams, 'error', $errorMessage);
+            return $this->handleAuthorizationError($request, $user, $connection);
         }
 
         $code = $request->query('code');
 
         if (! $code) {
-            return $this->finishRedirect($errorRedirectRoute, $errorRedirectParams, 'error', 'No authorization code received.');
+            return $this->failureRedirect($user, 'No authorization code received.');
         }
 
         try {
@@ -214,13 +184,13 @@ class AuthorizationController extends Controller
                 $connection->update(['state_token' => null]);
             }
 
-            return $this->finishRedirect($errorRedirectRoute, $errorRedirectParams, 'error', 'Failed to connect to your bank. Please try again.');
+            return $this->failureRedirect($user, 'Failed to connect to your bank. Please try again.');
         }
 
         $connection ??= $this->findPendingConnectionForSession($user, $sessionData);
 
         if (! $connection) {
-            return $this->finishRedirect($errorRedirectRoute, $errorRedirectParams, 'error', 'No pending connection found.');
+            return $this->failureRedirect($user, 'No pending connection found.');
         }
 
         $isReconnect = $connection->accounts()->exists();
@@ -262,6 +232,56 @@ class AuthorizationController extends Controller
         }
 
         return $this->finishRedirect('open-banking.map-accounts', ['connection' => $connection]);
+    }
+
+    /**
+     * Clean up after a bank that denied or cancelled the authorization.
+     *
+     * A pending connection that already has accounts is a reconnect, so it is kept
+     * and marked as failing. A brand new one has nothing worth keeping.
+     */
+    private function handleAuthorizationError(Request $request, User $user, ?BankingConnection $connection): RedirectResponse|Response
+    {
+        $errorDescription = $request->query('error_description');
+        $errorMessage = is_string($errorDescription) && $errorDescription !== ''
+            ? $errorDescription
+            : 'Authorization was denied or cancelled.';
+
+        Log::warning('EnableBanking authorization error', [
+            'error' => $request->query('error'),
+            'description' => $errorDescription,
+        ]);
+
+        $pendingConnection = $connection ?? $user->bankingConnections()
+            ->where('status', BankingConnectionStatus::Pending)
+            ->latest()
+            ->first();
+
+        if ($pendingConnection) {
+            if ($pendingConnection->accounts()->exists()) {
+                $pendingConnection->update([
+                    'status' => BankingConnectionStatus::Error,
+                    'error_message' => $errorMessage,
+                    'state_token' => null,
+                ]);
+            } else {
+                $pendingConnection->delete();
+            }
+        }
+
+        return $this->failureRedirect($user, $errorMessage);
+    }
+
+    /**
+     * Abandon the callback with a message, sending the user wherever they came from.
+     *
+     * A user still onboarding has no connections screen to land on yet.
+     */
+    private function failureRedirect(User $user, string $message): RedirectResponse|Response
+    {
+        return $user->isOnboarded()
+            ? $this->finishRedirect('settings.connections.index', [], 'error', $message)
+            : $this->finishRedirect('onboarding', ['step' => 'create-account'], 'error', $message);
     }
 
     /**

--- a/app/Http/Controllers/OpenBanking/AuthorizationController.php
+++ b/app/Http/Controllers/OpenBanking/AuthorizationController.php
@@ -171,20 +171,21 @@ class AuthorizationController extends Controller
 
         $code = $request->query('code');
 
-        if (! $code) {
-            return $this->failureRedirect($user, 'No authorization code received.');
+        // query() hands back an array for ?code[]=, which is truthy but not a code.
+        if (! $code || ! is_string($code)) {
+            return $this->finishWithError($user, 'No authorization code received.');
         }
 
         $sessionData = $this->createProviderSession($provider, $code, $connection);
 
         if ($sessionData === null) {
-            return $this->failureRedirect($user, 'Failed to connect to your bank. Please try again.');
+            return $this->finishWithError($user, 'Failed to connect to your bank. Please try again.');
         }
 
         $connection ??= $this->findPendingConnectionForSession($user, $sessionData);
 
         if (! $connection) {
-            return $this->failureRedirect($user, 'No pending connection found.');
+            return $this->finishWithError($user, 'No pending connection found.');
         }
 
         $isReconnect = $connection->accounts()->exists();
@@ -307,7 +308,7 @@ class AuthorizationController extends Controller
             }
         }
 
-        return $this->failureRedirect($user, $errorMessage);
+        return $this->finishWithError($user, $errorMessage);
     }
 
     /**
@@ -315,7 +316,7 @@ class AuthorizationController extends Controller
      *
      * A user still onboarding has no connections screen to land on yet.
      */
-    private function failureRedirect(User $user, string $message): RedirectResponse|Response
+    private function finishWithError(User $user, string $message): RedirectResponse|Response
     {
         return $user->isOnboarded()
             ? $this->finishRedirect('settings.connections.index', [], 'error', $message)

--- a/app/Http/Controllers/OpenBanking/AuthorizationController.php
+++ b/app/Http/Controllers/OpenBanking/AuthorizationController.php
@@ -175,15 +175,9 @@ class AuthorizationController extends Controller
             return $this->failureRedirect($user, 'No authorization code received.');
         }
 
-        try {
-            $sessionData = $provider->createSession($code);
-        } catch (\Throwable $e) {
-            Log::error('EnableBanking session creation failed', ['error' => $e->getMessage()]);
+        $sessionData = $this->createProviderSession($provider, $code, $connection);
 
-            if ($connection) {
-                $connection->update(['state_token' => null]);
-            }
-
+        if ($sessionData === null) {
             return $this->failureRedirect($user, 'Failed to connect to your bank. Please try again.');
         }
 
@@ -196,26 +190,70 @@ class AuthorizationController extends Controller
         $isReconnect = $connection->accounts()->exists();
 
         if ($isReconnect) {
-            $connection->update([
-                'session_id' => $sessionData['session_id'],
-                'status' => BankingConnectionStatus::Active,
-                'valid_until' => $sessionData['access']['valid_until'] ?? null,
-                'error_message' => null,
-                'state_token' => null,
-                // Reconnecting is the way out of a parked connection, so it has
-                // to hand back the full retry budget. Carrying the old count over
-                // meant the first failure after a reconnect could re-park it
-                // immediately, which is the state the user just paid SCA to leave.
-                'consecutive_sync_failures' => 0,
-            ]);
-
-            $this->refreshAccountIds($connection, $sessionData['accounts']);
-
-            SyncBankingConnectionJob::dispatch($connection);
-
-            return $this->finishRedirect('settings.connections.index', [], 'success', __('Bank account reconnected successfully.'));
+            return $this->completeReconnect($connection, $sessionData);
         }
 
+        return $this->completeFirstConnection($user, $connection, $sessionData, $accountUserCurrencyService);
+    }
+
+    /**
+     * Exchange the authorization code for a provider session, or null when the
+     * exchange fails. A failed exchange burns the state token with it.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function createProviderSession(BankingProviderInterface $provider, string $code, ?BankingConnection $connection): ?array
+    {
+        try {
+            return $provider->createSession($code);
+        } catch (\Throwable $e) {
+            Log::error('EnableBanking session creation failed', ['error' => $e->getMessage()]);
+
+            if ($connection) {
+                $connection->update(['state_token' => null]);
+            }
+
+            return null;
+        }
+    }
+
+    /**
+     * Point a connection that already has accounts at its new session and resync it.
+     *
+     * @param  array<string, mixed>  $sessionData
+     */
+    private function completeReconnect(BankingConnection $connection, array $sessionData): RedirectResponse|Response
+    {
+        $connection->update([
+            'session_id' => $sessionData['session_id'],
+            'status' => BankingConnectionStatus::Active,
+            'valid_until' => $sessionData['access']['valid_until'] ?? null,
+            'error_message' => null,
+            'state_token' => null,
+            // Reconnecting is the way out of a parked connection, so it has
+            // to hand back the full retry budget. Carrying the old count over
+            // meant the first failure after a reconnect could re-park it
+            // immediately, which is the state the user just paid SCA to leave.
+            'consecutive_sync_failures' => 0,
+        ]);
+
+        $this->refreshAccountIds($connection, $sessionData['accounts']);
+
+        SyncBankingConnectionJob::dispatch($connection);
+
+        return $this->finishRedirect('settings.connections.index', [], 'success', __('Bank account reconnected successfully.'));
+    }
+
+    /**
+     * Park the fetched accounts on the connection so the user can map them.
+     *
+     * Onboarding skips the mapping screen: every account is created up front so the
+     * user lands back on the onboarding step with data already syncing.
+     *
+     * @param  array<string, mixed>  $sessionData
+     */
+    private function completeFirstConnection(User $user, BankingConnection $connection, array $sessionData, AccountUserCurrencyService $accountUserCurrencyService): RedirectResponse|Response
+    {
         $connection->update([
             'session_id' => $sessionData['session_id'],
             'status' => BankingConnectionStatus::AwaitingMapping,

--- a/tests/Feature/OpenBanking/AuthorizationControllerTest.php
+++ b/tests/Feature/OpenBanking/AuthorizationControllerTest.php
@@ -196,6 +196,35 @@ test('callback without code redirects with error', function () {
     $response->assertSessionHas('error');
 });
 
+test('callback clears the state token when the session exchange fails', function () {
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->pending()->create([
+        'user_id' => $user->id,
+        'aspsp_name' => 'Test Bank',
+        'aspsp_country' => 'ES',
+        'state_token' => 'state-token-fails',
+    ]);
+
+    $mockProvider = Mockery::mock(BankingProviderInterface::class);
+    $mockProvider->shouldReceive('createSession')
+        ->with('test-code')
+        ->once()
+        ->andThrow(new RuntimeException('Provider is unreachable'));
+
+    $this->app->instance(BankingProviderInterface::class, $mockProvider);
+
+    $response = $this->actingAs($user)
+        ->get('/open-banking/callback?code=test-code&state=state-token-fails');
+
+    $response->assertRedirect(route('settings.connections.index'));
+    $response->assertSessionHas('error', 'Failed to connect to your bank. Please try again.');
+
+    // A state token left behind would be matched by a later callback for another bank.
+    $connection->refresh();
+    expect($connection->state_token)->toBeNull();
+    expect($connection->status)->toBe(BankingConnectionStatus::Pending);
+});
+
 test('callback with valid code stores pending accounts and redirects to mapping', function () {
     Queue::fake();
 

--- a/tests/Feature/OpenBanking/AuthorizationControllerTest.php
+++ b/tests/Feature/OpenBanking/AuthorizationControllerTest.php
@@ -188,12 +188,50 @@ test('callback with error during reconnect preserves existing connection', funct
     expect($connection->error_message)->toBe('User denied access');
 });
 
+test('callback with error and nothing pending still reports the error', function () {
+    $user = User::factory()->onboarded()->create();
+
+    $response = $this->actingAs($user)
+        ->get('/open-banking/callback?error=access_denied&error_description=User+denied+access');
+
+    $response->assertRedirect(route('settings.connections.index'));
+    $response->assertSessionHas('error', 'User denied access');
+});
+
+test('callback with error and no description falls back to a generic message', function () {
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->pending()->create([
+        'user_id' => $user->id,
+    ]);
+
+    $response = $this->actingAs($user)->get('/open-banking/callback?error=access_denied');
+
+    $response->assertRedirect(route('settings.connections.index'));
+    $response->assertSessionHas('error', 'Authorization was denied or cancelled.');
+
+    expect(BankingConnection::find($connection->id))->toBeNull();
+});
+
 test('callback without code redirects with error', function () {
     $user = User::factory()->onboarded()->create();
     $response = $this->actingAs($user)->get('/open-banking/callback');
 
     $response->assertRedirect(route('settings.connections.index'));
     $response->assertSessionHas('error');
+});
+
+test('callback rejects a non-string authorization code instead of failing', function () {
+    $user = User::factory()->onboarded()->create();
+
+    $mockProvider = Mockery::mock(BankingProviderInterface::class);
+    $mockProvider->shouldNotReceive('createSession');
+
+    $this->app->instance(BankingProviderInterface::class, $mockProvider);
+
+    $response = $this->actingAs($user)->get('/open-banking/callback?code[]=abc');
+
+    $response->assertRedirect(route('settings.connections.index'));
+    $response->assertSessionHas('error', 'No authorization code received.');
 });
 
 test('callback clears the state token when the session exchange fails', function () {


### PR DESCRIPTION
`AuthorizationController::callback` sat at cyclomatic complexity **16** against a
repo threshold of **10**, so the `crap` check went red on every PR that touched the
file regardless of what the diff did — most recently #782, where the change was one
array entry plus a comment. This brings it to **9** and leaves `.crap-ignore.json`
empty: the complexity is gone, not exempted.

Rebased onto `origin/main` after #782 merged; its `consecutive_sync_failures => 0`
reset is carried into the extracted reconnect helper.

## What moved

`callback` is a fixed-order OAuth funnel, so the order is preserved exactly and each
phase became a named private helper:

| New helper | What it holds |
| --- | --- |
| `handleAuthorizationError()` | the `error` query-param branch, including the pending-connection cleanup |
| `finishWithError()` | the two `isOnboarded()` ternaries picking the failure destination |
| `createProviderSession()` | the `createSession` try/catch and its state-token cleanup |
| `completeReconnect()` | the reconnect terminal branch |
| `completeFirstConnection()` | the first-time-connection terminal branch |

What is left in `callback` is a linear chain of guards ending in one of two named
completions. `finishWithError()` also collapses four repeated
`(route, params, 'error', message)` argument lists into one call each.

| Method | Before | After |
| --- | --- | --- |
| `callback` | 16 | **9** |
| `handleAuthorizationError` | — | 5 |
| `createProviderSession` | — | 3 |
| `completeFirstConnection` | — | 2 |
| `finishWithError` | — | 2 |
| `completeReconnect` | — | 1 |

9 rather than exactly 10 is deliberate: at 10 the next single added branch puts the
file straight back over the line, which is the problem this PR exists to fix.

## One deliberate behaviour change

Everything else is behaviour-preserving, but this bit is not, so it should not be
skimmed. Both reviews caught it independently, and it is a bug the refactor itself
introduced before it was fixed here.

`$request->query('code')` returns an **array** for `?code[]=abc`. An array is truthy,
so it clears the `! $code` guard. Before the split, the resulting `TypeError` was
raised *inside* the `createSession` try/catch and swallowed by `catch (\Throwable)`,
producing the graceful error page. After the split, the `string $code` parameter of
`createProviderSession()` raised it at the call site, *outside* the try — an uncaught
**500**.

The guard is now `! $code || ! is_string($code)`. Note this is deliberately not the
`! is_string($code) || $code === ''` both reviewers suggested: that form would start
accepting `?code=0`, which the original rejected as falsy.

Net effect for a malformed `?code[]=` request: it now renders "No authorization code
received." instead of "Failed to connect to your bank", and no longer clears the
connection's `state_token`. That is the better outcome — a burned token leaves the
pending connection unmatchable and forces the user to restart the bank
authorization — but it is a change, not a no-op. Enable Banking never sends
`code[]=`, so no real connect flow is affected.

## Verification

- `php artisan crap --base=origin/main --no-coverage` — pass, nothing above 10
- `php artisan test tests/Feature/OpenBanking` — **350 passed**, 1181 assertions
- `vendor/bin/pint --test`, `vendor/bin/phpstan` — pass, 0 errors
- `bun run dry` — pass, clone counts byte-identical to `origin/main` (176 PHP clones,
  2163 duplicated lines before and after), so the split introduced no duplication

### Tests added

Three branches the reviews found unguarded, all in code this diff moved:

- the session-exchange failure — the one branch whose control flow this refactor
  restructured, and it pins the `state_token` cleanup. Verified it has teeth by
  removing the cleanup and watching it fail.
- the non-string `code` above.
- the `error` callback with nothing pending (null guard), and the missing
  `error_description` fallback message.

### Live QA

Replayed real callbacks against the dev server with real DB rows (the callback is
stateless, keyed by `state_token`), and checked the row and the log after each:

| Callback | Result | Row after |
| --- | --- | --- |
| `error` + description, no accounts | error page, "User denied access" | soft-deleted |
| `error` + description, has accounts | error page, "User denied access" | kept, `status=error`, token cleared |
| `error`, no description | error page, "Authorization was denied or cancelled." | soft-deleted |
| no `code` | error page, "No authorization code received." | untouched, token intact |
| `?code[]=abc` | error page, "No authorization code received." — **no 500** | untouched, token intact |
| bad `code` | error page, "Failed to connect to your bank." | token cleared |
| no `state`, no session | 302 to `/login` | n/a |

The bad-`code` case reached the real Enable Banking API and came back 422, so the
extracted try/catch was exercised against a genuine provider failure, not a mock.

The success paths need a real bank session, so those went through the live sandbox
script (`tests/Browser/live/connect-bank.mjs`, real Sabadell + BBVA) — all four
scenarios pass:

- **settings-connect** → active, 5 accounts, 328 transactions
- **onboarding-connect** → active, 7 accounts auto-created (`completeFirstConnection`,
  not-onboarded branch)
- **reconnect-expired** → active, `valid_until` refreshed, 5 accounts retained
  (`completeReconnect`)
- **session-lost-return** → confirmation screen rendered, connection still finalized
  server-side (the authless iOS-PWA path)

Between the replayed failure callbacks and these, every branch of `callback` has been
exercised against the real provider. First run had two failures — the Sabadell sandbox
login timed out, and `reconnect-expired` reuses the connection that scenario creates,
so it then ran against a connection with zero accounts and correctly took the
first-connection branch. Both passed on a re-run with no code change.

## Out of scope

`findPendingConnectionForSession` in the same class is at complexity 11 and untouched
here. The `crap` check does not flag it because the diff does not touch its lines, but
the next PR that edits that method will go red on it.
