### PR TITLE
fix(subscriptions): round the high yearly price to a .99 monthly equivalent

### DIFF
--- a/config/subscriptions.php
+++ b/config/subscriptions.php
@@ -27,8 +27,13 @@ return [
     | control/high to roll a winner out to everyone without a deploy.
     |
     | Each variant needs its own Stripe price — run `php artisan stripe:sync-prices`
-    | BEFORE setting `started_at`. The yearly price is the monthly × 6, matching
-    | the control plan structure.
+    | BEFORE setting `started_at`.
+    |
+    | Yearly prices are built the way the control plan is: pick the monthly
+    | equivalent we want to advertise, ending in .99, and multiply by 12 — so
+    | 4.99 × 12 = 59.88, shown against 8.99 × 12 = 107.88 as the undiscounted
+    | reference. That is a ~6.7-month effective price rather than the control's
+    | ~6, because 8.99 ÷ 2 lands on 4.495 and there is no .99 at that level.
     |
     */
 
@@ -43,7 +48,7 @@ return [
                     'lookup' => 'whisper_pro_monthly_high',
                 ],
                 'yearly' => [
-                    'price' => 53.94,
+                    'price' => 59.88,
                     'original_price' => 107.88,
                     'lookup' => 'whisper_pro_yearly_high',
                 ],


### PR DESCRIPTION
Follow-up to #700, before the high arm has any exposure.

`53.94` was built as monthly × 6, which divides into **4.495/month** — the only price in the config whose monthly equivalent doesn't end in `.99`.

The control plan is built the other way round: pick the monthly equivalent to advertise, multiply by 12, and show it against monthly × 12 as the crossed-out reference. This applies the same construction to the high arm.

| | monthly | equiv./month | yearly | vs. original | discount |
|---|---|---|---|---|---|
| control | 3.99 | **1.99** | 23.88 | 47.88 | 50.1% |
| high — before | 8.99 | 4.495 ❌ | 53.94 | 107.88 | 50.0% |
| high — after | 8.99 | **4.99** | **59.88** | 107.88 | 44.5% |

## Trade-off

The effective term goes from 6 months to ~6.7, and the advertised discount from 50% to 44.5%, so the annual card's badge changes from "50% off" to "44% off". That's unavoidable at this price point: 8.99 ÷ 2 = 4.495, and there's no `.99` at that level. `53.88` (4.49/month) would have kept the ×6 almost exactly, but ends in `.49`, which is the thing being fixed.

`original_price` stays at `107.88` — it's 8.99 × 12, the same construction the control plan uses.

## Exposure

None. The experiment starts at 12:00 UTC and had **0 signups past the cutoff** when this was written, so no user has been shown or charged 53.94.

## After merging

`php artisan stripe:sync-prices` in production. The yearly high tier will report `↻ Price changed — creating new price and transferring lookup key` — that's correct, Stripe prices are immutable, so it mints a new one and moves `whisper_pro_yearly_high` onto it. The monthly tier and both control plans should report `✓ Already in sync`.

## Tests

No test changes. The fixtures in `PriceExperimentTest` and `SyncStripePricesCommandTest` set their own prices via `config()` on purpose — they prove the variant-override mechanism, not this particular number, and stay green whatever the real price is.
