### PR TITLE
fix(billing): block account deletion while Stripe can still charge the card

### DIFF
--- a/app/Console/Commands/DeleteUserCommand.php
+++ b/app/Console/Commands/DeleteUserCommand.php
@@ -51,13 +51,13 @@ class DeleteUserCommand extends Command
             return self::SUCCESS;
         }
 
-        $subscription = $this->activeSubscription($user);
+        $subscription = $user->collectableSubscription();
         $enableBankingConnections = $user->bankingConnections()
             ->with('accounts')
             ->where('provider', BankingProvider::EnableBanking)
             ->get();
 
-        if ($subscription && ! $this->confirm("User '{$user->email}' has an active Stripe subscription. Cancel it before deleting the user?")) {
+        if ($subscription && ! $this->confirm("User '{$user->email}' has a chargeable Stripe subscription ({$subscription->stripe_status}). Cancel it before deleting the user?")) {
             $this->info('Deletion cancelled.');
 
             return self::SUCCESS;
@@ -71,7 +71,7 @@ class DeleteUserCommand extends Command
 
         if ($subscription) {
             $this->cancelSubscription($user, $subscription);
-            $this->info("Cancelled active Stripe subscription for '{$user->email}'.");
+            $this->info("Cancelled Stripe subscription for '{$user->email}'.");
         }
 
         foreach ($enableBankingConnections as $connection) {
@@ -89,20 +89,9 @@ class DeleteUserCommand extends Command
         return self::SUCCESS;
     }
 
-    private function activeSubscription(User $user): ?Subscription
-    {
-        $subscription = $user->subscription('default');
-
-        if (! $subscription || ! $subscription->valid()) {
-            return null;
-        }
-
-        return $subscription;
-    }
-
     private function cancelSubscription(User $user, Subscription $subscription): void
     {
-        if ($user->hasStripeId()) {
+        if ($user->hasStripeId() && ! $user->hasSeededSubscription()) {
             $subscription->cancelNow();
 
             return;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -24,9 +24,12 @@ use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Laravel\Cashier\Billable;
+use Laravel\Cashier\Cashier;
+use Laravel\Cashier\Subscription;
 use Laravel\Fortify\TwoFactorAuthenticatable;
 use Laravel\Pennant\Concerns\HasFeatures;
 use Laravel\Sanctum\HasApiTokens;
+use Stripe\Subscription as StripeSubscription;
 
 /**
  * @property ?Carbon $last_logged_in_at
@@ -419,9 +422,44 @@ class User extends Authenticatable implements HasLocalePreference, MustVerifyEma
     }
 
     /**
-     * Whether the user is still being billed: on a trial or holding an
-     * active subscription that has not been cancelled (grace period excluded,
-     * as it will not renew). Such users must cancel before deleting their account.
+     * Stripe statuses that leave an invoice Stripe can still put on the card.
+     *
+     * Deliberately an allowlist: a status we do not know about must not block account
+     * deletion, or an unfamiliar one traps the user with nothing to cancel. Cashier's
+     * `valid()` cannot stand in for this — it reports `unpaid` and `incomplete` as
+     * inactive while Stripe keeps their invoices open. (`past_due` is absent from that
+     * list only because {@see Cashier::keepPastDueSubscriptionsActive()}
+     * is enabled in AppServiceProvider, so don't reach for `valid()` here again.)
+     */
+    private const COLLECTABLE_STRIPE_STATUSES = [
+        StripeSubscription::STATUS_ACTIVE,
+        StripeSubscription::STATUS_TRIALING,
+        StripeSubscription::STATUS_PAST_DUE,
+        StripeSubscription::STATUS_UNPAID,
+        StripeSubscription::STATUS_INCOMPLETE,
+    ];
+
+    /**
+     * The subscription Stripe can still collect on, whatever its payment state.
+     * A cancelled one (`ends_at` set, in grace period or over) issues no further
+     * invoices, so it does not count and does not stand in the way of deletion.
+     */
+    public function collectableSubscription(): ?Subscription
+    {
+        $subscription = $this->subscription('default');
+
+        if ($subscription === null || $subscription->canceled()) {
+            return null;
+        }
+
+        return in_array($subscription->stripe_status, self::COLLECTABLE_STRIPE_STATUSES, true)
+            ? $subscription
+            : null;
+    }
+
+    /**
+     * Whether the user is still being billed: on a trial or holding a subscription
+     * Stripe can still collect on. Such users must cancel before deleting their account.
      */
     public function hasActiveSubscriptionOrTrial(): bool
     {
@@ -433,11 +471,7 @@ class User extends Authenticatable implements HasLocalePreference, MustVerifyEma
             return true;
         }
 
-        $subscription = $this->subscription('default');
-
-        return $subscription !== null
-            && $subscription->valid()
-            && ! $subscription->onGracePeriod();
+        return $this->collectableSubscription() !== null;
     }
 
     /**

--- a/tests/Feature/DeleteUserCommandTest.php
+++ b/tests/Feature/DeleteUserCommandTest.php
@@ -144,7 +144,7 @@ test('does not delete other users data', function () {
     expect(Account::query()->where('user_id', $otherUser->id)->exists())->toBeTrue();
 });
 
-test('cancels active subscription before deleting user when confirmed', function () {
+test('cancels a chargeable subscription before deleting user when confirmed', function (string $status) {
     $this->travelTo(now()->setDate(2026, 4, 22)->setTime(10, 51, 24));
 
     $user = User::factory()->onboarded()->create([
@@ -156,7 +156,7 @@ test('cancels active subscription before deleting user when confirmed', function
         'user_id' => $user->id,
         'type' => 'default',
         'stripe_id' => 'sub_test123',
-        'stripe_status' => 'active',
+        'stripe_status' => $status,
         'stripe_price' => 'price_test123',
         'quantity' => 1,
     ]);
@@ -167,15 +167,15 @@ test('cancels active subscription before deleting user when confirmed', function
 
     $this->artisan('user:delete', ['email' => 'subscribed@example.com'])
         ->expectsConfirmation("Are you sure you want to mark user 'Subscribed User' (subscribed@example.com) as deleted? Their data will be preserved.", 'yes')
-        ->expectsConfirmation("User 'subscribed@example.com' has an active Stripe subscription. Cancel it before deleting the user?", 'yes')
-        ->expectsOutput("Cancelled active Stripe subscription for 'subscribed@example.com'.")
+        ->expectsConfirmation("User 'subscribed@example.com' has a chargeable Stripe subscription ({$status}). Cancel it before deleting the user?", 'yes')
+        ->expectsOutput("Cancelled Stripe subscription for 'subscribed@example.com'.")
         ->expectsOutput("User 'subscribed@example.com' has been marked as deleted. Their data remains in the database.")
         ->assertSuccessful();
 
     expect($subscription->fresh()->stripe_status)->toBe('canceled');
     expect($subscription->fresh()->ends_at)->not->toBeNull();
     expect(User::withTrashed()->find($user->id)?->deleted_at)->not->toBeNull();
-});
+})->with(['active', 'past_due', 'unpaid', 'incomplete']);
 
 test('cancels deletion when subscription cancellation is not confirmed', function () {
     $user = User::factory()->onboarded()->create([
@@ -198,12 +198,42 @@ test('cancels deletion when subscription cancellation is not confirmed', functio
 
     $this->artisan('user:delete', ['email' => 'subscribed@example.com'])
         ->expectsConfirmation("Are you sure you want to mark user 'Subscribed User' (subscribed@example.com) as deleted? Their data will be preserved.", 'yes')
-        ->expectsConfirmation("User 'subscribed@example.com' has an active Stripe subscription. Cancel it before deleting the user?", 'no')
+        ->expectsConfirmation("User 'subscribed@example.com' has a chargeable Stripe subscription (active). Cancel it before deleting the user?", 'no')
         ->expectsOutput('Deletion cancelled.')
         ->assertSuccessful();
 
     expect(User::query()->where('email', 'subscribed@example.com')->exists())->toBeTrue();
     expect(Subscription::query()->where('user_id', $user->id)->first()?->stripe_status)->toBe('active');
+});
+
+test('leaves an already cancelled subscription alone instead of cutting its grace period short', function () {
+    $user = User::factory()->onboarded()->create([
+        'email' => 'grace@example.com',
+        'name' => 'Grace User',
+    ]);
+
+    $subscription = Subscription::query()->create([
+        'user_id' => $user->id,
+        'type' => 'default',
+        'stripe_id' => 'sub_grace123',
+        'stripe_status' => 'active',
+        'stripe_price' => 'price_test123',
+        'quantity' => 1,
+        'ends_at' => now()->addDays(7),
+    ]);
+
+    $mockProvider = Mockery::mock(BankingProviderInterface::class);
+    $mockProvider->shouldNotReceive('revokeSession');
+    app()->instance(BankingProviderInterface::class, $mockProvider);
+
+    $this->artisan('user:delete', ['email' => 'grace@example.com'])
+        ->expectsConfirmation("Are you sure you want to mark user 'Grace User' (grace@example.com) as deleted? Their data will be preserved.", 'yes')
+        ->expectsOutput("User 'grace@example.com' has been marked as deleted. Their data remains in the database.")
+        ->assertSuccessful();
+
+    expect($subscription->fresh()->stripe_status)->toBe('active');
+    expect($subscription->fresh()->ends_at->toDateString())->toBe(now()->addDays(7)->toDateString());
+    expect(User::withTrashed()->find($user->id)?->deleted_at)->not->toBeNull();
 });
 
 test('revokes enable banking connections before deleting user when confirmed', function () {

--- a/tests/Feature/Settings/ProfileUpdateTest.php
+++ b/tests/Feature/Settings/ProfileUpdateTest.php
@@ -237,17 +237,43 @@ test('user on a trial cannot delete their account', function () {
     expect(User::query()->find($user->id))->not->toBeNull();
 });
 
-test('user with a cancelled subscription on grace period can delete their account', function () {
+test('user with a subscription Stripe can still collect on cannot delete their account', function (string $status) {
     config(['subscriptions.enabled' => true]);
 
     $user = User::factory()->create();
 
     $user->subscriptions()->create([
         'type' => 'default',
-        'stripe_id' => 'sub_grace_delete_test',
-        'stripe_status' => 'active',
+        'stripe_id' => "sub_{$status}_delete_test",
+        'stripe_status' => $status,
         'stripe_price' => 'price_delete_test',
-        'ends_at' => now()->addDays(7),
+    ]);
+
+    $response = $this
+        ->actingAs($user)
+        ->from(route('delete-account.edit'))
+        ->delete(route('profile.destroy'), [
+            'password' => 'password',
+        ]);
+
+    $response
+        ->assertSessionHasErrors('subscription')
+        ->assertRedirect(route('delete-account.edit'));
+
+    expect(User::query()->find($user->id))->not->toBeNull();
+})->with(['past_due', 'unpaid', 'incomplete']);
+
+test('user with a subscription Stripe cannot collect on can delete their account', function (string $status, bool $cancelled) {
+    config(['subscriptions.enabled' => true]);
+
+    $user = User::factory()->create();
+
+    $user->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => "sub_{$status}_delete_test",
+        'stripe_status' => $status,
+        'stripe_price' => 'price_delete_test',
+        'ends_at' => $cancelled ? now()->addDays(7) : null,
     ]);
 
     $response = $this
@@ -261,4 +287,9 @@ test('user with a cancelled subscription on grace period can delete their accoun
         ->assertRedirect(route('home'));
 
     expect(User::query()->find($user->id))->toBeNull();
-});
+})->with([
+    'cancelled, still on grace period' => ['active', true],
+    'checkout that never completed' => ['incomplete_expired', false],
+    'canceled with no end date' => ['canceled', false],
+    'paused, so nothing to collect' => ['paused', false],
+]);


### PR DESCRIPTION
## Why

Three production users were billed **after** deleting their account. Two of them (deleted 2026-06-01 and 2026-06-09) predate the deletion guard entirely — it shipped in #531 on 2026-06-14 — so this PR would not have saved them. The third (deleted 2026-07-16, one day before its trial converted) happened with the guard live and is **still unexplained**; see "What this does not fix".

What the guard *did* get wrong is which subscriptions count as chargeable. It asked Cashier's `valid()`:

```php
$subscription->valid() && ! $subscription->onGracePeriod()
```

`valid()` reports `unpaid` and `incomplete` subscriptions as inactive, while Stripe keeps their invoices open and can still put them on the card. Verified against the installed Cashier with this app's providers booted:

| `stripe_status` (`ends_at` NULL) | before | after |
| --- | --- | --- |
| `active` | blocked | blocked |
| `trialing` | blocked | blocked |
| `past_due` | blocked | blocked |
| `unpaid` | **allowed** | **blocked** |
| `incomplete` | **allowed** | **blocked** |
| `incomplete_expired` | allowed | allowed |
| `canceled`, no `ends_at` | blocked | **allowed** |
| `paused` | blocked | **allowed** |

Note `past_due` is only in the safe column because `Cashier::keepPastDueSubscriptionsActive()` (`AppServiceProvider.php:27`) flips it back to valid. That is a paywall decision, not a billing-safety one, and a deletion guard should not depend on it staying that way — the new code states the rule itself.

## What changed

- **`User::collectableSubscription()`** is now the single answer to "can Stripe still charge this?", built as an **allowlist** of Stripe statuses. An unfamiliar status fails open rather than trapping someone with nothing to cancel, which also closes two smaller traps: a `canceled` row with no `ends_at` (blocked deletion forever while the billing portal showed nothing to cancel) and `paused` (Stripe does not collect on it). `incomplete_expired` stays deletable — a checkout that never completed cannot be cancelled from the portal.
- **`hasActiveSubscriptionOrTrial()`** delegates to it, so both the `/settings/delete-account` page and `ProfileController::destroy` inherit the fix.
- **`user:delete`** kept a private `valid()`-based copy of the rule, so it deleted `unpaid`/`incomplete` users without cancelling anything in Stripe, and force-cancelled subscriptions already winding down in their grace period (cutting short time the user had paid for). It now shares `collectableSubscription()`, names the real status in the operator prompt, and bails out of the Stripe call for seeded demo/e2e subscriptions as `hasSeededSubscription()`'s contract requires.

## Tests

- `ProfileUpdateTest`: `unpaid` and `incomplete` are blocked (`past_due` kept as a regression guard in case `keepPastDueSubscriptionsActive()` is ever removed); the four states Stripe cannot collect on stay deletable, folded into one dataset.
- `DeleteUserCommandTest`: dataset extended to `unpaid` and `incomplete` — the statuses the command actually mishandled — plus a new case pinning that an already-cancelled subscription keeps its grace period.

## QA

Real browser QA against the running app, plus the console path:

- **`unpaid`** → `/settings/delete-account` shows "Please cancel your subscription before deleting your account" with a Manage billing link, and renders **no** delete button. Submitting is not reachable; the user row survives. (Before this change, that page showed the delete form.)
- **`incomplete_expired`** → delete form is present, dialog confirms, redirect to `/`, and the row is soft-deleted with the anonymised email. Not trapped.
- **`user:delete` on an `unpaid` user** → prompts `has a chargeable Stripe subscription (unpaid). Cancel it before deleting the user?`, cancels it, then soft-deletes. Previously it deleted the user and left the subscription live.

## Demo

https://github.com/user-attachments/assets/f8fd35e1-c78f-46c9-b020-f568d8e40fa9


<!-- PLACEHOLDER: drag the QA video here -->

## What this does not fix

1. **The 2026-07-16 case.** The guard was live and every code path that calls `markAsDeleted()` would have blocked it or cancelled the subscription first. Either it was deleted by hand (tinker/SQL), or there is a path I have not found. Worth settling before considering the incident closed.
2. **Two users still being billed since June.** `sub_1TdVklLRCmKA3oWMUuuvSXBW` and `sub_1TgPJyLRCmKA3oWMbeeiD35y` are still `active` with no `ends_at`. `user:delete` cannot help (it returns early on an already-deleted user) — they need cancelling in Stripe, and a refund decision.
3. **Local state is not Stripe.** 69 soft-deleted users have a `stripe_id` and no local subscription row at all; no guard reading our own tables can see a live subscription for them. A cancel-on-delete flow verified against the Stripe API would, and is the stronger follow-up.
4. **`SUBSCRIPTIONS_ENABLED` still gates the web guard.** `hasActiveSubscriptionOrTrial()` returns `false` when the flag is falsy, and an empty env var reads back falsy. It is definitely on in production (it also gates `EnsureUserIsSubscribed`), so it is not the cause of any known case — but "don't delete someone Stripe can still bill" is not a paywall concern and probably should not sit behind the paywall flag. Left alone here to keep this diff to one decision. `collectableSubscription()` itself is ungated, so `user:delete` protects regardless.
5. **Copy for the newly blocked states.** An `unpaid` or `incomplete` user reads "cancel your subscription" while believing they have none — they have been paywalled. Production has zero users in either state today, so I left the string (and its `es.json` twin) alone rather than widen the diff.

`crap` reports `DeleteUserCommand::handle` at complexity 11. It was already 11 on `main` and this diff only touches one line of it; splitting it would trade the warning for duplication, which `bun run dry` does gate.
