### PR TITLE
fix(banking): recognise a spent daily allowance, and stop it swallowing manual syncs

### DIFF
--- a/app/Http/Controllers/OpenBanking/ConnectionController.php
+++ b/app/Http/Controllers/OpenBanking/ConnectionController.php
@@ -72,6 +72,13 @@ class ConnectionController extends Controller
             'status' => BankingConnectionStatus::Active,
             'error_message' => null,
             'consecutive_sync_failures' => 0,
+            // The backoff exists to keep the *scheduler* off a provider that asked
+            // us to stop. A person asking for their own connection is the request
+            // to honour, and PSD2 budgets access with the user present separately
+            // from unattended access. Leaving it set meant the job returned early
+            // while this flashed "sync started" and nothing happened - for as long
+            // as the window had left.
+            'rate_limited_until' => null,
         ]);
 
         SyncBankingConnectionJob::dispatch($connection);

--- a/app/Jobs/SyncBankingConnectionJob.php
+++ b/app/Jobs/SyncBankingConnectionJob.php
@@ -22,6 +22,7 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
 use Sentry\State\Scope;
 
 use function Sentry\configureScope;
@@ -415,14 +416,44 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
             $body = $e->response->json();
             $message = is_array($body) ? (string) ($body['message'] ?? '') : '';
 
-            // Daily PSU consultation limit resets at midnight UTC.
-            if (str_contains(strtolower($message), 'daily')) {
+            if ($this->isExhaustedAccessAllowance($message)) {
                 return $now->copy()->utc()->addDay()->startOfDay();
             }
         }
 
-        // Default: back off one hour for consent / generic 429 responses.
+        // Default: back off one hour for a burst limit we know nothing else about.
         return $now->copy()->addHour();
+    }
+
+    /**
+     * Whether the provider is reporting a spent allowance rather than a burst.
+     *
+     * PSD2 budgets unattended access per consent per day, so these do not come back
+     * in an hour - they come back when the day does. Matched on the wordings the
+     * banks actually send, counted over 45 days of banking_sync_logs: "[HUB046]
+     * Allowed number of accesses exceeded for consent." (234), "Access exceeded"
+     * (94), "Maximum daily access exceeded" (48), "The access on the account has
+     * been exceeding the consented multiplicity per day." (37), "Daily PSU not
+     * present consultation limit has been exceeded" (11), and a localised pair,
+     * "CLO03941 - Operación no disponible. Has superado el número máximo de
+     * accesos." (4) plus its Catalan twin (1).
+     *
+     * ponytail: prose matching, because there is nothing better to key on -
+     * detail.error_name is `RateLimitException` for a spent daily allowance and for
+     * a plain burst alike. If Enable Banking ever separates the two, key on that.
+     * Note error_message only holds the first 120 bytes of the body, so a future
+     * attempt at a structured field has to start by logging the whole thing.
+     */
+    private function isExhaustedAccessAllowance(string $message): bool
+    {
+        return Str::contains($message, [
+            'daily',
+            'access exceeded',
+            'accesses exceeded',
+            'exceeding the consented',
+            'máximo de accesos',
+            'màxim d’accessos',
+        ], ignoreCase: true);
     }
 
     private function isAuthError(\Throwable $e): bool

--- a/tests/Feature/OpenBanking/SyncBankingConnectionJobTest.php
+++ b/tests/Feature/OpenBanking/SyncBankingConnectionJobTest.php
@@ -1680,7 +1680,7 @@ test('rate limit error sets backoff window without erroring connection', functio
     expect($connection->rate_limited_until->isFuture())->toBeTrue();
 });
 
-test('daily rate limit backoff lasts until next UTC midnight', function () {
+test('a spent access allowance backs off until the day rolls over', function (string $message) {
     $user = User::factory()->onboarded()->create();
     $connection = BankingConnection::factory()->create([
         'user_id' => $user->id,
@@ -1692,8 +1692,10 @@ test('daily rate limit backoff lasts until next UTC midnight', function () {
         'external_account_id' => 'ext-123',
     ]);
 
-    $body = json_encode(['code' => 429, 'message' => 'Daily PSU not present consultation limit has been exceeded']);
-    $response = new Response(429, ['Content-Type' => 'application/json'], $body);
+    $response = new Response(429, ['Content-Type' => 'application/json'], json_encode([
+        'code' => 429,
+        'message' => $message,
+    ]));
 
     $transactionSync = Mockery::mock(TransactionSyncService::class);
     $transactionSync->shouldReceive('sync')->andThrow(
@@ -1709,7 +1711,15 @@ test('daily rate limit backoff lasts until next UTC midnight', function () {
     $expected = now()->utc()->addDay()->startOfDay();
     expect($connection->rate_limited_until)->not->toBeNull();
     expect($connection->rate_limited_until->equalTo($expected))->toBeTrue();
-});
+})->with([
+    'Daily PSU not present consultation limit has been exceeded',
+    'Maximum daily access exceeded',
+    '[HUB046] Allowed number of accesses exceeded for consent.',
+    'Access exceeded',
+    'The access on the account has been exceeding the consented multiplicity per day.',
+    'CLO03941 - Operación no disponible. Has superado el número máximo de accesos.',
+    'CLO03941 - Operació no disponible. Has superat el nombre màxim d’accessos.',
+]);
 
 test('rate limit backoff honours Retry-After header', function () {
     $user = User::factory()->onboarded()->create();

--- a/tests/Feature/OpenBanking/SyncRetryAndLoggingTest.php
+++ b/tests/Feature/OpenBanking/SyncRetryAndLoggingTest.php
@@ -885,6 +885,28 @@ test('manual sync resets consecutive sync failures', function () {
     expect($connection->error_message)->toBeNull();
 });
 
+test('manual sync clears the rate limit backoff so it is not silently swallowed', function () {
+    $user = User::factory()->onboarded()->create();
+
+    // The scheduler is meant to stay off a provider that asked us to stop; a person
+    // asking for their own connection is a different request. Leaving the window in
+    // place meant the job returned early while the UI said "sync started".
+    $connection = BankingConnection::factory()->create([
+        'user_id' => $user->id,
+        'rate_limited_until' => now()->addHours(20),
+    ]);
+
+    Queue::fake(SyncBankingConnectionJob::class);
+
+    $this->actingAs($user)
+        ->post(route('settings.connections.sync', $connection))
+        ->assertRedirect();
+
+    $connection->refresh();
+    expect($connection->rate_limited_until)->toBeNull();
+    Queue::assertPushed(SyncBankingConnectionJob::class);
+});
+
 // --- Job-Level Failure Tests ---
 
 test('a job killed by the worker timeout does not spend a scheduled retry', function () {


### PR DESCRIPTION
> Sentry's MCP token is still expired, so this came from the production DB again.

## Two small fixes, and a much bigger finding I am *not* fixing here

I went after the rate-limit problem I flagged as the next big thing. The headline number is real — **490 rate-limit failures in 14 days**, and **14 of 18 Trade Republic connections have never once completed a sync** — but my framing of it was wrong, and the change I first wrote would have made those users slightly worse off. What survives is two narrow, verified fixes. The actual cure is scoped at the bottom.

## 1. Recognise a spent daily allowance from what the banks actually say

`resolveRateLimitBackoffUntil` treated a 429 as a daily-allowance error only when the message contained the literal word `daily`. Enable Banking's banks say it several other ways, all of which were getting the one-hour burst fallback:

| wording | events / connections (45d) |
|---|---|
| `[HUB046] Allowed number of accesses exceeded for consent.` | 234 / 88 |
| `Access exceeded` | 94 / 1 |
| `The access on the account has been exceeding the consented multiplicity per day.` | 39 / 3 |
| `CLO03941 - Operación no disponible. Has superado el número máximo de accesos.` (+ Catalan twin) | 5 / 2 |

The old one-hour window gave a free natural experiment: the later same-day runs *did* happen, so I can check whether they recovered. Across every wording above, **zero** later same-day attempts succeeded. `Too many requests` is deliberately left on the short path — 1.7% of its later same-day attempts do recover, so it is not a clean daily reset.

Matched on prose because there is nothing better: `detail.error_name` is `RateLimitException` for a spent allowance and a plain burst alike. Marked with a `ponytail:` note, including that a future attempt at a structured field has to start by logging the full body, since `error_message` keeps only the first 120 bytes.

**Honest scope**: for the largest widened cohort (HUB046) this saves almost nothing, because those 429s land on the 18:00 run and the next scheduled run is already after midnight. The saving is real for banks that exhaust their allowance earlier — Eurocaja Rural burns its last two runs every day, Postepay's wording says "per day" outright.

## 2. Stop the backoff from silently swallowing a manual sync

`ConnectionController::sync` cleared the status, the error message and the failure counter, then dispatched — but left `rate_limited_until`, which the job checks first. So "Sync started. Transactions will be updated shortly." was followed by nothing at all. Fix (1) makes that materially worse, turning a ≤1h swallow into the whole evening for the banks that exhaust their allowance at 18:00.

The backoff is there to keep the *scheduler* off a provider that asked us to stop. A person asking for their own connection is a different request, and PSD2 budgets access with the user present separately from unattended access. The other "try again" paths already clear everything else on the connection; this one row was the omission.

## What I dropped, and why

I first also raised the unexplained-429 fallback from 1h to 7h, so it would outlast the six-hourly schedule instead of expiring five hours before it — the mechanism really is inert today, and I have the receipts: of the ten connections currently holding a `rate_limited_until`, nine are exactly 60 minutes past the run that set them, because Enable Banking never sends `Retry-After`.

Both reviews showed it is worthless where it would apply, from different angles, and they were right:

- Trade Republic is 81% of all rate limits, and its **first** run after UTC midnight 429s as often as its fourth — 79% vs 73% over 21 days. Six idle hours already don't help, so no sub-day window can.
- The cohort is bimodal: 8 connections with **zero** successes in 21 days, 3 at ~97%. That is a per-consent condition, not something our cadence controls.
- Meanwhile those connections import transactions on nearly every run. A 7h window settles into 2 runs/day, so it would only have doubled their worst-case transaction staleness in exchange for nothing.

## The actual cure, deliberately deferred

Both reviews rank two levers above anything in this PR, and they are what fix the €0-balance users. **This PR does not claim to.**

**(a) Don't discard a run because the balance call was rate-limited.** This is the whole user-visible bug. Transactions import fine; the 429 lands on `getBalances`, which `EnableBankingSyncer::syncBalances` rethrows purely so the job can set the backoff — and that discards the run, so `last_synced_at` is never set. Consequences: the connections page shows an **indefinite spinner** ("Syncing transactions and balances…") and polls the server **every 5 seconds** for as long as it is open, `bank_transactions_email_cutoff_at` is never set so the daily email never works, and ~11 users see a €0 balance feeding net worth. Swallowing the 429 into metadata and applying the backoff on the success path costs zero extra provider calls and fixes all of it. Its own PR because threading the backoff out of the syncer needs a design, and last time I let a partial run report success both reviews were right to stop me.

**(b) Don't spend a provider access to rewrite a balance row we already have.** `BalanceSyncService` keys the row on `balance_date`, so four runs a day overwrite one value: ~1,740 balance calls/day producing ~305 new rows, ~82% redundant. This is the fix for the *non*-Trade-Republic cohort, and the evidence is clean — **every one of the 86 non-TR rate-limit events in 14 days happened on a connection that already had a balance row for that day**, and HUB046 fires on the 4th run of the day and essentially never on the first three (148 events at 18:00 vs 0 at 00:00 and 06:00). Needs a migration: the guard cannot key on `balance_date` (some banks report yesterday's `reference_date`, so it would never fire) nor on `updated_at` (an unchanged `updateOrCreate` leaves the model clean), so it wants an explicit last-read timestamp.

Also noted: the rate-limit message never reaches the user at all — `applyRateLimitBackoff` leaves the status Active while the connections page only renders `error_message` for Error connections — and the copy still says "wait a few minutes".

## Verification

`tests/Feature/OpenBanking`: 365 tests, 355 pass, the **same 10 failures as clean main** (Inertia page-render tests hitting the SSR `/render` endpoint). The daily-allowance test became a 7-case dataset covering every wording production sends, and it fails on all the new ones against the old matcher; the manual-sync test fails without its one-line fix. Net −7 lines of test code, because two tests I had written folded into the existing one. `pint`, `crap` and `dry` green.

## Auto-merge

Enabled. Both changes are small and evidence-backed: the matcher only moves wordings that provably never recover within the day onto a window that already existed and is already tested, and the second is a single column added to an update that already clears three of its siblings.
