### PR TITLE
feat(currency): add SGD (Singapore Dollar)

### DIFF
--- a/config/currencies.php
+++ b/config/currencies.php
@@ -194,5 +194,11 @@ return [
             'allows_primary' => true,
             'allows_account' => true,
         ],
+        [
+            'code' => 'SGD',
+            'name' => 'Singapore Dollar',
+            'allows_primary' => true,
+            'allows_account' => true,
+        ],
     ],
 ];

--- a/lang/es.json
+++ b/lang/es.json
@@ -1485,6 +1485,7 @@
     "Show this transfer category as money leaving available cash.": "Muestra esta categoría de transferencia como dinero que sale del saldo disponible.",
     "Sign up": "Crear cuenta",
     "Simple, transparent pricing": "Precios simples y transparentes",
+    "Singapore Dollar": "Dólar de Singapur",
     "Single-use. Works on monthly or yearly plans. Tied to your email — please keep it private.": "Un solo uso. Funciona con el plan mensual o anual. Está vinculado a tu email — guárdalo en privado.",
     "Skip": "Saltar",
     "Skip for now": "Omitir por ahora",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1434,6 +1434,7 @@
     "Show this transfer category as money leaving available cash.": "Affiche cette catégorie de transfert comme de l'argent sortant de votre solde disponible.",
     "Sign up": "Créer un compte",
     "Simple, transparent pricing": "Tarification simple et transparente",
+    "Singapore Dollar": "Dollar de Singapour",
     "Single-use. Works on monthly or yearly plans. Tied to your email — please keep it private.": "Usage unique. Il fonctionne avec le forfait mensuel ou annuel. Il est lié à votre e-mail : gardez-le privé.",
     "Skip": "Houblon",
     "Skip for now": "Passer pour l'instant",

--- a/resources/js/utils/currency.ts
+++ b/resources/js/utils/currency.ts
@@ -28,6 +28,7 @@ export function getCurrencySymbol(currencyCode: string): string {
         NGN: '₦',
         SEK: 'kr',
         THB: '฿',
+        SGD: 'S$',
     };
     return symbols[currencyCode] || currencyCode;
 }


### PR DESCRIPTION
## What
Add the Singapore Dollar as a supported currency.

## Compatibility
Provider covers `sgd` (standard ISO 4217). The conversion service lowercases codes and fetches `sgd.min.json` — same path RSD/NZD use. `exchange_rates` stores rates as JSON, so any 3-letter code works. Validation rules and Inertia currency props auto-derive from config.

## Changes
- `config/currencies.php` — SGD entry (`allows_primary` + `allows_account`)
- `lang/es.json` — Spanish translation
- `lang/fr.json` — French translation
- `resources/js/utils/currency.ts` — short symbol (S$) for SGD

Follows the RSD addition (#567) exactly; no code changes needed.