### PR TITLE
docs: stop claiming financial data is encrypted at rest

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 **The most secure way to understand your finances.**
 
-Whisper Money is a privacy-first personal finance application that helps you track, categorize, and understand your spending—without selling, sharing, or mining your financial data. The entire codebase is public, so you don't have to take our word for it.
+Whisper Money is a privacy-first personal finance application that helps you track, categorize, and understand your spending. We don't sell your data and we don't profile you for ads. The entire codebase is public, so you can check exactly where your data goes.
 
 > 🎮 **Try the Demo:** Experience Whisper Money with our [demo account](https://whisper.money/login?demo=1) - no registration required!
 
@@ -26,7 +26,7 @@ Whisper Money is a privacy-first personal finance application that helps you tra
 
 ## Features
 
-- 🔐 **Privacy-first** — Your data is never shared with third parties. You own it
+- 🔐 **Privacy-first** — You own your data and we never sell it. Self-host it and point the AI at a [local model](#ai-provider) to keep it entirely on your own infrastructure
 - 🏦 **Bank account management** — Track multiple accounts in one place
 - 📊 **Transaction categorization** — Automatic and manual categorization
 - 🤖 **Automation rules** — Set up rules to auto-categorize transactions

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 **The most secure way to understand your finances.**
 
-Whisper Money is a privacy-first personal finance application that helps you track, categorize, and understand your spending—all while keeping your financial data encrypted and secure.
+Whisper Money is a privacy-first personal finance application that helps you track, categorize, and understand your spending—without selling, sharing, or mining your financial data. The entire codebase is public, so you don't have to take our word for it.
 
 > 🎮 **Try the Demo:** Experience Whisper Money with our [demo account](https://whisper.money/login?demo=1) - no registration required!
 


### PR DESCRIPTION
## Why

The README opened with a promise the code does not keep:

> ...all while keeping your financial data **encrypted and secure**.

Encryption at rest is no longer part of the model — data is stored in plaintext and the only encryption code left is legacy (`*_iv` columns, `EncryptionKeyProvider`) kept around until production reaches zero encrypted rows. What *is* encrypted is unrelated to "your financial data": bank provider credentials and cookies.

That is a bad claim to leave in a public repo. Our whole privacy pitch is "the code is public, go read it", so the first paragraph a reader sees is the first thing they will check — and it did not hold up.

Reviewing that fix surfaced a second, stronger version of the same problem 11 lines below it:

> 🔐 **Privacy-first** — Your data is never shared with third parties. You own it

That one is contradicted by our own default: `CategorizeTransactions` sends each transaction's description, exact amount and creditor/debtor name to hosted Google Gemini (`AI_PROVIDER=gemini` is the default), with no redaction. The README's own AI Provider section already concedes this by selling Ollama as the option where "data never leaves your infrastructure". Fixing the intro and leaving the bullet would have read as an oversight rather than a correction.

## What changed

Two sentences in `README.md`, narrowed to claims the codebase actually backs:

| Before | After |
| --- | --- |
| ...keeping your financial data **encrypted and secure**. | We don't sell your data and we don't profile you for ads. The entire codebase is public, so you can check exactly where your data goes. |
| Your data is **never shared with third parties**. You own it | You own your data and we never sell it. Self-host it and point the AI at a [local model](#ai-provider) to keep it entirely on your own infrastructure |

No code, routes, commands or UI touched.

## QA

- Rendered both lines through GitHub's GFM markdown API — em dash, apostrophes and the `#ai-provider` anchor all render correctly.
- `bun run format` only globs `resources/`, `bun run dry` only `app/` + `resources/js`, and no markdown/link job exists in CI — so no check validates or rewraps `README.md`.
- Grepped `resources/` and `lang/` for other user-facing encryption claims (see follow-ups below).

## Follow-ups found while reviewing (deliberately out of scope here)

Same class of claim, still live, worth their own PRs:

1. **`onboarding/step-ai-suggestions.tsx:163-170`** — for any bank-connected user, AI consent is auto-POSTed and the consent screen is deliberately never rendered. The code comment justifies it on *cost*, not consent. Highest priority; this one is a compliance exposure, not a copy bug.
2. **`pages/privacy.tsx:184-188`** — the published privacy policy still promises "Encryption at Rest"; production is plain MySQL on an unencrypted volume. Its §5 processor list also omits Gemini, Sentry, PostHog, Resend, Discord and Enable Banking.
3. **`settings/billing.tsx`** contradicts itself in one file: `:64` "never shared with third parties" vs `:345` "we send each transaction's description, amount, and the merchant or sender name to our AI provider".
4. **`mail/verify-email.blade.php:6`** — every new signup is still told they will set up an "encryption key", removed in February.
5. **`welcome.tsx:2245`** — "**Our own AI** categorizes for you" is misleading while the default is Google's hosted API. `:2608` "fully open source" is also wrong for CC BY-NC 4.0.