### PR TITLE
fix(banking): stop a rate-limited balance call from discarding the whole run

### DIFF
--- a/app/Contracts/BankingConnectionSyncer.php
+++ b/app/Contracts/BankingConnectionSyncer.php
@@ -9,6 +9,13 @@ interface BankingConnectionSyncer
     /**
      * Sync every account belonging to the connection.
      *
+     * One key is read rather than just logged: `rate_limited_until`, an ISO 8601
+     * string, tells SyncBankingConnectionJob the provider has asked us to stay away
+     * until then. Return it when the run finished but hit a rate limit on the way -
+     * the alternative, throwing, discards a run whose transactions already landed.
+     * Omit it and the job clears any existing window, which is what a clean run
+     * should do.
+     *
      * @return array<string, mixed> Metadata to persist on the sync log.
      */
     public function sync(BankingConnection $connection, bool $isFirstSync): array;

--- a/app/Jobs/SyncBankingConnectionJob.php
+++ b/app/Jobs/SyncBankingConnectionJob.php
@@ -11,6 +11,7 @@ use App\Mail\BankingConnectionAuthFailedEmail;
 use App\Mail\BankingConnectionExpiredEmail;
 use App\Models\BankingConnection;
 use App\Models\BankingSyncLog;
+use App\Services\Banking\RateLimitBackoff;
 use App\Services\Banking\Sync\BankingConnectionSyncerFactory;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
@@ -19,10 +20,8 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
-use Illuminate\Support\Str;
 use Sentry\State\Scope;
 
 use function Sentry\configureScope;
@@ -112,11 +111,16 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
 
             $metadata = $syncer->sync($connection, $isFirstSync);
 
+            // A run can succeed and still owe the provider a rest: the syncer
+            // reports a rate limit it absorbed rather than throwing the whole run
+            // away over it. Anything else clears the window, as a clean run should.
+            $rateLimitedUntil = $metadata['rate_limited_until'] ?? null;
+
             $connection->update([
                 'status' => BankingConnectionStatus::Active,
                 'last_synced_at' => $syncedAt,
                 'error_message' => null,
-                'rate_limited_until' => null,
+                'rate_limited_until' => $rateLimitedUntil,
                 'consecutive_sync_failures' => 0,
             ]);
 
@@ -126,42 +130,64 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
 
             return;
         } catch (\Throwable $e) {
-            $context = [
-                'connection_id' => $connection->id,
-                'error' => $e->getMessage(),
-                'attempt' => $this->attempts(),
-            ];
+            $this->handleSyncFailure($connection, $syncer, $e, $startTime);
+        }
+    }
 
-            if ($e instanceof TransientBankingProviderException) {
-                $context['provider'] = $e->provider;
-                $context['status_code'] = $e->statusCode;
-                $context['provider_code'] = $e->providerCode;
-            }
+    /**
+     * Classify a failed sync and give the connection the treatment it earns:
+     * a provider backoff, a permanent park, or a retry.
+     */
+    private function handleSyncFailure(
+        BankingConnection $connection,
+        BankingConnectionSyncer $syncer,
+        \Throwable $e,
+        float $startTime,
+    ): void {
+        $this->reportSyncFailure($connection, $e);
 
-            // Only report once the connection actually gives up. Transient errors on a
-            // non-final attempt are recovered by the retry and would otherwise spam one
-            // warning per scheduled cycle for connections that ultimately sync fine.
-            if ($this->attempts() >= $this->tries || $this->isAuthError($e)) {
-                Log::log($e instanceof TransientBankingProviderException ? 'warning' : 'error', 'Banking sync failed', $context);
-            }
-
-            if ($this->isRateLimitError($e)) {
-                $this->applyRateLimitBackoff($connection, $e);
-                $this->logSyncAttempt($connection, BankingSyncLogStatus::Failed, $startTime, $e);
-
-                return;
-            }
-
+        if ($this->isRateLimitError($e)) {
+            $this->applyRateLimitBackoff($connection, $e);
             $this->logSyncAttempt($connection, BankingSyncLogStatus::Failed, $startTime, $e);
 
-            if ($this->isAuthError($e)) {
-                $this->handlePermanentError($connection, $syncer, $e);
-
-                return;
-            }
-
-            $this->handleTemporaryError($connection, $e);
+            return;
         }
+
+        $this->logSyncAttempt($connection, BankingSyncLogStatus::Failed, $startTime, $e);
+
+        if ($this->isAuthError($e)) {
+            $this->handlePermanentError($connection, $syncer, $e);
+
+            return;
+        }
+
+        $this->handleTemporaryError($connection, $e);
+    }
+
+    /**
+     * Log the failure, but only once the connection actually gives up. Transient
+     * errors on a non-final attempt are recovered by the retry and would otherwise
+     * spam one warning per scheduled cycle for connections that ultimately sync fine.
+     */
+    private function reportSyncFailure(BankingConnection $connection, \Throwable $e): void
+    {
+        if ($this->attempts() < $this->tries && ! $this->isAuthError($e)) {
+            return;
+        }
+
+        $context = [
+            'connection_id' => $connection->id,
+            'error' => $e->getMessage(),
+            'attempt' => $this->attempts(),
+        ];
+
+        if ($e instanceof TransientBankingProviderException) {
+            $context['provider'] = $e->provider;
+            $context['status_code'] = $e->statusCode;
+            $context['provider_code'] = $e->providerCode;
+        }
+
+        Log::log($e instanceof TransientBankingProviderException ? 'warning' : 'error', 'Banking sync failed', $context);
     }
 
     /**
@@ -380,7 +406,7 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
 
     private function isRateLimitError(\Throwable $e): bool
     {
-        return $e instanceof RequestException && $e->response->status() === 429;
+        return RateLimitBackoff::isRateLimit($e);
     }
 
     /**
@@ -389,7 +415,7 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
      */
     private function applyRateLimitBackoff(BankingConnection $connection, \Throwable $e): void
     {
-        $until = $this->resolveRateLimitBackoffUntil($e);
+        $until = RateLimitBackoff::until($e);
 
         $connection->update([
             'rate_limited_until' => $until,
@@ -400,60 +426,6 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
             'connection_id' => $connection->id,
             'rate_limited_until' => $until->toIso8601String(),
         ]);
-    }
-
-    private function resolveRateLimitBackoffUntil(\Throwable $e): Carbon
-    {
-        $now = now();
-
-        if ($e instanceof RequestException) {
-            $retryAfter = $e->response->header('Retry-After');
-
-            if (is_numeric($retryAfter) && (int) $retryAfter > 0) {
-                return $now->copy()->addSeconds((int) $retryAfter);
-            }
-
-            $body = $e->response->json();
-            $message = is_array($body) ? (string) ($body['message'] ?? '') : '';
-
-            if ($this->isExhaustedAccessAllowance($message)) {
-                return $now->copy()->utc()->addDay()->startOfDay();
-            }
-        }
-
-        // Default: back off one hour for a burst limit we know nothing else about.
-        return $now->copy()->addHour();
-    }
-
-    /**
-     * Whether the provider is reporting a spent allowance rather than a burst.
-     *
-     * PSD2 budgets unattended access per consent per day, so these do not come back
-     * in an hour - they come back when the day does. Matched on the wordings the
-     * banks actually send, counted over 45 days of banking_sync_logs: "[HUB046]
-     * Allowed number of accesses exceeded for consent." (234), "Access exceeded"
-     * (94), "Maximum daily access exceeded" (48), "The access on the account has
-     * been exceeding the consented multiplicity per day." (37), "Daily PSU not
-     * present consultation limit has been exceeded" (11), and a localised pair,
-     * "CLO03941 - Operación no disponible. Has superado el número máximo de
-     * accesos." (4) plus its Catalan twin (1).
-     *
-     * ponytail: prose matching, because there is nothing better to key on -
-     * detail.error_name is `RateLimitException` for a spent daily allowance and for
-     * a plain burst alike. If Enable Banking ever separates the two, key on that.
-     * Note error_message only holds the first 120 bytes of the body, so a future
-     * attempt at a structured field has to start by logging the whole thing.
-     */
-    private function isExhaustedAccessAllowance(string $message): bool
-    {
-        return Str::contains($message, [
-            'daily',
-            'access exceeded',
-            'accesses exceeded',
-            'exceeding the consented',
-            'máximo de accesos',
-            'màxim d’accessos',
-        ], ignoreCase: true);
     }
 
     private function isAuthError(\Throwable $e): bool

--- a/app/Services/Banking/RateLimitBackoff.php
+++ b/app/Services/Banking/RateLimitBackoff.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Services\Banking;
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+
+/**
+ * How long to stay off a provider that answered 429.
+ *
+ * Lives apart from SyncBankingConnectionJob because the syncer needs the same
+ * answer: a rate limit on the balance call must not throw away a run whose
+ * transactions already landed, so whoever catches it has to be able to say when
+ * we may come back.
+ *
+ * Static because it is a pure reading of the response - no state, no collaborators,
+ * and nothing worth faking in a test.
+ */
+final class RateLimitBackoff
+{
+    public static function isRateLimit(\Throwable $e): bool
+    {
+        return $e instanceof RequestException && $e->response->status() === 429;
+    }
+
+    public static function until(\Throwable $e): Carbon
+    {
+        $now = now();
+
+        if ($e instanceof RequestException) {
+            $retryAfter = $e->response->header('Retry-After');
+
+            if (is_numeric($retryAfter) && (int) $retryAfter > 0) {
+                return $now->copy()->addSeconds((int) $retryAfter);
+            }
+
+            $body = $e->response->json();
+            $message = is_array($body) ? (string) ($body['message'] ?? '') : '';
+
+            if (self::isExhaustedAccessAllowance($message)) {
+                return $now->copy()->utc()->addDay()->startOfDay();
+            }
+        }
+
+        // Default: back off one hour for a burst limit we know nothing else about.
+        return $now->copy()->addHour();
+    }
+
+    /**
+     * Whether the provider is reporting a spent allowance rather than a burst.
+     *
+     * PSD2 budgets unattended access per consent per day, so these do not come back
+     * in an hour - they come back when the day does. Matched on the wordings the
+     * banks actually send, counted over 45 days of banking_sync_logs: "[HUB046]
+     * Allowed number of accesses exceeded for consent." (234), "Access exceeded"
+     * (94), "Maximum daily access exceeded" (48), "The access on the account has
+     * been exceeding the consented multiplicity per day." (37), "Daily PSU not
+     * present consultation limit has been exceeded" (11), and a localised pair,
+     * "CLO03941 - Operación no disponible. Has superado el número máximo de
+     * accesos." (4) plus its Catalan twin (1).
+     *
+     * ponytail: prose matching, because there is nothing better to key on -
+     * detail.error_name is `RateLimitException` for a spent daily allowance and for
+     * a plain burst alike. If Enable Banking ever separates the two, key on that.
+     * Note error_message only holds the first 120 bytes of the body, so a future
+     * attempt at a structured field has to start by logging the whole thing.
+     */
+    private static function isExhaustedAccessAllowance(string $message): bool
+    {
+        return Str::contains($message, [
+            'daily',
+            'access exceeded',
+            'accesses exceeded',
+            'exceeding the consented',
+            'máximo de accesos',
+            'màxim d’accessos',
+        ], ignoreCase: true);
+    }
+}

--- a/app/Services/Banking/Sync/EnableBankingSyncer.php
+++ b/app/Services/Banking/Sync/EnableBankingSyncer.php
@@ -101,24 +101,7 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
             }
         }
 
-        // Report the failure only once every account has had its turn. The run
-        // still fails, so the connection keeps its Error state, its retries and its
-        // unset last_synced_at exactly as before - the one thing that changes is
-        // that the accounts behind the failing one were attempted at all.
-        //
-        // Unless the provider also rate limited us, in which case its window wins:
-        // throwing would drop it, and the scheduler would come straight back for
-        // what is left of the allowance. The transaction failure retries next cycle
-        // either way, so nothing is lost by letting the deadline take precedence.
-        if ($transactionFailure !== null && $rateLimitedUntil === null) {
-            throw $transactionFailure;
-        }
-
-        if ($isFirstSync) {
-            $connection->update(['bank_transactions_email_cutoff_at' => now()]);
-        } elseif ($connection->user->canReceiveEmails()) {
-            SendDailyBankTransactionsSyncedEmailJob::dispatch($connection->user, now()->toDateString());
-        }
+        $this->finishRun($connection, $isFirstSync, $transactionFailure, $rateLimitedUntil);
 
         return array_filter([
             'transactions_synced' => array_sum($transactionsPerBank),
@@ -173,6 +156,67 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
     }
 
     /**
+     * Decide what the run amounted to, once every account has had its turn.
+     */
+    private function finishRun(
+        BankingConnection $connection,
+        bool $isFirstSync,
+        ?TransientBankingProviderException $transactionFailure,
+        ?Carbon $rateLimitedUntil,
+    ): void {
+        // Report the failure only once every account has had its turn. The run
+        // still fails, so the connection keeps its Error state, its retries and its
+        // unset last_synced_at exactly as before - the one thing that changes is
+        // that the accounts behind the failing one were attempted at all.
+        //
+        // Unless the provider also rate limited us, in which case its window wins:
+        // throwing would drop it, and the scheduler would come straight back for
+        // what is left of the allowance. The transaction failure retries next cycle
+        // either way, so nothing is lost by letting the deadline take precedence.
+        if ($transactionFailure !== null && $rateLimitedUntil === null) {
+            throw $transactionFailure;
+        }
+
+        if ($isFirstSync) {
+            $connection->update(['bank_transactions_email_cutoff_at' => now()]);
+        } elseif ($connection->user->canReceiveEmails()) {
+            SendDailyBankTransactionsSyncedEmailJob::dispatch($connection->user, now()->toDateString());
+        }
+
+    }
+
+    /**
+     * Whether this account still owes us the daily balances behind its transactions.
+     *
+     * Widens the connection's first sync rather than replacing it: an account that
+     * would have been backfilled before still is. The connection-level
+     * flag flips false the moment any run completes, and an account whose balance
+     * call failed on that run - rate limited, or just refused - would then never get
+     * its history computed: getBalanceAt carries the last balance backwards and
+     * returns 0 before the first row, so the account and the net-worth chart read a
+     * flat zero for every month before its first balance, permanently. The only way
+     * back was an operator running `banking:sync --full`.
+     *
+     * Checked before the balance call, since that call writes today's row and would
+     * make an account with no history look like it had some. calculateHistoricalBalances
+     * skips dates it already has, so asking again costs one query and writes nothing.
+     */
+    private function needsHistoricalBalances(Account $account): bool
+    {
+        $earliestTransaction = $account->transactions()
+            ->where('source', TransactionSource::EnableBanking)
+            ->min('transaction_date');
+
+        if ($earliestTransaction === null) {
+            return false;
+        }
+
+        return ! $account->balances()
+            ->where('balance_date', '<=', $earliestTransaction)
+            ->exists();
+    }
+
+    /**
      * Sync one account's balances, tolerating a provider that will not serve them.
      *
      * @return array{0: bool, 1: Carbon|null} Whether the balances were synced, and
@@ -181,10 +225,12 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
      */
     private function syncBalances(Account $account, bool $isFirstSync): array
     {
+        $needsHistory = $this->needsHistoricalBalances($account);
+
         try {
             $this->balanceSync->sync($account);
 
-            if ($isFirstSync && ! $account->isLinked()) {
+            if (($isFirstSync || $needsHistory) && ! $account->isLinked()) {
                 $this->balanceSync->calculateHistoricalBalances($account);
             }
 

--- a/app/Services/Banking/Sync/EnableBankingSyncer.php
+++ b/app/Services/Banking/Sync/EnableBankingSyncer.php
@@ -11,8 +11,9 @@ use App\Jobs\SendDailyBankTransactionsSyncedEmailJob;
 use App\Models\Account;
 use App\Models\BankingConnection;
 use App\Services\Banking\BalanceSyncService;
+use App\Services\Banking\RateLimitBackoff;
 use App\Services\Banking\TransactionSyncService;
-use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Log;
 
 class EnableBankingSyncer extends AbstractBankingConnectionSyncer
@@ -30,6 +31,13 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
      * that follows would skip the history in between for good.
      */
     private const int SHORT_WINDOW_DAYS = 90;
+
+    /**
+     * Set when a balance call was rate limited, so the run can finish and still
+     * hand the provider's window to the job. Reset on every sync because syncers
+     * are resolved once and reused across connections.
+     */
+    private ?Carbon $rateLimitedUntil = null;
 
     public function __construct(
         private TransactionSyncService $transactionSync,
@@ -53,6 +61,7 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
         $transactionsPerBank = [];
         $balanceFailed = 0;
         $transactionFailure = null;
+        $this->rateLimitedUntil = null;
 
         $connection->load('accounts.bank');
 
@@ -82,6 +91,12 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
                 $balanceFailed++;
             }
 
+            // The provider asked us to stop; the accounts left would only spend
+            // allowance we no longer have.
+            if ($this->rateLimitedUntil !== null) {
+                break;
+            }
+
             if ($created > 0) {
                 $bankName = $account->bank->name ?? __('Unknown Bank');
                 $transactionsPerBank[$bankName] = ($transactionsPerBank[$bankName] ?? 0) + $created;
@@ -106,6 +121,7 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
             'transactions_synced' => array_sum($transactionsPerBank),
             'transactions_per_bank' => $transactionsPerBank,
             'balance_failed' => $balanceFailed,
+            'rate_limited_until' => $this->rateLimitedUntil,
         ];
     }
 
@@ -169,11 +185,26 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
 
             return true;
         } catch (\Throwable $e) {
-            // An expired consent needs the user to reconnect, and a rate limit has
-            // to reach the job so it applies the provider backoff: swallowing it
-            // would keep burning the remaining daily quota.
-            if ($e instanceof ExpiredBankingSessionException || $this->isRateLimit($e)) {
+            // An expired consent needs the user to reconnect: nothing here can help.
+            if ($e instanceof ExpiredBankingSessionException) {
                 throw $e;
+            }
+
+            // A rate limit still has to reach the connection so we stop asking, but
+            // throwing it discarded a run whose transactions had already landed -
+            // and since last_synced_at is only written on success, that connection
+            // then looked like it had never synced at all. Report it instead and let
+            // the caller stop the loop and hand the window to the job.
+            if (RateLimitBackoff::isRateLimit($e)) {
+                $this->rateLimitedUntil = RateLimitBackoff::until($e);
+
+                Log::warning('EnableBanking balance sync rate limited, keeping the run', [
+                    'connection_id' => $account->banking_connection_id,
+                    'account_id' => $account->id,
+                    'rate_limited_until' => $this->rateLimitedUntil->toIso8601String(),
+                ]);
+
+                return false;
             }
 
             // Anything else is not worth losing the run over. Balances are a
@@ -219,10 +250,5 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
         $start = $watermark->toDateString() > $dateTo ? now() : $watermark;
 
         return $start->copy()->subDays(self::WATERMARK_OVERLAP_DAYS)->toDateString();
-    }
-
-    private function isRateLimit(\Throwable $e): bool
-    {
-        return $e instanceof RequestException && $e->response->status() === 429;
     }
 }

--- a/app/Services/Banking/Sync/EnableBankingSyncer.php
+++ b/app/Services/Banking/Sync/EnableBankingSyncer.php
@@ -32,13 +32,6 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
      */
     private const int SHORT_WINDOW_DAYS = 90;
 
-    /**
-     * Set when a balance call was rate limited, so the run can finish and still
-     * hand the provider's window to the job. Reset on every sync because syncers
-     * are resolved once and reused across connections.
-     */
-    private ?Carbon $rateLimitedUntil = null;
-
     public function __construct(
         private TransactionSyncService $transactionSync,
         private BalanceSyncService $balanceSync,
@@ -61,7 +54,7 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
         $transactionsPerBank = [];
         $balanceFailed = 0;
         $transactionFailure = null;
-        $this->rateLimitedUntil = null;
+        $rateLimitedUntil = null;
 
         $connection->load('accounts.bank');
 
@@ -87,19 +80,24 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
                 $transactionFailure ??= $this->recordAccountTransactionFailure($account, $e);
             }
 
-            if (! $this->syncBalances($account, $isFirstSync)) {
-                $balanceFailed++;
-            }
+            [$balanceSynced, $balanceRateLimit] = $this->syncBalances($account, $isFirstSync);
 
-            // The provider asked us to stop; the accounts left would only spend
-            // allowance we no longer have.
-            if ($this->rateLimitedUntil !== null) {
-                break;
+            if (! $balanceSynced) {
+                $balanceFailed++;
             }
 
             if ($created > 0) {
                 $bankName = $account->bank->name ?? __('Unknown Bank');
                 $transactionsPerBank[$bankName] = ($transactionsPerBank[$bankName] ?? 0) + $created;
+            }
+
+            // The provider asked us to stop; the accounts left would only spend
+            // allowance we no longer have. Counted above first - these rows were
+            // imported, and the sync log is what we read to size problems like this.
+            if ($balanceRateLimit !== null) {
+                $rateLimitedUntil = $balanceRateLimit;
+
+                break;
             }
         }
 
@@ -107,7 +105,12 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
         // still fails, so the connection keeps its Error state, its retries and its
         // unset last_synced_at exactly as before - the one thing that changes is
         // that the accounts behind the failing one were attempted at all.
-        if ($transactionFailure !== null) {
+        //
+        // Unless the provider also rate limited us, in which case its window wins:
+        // throwing would drop it, and the scheduler would come straight back for
+        // what is left of the allowance. The transaction failure retries next cycle
+        // either way, so nothing is lost by letting the deadline take precedence.
+        if ($transactionFailure !== null && $rateLimitedUntil === null) {
             throw $transactionFailure;
         }
 
@@ -117,12 +120,12 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
             SendDailyBankTransactionsSyncedEmailJob::dispatch($connection->user, now()->toDateString());
         }
 
-        return [
+        return array_filter([
             'transactions_synced' => array_sum($transactionsPerBank),
             'transactions_per_bank' => $transactionsPerBank,
             'balance_failed' => $balanceFailed,
-            'rate_limited_until' => $this->rateLimitedUntil,
-        ];
+            'rate_limited_until' => $rateLimitedUntil?->toIso8601String(),
+        ], fn ($value) => $value !== null);
     }
 
     /**
@@ -172,9 +175,11 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
     /**
      * Sync one account's balances, tolerating a provider that will not serve them.
      *
-     * @return bool Whether the balances were synced
+     * @return array{0: bool, 1: Carbon|null} Whether the balances were synced, and
+     *                                        when the provider will have us back if
+     *                                        it rate limited us
      */
-    private function syncBalances(Account $account, bool $isFirstSync): bool
+    private function syncBalances(Account $account, bool $isFirstSync): array
     {
         try {
             $this->balanceSync->sync($account);
@@ -183,7 +188,7 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
                 $this->balanceSync->calculateHistoricalBalances($account);
             }
 
-            return true;
+            return [true, null];
         } catch (\Throwable $e) {
             // An expired consent needs the user to reconnect: nothing here can help.
             if ($e instanceof ExpiredBankingSessionException) {
@@ -196,15 +201,15 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
             // then looked like it had never synced at all. Report it instead and let
             // the caller stop the loop and hand the window to the job.
             if (RateLimitBackoff::isRateLimit($e)) {
-                $this->rateLimitedUntil = RateLimitBackoff::until($e);
+                $until = RateLimitBackoff::until($e);
 
                 Log::warning('EnableBanking balance sync rate limited, keeping the run', [
                     'connection_id' => $account->banking_connection_id,
                     'account_id' => $account->id,
-                    'rate_limited_until' => $this->rateLimitedUntil->toIso8601String(),
+                    'rate_limited_until' => $until->toIso8601String(),
                 ]);
 
-                return false;
+                return [false, $until];
             }
 
             // Anything else is not worth losing the run over. Balances are a
@@ -217,7 +222,7 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
                 'error' => $e->getMessage(),
             ]);
 
-            return false;
+            return [false, null];
         }
     }
 

--- a/tests/Feature/OpenBanking/EnableBankingPartialAccountFailureTest.php
+++ b/tests/Feature/OpenBanking/EnableBankingPartialAccountFailureTest.php
@@ -183,3 +183,37 @@ test('a rate limit still reaches the job instead of being swallowed per account'
     $connection->refresh();
     expect($connection->rate_limited_until)->not->toBeNull();
 });
+
+test('a balance rate limit stops the loop instead of spending what is left', function () {
+    $connection = enableBankingConnectionWithAccounts(3);
+    // Production's shape: these connections have never recorded a completed run,
+    // which is the whole symptom.
+    $connection->update(['last_synced_at' => null]);
+
+    $attempted = 0;
+    $transactionSync = Mockery::mock(TransactionSyncService::class);
+    $transactionSync->shouldReceive('sync')->andReturnUsing(function () use (&$attempted) {
+        $attempted++;
+
+        return 5;
+    });
+
+    $balanceSync = Mockery::mock(BalanceSyncService::class);
+    $balanceSync->shouldReceive('sync')->andThrow(new RequestException(
+        new Illuminate\Http\Client\Response(new Response(429, [], json_encode([
+            'code' => 429,
+            'message' => 'Maximum daily access exceeded',
+        ])))
+    ));
+
+    runSync(finalAttemptJobFor($connection), $transactionSync, $balanceSync);
+
+    // The allowance is spent, so the accounts behind this one would only burn what
+    // is not there. The run still counts for the account that did import.
+    expect($attempted)->toBe(1);
+
+    $connection->refresh();
+    expect($connection->last_synced_at)->not->toBeNull();
+    expect($connection->rate_limited_until->toIso8601String())
+        ->toBe(now()->utc()->addDay()->startOfDay()->toIso8601String());
+});

--- a/tests/Feature/OpenBanking/EnableBankingPartialAccountFailureTest.php
+++ b/tests/Feature/OpenBanking/EnableBankingPartialAccountFailureTest.php
@@ -1,10 +1,12 @@
 <?php
 
 use App\Enums\BankingConnectionStatus;
+use App\Enums\BankingSyncLogStatus;
 use App\Exceptions\Banking\TransientBankingProviderException;
 use App\Jobs\SyncBankingConnectionJob;
 use App\Models\Account;
 use App\Models\BankingConnection;
+use App\Models\BankingSyncLog;
 use App\Models\User;
 use App\Services\Banking\BalanceSyncService;
 use App\Services\Banking\TransactionSyncService;
@@ -199,7 +201,8 @@ test('a balance rate limit stops the loop instead of spending what is left', fun
     });
 
     $balanceSync = Mockery::mock(BalanceSyncService::class);
-    $balanceSync->shouldReceive('sync')->andThrow(new RequestException(
+    // The balance call is the one actually spending the allowance, so pin it too.
+    $balanceSync->shouldReceive('sync')->once()->andThrow(new RequestException(
         new Illuminate\Http\Client\Response(new Response(429, [], json_encode([
             'code' => 429,
             'message' => 'Maximum daily access exceeded',
@@ -216,4 +219,41 @@ test('a balance rate limit stops the loop instead of spending what is left', fun
     expect($connection->last_synced_at)->not->toBeNull();
     expect($connection->rate_limited_until->toIso8601String())
         ->toBe(now()->utc()->addDay()->startOfDay()->toIso8601String());
+
+    // The rate-limited account's rows were imported, so the log has to say so -
+    // this is the table we read to size problems like this one.
+    $log = BankingSyncLog::where('banking_connection_id', $connection->id)
+        ->where('status', BankingSyncLogStatus::Success)->sole();
+    expect($log->metadata['transactions_synced'])->toBe(5);
+});
+
+test('a rate limit outranks a transaction failure deferred from an earlier account', function () {
+    $connection = enableBankingConnectionWithAccounts(3);
+    $connection->update(['last_synced_at' => null]);
+    $refusedAccountId = $connection->accounts[0]->id;
+
+    $transactionSync = Mockery::mock(TransactionSyncService::class);
+    $transactionSync->shouldReceive('sync')->andReturnUsing(function ($account) use ($refusedAccountId) {
+        if ($account->id === $refusedAccountId) {
+            throw aspspError();
+        }
+
+        return 5;
+    });
+
+    $balanceSync = Mockery::mock(BalanceSyncService::class);
+    $balanceSync->shouldReceive('sync')->andThrow(new RequestException(
+        new Illuminate\Http\Client\Response(new Response(429, [], json_encode([
+            'code' => 429,
+            'message' => 'Maximum daily access exceeded',
+        ])))
+    ));
+
+    runSync(finalAttemptJobFor($connection), $transactionSync, $balanceSync);
+
+    // Throwing the deferred transaction failure here would drop the provider's
+    // window, and the scheduler would come straight back for what is left of the
+    // allowance. The transaction failure retries next cycle either way.
+    $connection->refresh();
+    expect($connection->rate_limited_until)->not->toBeNull();
 });

--- a/tests/Feature/OpenBanking/EnableBankingPartialAccountFailureTest.php
+++ b/tests/Feature/OpenBanking/EnableBankingPartialAccountFailureTest.php
@@ -7,6 +7,7 @@ use App\Jobs\SyncBankingConnectionJob;
 use App\Models\Account;
 use App\Models\BankingConnection;
 use App\Models\BankingSyncLog;
+use App\Models\Transaction;
 use App\Models\User;
 use App\Services\Banking\BalanceSyncService;
 use App\Services\Banking\TransactionSyncService;
@@ -256,4 +257,52 @@ test('a rate limit outranks a transaction failure deferred from an earlier accou
     // allowance. The transaction failure retries next cycle either way.
     $connection->refresh();
     expect($connection->rate_limited_until)->not->toBeNull();
+});
+
+test('an account still gets its balance history after the connection has synced before', function () {
+    $connection = enableBankingConnectionWithAccounts(1);
+    $account = $connection->accounts[0];
+
+    // The connection has synced before, so the old gate ($isFirstSync) was closed
+    // for good - which is what a rate-limited first run leaves behind. The account
+    // itself has transactions and no balance older than them, so it is still owed
+    // its daily history.
+    Transaction::factory()->enableBanking()->plaintext()->create([
+        'user_id' => $connection->user_id,
+        'account_id' => $account->id,
+        'transaction_date' => now()->subMonths(2)->toDateString(),
+    ]);
+
+    $transactionSync = Mockery::mock(TransactionSyncService::class);
+    $transactionSync->shouldReceive('sync')->andReturn(0);
+
+    $balanceSync = Mockery::mock(BalanceSyncService::class);
+    $balanceSync->shouldReceive('sync')->once();
+    $balanceSync->shouldReceive('calculateHistoricalBalances')->once();
+
+    runSync(finalAttemptJobFor($connection), $transactionSync, $balanceSync);
+});
+
+test('an account that already has balance history is not asked for it again', function () {
+    $connection = enableBankingConnectionWithAccounts(1);
+    $account = $connection->accounts[0];
+
+    Transaction::factory()->enableBanking()->plaintext()->create([
+        'user_id' => $connection->user_id,
+        'account_id' => $account->id,
+        'transaction_date' => now()->subMonth()->toDateString(),
+    ]);
+    $account->balances()->create([
+        'balance_date' => now()->subMonths(2)->toDateString(),
+        'balance' => 1000,
+    ]);
+
+    $transactionSync = Mockery::mock(TransactionSyncService::class);
+    $transactionSync->shouldReceive('sync')->andReturn(0);
+
+    $balanceSync = Mockery::mock(BalanceSyncService::class);
+    $balanceSync->shouldReceive('sync')->once();
+    $balanceSync->shouldNotReceive('calculateHistoricalBalances');
+
+    runSync(finalAttemptJobFor($connection), $transactionSync, $balanceSync);
 });

--- a/tests/Feature/OpenBanking/SyncBankingConnectionJobTest.php
+++ b/tests/Feature/OpenBanking/SyncBankingConnectionJobTest.php
@@ -332,12 +332,17 @@ test('a rate limited balance call keeps the transactions and still backs off', f
 
     $connection->refresh();
 
-    // The quota is per consent: swallowing the 429 here would keep the next
-    // scheduled runs burning what is left of it.
+    // The quota is per consent, so the connection still owes the provider a rest.
     expect($connection->status)->toBe(BankingConnectionStatus::Active)
         ->and($connection->rate_limited_until)->not->toBeNull()
         ->and($connection->rate_limited_until->isFuture())->toBeTrue()
         ->and($account->transactions()->count())->toBe(1);
+
+    // But the run counts. Throwing the 429 discarded it, and since last_synced_at
+    // is only written on success the connection then looked like it had never
+    // synced at all - which is what put ~11 production users on an indefinite
+    // "Syncing…" spinner with a EUR 0 balance while their transactions arrived daily.
+    expect($connection->last_synced_at)->not->toBeNull();
 });
 
 test('an expired session during the balance call is not swallowed', function () {


### PR DESCRIPTION
> Sentry's MCP token has been expired for five days, so this came from the production DB again.

## The bug

`EnableBankingSyncer::syncBalances` rethrew a 429 so the job would set `rate_limited_until`. That worked — and it also threw away a run whose transactions had already imported. Since `last_synced_at` is only written on the job's success path, the connection was left looking like it had never synced.

Production: **13 accounts across 11 users** have Enable Banking transactions and **zero** `account_balances` rows. One Trade Republic account has 161 transactions, the most recent imported the morning I measured, and a NULL `last_synced_at` since 2026-07-26.

The visible cost is worse than a missing balance:

- `connections.tsx:60,386` keys **both** an indefinite "Syncing transactions and balances…" state **and a 5-second poll** on `status === 'active' && !last_synced_at`. Ten live users have a settings tab that polls the server every five seconds for as long as it is open.
- `OnboardingController::syncStatus:87-103` computes `failed = !pending && $unsynced->isNotEmpty()`, which is exactly this state — so a **brand-new user is told their first sync failed** while their transactions are already in the app. One production connection hit that on its first sync on 2026-08-16.
- The rate-limit message was never shown either: `applyRateLimitBackoff` leaves the status Active, and the page only renders `error_message` when the status is Error.

## The change

`syncBalances` returns `[bool $synced, ?Carbon $until]`. The loop records the window in a local, tallies the imported transactions, then breaks — the accounts behind it would only spend an allowance we no longer have. The syncer returns `rate_limited_until` as an ISO string in its metadata, and the job applies it on the success path instead of hardcoding `null`. **We ask no more often than before; the run just keeps what it had already earned.**

Commits are one per finding, and two of them are corrections to my own first attempt:

- **`f0828a52`** — a regression against main. An earlier account's transactions can fail transiently while a later account's balance is rate-limited; the deferred `throw` then ran and the window was never returned, so the scheduler came straight back for what was left of the daily allowance. On main the rethrown 429 escaped first, so the rate limit always won. Now it wins deliberately. The `break` also sat above the `if ($created > 0)` tally, so the rate-limited account's rows were logged as zero — in the very table I read to size this. And the mutable property became a local, which is what made both bugs visible instead of hidden.
- **`5c22c317`** — `calculateHistoricalBalances` was gated on the *connection's* first sync, which flips false the moment any run completes. Writing `last_synced_at` on a rate-limited run is exactly what closes that door, so these accounts would have lost their daily history for good: `getBalanceAt` returns 0 before the first row, so the account and the net-worth chart read a flat zero for every prior month, permanently. Now the account's own state is asked **as well as**, not instead of, the connection's first sync — my first attempt replaced it and broke four existing tests, correctly.

## Verification

`tests/Feature/OpenBanking`: 369 tests, 359 pass, and the **same 10 failures as clean main** (Inertia page-render tests hitting the SSR `/render` endpoint, which has no local server). Every behavioural change has a test that fails when only that change is reverted — including the two that did not discriminate at first: the pre-existing `a rate limited balance call keeps the transactions and still backs off` passed either way, because everything it asserted was already true, so it now asserts `last_synced_at`; and my own multi-account test passed without the fix because the helper seeded `last_synced_at`, so it now starts from NULL like production. `pint`, `crap` and `dry` green.

## Scope, honestly

- **This fixes the balance-call 429 only.** A 429 from the *transactions* call falls through every classifier in `EnableBankingProvider` and is rethrown raw, escaping the syncer's catch list, so that variant still discards the run. Three of the 11 connections have not imported in 10+ days while failing four times a day, which is consistent with either variant. So: not all 11.
- **The balance stays €0 until the provider lets us back.** For these connections that is not transient — every sync-log row for the last ten days is a 429, and the dominant body is `{"message":"Too many requests"}`, which is a burst limit on the one-hour path, hit in the same 06:0x window every run. This change removes a false "syncing" state and a false onboarding failure; it does not make a balance appear.
- **These ten users will start receiving the daily "transactions synced" email**, which the discarded run had been suppressing. The cutoff is stamped on the same run, so the existing backlog is not emailed — only new transactions.

## Follow-ups

- **Keep one observable signal for "Active but balances never landed."** `status = 'active' AND last_synced_at IS NULL` is the query that found these 11, and this change deletes it. `rate_limited_until` is already serialised to the frontend and just missing from `types/banking.ts`, so a "Balances unavailable, retrying" line on the connection card is cheap.
- **The real cause is still quota.** ~82% of the ~1,740 daily balance calls rewrite a row we already have, because `BalanceSyncService` keys on `balance_date`. Cutting that takes 8 accesses per account per day to 5. It needs a migration for a last-read timestamp — the guard cannot key on `balance_date` (some banks report yesterday's `reference_date`) nor on `updated_at` (an unchanged `updateOrCreate` leaves the model clean).
- Record the swallowed transaction failure in the metadata next to `balance_failed`.

## Why this is a draft

The product review agent failed twice — once mid-response, once stalled — before a third attempt completed, and its verdict was "sound, I'd ship it". I am drafting anyway because **this is the third time I have proposed letting a partially-failed run report success**, and the two previous reviews were right to stop me. Both of the objections that killed the earlier attempt were checked here: the email cutoff turns out to be *stricter* than the NULL it replaces, and the historical-balance loss is real and is fixed in `5c22c317`. That is a good outcome, but it is also exactly the pattern where my own confidence has been wrong before, and the change alters what "a successful sync" means for every Enable Banking connection.

Unrelated: four files in my working tree belong to someone else's in-progress `User`/subscription refactor. I left them alone and staged explicit paths; they are not in this branch.
