### PR TITLE
fix(observability): stop a failed hover-prefetch being reported, and speak up when a real one fails

### DIFF
--- a/lang/es.json
+++ b/lang/es.json
@@ -2203,6 +2203,7 @@
     "New: :name": "Nueva: :name",
     "Preview matching transactions": "Ver transacciones coincidentes",
     "Loading…": "Cargando…",
+    "We could not reach the server. Check your connection.": "No hemos podido conectar con el servidor. Comprueba tu conexión.",
     ":count of :total uncategorized transactions match": ":count de :total transacciones sin categorizar coinciden",
     "Matching transactions": "Transacciones coincidentes",
     "Preview :count matching transactions": "Ver :count transacciones coincidentes",

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -26,6 +26,7 @@ import { SyncProvider } from './contexts/sync-context';
 import { initializeTheme } from './hooks/use-appearance';
 import { initializeChartColorScheme } from './hooks/use-chart-color-scheme';
 import { installChunkLoadRecovery } from './lib/chunk-load-recovery';
+import { installFailedNavigationToast } from './lib/failed-navigation-toast';
 import { leavePage } from './lib/leave-page';
 import { initializePostHog } from './lib/posthog';
 import { trackPrefetchedUrls } from './lib/prefetch-tracker';
@@ -44,6 +45,7 @@ import { __, setTranslations } from './utils/i18n';
 
 installChunkLoadRecovery();
 trackPrefetchedUrls();
+installFailedNavigationToast();
 
 Sentry.init({
     dsn: import.meta.env.SENTRY_LARAVEL_DSN,

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -28,10 +28,12 @@ import { initializeChartColorScheme } from './hooks/use-chart-color-scheme';
 import { installChunkLoadRecovery } from './lib/chunk-load-recovery';
 import { leavePage } from './lib/leave-page';
 import { initializePostHog } from './lib/posthog';
+import { trackPrefetchedUrls } from './lib/prefetch-tracker';
 import {
     isBrowserExtensionNoise,
     isChunkLoadErrorEvent,
     isFacebookInAppBrowserJavaBridgeNoise,
+    isFailedPrefetchNoise,
     isPageLeaveAbortNoise,
     isPostMessageDataCloneNoise,
     isSafariCashbackExtensionNoise,
@@ -41,6 +43,7 @@ import type { ExpiredBankingConnectionNotification, SharedData } from './types';
 import { __, setTranslations } from './utils/i18n';
 
 installChunkLoadRecovery();
+trackPrefetchedUrls();
 
 Sentry.init({
     dsn: import.meta.env.SENTRY_LARAVEL_DSN,
@@ -52,6 +55,7 @@ Sentry.init({
         if (
             isChunkLoadErrorEvent(event) ||
             isPageLeaveAbortNoise(event) ||
+            isFailedPrefetchNoise(event) ||
             isBrowserExtensionNoise(event) ||
             isPostMessageDataCloneNoise(event) ||
             isFacebookInAppBrowserJavaBridgeNoise(event) ||

--- a/resources/js/lib/failed-navigation-toast.test.ts
+++ b/resources/js/lib/failed-navigation-toast.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const toastError = vi.fn();
+
+async function freshModules() {
+    vi.resetModules();
+    toastError.mockClear();
+
+    const listeners: Record<string, (e: unknown) => void> = {};
+
+    vi.doMock('@inertiajs/react', () => ({
+        router: {
+            on: (name: string, cb: (e: unknown) => void) => {
+                listeners[name] = cb;
+
+                return () => delete listeners[name];
+            },
+        },
+    }));
+    vi.doMock('sonner', () => ({ toast: { error: toastError } }));
+
+    const tracker = await import('./prefetch-tracker');
+    const { installFailedNavigationToast } =
+        await import('./failed-navigation-toast');
+
+    tracker.trackPrefetchedUrls();
+    installFailedNavigationToast();
+
+    return { listeners };
+}
+
+function failure(url: string) {
+    return { detail: { error: { url } } };
+}
+
+function prefetching(url: string) {
+    return { detail: { visit: { url: new URL(url) } } };
+}
+
+describe('installFailedNavigationToast', () => {
+    it('tells the user when a navigation they asked for died on the network', async () => {
+        const { listeners } = await freshModules();
+
+        listeners.networkError?.(failure('https://whisper.money/budgets'));
+
+        expect(toastError).toHaveBeenCalledOnce();
+    });
+
+    it('says nothing about a page we only guessed at', async () => {
+        const { listeners } = await freshModules();
+
+        listeners.prefetching?.(prefetching('https://whisper.money/cashflow'));
+        listeners.networkError?.(failure('https://whisper.money/cashflow'));
+
+        expect(toastError).not.toHaveBeenCalled();
+    });
+
+    it('speaks up once the user commits to the page we guessed at', async () => {
+        const { listeners } = await freshModules();
+
+        listeners.prefetching?.(prefetching('https://whisper.money/cashflow'));
+        listeners.before?.({
+            detail: {
+                visit: {
+                    url: new URL('https://whisper.money/cashflow'),
+                    prefetch: false,
+                },
+            },
+        });
+        listeners.networkError?.(failure('https://whisper.money/cashflow'));
+
+        expect(toastError).toHaveBeenCalledOnce();
+    });
+
+    it('still speaks up when the error carries no url', async () => {
+        const { listeners } = await freshModules();
+
+        listeners.networkError?.({ detail: { error: {} } });
+
+        expect(toastError).toHaveBeenCalledOnce();
+    });
+});

--- a/resources/js/lib/failed-navigation-toast.ts
+++ b/resources/js/lib/failed-navigation-toast.ts
@@ -1,0 +1,37 @@
+import { __ } from '@/utils/i18n';
+import { router } from '@inertiajs/react';
+import { toast } from 'sonner';
+import { wasPrefetched } from './prefetch-tracker';
+
+/**
+ * Tells the user when a navigation or a save died on the network.
+ *
+ * Inertia's only response to a transport failure is to stop: the progress bar
+ * retracts, `processing` clears, and nothing else happens. So a click goes nowhere
+ * and a save silently does not save - one of the failures in production was a
+ * `PATCH /settings/accounts/{uuid}`, which is a change the user believed they had
+ * made.
+ *
+ * Stays quiet for requests nobody asked for. A hover prefetch that fails costs the
+ * user nothing, and saying so would be noise about a page they may never open.
+ *
+ * Deliberately does not call `preventDefault()`: that would skip the cleanup Inertia
+ * runs for a failed prefetch, leaving a dead entry that a later click waits on
+ * forever.
+ */
+export function installFailedNavigationToast(): void {
+    router.on('networkError', (event) => {
+        const failedUrl = (event.detail.error as { url?: string }).url;
+
+        if (failedUrl !== undefined && wasPrefetched(failedUrl)) {
+            return;
+        }
+
+        toast.error(
+            __('We could not reach the server. Check your connection.'),
+            {
+                id: 'network-error',
+            },
+        );
+    });
+}

--- a/resources/js/lib/prefetch-tracker.ts
+++ b/resources/js/lib/prefetch-tracker.ts
@@ -1,0 +1,46 @@
+import { router } from '@inertiajs/react';
+
+/**
+ * Remembers which URLs we speculatively fetched, so a failed one can be told apart
+ * from a request the user actually asked for.
+ *
+ * Every sidebar item is a `<Link prefetch>`, so hovering the nav fires a request for
+ * a page nobody has committed to visiting. When one of those fails at the transport
+ * level Inertia rejects inside its own prefetch promise — a rejection app code cannot
+ * reach, since `preventDefault()` on the networkError event would also skip the
+ * `onPrefetchError` cleanup that keeps the URL prefetchable. So the only place left
+ * to recognise it is Sentry's beforeSend, and that needs to know it was a guess.
+ *
+ * Kept by timestamp rather than cleared on completion: `finish` fires before the
+ * rejection is captured, so anything cleared there would already be gone by the time
+ * beforeSend asks.
+ */
+const prefetchedAt = new Map<string, number>();
+
+/**
+ * How long a prefetch stays attributable. Longer than any request that is still in
+ * flight, short enough that a genuine failure minutes later is still reported.
+ */
+const ATTRIBUTION_WINDOW_MS = 60_000;
+
+export function trackPrefetchedUrls(): () => void {
+    return router.on('prefetching', (event) => {
+        prefetchedAt.set(event.detail.visit.url.href, Date.now());
+    });
+}
+
+export function wasPrefetched(url: string): boolean {
+    const at = prefetchedAt.get(url);
+
+    if (at === undefined) {
+        return false;
+    }
+
+    if (Date.now() - at > ATTRIBUTION_WINDOW_MS) {
+        prefetchedAt.delete(url);
+
+        return false;
+    }
+
+    return true;
+}

--- a/resources/js/lib/prefetch-tracker.ts
+++ b/resources/js/lib/prefetch-tracker.ts
@@ -1,32 +1,59 @@
 import { router } from '@inertiajs/react';
 
 /**
- * Remembers which URLs we speculatively fetched, so a failed one can be told apart
- * from a request the user actually asked for.
+ * Remembers which URLs we only speculatively fetched, so a failed one can be told
+ * apart from a request someone was actually waiting for.
  *
- * Every sidebar item is a `<Link prefetch>`, so hovering the nav fires a request for
- * a page nobody has committed to visiting. When one of those fails at the transport
- * level Inertia rejects inside its own prefetch promise — a rejection app code cannot
- * reach, since `preventDefault()` on the networkError event would also skip the
- * `onPrefetchError` cleanup that keeps the URL prefetchable. So the only place left
- * to recognise it is Sentry's beforeSend, and that needs to know it was a guess.
+ * Every sidebar item is a `<Link prefetch>`, so hovering the nav fetches a page
+ * nobody has committed to visiting. When one of those fails at the transport level
+ * the rejection is unreachable from app code: it is discarded inside Inertia, and
+ * `preventDefault()` on the networkError event would skip `onPrefetchError` — which
+ * is the call that removes the dead entry from `inFlightRequests`. Without it a
+ * later real click resolves the cache to that entry and awaits a promise that can
+ * never settle, so the click hangs with the progress bar up. Recognising it in
+ * Sentry's beforeSend is what is left, and that needs to know it was a guess.
  *
- * Kept by timestamp rather than cleared on completion: `finish` fires before the
- * rejection is captured, so anything cleared there would already be gone by the time
- * beforeSend asks.
+ * Kept by timestamp rather than cleared on completion, because `finish` fires on the
+ * rejecting chain before the unhandled rejection is captured — anything cleared
+ * there would already be gone by the time beforeSend asks.
  */
 const prefetchedAt = new Map<string, number>();
 
 /**
- * How long a prefetch stays attributable. Longer than any request that is still in
- * flight, short enough that a genuine failure minutes later is still reported.
+ * Backstop for a prefetch nobody ever asked for afterwards. Matched to Inertia's own
+ * `cacheFor` default: past that a successful prefetch has been evicted, so a click
+ * issues a fresh request and its failure is the user's, not ours to explain away.
+ * Inertia sets no XHR timeout, so a hung request can still fail after this and be
+ * reported - which is the safe direction to be wrong in.
  */
-const ATTRIBUTION_WINDOW_MS = 60_000;
+const ATTRIBUTION_WINDOW_MS = 30_000;
 
-export function trackPrefetchedUrls(): () => void {
-    return router.on('prefetching', (event) => {
-        prefetchedAt.set(event.detail.visit.url.href, Date.now());
+export function trackPrefetchedUrls(): void {
+    router.on('prefetching', (event) => {
+        prefetchedAt.set(requestKey(event.detail.visit.url), Date.now());
     });
+
+    // The moment someone asks for the page themselves, its failure is theirs and not
+    // a guess - including when they click while our prefetch is still in flight,
+    // which is the common case: Inertia hands them that same request and shows the
+    // progress bar, so they are visibly waiting on it. This also keeps the map
+    // bounded, rather than relying on the window above.
+    router.on('before', (event) => {
+        if (!event.detail.visit.prefetch) {
+            prefetchedAt.delete(requestKey(event.detail.visit.url));
+        }
+    });
+}
+
+/**
+ * Inertia strips the fragment before sending, so the URL in the error never carries
+ * one and the key must not either.
+ */
+function requestKey(url: URL): string {
+    const withoutHash = new URL(url.href);
+    withoutHash.hash = '';
+
+    return withoutHash.href;
 }
 
 export function wasPrefetched(url: string): boolean {

--- a/resources/js/lib/sentry.test.ts
+++ b/resources/js/lib/sentry.test.ts
@@ -401,7 +401,7 @@ describe('isBrowserExtensionNoise', () => {
 });
 
 describe('isFailedPrefetchNoise', () => {
-    async function freshModules() {
+    async function freshModulesWithFakedRouter() {
         vi.resetModules();
         const listeners: Record<string, (e: unknown) => void> = {};
         vi.doMock('@inertiajs/react', () => ({
@@ -421,6 +421,11 @@ describe('isFailedPrefetchNoise', () => {
         return { ...tracker, ...sentry, listeners };
     }
 
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.doUnmock('@inertiajs/react');
+    });
+
     function networkError(url: string): Event {
         return {
             exception: {
@@ -435,7 +440,8 @@ describe('isFailedPrefetchNoise', () => {
     }
 
     it('drops the failure of a page we only guessed at', async () => {
-        const { isFailedPrefetchNoise, listeners } = await freshModules();
+        const { isFailedPrefetchNoise, listeners } =
+            await freshModulesWithFakedRouter();
 
         // Hovering the sidebar prefetches Cashflow from whatever page you are on.
         listeners.prefetching?.({
@@ -452,7 +458,7 @@ describe('isFailedPrefetchNoise', () => {
     });
 
     it('keeps the failure of a navigation someone was waiting for', async () => {
-        const { isFailedPrefetchNoise } = await freshModules();
+        const { isFailedPrefetchNoise } = await freshModulesWithFakedRouter();
 
         // Never prefetched, so this is a click that went nowhere - the case the
         // suppression must not swallow.
@@ -464,7 +470,8 @@ describe('isFailedPrefetchNoise', () => {
     });
 
     it('stops attributing a prefetch once its window has passed', async () => {
-        const { isFailedPrefetchNoise, listeners } = await freshModules();
+        const { isFailedPrefetchNoise, listeners } =
+            await freshModulesWithFakedRouter();
 
         listeners.prefetching?.({
             detail: {
@@ -482,7 +489,7 @@ describe('isFailedPrefetchNoise', () => {
     });
 
     it('keeps a network error that is not Inertia-shaped', async () => {
-        const { isFailedPrefetchNoise } = await freshModules();
+        const { isFailedPrefetchNoise } = await freshModulesWithFakedRouter();
 
         expect(
             isFailedPrefetchNoise({
@@ -491,5 +498,58 @@ describe('isFailedPrefetchNoise', () => {
                 },
             }),
         ).toBe(false);
+    });
+
+    it('keeps the failure of a click that landed on our in-flight prefetch', async () => {
+        const { isFailedPrefetchNoise, listeners } =
+            await freshModulesWithFakedRouter();
+
+        listeners.prefetching?.({
+            detail: {
+                visit: { url: new URL('https://whisper.money/cashflow') },
+            },
+        });
+
+        // Clicking while the prefetch is still in flight hands the user that same
+        // request, progress bar and all - so from here its failure is theirs.
+        listeners.before?.({
+            detail: {
+                visit: {
+                    url: new URL('https://whisper.money/cashflow'),
+                    prefetch: false,
+                },
+            },
+        });
+
+        expect(
+            isFailedPrefetchNoise(
+                networkError('https://whisper.money/cashflow'),
+            ),
+        ).toBe(false);
+    });
+
+    it('still ignores a prefetch that starts while another page is loading', async () => {
+        const { isFailedPrefetchNoise, listeners } =
+            await freshModulesWithFakedRouter();
+
+        listeners.before?.({
+            detail: {
+                visit: {
+                    url: new URL('https://whisper.money/budgets'),
+                    prefetch: false,
+                },
+            },
+        });
+        listeners.prefetching?.({
+            detail: {
+                visit: { url: new URL('https://whisper.money/cashflow') },
+            },
+        });
+
+        expect(
+            isFailedPrefetchNoise(
+                networkError('https://whisper.money/cashflow'),
+            ),
+        ).toBe(true);
     });
 });

--- a/resources/js/lib/sentry.test.ts
+++ b/resources/js/lib/sentry.test.ts
@@ -399,3 +399,97 @@ describe('isBrowserExtensionNoise', () => {
         expect(isBrowserExtensionNoise(event)).toBe(false);
     });
 });
+
+describe('isFailedPrefetchNoise', () => {
+    async function freshModules() {
+        vi.resetModules();
+        const listeners: Record<string, (e: unknown) => void> = {};
+        vi.doMock('@inertiajs/react', () => ({
+            router: {
+                on: (name: string, cb: (e: unknown) => void) => {
+                    listeners[name] = cb;
+
+                    return () => delete listeners[name];
+                },
+            },
+        }));
+
+        const tracker = await import('./prefetch-tracker');
+        const sentry = await import('./sentry');
+        tracker.trackPrefetchedUrls();
+
+        return { ...tracker, ...sentry, listeners };
+    }
+
+    function networkError(url: string): Event {
+        return {
+            exception: {
+                values: [
+                    {
+                        type: 'HttpNetworkError',
+                        value: `Network error (${url})`,
+                    },
+                ],
+            },
+        };
+    }
+
+    it('drops the failure of a page we only guessed at', async () => {
+        const { isFailedPrefetchNoise, listeners } = await freshModules();
+
+        // Hovering the sidebar prefetches Cashflow from whatever page you are on.
+        listeners.prefetching?.({
+            detail: {
+                visit: { url: new URL('https://whisper.money/cashflow') },
+            },
+        });
+
+        expect(
+            isFailedPrefetchNoise(
+                networkError('https://whisper.money/cashflow'),
+            ),
+        ).toBe(true);
+    });
+
+    it('keeps the failure of a navigation someone was waiting for', async () => {
+        const { isFailedPrefetchNoise } = await freshModules();
+
+        // Never prefetched, so this is a click that went nowhere - the case the
+        // suppression must not swallow.
+        expect(
+            isFailedPrefetchNoise(
+                networkError('https://whisper.money/budgets'),
+            ),
+        ).toBe(false);
+    });
+
+    it('stops attributing a prefetch once its window has passed', async () => {
+        const { isFailedPrefetchNoise, listeners } = await freshModules();
+
+        listeners.prefetching?.({
+            detail: {
+                visit: { url: new URL('https://whisper.money/cashflow') },
+            },
+        });
+
+        vi.setSystemTime(Date.now() + 61_000);
+
+        expect(
+            isFailedPrefetchNoise(
+                networkError('https://whisper.money/cashflow'),
+            ),
+        ).toBe(false);
+    });
+
+    it('keeps a network error that is not Inertia-shaped', async () => {
+        const { isFailedPrefetchNoise } = await freshModules();
+
+        expect(
+            isFailedPrefetchNoise({
+                exception: {
+                    values: [{ type: 'AxiosError', value: 'Network Error' }],
+                },
+            }),
+        ).toBe(false);
+    });
+});

--- a/resources/js/lib/sentry.ts
+++ b/resources/js/lib/sentry.ts
@@ -1,6 +1,7 @@
 import type { Event } from '@sentry/react';
 import { isChunkLoadError } from './chunk-load-recovery';
 import { isLeavingPage } from './leave-page';
+import { wasPrefetched } from './prefetch-tracker';
 
 const CLONE_ERROR_MESSAGE_PATTERN =
     /object (can not|could not|couldn't|can't) be cloned/i;
@@ -13,6 +14,9 @@ const CLONE_ERROR_MESSAGE_PATTERN =
 // `Network error (https://whisper.money/onboarding)`. Matching that tail
 // explicitly rather than loosening to a prefix keeps "Failed to fetch
 // dynamically imported module: …" out — that is a chunk load, not an abort.
+// Inertia's own wrapper appends the request URL, which is the only place the failed
+// URL survives to beforeSend.
+const INERTIA_NETWORK_ERROR_PATTERN = /^network error \((.+)\)$/i;
 const ABORTED_REQUEST_MESSAGE_PATTERN =
     /^(network error|request aborted|failed to fetch|load failed)( \(.+\))?$/i;
 const FACEBOOK_IAB_JAVA_OBJECT_GONE_PATTERN =
@@ -109,6 +113,27 @@ export function isPageLeaveAbortNoise(event: Event): boolean {
         event.exception?.values?.some((exception) =>
             ABORTED_REQUEST_MESSAGE_PATTERN.test(exception.value ?? ''),
         ) ?? false
+    );
+}
+
+/**
+ * A speculative request that failed.
+ *
+ * Every sidebar item is a `<Link prefetch>`, so hovering the nav fetches a page the
+ * user has not committed to. When one fails there is nothing to fix and nothing the
+ * user notices - the next real click just makes a real request, and Inertia has
+ * already dropped the dead entry so the click is not wedged. Reporting it buries the
+ * navigations that genuinely failed on someone who was waiting for one.
+ */
+export function isFailedPrefetchNoise(event: Event): boolean {
+    return (
+        event.exception?.values?.some((exception) => {
+            const failedUrl = INERTIA_NETWORK_ERROR_PATTERN.exec(
+                exception.value ?? '',
+            )?.[1];
+
+            return failedUrl !== undefined && wasPrefetched(failedUrl);
+        }) ?? false
     );
 }
 

--- a/resources/js/lib/sentry.ts
+++ b/resources/js/lib/sentry.ts
@@ -14,11 +14,14 @@ const CLONE_ERROR_MESSAGE_PATTERN =
 // `Network error (https://whisper.money/onboarding)`. Matching that tail
 // explicitly rather than loosening to a prefix keeps "Failed to fetch
 // dynamically imported module: …" out — that is a chunk load, not an abort.
-// Inertia's own wrapper appends the request URL, which is the only place the failed
-// URL survives to beforeSend.
-const INERTIA_NETWORK_ERROR_PATTERN = /^network error \((.+)\)$/i;
 const ABORTED_REQUEST_MESSAGE_PATTERN =
     /^(network error|request aborted|failed to fetch|load failed)( \(.+\))?$/i;
+// A strict subset of the pattern above, capturing the URL rather than just allowing
+// it: that tail is the only place the *failed* request's URL survives as far as
+// beforeSend, since Sentry's `url` tag is the page the user was on. Depends on
+// Inertia's internal message format, which has no stability contract — if it changes,
+// this stops matching and the noise comes back, which is the safe direction.
+const INERTIA_NETWORK_ERROR_PATTERN = /^network error \((.+)\)$/i;
 const FACEBOOK_IAB_JAVA_OBJECT_GONE_PATTERN =
     /Error invoking .+: Java object is gone/i;
 const SAFARI_CASHBACK_EXTENSION_PATTERN = /response\.cashbackReminder/i;


### PR DESCRIPTION
> Sentry came back after five days. First thing I did was collect on the prediction in #780: the old `AxiosError` issue is gone from the queue, and what replaced it has the Inertia v3 shape and is **not** suppressed — because those users were *on* the page, not leaving it. The gate discriminates, which was the failure mode to rule out.

## What the issue actually is

`PHP-LARAVEL-5C` — 7 users, 9 events, 4 days, plus a 1-event twin. **It groups by stacktrace (`culprit: s.onerror`), not by message**, so the title is only the newest event. Its nine events carry **eight different failing URLs**:

| failing request | prefetched? |
|---|---|
| `/cashflow`, `/dashboard`, `/budgets` ×2, `/transactions` | yes — sidebar `<Link prefetch>` |
| `/transactions?category_ids=…` | no — a filter that never applied |
| `/onboarding?step=create-account` ×2 | no — the `usePoll` on the connect step |
| `PATCH /settings/accounts/{uuid}` | no — **a save that silently did not save** |

I had this wrong at first. I read the issue title and the `url` tag (the page the user was on) and concluded "the failed URL is always `/cashflow`". I never checked the failed URL per event. The review did, and it changes the shape of the fix: this branch **thins** the group, it does not silence it.

## Two changes

**1. A failed hover-prefetch is no longer reported.** Every sidebar item is a `<Link prefetch>`, so hovering the nav fetches a page nobody has committed to. Nothing breaks when one fails — Inertia's `onPrefetchError` has already removed the dead in-flight entry, so the next real click is not wedged — but it buries the navigations that genuinely failed on someone who *was* waiting.

That rejection is unreachable from app code, and the reason matters more than I first wrote: `preventDefault()` on `networkError` runs *before* `onPrefetchError`, so silencing it there would leave the in-flight entry forever, and a later click would resolve the cache to a promise that can never settle — hanging with the progress bar up. So recognition goes to `beforeSend`, alongside five existing noise predicates, and `prefetch-tracker` supplies the one fact it needs.

**2. A navigation or save that dies on the network now tells the user.** Inertia just stops: progress bar retracts, `processing` clears, nothing else. I had left this out because I could not tell a prefetch from a click where the error surfaces — but the tracker built for (1) *is* that missing fact. So the blocker was mine. Requests nobody asked for stay silent; everything else gets a toast.

## The correction that mattered most

My first version would have dropped a real dead click, and one is in this very issue. Event `6c13e2e6`: hover-prefetch of `/budgets` at 16:03:06, then at 16:03:41 a click on a **breadcrumb** link — plain `<Link>`, no prefetch — that failed 82 ms later and went nowhere. Thirty-six seconds after the prefetch: inside my 60-second window.

Two things fix it. Inertia fires `before` with `visit.prefetch` ahead of sending anything, including ahead of adopting an in-flight prefetch, so a URL stops being attributable the moment someone asks for it themselves. That also covers the common case — hover delay is 75 ms, so almost every deliberate sidebar click is preceded by a prefetch of the same URL, and Inertia hands the click that same request while the user watches the progress bar. And the window drops to 30 s to match Inertia's own `cacheFor`: past that a successful prefetch is already evicted, so the 30–60 s band was pure false suppression.

Untracking on `before` also bounds the map by construction rather than by a timer, which matters the day someone puts `prefetch` on a per-row link.

## Verification

381/381 JS tests, `lint`, `dry` and `build` green. The behavioural cases each have a test that fails without their mechanism: prefetch suppressed, real navigation still reported, hover-then-click still reported, window expiry, and a prefetch starting mid-navigation still ignored. The tests no longer leave a frozen clock or a module mock behind for the rest of the file.

## Follow-ups worth their own PRs

Two came out of the review and are unrelated to this change, but both are cheap and measured:

- **`/cashflow` ships ~415 KB of JSON nobody reads.** `CashflowController` passes `categories`, `accounts` and `banks`; the page reads only `auth`, `period`, `periodType`, and no layout or child reads them either. `Bank::availableForUser` returns every global bank — 2387 rows, measured on prod. It also **double-fetches**: a mount-time `router.visit` appends `?period=…`, so every open loads the page twice.
- **~430 KB of vitest ships in the production bundle** (115 KB gzip). `import.meta.glob('./pages/**/*.tsx')` matches `pages/settings/billing.test.tsx` and `connections.test.tsx`. Narrowing the glob or moving those two files fixes it for every user.

Also noted and not done: `prefetch="click"` would remove this whole ambiguity, but it must not be adopted while this filter exists as written — in click mode the prefetch *is* the user's committed action, so every failure would be suppressed.

## Auto-merge

Enabled. Change (1) only stops reporting, and its one risky path — attributing a real click to an earlier guess — is closed by the `before` signal and pinned by a test built from the actual production event that exposed it. Change (2) is additive: a toast where the app previously said nothing, with no `preventDefault()` so every Inertia cleanup path is untouched.
