### PR TITLE
fix(budgets): re-derive budget membership when labels are attached without a model event

### DIFF
--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\BulkUpdateTransactionsRequest;
 use App\Http\Requests\IndexTransactionRequest;
 use App\Http\Requests\StoreTransactionRequest;
 use App\Http\Requests\UpdateTransactionRequest;
+use App\Jobs\ReassignTransactionsToBudgets;
 use App\Models\Account;
 use App\Models\AutomationRule;
 use App\Models\Bank;
@@ -338,6 +339,12 @@ class TransactionController extends Controller
             $this->syncLabels($transactions, $request->input('label_ids') ?? []);
         }
 
+        // Neither branch above fires a model event — the category goes through a
+        // query-builder mass update and the labels through the pivot — so nothing
+        // else would re-derive which budgets now track these transactions.
+        // Silently: editing existing rows is not new spending.
+        ReassignTransactionsToBudgets::dispatch($transactions->pluck('id')->all(), notify: false);
+
         return response()->json([
             'message' => 'Transactions updated successfully',
             'count' => $transactions->count(),
@@ -403,7 +410,12 @@ class TransactionController extends Controller
 
     /**
      * Labels are a relation, so they are replaced row by row rather than in the
-     * mass update. The save() bumps updated_at, which the sync alone would not.
+     * mass update.
+     *
+     * The sync fires no model event, and neither does the save() — these models
+     * were loaded before the mass update and nothing dirties them, so save() skips
+     * performUpdate() entirely. bulkUpdate() queues the budget reassignment that
+     * the missing event would have triggered.
      *
      * @param  Collection<int, Transaction>  $transactions
      * @param  list<string>  $labelIds

--- a/app/Jobs/ReEvaluateTransactionRulesJob.php
+++ b/app/Jobs/ReEvaluateTransactionRulesJob.php
@@ -47,12 +47,18 @@ class ReEvaluateTransactionRulesJob implements ShouldQueue
         $updated = 0;
 
         $query->with(['account.bank', 'category', 'labels'])->chunkById(100, function ($transactions) use ($service, $total, &$processed, &$updated) {
+            $reassignIds = [];
+
             foreach ($transactions as $transaction) {
                 $categoryBefore = $transaction->category_id;
                 $labelsBefore = $transaction->labels->pluck('id')->sort()->values()->all();
                 $notesBefore = $transaction->notes;
 
-                $service->applyRules($transaction);
+                // The reassignment is batched per chunk below, so this must not
+                // queue a job of its own for every transaction it changes.
+                if ($service->applyRules($transaction, reassignBudgets: false)) {
+                    $reassignIds[] = $transaction->id;
+                }
 
                 $transaction->refresh();
                 $categoryAfter = $transaction->category_id;
@@ -65,6 +71,12 @@ class ReEvaluateTransactionRulesJob implements ShouldQueue
 
                 $processed++;
                 $this->updateProgress(status: 'processing', processed: $processed, total: $total, updated: $updated);
+            }
+
+            // Re-evaluating the whole history is an administrative act, not
+            // spending, so it must not raise budget emails.
+            if ($reassignIds !== []) {
+                ReassignTransactionsToBudgets::dispatch($reassignIds, notify: false);
             }
         });
 

--- a/app/Jobs/ReassignTransactionsToBudgets.php
+++ b/app/Jobs/ReassignTransactionsToBudgets.php
@@ -22,6 +22,10 @@ class ReassignTransactionsToBudgets implements ShouldQueue
 {
     use Queueable;
 
+    public int $tries = 3;
+
+    public int $backoff = 10;
+
     /**
      * @param  array<int, string>  $transactionIds
      * @param  bool  $notify  set to false for bulk applies, where the budget

--- a/app/Jobs/ReassignTransactionsToBudgets.php
+++ b/app/Jobs/ReassignTransactionsToBudgets.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Transaction;
+use App\Services\BudgetTransactionService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Foundation\Queue\Queueable;
+
+/**
+ * Re-derive budget membership for transactions whose category or labels changed
+ * without a model event.
+ *
+ * Pivot writes and mass updates fire nothing, so `AssignTransactionToBudget`
+ * never runs for them and the transaction stays in whatever budget it was in —
+ * typically the catch-all, even once a budget tracks its new label. This job
+ * stands in for the missing event without re-broadcasting `TransactionUpdated`,
+ * which would also re-run the automation rules that dispatched it.
+ */
+class ReassignTransactionsToBudgets implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * @param  array<int, string>  $transactionIds
+     * @param  bool  $notify  set to false for bulk applies, where the budget
+     *                        emails would describe limits crossed long ago
+     */
+    public function __construct(
+        public array $transactionIds,
+        public bool $notify = true,
+    ) {}
+
+    public function handle(BudgetTransactionService $service): void
+    {
+        Transaction::query()
+            ->whereIn('id', $this->transactionIds)
+            ->with('labels')
+            ->chunkById(200, function (Collection $transactions) use ($service): void {
+                foreach ($transactions as $transaction) {
+                    $service->assignTransaction($transaction, notify: $this->notify);
+                }
+            });
+    }
+}

--- a/app/Mcp/Tools/LabelTransaction.php
+++ b/app/Mcp/Tools/LabelTransaction.php
@@ -2,6 +2,7 @@
 
 namespace App\Mcp\Tools;
 
+use App\Jobs\ReassignTransactionsToBudgets;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
@@ -43,6 +44,10 @@ class LabelTransaction extends WriteTool
         if ($remove->isNotEmpty()) {
             $transaction->labels()->detach($remove->pluck('id')->all());
         }
+
+        // Pivot writes fire no model event, so nothing would re-derive which
+        // budgets now track this transaction by label.
+        ReassignTransactionsToBudgets::dispatch([$transaction->id]);
 
         return $this->json(['transaction' => $this->presentTransaction($transaction->refresh())]);
     }

--- a/app/Mcp/Tools/LabelTransaction.php
+++ b/app/Mcp/Tools/LabelTransaction.php
@@ -46,8 +46,10 @@ class LabelTransaction extends WriteTool
         }
 
         // Pivot writes fire no model event, so nothing would re-derive which
-        // budgets now track this transaction by label.
-        ReassignTransactionsToBudgets::dispatch([$transaction->id]);
+        // budgets now track this transaction by label. Silently: relabelling an
+        // existing transaction is not new spending, and removing a label would
+        // otherwise announce a months-old expense as new in the catch-all budget.
+        ReassignTransactionsToBudgets::dispatch([$transaction->id], notify: false);
 
         return $this->json(['transaction' => $this->presentTransaction($transaction->refresh())]);
     }

--- a/app/Services/AutomationRuleService.php
+++ b/app/Services/AutomationRuleService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Enums\CategorySource;
+use App\Jobs\ReassignTransactionsToBudgets;
 use App\Models\AutomationRule;
 use App\Models\LabelTransaction;
 use App\Models\Transaction;
@@ -40,8 +41,8 @@ class AutomationRuleService
         $transactionData = $this->prepareTransactionData($transaction);
         $matchedRule = $this->evaluateRules($rules, $transactionData);
 
-        if ($matchedRule) {
-            $this->applyActions($transaction, $matchedRule);
+        if ($matchedRule && $this->applyActions($transaction, $matchedRule)) {
+            ReassignTransactionsToBudgets::dispatch([$transaction->id]);
         }
     }
 
@@ -98,73 +99,128 @@ class AutomationRuleService
             }
         }
 
-        $changedTransactionIds = [];
+        $changedTransactionIds = array_values(array_unique(array_merge(
+            $this->applyCategoryInBulk($transactions, $rule),
+            $this->applyNoteInBulk($transactions, $rule),
+            $this->applyLabelsInBulk($transactions, $rule),
+        )));
 
-        if ($rule->action_category_id !== null) {
-            $categoryTransactionIds = $transactions
-                ->filter(fn (Transaction $transaction): bool => $transaction->category_id !== $rule->action_category_id)
-                ->pluck('id')
-                ->all();
-
-            if ($categoryTransactionIds !== []) {
-                Transaction::query()
-                    ->whereIn('id', $categoryTransactionIds)
-                    ->update([
-                        'category_id' => $rule->action_category_id,
-                        'category_source' => CategorySource::Rule->value,
-                        'categorized_by_rule_id' => $rule->id,
-                        'updated_at' => now(),
-                    ]);
-
-                foreach ($categoryTransactionIds as $transactionId) {
-                    $changedTransactionIds[$transactionId] = true;
-                }
-            }
-        }
-
-        if ($rule->action_note && $rule->action_note_iv === null) {
-            foreach ($transactions as $transaction) {
-                $existingNotes = $transaction->notes ?? '';
-
-                if ($this->noteAlreadyPresent($existingNotes, $rule->action_note)) {
-                    continue;
-                }
-
-                $transaction->notes = $existingNotes
-                    ? $existingNotes."\n".$rule->action_note
-                    : $rule->action_note;
-                $transaction->saveQuietly();
-                $changedTransactionIds[$transaction->id] = true;
-            }
-        }
-
-        $labelIds = $rule->labels->pluck('id')->all();
-        if ($labelIds !== []) {
-            $now = now();
-            $labelTransactionRows = [];
-
-            foreach ($transactions as $transaction) {
-                $transactionLabelIds = $transaction->labels->pluck('id')->all();
-                $missingLabelIds = array_diff($labelIds, $transactionLabelIds);
-
-                foreach ($missingLabelIds as $labelId) {
-                    $labelTransactionRows[] = [
-                        'id' => (string) Str::uuid(),
-                        'label_id' => $labelId,
-                        'transaction_id' => $transaction->id,
-                        'created_at' => $now,
-                        'updated_at' => $now,
-                    ];
-                    $changedTransactionIds[$transaction->id] = true;
-                }
-            }
-
-            if ($labelTransactionRows !== []) {
-                LabelTransaction::query()->insertOrIgnore($labelTransactionRows);
-            }
+        if ($changedTransactionIds !== []) {
+            // One job for the whole batch: the mass update and the pivot insert
+            // above fire no model event, so nothing else re-derives which budgets
+            // now track these transactions — and dispatching per row would queue a
+            // job for every transaction the rule touched.
+            ReassignTransactionsToBudgets::dispatch($changedTransactionIds, notify: false);
         }
 
         return count($changedTransactionIds);
+    }
+
+    /**
+     * Set the rule's category on every transaction that does not already carry
+     * it, in a single mass update.
+     *
+     * @param  EloquentCollection<int, Transaction>  $transactions
+     * @return array<int, string> ids of the transactions changed
+     */
+    private function applyCategoryInBulk(EloquentCollection $transactions, AutomationRule $rule): array
+    {
+        if ($rule->action_category_id === null) {
+            return [];
+        }
+
+        $transactionIds = $transactions
+            ->filter(fn (Transaction $transaction): bool => $transaction->category_id !== $rule->action_category_id)
+            ->pluck('id')
+            ->all();
+
+        if ($transactionIds === []) {
+            return [];
+        }
+
+        Transaction::query()
+            ->whereIn('id', $transactionIds)
+            ->update([
+                'category_id' => $rule->action_category_id,
+                'category_source' => CategorySource::Rule->value,
+                'categorized_by_rule_id' => $rule->id,
+                'updated_at' => now(),
+            ]);
+
+        return $transactionIds;
+    }
+
+    /**
+     * Append the rule's note where it is not already present. Encrypted notes are
+     * skipped because applying them requires the user's key.
+     *
+     * @param  EloquentCollection<int, Transaction>  $transactions
+     * @return array<int, string> ids of the transactions changed
+     */
+    private function applyNoteInBulk(EloquentCollection $transactions, AutomationRule $rule): array
+    {
+        if (! $rule->action_note || $rule->action_note_iv !== null) {
+            return [];
+        }
+
+        $transactionIds = [];
+
+        foreach ($transactions as $transaction) {
+            $existingNotes = $transaction->notes ?? '';
+
+            if ($this->noteAlreadyPresent($existingNotes, $rule->action_note)) {
+                continue;
+            }
+
+            $transaction->notes = $existingNotes
+                ? $existingNotes."\n".$rule->action_note
+                : $rule->action_note;
+            $transaction->saveQuietly();
+            $transactionIds[] = $transaction->id;
+        }
+
+        return $transactionIds;
+    }
+
+    /**
+     * Attach the rule's labels in a single pivot insert, skipping the pairs that
+     * already exist.
+     *
+     * @param  EloquentCollection<int, Transaction>  $transactions
+     * @return array<int, string> ids of the transactions changed
+     */
+    private function applyLabelsInBulk(EloquentCollection $transactions, AutomationRule $rule): array
+    {
+        $labelIds = $rule->labels->pluck('id')->all();
+
+        if ($labelIds === []) {
+            return [];
+        }
+
+        $now = now();
+        $labelTransactionRows = [];
+        $transactionIds = [];
+
+        foreach ($transactions as $transaction) {
+            $missingLabelIds = array_diff($labelIds, $transaction->labels->pluck('id')->all());
+
+            foreach ($missingLabelIds as $labelId) {
+                $labelTransactionRows[] = [
+                    'id' => (string) Str::uuid(),
+                    'label_id' => $labelId,
+                    'transaction_id' => $transaction->id,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ];
+                $transactionIds[] = $transaction->id;
+            }
+        }
+
+        if ($labelTransactionRows !== []) {
+            LabelTransaction::query()->insertOrIgnore($labelTransactionRows);
+        }
+
+        return $transactionIds;
     }
 
     /**

--- a/app/Services/AutomationRuleService.php
+++ b/app/Services/AutomationRuleService.php
@@ -15,6 +15,14 @@ use JWadhams\JsonLogic;
 class AutomationRuleService
 {
     /**
+     * How many transaction ids ride in one reassignment job.
+     *
+     * ponytail: fixed 500; only the AI suggestion path is unbounded, and it has
+     * never come close to needing a smarter split.
+     */
+    private const REASSIGN_BATCH_SIZE = 500;
+
+    /**
      * Per-user rule cache, memoized for the lifetime of this service instance.
      *
      * Bulk re-evaluation calls applyRules() once per transaction; without this
@@ -26,24 +34,34 @@ class AutomationRuleService
      */
     private array $rulesByUser = [];
 
-    public function applyRules(Transaction $transaction): void
+    /**
+     * @param  bool  $reassignBudgets  set to false when the caller loops over many
+     *                                 transactions and batches the reassignment
+     *                                 itself, so this does not queue one job per row
+     * @return bool whether the rule changed something budget membership depends on
+     */
+    public function applyRules(Transaction $transaction, bool $reassignBudgets = true): bool
     {
         if ($transaction->description_iv !== null) {
-            return;
+            return false;
         }
 
         $rules = $this->rulesForUser($transaction->user_id);
 
         if ($rules->isEmpty()) {
-            return;
+            return false;
         }
 
         $transactionData = $this->prepareTransactionData($transaction);
         $matchedRule = $this->evaluateRules($rules, $transactionData);
 
-        if ($matchedRule && $this->applyActions($transaction, $matchedRule)) {
+        $affectsBudgets = $matchedRule !== null && $this->applyActions($transaction, $matchedRule);
+
+        if ($affectsBudgets && $reassignBudgets) {
             ReassignTransactionsToBudgets::dispatch([$transaction->id]);
         }
+
+        return $affectsBudgets;
     }
 
     /**
@@ -99,21 +117,34 @@ class AutomationRuleService
             }
         }
 
-        $changedTransactionIds = array_values(array_unique(array_merge(
-            $this->applyCategoryInBulk($transactions, $rule),
-            $this->applyNoteInBulk($transactions, $rule),
-            $this->applyLabelsInBulk($transactions, $rule),
-        )));
+        // Kept in this order: the note is appended with saveQuietly(), which must
+        // run after the category mass update so it writes only the notes column.
+        $categorizedIds = $this->applyCategoryInBulk($transactions, $rule);
+        $notedIds = $this->applyNoteInBulk($transactions, $rule);
+        $labelledIds = $this->applyLabelsInBulk($transactions, $rule);
 
-        if ($changedTransactionIds !== []) {
-            // One job for the whole batch: the mass update and the pivot insert
-            // above fire no model event, so nothing else re-derives which budgets
-            // now track these transactions — and dispatching per row would queue a
-            // job for every transaction the rule touched.
-            ReassignTransactionsToBudgets::dispatch($changedTransactionIds, notify: false);
+        // A note never changes which budget counts a transaction, so it does not
+        // earn a reassignment — but it does count as a change for the caller.
+        $this->reassignInBatches(array_merge($categorizedIds, $labelledIds));
+
+        return count(array_unique(array_merge($categorizedIds, $notedIds, $labelledIds)));
+    }
+
+    /**
+     * Queue the budget reassignment of transactions the bulk apply changed.
+     *
+     * The mass update and the pivot insert fire no model event, so nothing else
+     * re-derives which budgets now track them. Dispatching per row would queue a
+     * job for every transaction the rule touched, and dispatching one job for
+     * everything would put an unbounded id list in a single queue payload.
+     *
+     * @param  array<int, string>  $transactionIds
+     */
+    private function reassignInBatches(array $transactionIds): void
+    {
+        foreach (array_chunk(array_values(array_unique($transactionIds)), self::REASSIGN_BATCH_SIZE) as $batch) {
+            ReassignTransactionsToBudgets::dispatch($batch, notify: false);
         }
-
-        return count($changedTransactionIds);
     }
 
     /**
@@ -366,16 +397,20 @@ class AutomationRuleService
         }
     }
 
+    /**
+     * @return bool whether the actions changed something budget membership
+     *              depends on — the note is deliberately not one of them
+     */
     private function applyActions(Transaction $transaction, AutomationRule $rule): bool
     {
-        $changed = false;
+        $affectsBudgets = false;
 
         if ($rule->action_category_id !== null
             && $transaction->category_id !== $rule->action_category_id) {
             $transaction->category_id = $rule->action_category_id;
             $transaction->category_source = CategorySource::Rule;
             $transaction->categorized_by_rule_id = $rule->id;
-            $changed = true;
+            $affectsBudgets = true;
         }
 
         // Only apply plain (unencrypted) notes — encrypted notes require the user's key
@@ -387,7 +422,6 @@ class AutomationRuleService
                 $transaction->notes = $existingNotes
                     ? $existingNotes."\n".$ruleNote
                     : $ruleNote;
-                $changed = true;
             }
         }
 
@@ -399,11 +433,11 @@ class AutomationRuleService
         if (! empty($labelIds)) {
             $result = $transaction->labels()->syncWithoutDetaching($labelIds);
             if (! empty($result['attached'])) {
-                $changed = true;
+                $affectsBudgets = true;
             }
         }
 
-        return $changed;
+        return $affectsBudgets;
     }
 
     private function noteAlreadyPresent(string $existingNotes, string $note): bool

--- a/tests/Feature/AutomationRuleApplicationTest.php
+++ b/tests/Feature/AutomationRuleApplicationTest.php
@@ -214,7 +214,12 @@ test('apply endpoint runs synchronously when matches are below threshold', funct
         ->assertJsonPath('total', 3);
 
     Queue::assertNotPushed(ApplySingleAutomationRuleJob::class);
-    // One reassignment job for the whole batch, not one per transaction.
+    // One reassignment job for the whole batch, not one per transaction, and
+    // silent: applying a rule to history is not new spending.
+    Queue::assertPushed(
+        ReassignTransactionsToBudgets::class,
+        fn (ReassignTransactionsToBudgets $job): bool => $job->notify === false,
+    );
     Queue::assertPushed(ReassignTransactionsToBudgets::class, 1);
 
     expect(
@@ -267,6 +272,7 @@ test('apply endpoint batches category and label writes', function () {
         ->and($perTransactionPivotLookupQueries)->toHaveCount(0);
 
     Queue::assertNotPushed(ApplySingleAutomationRuleJob::class);
+    Queue::assertPushed(ReassignTransactionsToBudgets::class, 1);
     $this->assertDatabaseCount('label_transaction', 5);
 });
 

--- a/tests/Feature/AutomationRuleApplicationTest.php
+++ b/tests/Feature/AutomationRuleApplicationTest.php
@@ -3,6 +3,7 @@
 use App\Events\TransactionCreated;
 use App\Events\TransactionUpdated;
 use App\Jobs\ApplySingleAutomationRuleJob;
+use App\Jobs\ReassignTransactionsToBudgets;
 use App\Models\Account;
 use App\Models\AutomationRule;
 use App\Models\Bank;
@@ -212,7 +213,9 @@ test('apply endpoint runs synchronously when matches are below threshold', funct
         ->assertJsonPath('updated', 3)
         ->assertJsonPath('total', 3);
 
-    Queue::assertNothingPushed();
+    Queue::assertNotPushed(ApplySingleAutomationRuleJob::class);
+    // One reassignment job for the whole batch, not one per transaction.
+    Queue::assertPushed(ReassignTransactionsToBudgets::class, 1);
 
     expect(
         Transaction::where('user_id', $this->user->id)
@@ -263,7 +266,7 @@ test('apply endpoint batches category and label writes', function () {
     expect($transactionUpdateQueries)->toHaveCount(1)
         ->and($perTransactionPivotLookupQueries)->toHaveCount(0);
 
-    Queue::assertNothingPushed();
+    Queue::assertNotPushed(ApplySingleAutomationRuleJob::class);
     $this->assertDatabaseCount('label_transaction', 5);
 });
 

--- a/tests/Feature/LabelBudgetReassignmentTest.php
+++ b/tests/Feature/LabelBudgetReassignmentTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Enums\CategoryType;
+use App\Jobs\ReassignTransactionsToBudgets;
+use App\Jobs\ReEvaluateTransactionRulesJob;
 use App\Mcp\Servers\WhisperMoneyServer;
 use App\Mcp\Tools\LabelTransaction;
 use App\Models\Account;
@@ -13,6 +15,7 @@ use App\Models\Label;
 use App\Models\Transaction;
 use App\Models\User;
 use App\Services\AutomationRuleService;
+use Illuminate\Support\Facades\Queue;
 
 function periodCovering(Budget $budget): BudgetPeriod
 {
@@ -105,6 +108,45 @@ test('the bulk apply reassigns transactions whose category it mass-updated', fun
     app(AutomationRuleService::class)->applyRuleActionsToTransactions($transactions, $rule);
 
     expect(budgetsOf($this->transaction))->toBe([$categoryPeriod->id]);
+});
+
+test('the bulk actions bar moves the labelled transactions into the label budget', function () {
+    $this->actingAs($this->user)
+        ->patchJson(route('transactions.bulk-update'), [
+            'transaction_ids' => [$this->transaction->id],
+            'label_ids' => [$this->label->id],
+        ])
+        ->assertOk();
+
+    expect(budgetsOf($this->transaction))->toBe([$this->labelPeriod->id]);
+});
+
+test('the bulk actions bar reassigns after a mass category update', function () {
+    $tracked = Category::factory()->create(['user_id' => $this->user->id, 'type' => CategoryType::Expense]);
+    $categoryPeriod = periodCovering(Budget::factory()->forCategories($tracked)->create(['user_id' => $this->user->id]));
+
+    $this->actingAs($this->user)
+        ->patchJson(route('transactions.bulk-update'), [
+            'transaction_ids' => [$this->transaction->id],
+            'category_id' => $tracked->id,
+        ])
+        ->assertOk();
+
+    expect(budgetsOf($this->transaction))->toBe([$categoryPeriod->id]);
+});
+
+test('re-evaluating the rules over the whole history queues one silent job per chunk', function () {
+    Queue::fake();
+    labelRule($this->user, $this->label);
+
+    (new ReEvaluateTransactionRulesJob($this->user, 'job-1'))->handle(app(AutomationRuleService::class));
+
+    Queue::assertPushed(
+        ReassignTransactionsToBudgets::class,
+        fn (ReassignTransactionsToBudgets $job): bool => $job->notify === false
+            && $job->transactionIds === [$this->transaction->id],
+    );
+    Queue::assertPushed(ReassignTransactionsToBudgets::class, 1);
 });
 
 test('the MCP tool reassigns the transaction when it attaches and when it removes a label', function () {

--- a/tests/Feature/LabelBudgetReassignmentTest.php
+++ b/tests/Feature/LabelBudgetReassignmentTest.php
@@ -1,0 +1,126 @@
+<?php
+
+use App\Enums\CategoryType;
+use App\Mcp\Servers\WhisperMoneyServer;
+use App\Mcp\Tools\LabelTransaction;
+use App\Models\Account;
+use App\Models\AutomationRule;
+use App\Models\Budget;
+use App\Models\BudgetPeriod;
+use App\Models\BudgetTransaction;
+use App\Models\Category;
+use App\Models\Label;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Services\AutomationRuleService;
+
+function periodCovering(Budget $budget): BudgetPeriod
+{
+    return BudgetPeriod::factory()->create([
+        'budget_id' => $budget->id,
+        'start_date' => now()->subDays(30),
+        'end_date' => now()->addDays(30),
+    ]);
+}
+
+function budgetsOf(Transaction $transaction): array
+{
+    return BudgetTransaction::query()
+        ->where('transaction_id', $transaction->id)
+        ->pluck('budget_period_id')
+        ->all();
+}
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->label = Label::factory()->create(['user_id' => $this->user->id, 'name' => 'Miami 26']);
+
+    $category = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'type' => CategoryType::Expense,
+    ]);
+
+    $this->catchAllPeriod = periodCovering(Budget::factory()->catchAll()->create(['user_id' => $this->user->id]));
+    $this->labelPeriod = periodCovering(Budget::factory()->forLabels($this->label)->create(['user_id' => $this->user->id]));
+
+    // Created before it carries the label, so it lands in the catch-all — the
+    // exact state each of the three label paths used to leave behind.
+    $this->transaction = Transaction::factory()->plaintext()->create([
+        'user_id' => $this->user->id,
+        'account_id' => Account::factory()->create(['user_id' => $this->user->id])->id,
+        'category_id' => $category->id,
+        'description' => 'Hotel Miami',
+        'transaction_date' => now(),
+        'amount' => -1000,
+    ]);
+
+    expect(budgetsOf($this->transaction))->toBe([$this->catchAllPeriod->id]);
+});
+
+function labelRule(User $user, Label $label): AutomationRule
+{
+    $rule = AutomationRule::factory()->create([
+        'user_id' => $user->id,
+        'priority' => 1,
+        'rules_json' => ['in' => ['hotel', ['var' => 'description']]],
+        'action_category_id' => null,
+    ]);
+
+    $rule->labels()->attach($label->id);
+
+    return $rule->load('labels');
+}
+
+test('a rule labelling a single transaction moves it into the label budget', function () {
+    labelRule($this->user, $this->label);
+
+    app(AutomationRuleService::class)->applyRules($this->transaction);
+
+    expect(budgetsOf($this->transaction))->toBe([$this->labelPeriod->id]);
+});
+
+test('applying a rule in bulk moves every labelled transaction into the label budget', function () {
+    $rule = labelRule($this->user, $this->label);
+
+    $transactions = Transaction::query()->whereKey($this->transaction->id)->with('labels')->get();
+
+    app(AutomationRuleService::class)->applyRuleActionsToTransactions($transactions, $rule);
+
+    expect(budgetsOf($this->transaction))->toBe([$this->labelPeriod->id]);
+});
+
+test('the bulk apply reassigns transactions whose category it mass-updated', function () {
+    $tracked = Category::factory()->create(['user_id' => $this->user->id, 'type' => CategoryType::Expense]);
+    $categoryPeriod = periodCovering(Budget::factory()->forCategories($tracked)->create(['user_id' => $this->user->id]));
+
+    $rule = AutomationRule::factory()->create([
+        'user_id' => $this->user->id,
+        'priority' => 1,
+        'rules_json' => ['in' => ['hotel', ['var' => 'description']]],
+        'action_category_id' => $tracked->id,
+    ]);
+
+    $transactions = Transaction::query()->whereKey($this->transaction->id)->with('labels')->get();
+
+    app(AutomationRuleService::class)->applyRuleActionsToTransactions($transactions, $rule);
+
+    expect(budgetsOf($this->transaction))->toBe([$categoryPeriod->id]);
+});
+
+test('the MCP tool reassigns the transaction when it attaches and when it removes a label', function () {
+    $this->user->withAccessToken($this->user->createToken('mcp', ['mcp:read', 'mcp:write'])->accessToken);
+
+    WhisperMoneyServer::actingAs($this->user)->tool(LabelTransaction::class, [
+        'transaction_id' => $this->transaction->id,
+        'add_label_ids' => [$this->label->id],
+    ])->assertOk();
+
+    expect(budgetsOf($this->transaction))->toBe([$this->labelPeriod->id]);
+
+    WhisperMoneyServer::actingAs($this->user)->tool(LabelTransaction::class, [
+        'transaction_id' => $this->transaction->id,
+        'remove_label_ids' => [$this->label->id],
+    ])->assertOk();
+
+    expect(budgetsOf($this->transaction))->toBe([$this->catchAllPeriod->id]);
+});


### PR DESCRIPTION
## Problem

Since #781 a catch-all budget ("Not budgeted") yields to any budget that tracks a
transaction by category **or** label in a period covering its date. Reassignment is
driven by `TransactionCreated` / `TransactionUpdated`, whose listener is
`AssignTransactionToBudget`.

Pivot writes and query-builder mass updates fire no model event. So every path that
attaches a label without a real `save()` left the transaction assigned to whatever it
was before — typically stuck in the catch-all and missing from the budget that tracks
its label.

In production, 44 expenses carrying one label never entered their label budget:
`label_transaction.created_at` is ~10 minutes later than `transactions.updated_at` on
each of them, i.e. the listener ran before the label existed and nothing ran after.

## The paths that were broken

| Path | Write | Event |
|---|---|---|
| `AutomationRuleService::applyActions` | `saveQuietly()` + `syncWithoutDetaching` | none |
| `AutomationRuleService::applyRuleActionsToTransactions` | `LabelTransaction::insertOrIgnore` + mass category `update()` | none |
| `Mcp\Tools\LabelTransaction` | `syncWithoutDetaching` / `detach` | none |
| `TransactionController::bulkUpdate` | mass category `update()` + `labels()->sync()` | none |

The last one was found during review and is the surface users hit most — the
bulk-actions bar in the transactions table. Its `syncLabels()` helper does
`sync()` then `save()`, but those models are loaded before the mass update and
nothing dirties them, so `Model::save()` skips `performUpdate()` and fires nothing.
The docblock claiming the `save()` bumped `updated_at` was wrong and is corrected.

## The fix

A dedicated `ReassignTransactionsToBudgets` job, dispatched from each path, rather
than re-broadcasting `TransactionUpdated` — which would also re-run the automation
rules that dispatched it. The job takes ids, not models, so a retry never works from
a stale payload.

Batching, so no path queues one job per row:

- the bulk rule apply dispatches per batch of 500 ids (the AI suggestion path is the
  one caller that can hand it an unbounded list)
- `ReEvaluateTransactionRulesJob` loops `applyRules()` over the user's whole history,
  so `applyRules()` takes `reassignBudgets` and that job batches one job per chunk
- `TransactionController::bulkUpdate` dispatches once for the whole selection

Notifications are suppressed (`notify: false`) everywhere the change is an
administrative edit rather than new spending: bulk rule applies, re-evaluating rules
over history, the bulk-actions bar, and MCP relabelling. Otherwise removing a label
would announce a months-old expense as new in the catch-all budget. The single
transaction matched by a rule at creation time keeps notifications on. Suppressing
them leaves `close_to_limit_notified` / `over_limit_notified` unclaimed, so the next
genuine transaction into that budget still alerts.

A note never changes which budget counts a transaction, so a note-only rule no longer
earns a reassignment on either path.

`applyRuleActionsToTransactions` was doing category, note and label work inline; the
three branches are extracted so the added dispatch keeps the method under the
repo's complexity-10 gate.

## Deploy step

This stops the state from going stale again, it does not repair what is already
stale. After deploy:

```
php artisan budgets:reassign-labeled [--user=<email>] [--dry-run]
```

## Tests

`tests/Feature/LabelBudgetReassignmentTest.php` covers all four paths plus the
re-evaluate batching, each asserting the transaction actually leaves the catch-all
and lands in the label budget. All seven fail on `main` and pass here.
`AutomationRuleApplicationTest` now pins that the bulk apply queues exactly one
reassignment job and that it is silent.

## QA

Verified in the browser against the running app with a throwaway account: a
catch-all budget and a label budget over the same period, four expenses starting in
the catch-all.

- Selecting all four in the transactions table and applying the label moves
  **Not budgeted $540.00 → $0.00** and **Miami 26 $0.00 → $540.00**, confirmed in
  `budget_transactions`.
- "Remove all labels" hands them back to the catch-all.

## Demo

<!-- PLACEHOLDER: drag the QA video here -->

https://github.com/user-attachments/assets/5a135257-42cf-42a7-a66a-3f76bf773e0c



## Follow-ups (not in this PR)

- Soft-deleting a label leaves its budget still counting the transactions; the
  catch-all never takes them back.
- `CategoryTree::deleteSubtree` mass-nulls `category_id` with no event, so cascade
  category deletion leaves transactions in their old category budget.
- `BudgetService::create` only adds rows for a new budget's historical transactions;
  it never removes their catch-all rows, so creating a label budget next to an
  existing catch-all double-counts until something else reassigns them.
