### PR TITLE
fix(ui): cap the app page width so the dashboard stops stretching on wide screens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
         run: php artisan passport:keys --force
 
       - name: Browser Tests
-        run: ./vendor/bin/pest --testsuite=Browser --ci --shard=${{ matrix.shard }}/6
+        run: ./vendor/bin/pest --testsuite=Browser --ci --shard=${{ matrix.shard }}/5
         env:
           TESTCONTAINERS: false
           DB_CONNECTION: mysql

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -68,6 +68,9 @@
     --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
     --color-sidebar-border: var(--sidebar-border);
     --color-sidebar-ring: var(--sidebar-ring);
+
+    /* Width the app pages are capped to, so they don't stretch on wide screens: max-w-page */
+    --container-page: 80rem;
 }
 
 :root {

--- a/resources/js/components/app-sidebar-header.tsx
+++ b/resources/js/components/app-sidebar-header.tsx
@@ -32,7 +32,10 @@ export function AppSidebarHeader({
     return (
         <header className="flex min-h-16 shrink-0 items-center border-b border-sidebar-border/50 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:min-h-12">
             {/* Padding lives inside the capped row so it lines up with the page content */}
-            <div className="mx-auto flex w-full max-w-page items-center justify-between gap-2 px-5 sm:px-6">
+            <div
+                className="mx-auto flex w-full max-w-page items-center justify-between gap-2 px-5 sm:px-6"
+                data-testid="page-header"
+            >
                 <div className="flex items-center gap-2 sm:hidden">
                     {mobileLeading ?? <AppLogo mobile />}
                 </div>

--- a/resources/js/components/app-sidebar-header.tsx
+++ b/resources/js/components/app-sidebar-header.tsx
@@ -30,9 +30,9 @@ export function AppSidebarHeader({
         (hasEncryptedTransactions || hasEncryptedAccounts);
 
     return (
-        <header className="flex min-h-16 shrink-0 items-center border-b border-sidebar-border/50 px-5 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:min-h-12 sm:px-6 md:px-4">
-            {/* Kept in sync with the content max-width in AppSidebarLayout */}
-            <div className="mx-auto flex w-full max-w-7xl items-center justify-between gap-2">
+        <header className="flex min-h-16 shrink-0 items-center border-b border-sidebar-border/50 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:min-h-12">
+            {/* Padding lives inside the capped row so it lines up with the page content */}
+            <div className="mx-auto flex w-full max-w-page items-center justify-between gap-2 px-5 sm:px-6">
                 <div className="flex items-center gap-2 sm:hidden">
                     {mobileLeading ?? <AppLogo mobile />}
                 </div>

--- a/resources/js/components/app-sidebar-header.tsx
+++ b/resources/js/components/app-sidebar-header.tsx
@@ -30,30 +30,33 @@ export function AppSidebarHeader({
         (hasEncryptedTransactions || hasEncryptedAccounts);
 
     return (
-        <header className="flex min-h-16 shrink-0 items-center justify-between gap-2 border-b border-sidebar-border/50 px-5 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:min-h-12 sm:px-6 md:px-4">
-            <div className="flex items-center gap-2 sm:hidden">
-                {mobileLeading ?? <AppLogo mobile />}
-            </div>
-            <div className="hidden items-center gap-2 sm:flex">
-                <SidebarTrigger className="-ml-1" />
-                <Breadcrumbs breadcrumbs={breadcrumbs} />
-            </div>
-            <div className="flex items-center gap-2">
-                <ImportTransactionsButton />
-                {showEncryptionButton && (
-                    <>
-                        <Separator
-                            orientation="vertical"
-                            className="data-[orientation=vertical]:h-6"
-                        />
-                        <EncryptionKeyButton />
-                    </>
-                )}
-                <Separator
-                    orientation="vertical"
-                    className="data-[orientation=vertical]:h-6 sm:hidden"
-                />
-                <NavUser className="sm:hidden" />
+        <header className="flex min-h-16 shrink-0 items-center border-b border-sidebar-border/50 px-5 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:min-h-12 sm:px-6 md:px-4">
+            {/* Kept in sync with the content max-width in AppSidebarLayout */}
+            <div className="mx-auto flex w-full max-w-7xl items-center justify-between gap-2">
+                <div className="flex items-center gap-2 sm:hidden">
+                    {mobileLeading ?? <AppLogo mobile />}
+                </div>
+                <div className="hidden items-center gap-2 sm:flex">
+                    <SidebarTrigger className="-ml-1" />
+                    <Breadcrumbs breadcrumbs={breadcrumbs} />
+                </div>
+                <div className="flex items-center gap-2">
+                    <ImportTransactionsButton />
+                    {showEncryptionButton && (
+                        <>
+                            <Separator
+                                orientation="vertical"
+                                className="data-[orientation=vertical]:h-6"
+                            />
+                            <EncryptionKeyButton />
+                        </>
+                    )}
+                    <Separator
+                        orientation="vertical"
+                        className="data-[orientation=vertical]:h-6 sm:hidden"
+                    />
+                    <NavUser className="sm:hidden" />
+                </div>
             </div>
         </header>
     );

--- a/resources/js/layouts/app/app-sidebar-layout.tsx
+++ b/resources/js/layouts/app/app-sidebar-layout.tsx
@@ -29,7 +29,12 @@ export default function AppSidebarLayout({
                     breadcrumbs={breadcrumbs}
                     mobileLeading={mobileLeading}
                 />
-                {children}
+                <div
+                    className="mx-auto w-full max-w-7xl"
+                    data-testid="page-content"
+                >
+                    {children}
+                </div>
             </AppContent>
         </AppShell>
     );

--- a/resources/js/layouts/app/app-sidebar-layout.tsx
+++ b/resources/js/layouts/app/app-sidebar-layout.tsx
@@ -30,7 +30,7 @@ export default function AppSidebarLayout({
                     mobileLeading={mobileLeading}
                 />
                 <div
-                    className="mx-auto w-full max-w-7xl"
+                    className="mx-auto flex w-full max-w-page flex-1 flex-col"
                     data-testid="page-content"
                 >
                     {children}

--- a/resources/js/layouts/settings/layout.tsx
+++ b/resources/js/layouts/settings/layout.tsx
@@ -213,7 +213,7 @@ export default function SettingsLayout({ children }: PropsWithChildren) {
     );
 
     return (
-        <div className="px-4 py-6">
+        <div className="p-6">
             <Heading
                 title={__('Settings')}
                 description={__('Manage your profile and account settings')}

--- a/tests/Browser/BudgetsFeatureNavigationTest.php
+++ b/tests/Browser/BudgetsFeatureNavigationTest.php
@@ -126,10 +126,8 @@ test('user cannot access another users budget', function () {
     $user2 = User::factory()->create(['onboarded_at' => now()]);
 
     $category = Category::factory()->create(['user_id' => $user1->id]);
-    $budget = Budget::factory()->create([
-        'user_id' => $user1->id,
-        'category_id' => $category->id,
-    ]);
+    $budget = Budget::factory()->create(['user_id' => $user1->id]);
+    $budget->categories()->attach($category->id);
 
     $response = $this->actingAs($user2)->get("/budgets/{$budget->id}");
 

--- a/tests/Browser/PageWidthTest.php
+++ b/tests/Browser/PageWidthTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+
+it('caps the app content width on wide screens', function () {
+    $user = User::factory()->onboarded()->create();
+
+    actingAs($user);
+
+    $page = visit('/dashboard')->on()->desktop();
+
+    $measures = $page->script(<<<'JS'
+        (() => {
+            const content = document.querySelector('[data-testid="page-content"]');
+
+            return {
+                viewport: window.innerWidth,
+                content: content.getBoundingClientRect().width,
+            };
+        })()
+    JS);
+
+    expect($measures['viewport'])->toBeGreaterThan(1280);
+    expect($measures['content'])->toBeLessThanOrEqual(1280);
+});

--- a/tests/Browser/PageWidthTest.php
+++ b/tests/Browser/PageWidthTest.php
@@ -4,24 +4,35 @@ use App\Models\User;
 
 use function Pest\Laravel\actingAs;
 
-it('caps the app content width on wide screens', function () {
+it('caps the app content width on wide screens and keeps the header aligned', function () {
     $user = User::factory()->onboarded()->create();
 
     actingAs($user);
 
-    $page = visit('/dashboard')->on()->desktop();
+    $page = visit('/dashboard')
+        ->on()
+        ->desktop()
+        ->assertSee('Overview of your financial health');
 
     $measures = $page->script(<<<'JS'
         (() => {
             const content = document.querySelector('[data-testid="page-content"]');
+            const headerRow = document.querySelector('header > div');
 
             return {
-                viewport: window.innerWidth,
+                available: content.parentElement.getBoundingClientRect().width,
                 content: content.getBoundingClientRect().width,
+                contentLeft: content.getBoundingClientRect().left,
+                headerRowLeft: headerRow.getBoundingClientRect().left,
             };
         })()
     JS);
 
-    expect($measures['viewport'])->toBeGreaterThan(1280);
-    expect($measures['content'])->toBeLessThanOrEqual(1280);
+    // Guard: without room to spare the cap would not kick in and the test would prove nothing.
+    expect($measures['available'])->toBeGreaterThan(1280);
+    // 1280px is `--container-page` (80rem), used through the `max-w-page` utility.
+    expect($measures['content'])->toEqualWithDelta(1280, 1);
+    expect($measures['headerRowLeft'])->toEqualWithDelta($measures['contentLeft'], 1);
+
+    $page->assertNoJavascriptErrors();
 });

--- a/tests/Browser/PageWidthTest.php
+++ b/tests/Browser/PageWidthTest.php
@@ -17,7 +17,7 @@ it('caps the app content width on wide screens and keeps the header aligned', fu
     $measures = $page->script(<<<'JS'
         (() => {
             const content = document.querySelector('[data-testid="page-content"]');
-            const headerRow = document.querySelector('header > div');
+            const headerRow = document.querySelector('[data-testid="page-header"]');
 
             return {
                 available: content.parentElement.getBoundingClientRect().width,


### PR DESCRIPTION
On a wide monitor the app pages stretched to the full viewport: the net worth chart, the account cards and the transactions table spread across 1900+ px, which makes them hard to read and looks broken next to the rest of the UI.

## What changed

- `AppSidebarLayout` now wraps the page content in a centred container capped at `max-w-page` (1280px), so every page under the sidebar layout — dashboard, accounts, cashflow, transactions, budgets and settings — stops stretching. Below ~1536px of viewport nothing changes, the cap simply doesn't engage.
- The cap is a Tailwind v4 theme token (`--container-page: 80rem`) instead of a literal class repeated in two files, so the layout and the header row can't drift apart.
- The header row is capped the same way and its horizontal padding moved inside that row, so the breadcrumbs stay lined up with the page heading instead of drifting to the far left of the screen. Note this is a change at **every** desktop width, not only wide ones: the header gutter goes from 16px to 24px on `md+` so it matches the pages' `p-6`.
- Settings pages used a 16px gutter, which would have left their heading 8px off the new header padding — they now use the same `p-6` as the rest of the app pages.

## Drive-by

`browser-tests-matrix` declared five shards but ran `--shard=N/6`, so a sixth of the browser suite (potentially including the test added here) never ran. The split is now `/5`, which is what the matrix actually launches.

That immediately surfaced a test broken on `main`: `BudgetsFeatureNavigationTest` still passed `category_id` to `Budget::factory()`, a column dropped when budget categories moved to a pivot table, so it died with a QueryException. It lived in the shard that never ran. Fixed here to attach through the pivot, otherwise this PR can't go green.

## Tests

`tests/Browser/PageWidthTest.php` measures the rendered layout on a desktop viewport: it asserts there is more than 1280px available (otherwise the cap wouldn't engage and the test would prove nothing), that the content box is exactly 1280px, and that the header row shares its left edge with the content.

## QA

Manually QA'd against the running app on the six pages at 1920x1080, plus 1280x800 and 390x844:

| Screen | Content width | Header aligned | Horizontal overflow |
| --- | --- | --- | --- |
| 1920x1080 (all six pages) | 1280px | yes | no |
| 1280x800 | 1016px (uncapped, unchanged) | yes | no |
| 390x844 | 390px (uncapped, unchanged) | yes | no |

Also checked with the sidebar collapsed (still capped, still aligned), on an account detail page, and with the import drawer open (portalled, unaffected).

## Demo

<!-- PLACEHOLDER: drag dashboard-max-width-qa.mp4 here -->

https://github.com/user-attachments/assets/682a8a6c-a302-4e16-ae1b-8e0fbae7077e

