### PR TITLE
feat(banking): tell users to opt out of Coinbase's IP allowlist

### DIFF
--- a/app/Http/Controllers/OpenBanking/CoinbaseController.php
+++ b/app/Http/Controllers/OpenBanking/CoinbaseController.php
@@ -43,6 +43,6 @@ class CoinbaseController extends CryptoPortfolioConnectController
 
     protected function credentialErrorMessage(\Throwable $e): string
     {
-        return 'Invalid API credentials or failed to connect to Coinbase.';
+        return 'Invalid API credentials or failed to connect to Coinbase. Use a view-only key with "Opt-out of IP allowlisting" ticked.';
     }
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -1774,7 +1774,7 @@
     "Use a negative value for expenses (e.g. -21.99) and a positive value for income.": "Usa un valor negativo para gastos (ej. -21,99) y un valor positivo para ingresos.",
     "Use a strong password (minimum 12 characters). This password will encrypt your data.": "Usa una contraseña fuerte (mínimo 12 caracteres). Esta contraseña encriptará tus datos.",
     "Use a strong password (minimum 12 characters). This\\n                            password will encrypt your data.": "Usa una contraseña segura (mínimo 12 caracteres). Esta contraseña cifrará tus datos.",
-    "Use a view-only key.": "Usa una clave de solo lectura.",
+    "Use a view-only key, and tick \"Opt-out of IP allowlisting\" so the key works from our servers.": "Usa una clave de solo lectura y marca «Opt-out of IP allowlisting» para que la clave funcione desde nuestros servidores.",
     "Use code **:code** to get **80% off** your first period (monthly or yearly!)": "Usa el código **:code** para obtener **80% de descuento** en tu primer período (¡mensual o anual!)",
     "Use code **CONTINUE50** to get **50% off** all current and future payments - works for both monthly and yearly subscriptions.": "Usa el código **CONTINUE50** para obtener **50% de descuento** en todos los pagos actuales y futuros, funciona para suscripciones mensuales y anuales.",
     "Use the balance on the latest transaction date as a reference to compute balances for older dates.": "Usa el balance de la fecha de la última transacción como referencia para calcular los balances de fechas anteriores.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1722,7 +1722,7 @@
     "Use a negative value for expenses (e.g. -21.99) and a positive value for income.": "Utilisez une valeur négative pour les dépenses (par exemple -21,99) et une valeur positive pour les revenus.",
     "Use a strong password (minimum 12 characters). This password will encrypt your data.": "Utilisez un mot de passe fort (minimum 12 caractères). Ce mot de passe cryptera vos données.",
     "Use a strong password (minimum 12 characters). This\\n                            password will encrypt your data.": "Utilisez un mot de passe fort (minimum 12 caractères). Ce mot de passe cryptera vos données.",
-    "Use a view-only key.": "Utilisez une clé en lecture seule.",
+    "Use a view-only key, and tick \"Opt-out of IP allowlisting\" so the key works from our servers.": "Utilisez une clé en lecture seule et cochez « Opt-out of IP allowlisting » pour que la clé fonctionne depuis nos serveurs.",
     "Use code **:code** to get **80% off** your first period (monthly or yearly!)": "Utilisez le code **:code** pour bénéficier de **80 % de réduction** sur vos premières règles (mensuelles ou annuelles !)",
     "Use code **CONTINUE50** to get **50% off** all current and future payments - works for both monthly and yearly subscriptions.": "Utilisez le code **CONTINUE50** pour obtenir **50 % de réduction** sur tous les paiements actuels et futurs, fonctionne pour les abonnements mensuels et annuels.",
     "Use the balance on the latest transaction date as a reference to compute balances for older dates.": "Utilisez le solde à partir de la date de la dernière transaction comme référence pour calculer les soldes des dates précédentes.",

--- a/resources/js/lib/connect-providers.test.ts
+++ b/resources/js/lib/connect-providers.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { CONNECT_PROVIDERS } from './connect-providers';
+
+/**
+ * The registry's copy reaches __() through variables, so the Spanish
+ * completeness check in tests/Feature/LocalizationTest.php — which only
+ * extracts literal __('…') arguments from source — never sees any of it. A
+ * provider added or a sentence reworded here would ship untranslated with a
+ * green CI. This closes that gap.
+ */
+const spanish = JSON.parse(readFileSync('lang/es.json', 'utf8')) as Record<
+    string,
+    string
+>;
+
+const copyStrings = CONNECT_PROVIDERS.flatMap((provider) => [
+    provider.headerDescription,
+    provider.cardDescription,
+    provider.help.before,
+    provider.help.link,
+    ...(provider.help.after ? [provider.help.after] : []),
+    ...provider.fields.flatMap((field) => [
+        field.label,
+        ...(field.placeholder ? [field.placeholder] : []),
+    ]),
+]);
+
+describe('connect provider copy', () => {
+    it('is fully translated into Spanish', () => {
+        const missing = copyStrings.filter(
+            (key) => !Object.hasOwn(spanish, key),
+        );
+
+        expect(missing).toEqual([]);
+    });
+});

--- a/resources/js/lib/connect-providers.test.ts
+++ b/resources/js/lib/connect-providers.test.ts
@@ -5,7 +5,7 @@ import { CONNECT_PROVIDERS } from './connect-providers';
 /**
  * The registry's copy reaches __() through variables, so the Spanish
  * completeness check in tests/Feature/LocalizationTest.php — which only
- * extracts literal __('…') arguments from source — never sees any of it. A
+ * extracts string literals passed straight to __() — never sees any of it. A
  * provider added or a sentence reworded here would ship untranslated with a
  * green CI. This closes that gap.
  */

--- a/resources/js/lib/connect-providers.tsx
+++ b/resources/js/lib/connect-providers.tsx
@@ -173,7 +173,7 @@ export const CONNECT_PROVIDERS: ConnectProvider[] = [
             before: 'Create a CDP API key (Ed25519 recommended) in the Coinbase Developer Platform under',
             href: 'https://portal.cdp.coinbase.com/access/api',
             link: 'API Keys',
-            after: 'Use a view-only key.',
+            after: 'Use a view-only key, and tick "Opt-out of IP allowlisting" so the key works from our servers.',
         },
     },
     {
@@ -273,18 +273,25 @@ export function isProviderComplete(
 
 export function ProviderHelp({ help }: { help: ConnectProvider['help'] }) {
     return (
-        <p className="text-xs text-muted-foreground">
-            {__(help.before)}{' '}
-            <a
-                href={help.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="underline"
-            >
-                {__(help.link)}
-            </a>
-            {help.after ? <>. {__(help.after)}</> : '.'}
-        </p>
+        <div className="space-y-1.5">
+            <p className="text-xs text-muted-foreground">
+                {__(help.before)}{' '}
+                <a
+                    href={help.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline"
+                >
+                    {__(help.link)}
+                </a>
+                .
+            </p>
+            {/* Own paragraph, not muted: these are settings the provider's own
+                form gets wrong by default, so they have to survive skimming. */}
+            {help.after && (
+                <p className="text-xs font-medium">{__(help.after)}</p>
+            )}
+        </div>
     );
 }
 

--- a/tests/Feature/OpenBanking/CoinbaseControllerTest.php
+++ b/tests/Feature/OpenBanking/CoinbaseControllerTest.php
@@ -80,7 +80,7 @@ test('invalid coinbase credentials return 422', function () {
     ]);
 
     $response->assertUnprocessable();
-    $response->assertJsonFragment(['message' => 'Invalid API credentials or failed to connect to Coinbase.']);
+    $response->assertJsonFragment(['message' => 'Invalid API credentials or failed to connect to Coinbase. Use a view-only key with "Opt-out of IP allowlisting" ticked.']);
 
     $this->assertDatabaseMissing('banking_connections', [
         'user_id' => $user->id,


### PR DESCRIPTION
Coinbase's CDP key form asks for an **IP allowlist**, and users connecting an
account did not know what to do with it. It is not optional-looking: a key left
pinned to an IP simply never authenticates from our servers, so the ones who
guessed wrong ended up with a key that could not work — and the connect error
then told them their *credentials* were invalid, so they regenerated the key
and hit the identical wall.

Two places now say it, in the same words:

- **The connect help**, next to the App Key ID / Secret inputs — and on its own
  line rather than as the tail clause of the muted sentence, because it is an
  instruction to act on *before* leaving for Coinbase, not background reading.
  Same copy reaches the inline connect flow and the Update Credentials dialog
  for free (one registry, one `ProviderHelp`).
- **The failure message**, for everyone who already created a restricted key:
  `Invalid API credentials or failed to connect to Coinbase. Use a view-only key
  with "Opt-out of IP allowlisting" ticked.`

### On the label

The quoted string is the checkbox as it reads in the CDP portal today. Coinbase's
own docs write it without the hyphen ("Opt out of IP allowlisting"), so if their
form gets reworded this copy needs the same edit — worth knowing before someone
files it as a typo.

The alternative to opting out is allowlisting our egress IP, which would be the
stronger advice for a privacy-first product. Nothing in the repo documents a
stable egress IP, so opt-out is what we can honestly tell users; if the platform
can pin one, this copy should change.

### Test

`resources/js/lib/connect-providers.test.ts` asserts every translatable string
in `CONNECT_PROVIDERS` exists in `lang/es.json`. The registry's copy reaches
`__()` through variables, so `LocalizationTest`'s extractor (literal `__('…')`
only) has never covered any of it: forgetting a Spanish translation here has
always been a green build. It passes today, so it is a ratchet, not a fix.
`lang/fr.json` is short 13 registry strings; French is warning-only by policy,
and the new line is translated there too.

## QA

Real browser run against the dev server, logged in as a throwaway user:
connect dialog → country → Coinbase → the help text renders as its own emphasised
line, light and dark; bogus-but-valid-shaped credentials → the real 422 comes
back carrying the new hint; the flow repeated with the account in Spanish to
confirm the translation renders rather than falling back to English.

## Demo
<img width="1272" height="782" alt="image" src="https://github.com/user-attachments/assets/06f71343-f75d-4cb0-9d1d-55ab8796b1c6" />
