### PR TITLE
perf(cashflow): stop shipping 448KB of banks twice, and keep the page tests out of the bundle

### DIFF
--- a/app/Http/Controllers/CashflowController.php
+++ b/app/Http/Controllers/CashflowController.php
@@ -2,9 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Account;
-use App\Models\Bank;
-use App\Models\Category;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -13,24 +10,6 @@ class CashflowController extends Controller
 {
     public function __invoke(Request $request): Response
     {
-        $user = $request->user();
-
-        $categories = Category::query()
-            ->where('user_id', $user->id)
-            ->forDisplay()
-            ->get();
-
-        $accounts = Account::query()
-            ->where('user_id', $user->id)
-            ->with('bank')
-            ->orderBy('name')
-            ->get();
-
-        $banks = Bank::query()
-            ->availableForUser($user)
-            ->orderBy('name')
-            ->get();
-
         $periodType = $request->query('period_type');
         $validPeriodType = is_string($periodType) && in_array($periodType, ['month', 'quarter', 'year'], true)
             ? $periodType
@@ -39,10 +18,11 @@ class CashflowController extends Controller
         $period = $request->query('period');
         $validPeriod = $this->validPeriod($period, $validPeriodType);
 
+        // This used to also send categories, accounts and banks. HandleInertiaRequests
+        // already shares all three on every response, and page props win the merge, so
+        // the only thing the controller's copies did was replace them - with a `banks`
+        // that was every *global* bank rather than the user's own.
         return Inertia::render('cashflow/index', [
-            'categories' => $categories,
-            'accounts' => $accounts,
-            'banks' => $banks,
             'period' => $validPeriod,
             'periodType' => $validPeriodType,
         ]);

--- a/app/Http/Controllers/CashflowController.php
+++ b/app/Http/Controllers/CashflowController.php
@@ -18,10 +18,7 @@ class CashflowController extends Controller
         $period = $request->query('period');
         $validPeriod = $this->validPeriod($period, $validPeriodType);
 
-        // This used to also send categories, accounts and banks. HandleInertiaRequests
-        // already shares all three on every response, and page props win the merge, so
-        // the only thing the controller's copies did was replace them - with a `banks`
-        // that was every *global* bank rather than the user's own.
+        // categories, accounts and banks arrive via HandleInertiaRequests::share().
         return Inertia::render('cashflow/index', [
             'period' => $validPeriod,
             'periodType' => $validPeriodType,

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -183,9 +183,13 @@ createInertiaApp({
     resolve: (name) =>
         resolvePageComponent(
             `./pages/${name}.tsx`,
-            import.meta.glob<{ default: ResolvedComponent }>(
+            // Excluding the tests that live next to their pages: without it Vite
+            // treats each one as a page entry and bundles what it imports, which
+            // put four test chunks and 430KB of vitest into the production build.
+            import.meta.glob<{ default: ResolvedComponent }>([
                 './pages/**/*.tsx',
-            ),
+                '!./pages/**/*.test.tsx',
+            ]),
         ).then((module) => module.default),
     setup({ el, App, props }) {
         const root = createRoot(el);

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -185,7 +185,7 @@ createInertiaApp({
             `./pages/${name}.tsx`,
             // Excluding the tests that live next to their pages: without it Vite
             // treats each one as a page entry and bundles what it imports, which
-            // put four test chunks and 430KB of vitest into the production build.
+            // pulls vitest into the production build.
             import.meta.glob<{ default: ResolvedComponent }>([
                 './pages/**/*.tsx',
                 '!./pages/**/*.test.tsx',

--- a/resources/js/hooks/use-period-url-sync.test.ts
+++ b/resources/js/hooks/use-period-url-sync.test.ts
@@ -1,0 +1,91 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ replace: vi.fn() }));
+
+vi.mock('@inertiajs/react', () => ({
+    router: { replace: mocks.replace },
+}));
+
+vi.mock('@/routes', () => ({
+    cashflow: ({ query }: { query: Record<string, string> }) => ({
+        url: `/cashflow?period=${query.period}&period_type=${query.period_type}`,
+    }),
+}));
+
+const { usePeriodUrlSync } = await import('./use-period-url-sync');
+
+describe('usePeriodUrlSync', () => {
+    beforeEach(() => {
+        mocks.replace.mockClear();
+    });
+
+    it('writes the period into the URL without asking the server', () => {
+        renderHook(() =>
+            usePeriodUrlSync(new Date('2026-08-17'), 'month', null, 'month'),
+        );
+
+        expect(mocks.replace).toHaveBeenCalledOnce();
+
+        const [params] = mocks.replace.mock.calls[0];
+        expect(params.url).toBe('/cashflow?period=2026-08&period_type=month');
+        // Both are load-bearing: the props callback is what makes the guard go false
+        // on the next render, and preserveState defaults to false for a client-side
+        // visit, which would remount the page and reset the period that drove us here.
+        expect(params.preserveState).toBe(true);
+        expect(typeof params.props).toBe('function');
+    });
+
+    it('leaves the URL alone once it already carries the period', () => {
+        renderHook(() =>
+            usePeriodUrlSync(
+                new Date('2026-08-17'),
+                'month',
+                '2026-08',
+                'month',
+            ),
+        );
+
+        expect(mocks.replace).not.toHaveBeenCalled();
+    });
+
+    it('terminates: the props it hands back satisfy its own guard', () => {
+        const { rerender } = renderHook(
+            ({ initialPeriod }: { initialPeriod: string | null }) =>
+                usePeriodUrlSync(
+                    new Date('2026-08-17'),
+                    'month',
+                    initialPeriod,
+                    'month',
+                ),
+            { initialProps: { initialPeriod: null as string | null } },
+        );
+
+        const [params] = mocks.replace.mock.calls[0];
+        const nextProps = params.props({ period: null, periodType: 'month' });
+
+        // Feeding its own output back in is what a re-render does. If this still
+        // fired, the page would loop forever.
+        rerender({ initialPeriod: nextProps.period });
+
+        expect(mocks.replace).toHaveBeenCalledOnce();
+    });
+
+    it('formats quarter and year periods', () => {
+        renderHook(() =>
+            usePeriodUrlSync(
+                new Date('2026-08-17'),
+                'quarter',
+                null,
+                'quarter',
+            ),
+        );
+        expect(mocks.replace.mock.calls[0][0].url).toContain('period=2026-Q3');
+
+        mocks.replace.mockClear();
+        renderHook(() =>
+            usePeriodUrlSync(new Date('2026-08-17'), 'year', null, 'year'),
+        );
+        expect(mocks.replace.mock.calls[0][0].url).toContain('period=2026&');
+    });
+});

--- a/resources/js/hooks/use-period-url-sync.ts
+++ b/resources/js/hooks/use-period-url-sync.ts
@@ -1,0 +1,65 @@
+import { cashflow } from '@/routes';
+import { router } from '@inertiajs/react';
+import { format, getQuarter } from 'date-fns';
+import { useEffect } from 'react';
+
+export type CashflowPeriodType = 'month' | 'quarter' | 'year';
+
+function formatPeriodParam(
+    currentDate: Date,
+    periodType: CashflowPeriodType,
+): string {
+    if (periodType === 'quarter') {
+        return `${format(currentDate, 'yyyy')}-Q${getQuarter(currentDate)}`;
+    }
+
+    if (periodType === 'year') {
+        return format(currentDate, 'yyyy');
+    }
+
+    return format(currentDate, 'yyyy-MM');
+}
+
+/**
+ * Keeps the period the user is looking at in the URL, so a refresh or a shared link
+ * lands on the same one.
+ *
+ * A client-side visit, not a request: the server has nothing to add here. Asking it
+ * re-renders every shared prop — including ~73KB gzipped of translations for the 79%
+ * of users on Spanish — to be told a period we just computed. On a bare /cashflow
+ * `initialPeriod` is null while the formatted param never is, so the guard is always
+ * true on mount: this used to cost a second full page request on every open, and
+ * another on every period change.
+ *
+ * Two arguments are load-bearing. The `props` callback is what makes the guard go
+ * false on the next render; without it this loops forever. And `preserveState` must
+ * stay true, because it defaults to false for a client-side visit and the component
+ * would remount, resetting the very state that drove us here.
+ */
+export function usePeriodUrlSync(
+    currentDate: Date,
+    periodType: CashflowPeriodType,
+    initialPeriod: string | null,
+    initialPeriodType: string,
+): void {
+    useEffect(() => {
+        const periodParam = formatPeriodParam(currentDate, periodType);
+
+        if (initialPeriod === periodParam && initialPeriodType === periodType) {
+            return;
+        }
+
+        router.replace({
+            url: cashflow({
+                query: { period: periodParam, period_type: periodType },
+            }).url,
+            props: (props) => ({
+                ...props,
+                period: periodParam,
+                periodType,
+            }),
+            preserveScroll: true,
+            preserveState: true,
+        });
+    }, [currentDate, initialPeriod, initialPeriodType, periodType]);
+}

--- a/resources/js/pages/cashflow/index.tsx
+++ b/resources/js/pages/cashflow/index.tsx
@@ -6,6 +6,7 @@ import { CashflowTrendChart, SankeyChart } from '@/components/charts';
 import HeadingSmall from '@/components/heading-small';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { CashflowPeriodType, useCashflowData } from '@/hooks/use-cashflow-data';
+import { usePeriodUrlSync } from '@/hooks/use-period-url-sync';
 import AppSidebarLayout from '@/layouts/app/app-sidebar-layout';
 import { cashflow } from '@/routes';
 import { BreadcrumbItem } from '@/types';

--- a/resources/js/pages/cashflow/index.tsx
+++ b/resources/js/pages/cashflow/index.tsx
@@ -10,19 +10,17 @@ import AppSidebarLayout from '@/layouts/app/app-sidebar-layout';
 import { cashflow } from '@/routes';
 import { BreadcrumbItem } from '@/types';
 import { __ } from '@/utils/i18n';
-import { Head, router, usePage } from '@inertiajs/react';
+import { Head, usePage } from '@inertiajs/react';
 import {
     endOfMonth,
     endOfQuarter,
     endOfYear,
-    format,
-    getQuarter,
     parse,
     startOfMonth,
     startOfQuarter,
     startOfYear,
 } from 'date-fns';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
@@ -92,21 +90,6 @@ function getPeriodRange(
     };
 }
 
-function formatPeriodParam(
-    currentDate: Date,
-    periodType: CashflowPeriodType,
-): string {
-    if (periodType === 'quarter') {
-        return `${format(currentDate, 'yyyy')}-Q${getQuarter(currentDate)}`;
-    }
-
-    if (periodType === 'year') {
-        return format(currentDate, 'yyyy');
-    }
-
-    return format(currentDate, 'yyyy-MM');
-}
-
 export default function CashflowPage() {
     const {
         auth,
@@ -144,29 +127,7 @@ export default function CashflowPage() {
         periodType,
     });
 
-    useEffect(() => {
-        const periodParam = formatPeriodParam(currentDate, periodType);
-
-        if (initialPeriod !== periodParam || initialPeriodType !== periodType) {
-            // A client-side visit: this effect only exists to put the period in the
-            // URL so a refresh or a shared link keeps it. Asking the server would
-            // re-render every shared prop for an answer we already have - and on a
-            // bare /cashflow the guard is always true, so that was a second full
-            // request on every open and on every period change.
-            router.replace({
-                url: cashflow({
-                    query: { period: periodParam, period_type: periodType },
-                }).url,
-                props: (props) => ({
-                    ...props,
-                    period: periodParam,
-                    periodType,
-                }),
-                preserveScroll: true,
-                preserveState: true,
-            });
-        }
-    }, [currentDate, initialPeriod, initialPeriodType, periodType]);
+    usePeriodUrlSync(currentDate, periodType, initialPeriod, initialPeriodType);
 
     return (
         <AppSidebarLayout breadcrumbs={breadcrumbs}>

--- a/resources/js/pages/cashflow/index.tsx
+++ b/resources/js/pages/cashflow/index.tsx
@@ -148,16 +148,23 @@ export default function CashflowPage() {
         const periodParam = formatPeriodParam(currentDate, periodType);
 
         if (initialPeriod !== periodParam || initialPeriodType !== periodType) {
-            router.visit(
-                cashflow({
+            // A client-side visit: this effect only exists to put the period in the
+            // URL so a refresh or a shared link keeps it. Asking the server would
+            // re-render every shared prop for an answer we already have - and on a
+            // bare /cashflow the guard is always true, so that was a second full
+            // request on every open and on every period change.
+            router.replace({
+                url: cashflow({
                     query: { period: periodParam, period_type: periodType },
                 }).url,
-                {
-                    preserveScroll: true,
-                    preserveState: true,
-                    replace: true,
-                },
-            );
+                props: (props) => ({
+                    ...props,
+                    period: periodParam,
+                    periodType,
+                }),
+                preserveScroll: true,
+                preserveState: true,
+            });
         }
     }, [currentDate, initialPeriod, initialPeriodType, periodType]);
 

--- a/resources/js/ssr.tsx
+++ b/resources/js/ssr.tsx
@@ -17,9 +17,11 @@ createServer((page) =>
         resolve: (name) =>
             resolvePageComponent(
                 `./pages/${name}.tsx`,
-                import.meta.glob<{ default: ResolvedComponent }>(
+                // See app.tsx: keeps the page tests out of the bundle.
+                import.meta.glob<{ default: ResolvedComponent }>([
                     './pages/**/*.tsx',
-                ),
+                    '!./pages/**/*.test.tsx',
+                ]),
             ).then((module) => module.default),
         setup: ({ App, props }) => {
             const initialPageProps = props.initialPage?.props as


### PR DESCRIPTION
> Sentry's queue is down to the two prefetch issues #800 addresses, with no events since it deployed. So this cycle went after two measured pieces of waste from the previous review. Both were real; one was **smaller** than advertised and one was **bigger**, and I have corrected both figures below.

## 1. Cashflow was replacing its shared props with a heavier copy

`CashflowController` sent `categories`, `accounts` and `banks`. Deleting them is not a removal: `HandleInertiaRequests` already shares all three on every authenticated response as plain closures — always resolved, always sent — and props merge as `array_merge(shared, page)`, so the page's copy wins. The controller's only effect was to **replace** the shared versions.

That mattered for one of them:

| | rows | JSON | gzipped |
|---|---|---|---|
| controller's `banks` (`Bank::availableForUser`) | 2387 (every global bank) | **448 KB** | **83 KB** |
| shared `banks` (`$user->banks()`) | 1960 across 4127 users = 0.47 each | ~nil | ~nil |

And the page fetched itself twice per visit, so an open shipped it twice — ~166 KB gzipped, and on a cold hit escaped into `data-page` in the document body ahead of first paint.

The page reads only `auth`/`period`/`periodType` and charts everything from the cashflow API endpoints, so nothing consumed the difference. The controller is now just period parsing.

**I had this wrong twice and both corrections came from review.** First I described it as removing props the page never read — it doesn't remove them, and the win is the payload's *size*. Then I kept `categories` on the grounds that `CashflowAnalyticsTest` pins `has('categories', 2)` and that removing it needed a human call; the shared closure is `$user->categories()->forDisplay()->get()`, the same query the controller ran, so the assertion holds either way.

## 2. The second request per visit is gone

The mount effect exists only to put the period in the URL so a refresh or a shared link keeps it. It used `router.visit`, and on a bare `/cashflow` `initialPeriod` is null while `formatPeriodParam` always returns a string — so the guard was always true and every open, **plus every period-arrow click**, cost a full second page request. `router.replace` is a client-side visit: URL and props update without touching the server, and the guard still terminates because it compares against those same props.

I had left this alone reasoning the second request was cheap once the bank list was gone. It is not: shared props carry `translations`, **264 KB raw / 73 KB gzipped** of `lang/es.json`, and 3269 of 4127 users are `es`. That, not the banks, was what the second request was really paying for.

## 3. The page tests are out of the production bundle

`import.meta.glob('./pages/**/*.tsx')` matched the four tests that live beside their pages, so Vite treated each as a page entry: the client build carried `billing.test`, `connections.test`, `login.test`, `Show.test` and `vi.DgezovHB-DbGNK21D.js` at **429,791 bytes** — the fourth-largest asset.

**Smaller than it sounds, and I want that on the record**: no user downloads it. Page chunks are lazy, every `Inertia::render()` names a literal page, and Laravel's Vite helper preloads only static imports so glob chunks are skipped. It is deploy weight plus a production artifact that names a devDependency. It is also insurance — `Vite::prefetch()` walks the entry's dynamic imports recursively, so the day anyone enables it users *would* download all of it.

Verified in Vite's implementation rather than assumed: it splits the glob array into affirmed and negated (`!`-prefixed, stripped) and matches `affirmed(file) && !negated(file)`.

## Why this is a draft, precisely

**Neither the production build nor the PHP suite could run locally.** A `composer run dev` has been up for ~8 hours and the Vite config's wayfinder plugin leaves `php artisan wayfinder:generate --with-form` hanging at 0% CPU, which stalls every local `bun run build`; the Pest suite times out on testcontainer contention, and `CashflowPageTest` fails **7 of 8 on clean main** anyway with `StrayRequestException` against `__inertia_ssr` on port 5173 — the dev server holds that port without serving SSR. I established that baseline, so the failures are not mine, but it means I could not positively confirm the tests pass either.

What I did verify: `pint`, `eslint` and `prettier` clean; the shared-prop equivalence read directly out of `HandleInertiaRequests`; Vite's negation semantics read out of its source; and the 429,791-byte figure observed in `public/build/assets` before the change.

**Also unreviewed:** change 2 (`router.replace`) was written after the review agents were launched, so no reviewer has seen it. It is the only behaviour change here — everything else is payload — and it touches URL/history handling, which is worth a look.

CI runs both `bun run build` and the full Pest suite as checks, so it is the real gate.

## Follow-up worth more than this PR

The same 448 KB global bank list still ships to **`transactions/index`**, `transactions/categorize` and `budgets/show` — the highest-traffic pages in the app. Every consumer uses it only as an id→bank lookup for a bank that is already embedded in the account (`accounts` is loaded `with('bank')`), e.g. `banks.find((b) => b.id === account.bank!.id)` in `category-cell.tsx`, `edit-transaction-dialog.tsx` and `use-categorize-transactions.ts`. Keying off `account.bank` instead removes it. That also fixes a latent bug: `pages/Accounts/Show.tsx` takes `banks` from shared props only, so after editing a transaction there any global bank's logo and name disappear until reload.

Beyond that, `translations` at 73 KB gzipped on every response for 79% of users is the systemic one; Inertia v3's `OnceProp` is built for exactly that.
