### PR TITLE
feat(banking): measure bank connection health and alert on the fully broken ones

### DIFF
--- a/app/Console/Commands/BankHealthCommand.php
+++ b/app/Console/Commands/BankHealthCommand.php
@@ -1,0 +1,510 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Console\Commands\Concerns\QueriesBankFailures;
+use App\Enums\BankingConnectionStatus;
+use App\Mail\BankHealthAlertEmail;
+use App\Models\BankingConnection;
+use Carbon\CarbonInterface;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Mail;
+
+/**
+ * How every Enable Banking bank is doing, in one table, and an email for the
+ * ones that are broken for everybody.
+ *
+ * There are two ways a bank fails and the report covers both, because there is
+ * a command to notify the users for each: an authorization that never completes
+ * ({@see NotifyBankConnectFailureCommand}) and connections that used to work and
+ * stopped ({@see NotifyBankOutageCommand}). Which bank is in which state is
+ * decided by those commands' own predicates, shared through
+ * {@see QueriesBankFailures}, so the table cannot claim something different from
+ * the notice it tells the operator to send.
+ *
+ * The metric is internal: nothing here is shown to a user, and the email goes to
+ * REPORT_RECIPIENTS.
+ */
+class BankHealthCommand extends Command
+{
+    use QueriesBankFailures;
+
+    /**
+     * A bank nobody is currently connected to, so the sync half of the report has
+     * nothing to say about it.
+     */
+    private const NO_LIVE_CONNECTIONS = [
+        'live' => 0,
+        'live_users' => 0,
+        'rate_limited' => 0,
+        'syncing' => 0,
+        'failing' => 0,
+        'failing_users' => 0,
+        'newest_sync' => null,
+    ];
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'banking:health
+                            {--email : Also email the owners about the banks that are broken for everyone}
+                            {--repeat-after=7 : Days before the same bank can be alerted about again}
+                            {--stale-hours=48 : Hours without a successful sync before a live connection counts as failing}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Report how every Enable Banking bank is doing, and alert on the ones that are broken for everyone';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $banks = $this->collectBanks();
+
+        if ($banks->isEmpty()) {
+            $this->info('No Enable Banking connection on record.');
+
+            return self::SUCCESS;
+        }
+
+        $this->renderReport($banks);
+
+        if (! $this->option('email')) {
+            return self::SUCCESS;
+        }
+
+        return $this->sendAlert($banks);
+    }
+
+    /**
+     * One row per bank, worst first, with both funnels already summarised.
+     *
+     * @return Collection<int, array<string, mixed>>
+     */
+    private function collectBanks(): Collection
+    {
+        $failures = $this->authorizationFailures();
+        $sync = $this->syncHealth();
+
+        return $this->attempts()
+            ->map(fn (array $bank, string $key) => $this->summarise([
+                ...$bank,
+                ...($failures->get($key) ?? ['failed_authorizations' => 0, 'affected_users' => 0]),
+                ...($sync->get($key) ?? self::NO_LIVE_CONNECTIONS),
+            ]))
+            ->sortBy([['severity', 'desc'], ['failing', 'desc'], ['users', 'desc'], ['name', 'asc']])
+            ->values();
+    }
+
+    /**
+     * Every bank we have ever tried to connect, with its authorization funnel.
+     *
+     * Soft-deleted rows are counted on purpose: a bank whose every attempt failed
+     * has nothing but soft-deleted rows, and leaving them out would report it as a
+     * bank nobody ever tried.
+     *
+     * @return Collection<string, array{name: string, country: string, attempts: int, users: int, sessions: int}>
+     */
+    private function attempts(): Collection
+    {
+        return BankingConnection::withTrashed()
+            ->tap($this->matchesEnableBanking())
+            ->groupBy('aspsp_name', 'aspsp_country')
+            // COUNT over a nullable column skips the nulls, so this counts the
+            // authorizations that actually completed.
+            ->selectRaw('aspsp_name, aspsp_country, COUNT(*) as attempts, COUNT(DISTINCT user_id) as users, COUNT(session_id) as sessions')
+            ->toBase()
+            ->get()
+            ->keyBy(fn (object $row): string => $this->bankIdentifier($row->aspsp_name, $row->aspsp_country))
+            ->map(fn (object $row): array => [
+                'name' => (string) $row->aspsp_name,
+                'country' => (string) $row->aspsp_country,
+                'attempts' => (int) $row->attempts,
+                'users' => (int) $row->users,
+                'sessions' => (int) $row->sessions,
+            ]);
+    }
+
+    /**
+     * The attempts each bank's own authorization rejected.
+     *
+     * @return Collection<string, array{failed_authorizations: int, affected_users: int}>
+     */
+    private function authorizationFailures(): Collection
+    {
+        return BankingConnection::query()
+            ->tap($this->failedAuthorizations($this->matchesEnableBanking()))
+            ->groupBy('aspsp_name', 'aspsp_country')
+            ->selectRaw('aspsp_name, aspsp_country, COUNT(*) as failed_authorizations, COUNT(DISTINCT user_id) as affected_users')
+            ->toBase()
+            ->get()
+            ->keyBy(fn (object $row): string => $this->bankIdentifier($row->aspsp_name, $row->aspsp_country))
+            ->map(fn (object $row): array => [
+                'failed_authorizations' => (int) $row->failed_authorizations,
+                'affected_users' => (int) $row->affected_users,
+            ]);
+    }
+
+    /**
+     * How the connections the scheduler is still retrying are actually doing.
+     *
+     * The population is small enough (a few hundred rows) to summarise in PHP,
+     * which keeps the two states below readable instead of hidden in conditional
+     * SQL aggregates.
+     *
+     * @return Collection<string, array<string, mixed>>
+     */
+    private function syncHealth(): Collection
+    {
+        return BankingConnection::query()
+            ->tap($this->matchesOutage($this->matchesEnableBanking()))
+            ->get(['aspsp_name', 'aspsp_country', 'user_id', 'status', 'last_synced_at', 'rate_limited_until'])
+            ->groupBy(fn (BankingConnection $connection): string => $this->bankIdentifier(
+                (string) $connection->aspsp_name,
+                (string) $connection->aspsp_country,
+            ))
+            ->map(fn (Collection $connections): array => $this->summariseSync($connections));
+    }
+
+    /**
+     * @param  Collection<int, BankingConnection>  $connections
+     * @return array{live: int, live_users: int, rate_limited: int, syncing: int, failing: int, failing_users: int, newest_sync: CarbonInterface|null}
+     */
+    private function summariseSync(Collection $connections): array
+    {
+        [$backingOff, $syncing] = $connections->partition(fn (BankingConnection $connection): bool => $this->isBackingOff($connection));
+        $failing = $syncing->filter(fn (BankingConnection $connection): bool => $this->isFailing($connection));
+
+        return [
+            'live' => $connections->count(),
+            'live_users' => $connections->unique('user_id')->count(),
+            'rate_limited' => $backingOff->count(),
+            'syncing' => $syncing->count(),
+            'failing' => $failing->count(),
+            'failing_users' => $failing->unique('user_id')->count(),
+            'newest_sync' => $connections->max('last_synced_at'),
+        ];
+    }
+
+    /**
+     * Whether the provider is throttling this connection rather than failing it.
+     *
+     * This is the one state the report has to hold apart by hand. Trade Republic
+     * accounts for most of our rate limits and its 429 lands on the balances call,
+     * *after* the transactions import; the syncer rethrows so the job can set a
+     * backoff, which discards the whole run and never writes `last_synced_at`. So
+     * a connection can be importing data perfectly and still look permanently
+     * stale. Counted as failing it would put the bank in this report's alert with
+     * an outage notice its users must not get.
+     *
+     * The window, rather than `rate_limited_until` simply being in the future,
+     * covers the gap between a backoff elapsing and the next scheduled sync
+     * getting round to retrying it.
+     */
+    private function isBackingOff(BankingConnection $connection): bool
+    {
+        return $connection->rate_limited_until !== null
+            && $connection->rate_limited_until->greaterThan(now()->subHours($this->staleHours()));
+    }
+
+    /**
+     * Whether a connection the scheduler is still retrying has stopped producing
+     * data.
+     *
+     * `consecutive_sync_failures` is deliberately not the signal: it is 0 on every
+     * live connection in production, because it is only written on the path that
+     * also caps the retries — and passing the cap takes the connection out of this
+     * population altogether. What is left is the status the last run wrote and the
+     * sync clock. The scheduler runs every six hours, so the default 48 hours is
+     * eight missed attempts in a row: long past transient.
+     */
+    private function isFailing(BankingConnection $connection): bool
+    {
+        return $connection->status === BankingConnectionStatus::Error
+            || $connection->last_synced_at === null
+            || $connection->last_synced_at->lessThan(now()->subHours($this->staleHours()));
+    }
+
+    /**
+     * The verdict on one bank: which failure mode it is in, if any, how to notify
+     * its users, and how badly it sorts.
+     *
+     * @param  array<string, mixed>  $bank
+     * @return array<string, mixed>
+     */
+    private function summarise(array $bank): array
+    {
+        $displayName = "{$bank['name']} ({$bank['country']})";
+
+        return [
+            ...$bank,
+            'key' => $this->bankIdentifier((string) $bank['name'], (string) $bank['country']),
+            'display_name' => $displayName,
+            'state' => $this->state($bank),
+            'severity' => $this->severity($bank),
+            'notify_command' => $this->notifyCommand($bank),
+            'reason' => $this->reason($bank),
+        ];
+    }
+
+    /**
+     * Whether the bank rejected people and has never once let anybody in. The
+     * callback error code is not stored, so a rejection on a bank that does
+     * connect is just as likely to be someone cancelling at their bank.
+     *
+     * @param  array<string, mixed>  $bank
+     */
+    private function neverConnected(array $bank): bool
+    {
+        return $bank['sessions'] === 0 && $bank['failed_authorizations'] > 0;
+    }
+
+    /**
+     * Whether that is provably the bank's fault rather than one person's bad
+     * afternoon, which is what `banking:notify-connect-failure` apologises for.
+     *
+     * @param  array<string, mixed>  $bank
+     */
+    private function neverAuthorizes(array $bank): bool
+    {
+        return $this->neverConnected($bank)
+            && $bank['affected_users'] >= self::MIN_AFFECTED_USERS;
+    }
+
+    /**
+     * Whether every connection the bank could still be syncing has stopped, which
+     * is what `banking:notify-outage` announces. Throttled connections are out of
+     * both halves of the fraction: they are not failing, and they are not proof
+     * the bank works either.
+     *
+     * @param  array<string, mixed>  $bank
+     */
+    private function isFullyDown(array $bank): bool
+    {
+        return $bank['failing'] > 0
+            && $bank['failing'] === $bank['syncing']
+            && $bank['failing_users'] >= self::MIN_AFFECTED_USERS;
+    }
+
+    /**
+     * The verdict in one cell. `BROKEN` is the only state that gets an email, so
+     * everything one bar short of it says which bar it missed rather than reading
+     * as a milder problem: a bank failing all of its connections for a single user
+     * is not degraded, it is unproven.
+     *
+     * @param  array<string, mixed>  $bank
+     */
+    private function state(array $bank): string
+    {
+        if ($this->neverAuthorizes($bank)) {
+            return 'BROKEN: never connects';
+        }
+
+        // A bank that never completed an authorization has no live connection to
+        // say anything about, so the sync half below would only report silence.
+        if ($this->neverConnected($bank)) {
+            return "unproven: never connects, {$bank['affected_users']} user(s)";
+        }
+
+        return $this->syncState($bank);
+    }
+
+    /**
+     * @param  array<string, mixed>  $bank
+     */
+    private function syncState(array $bank): string
+    {
+        return match (true) {
+            $this->isFullyDown($bank) => "BROKEN: {$bank['failing']}/{$bank['syncing']} not syncing",
+            $bank['failing'] > 0 && $bank['failing'] === $bank['syncing'] => "unproven: {$bank['failing']}/{$bank['syncing']} not syncing, {$bank['failing_users']} user(s)",
+            $bank['failing'] > 0 => "degraded: {$bank['failing']}/{$bank['syncing']} not syncing",
+            $bank['live'] > 0 && $bank['rate_limited'] === $bank['live'] => 'throttled',
+            $bank['live'] > 0 => 'ok',
+            default => 'nobody connected',
+        };
+    }
+
+    /**
+     * Sort weight, so a table too long to read still opens on the banks that need
+     * a decision.
+     *
+     * @param  array<string, mixed>  $bank
+     */
+    private function severity(array $bank): int
+    {
+        return match (true) {
+            $this->neverAuthorizes($bank), $this->isFullyDown($bank) => 3,
+            $this->neverConnected($bank), $bank['failing'] > 0 => 2,
+            $bank['rate_limited'] > 0 => 1,
+            default => 0,
+        };
+    }
+
+    /**
+     * The command that tells this bank's users about it, ready to paste, or null
+     * when the bank is not broken enough to write to anybody.
+     *
+     * @param  array<string, mixed>  $bank
+     */
+    private function notifyCommand(array $bank): ?string
+    {
+        $command = match (true) {
+            $this->neverAuthorizes($bank) => 'banking:notify-connect-failure',
+            $this->isFullyDown($bank) => 'banking:notify-outage',
+            default => null,
+        };
+
+        if ($command === null) {
+            return null;
+        }
+
+        // Double quotes so the operator can read the bank name, with the four
+        // characters a shell still expands inside them escaped.
+        $name = addcslashes((string) $bank['name'], '"\\$`');
+
+        return "php artisan {$command} \"{$name}\" --country={$bank['country']}";
+    }
+
+    /**
+     * Why this bank is being alerted about, in one sentence, so the email stands
+     * on its own.
+     *
+     * @param  array<string, mixed>  $bank
+     */
+    private function reason(array $bank): ?string
+    {
+        if ($this->neverAuthorizes($bank)) {
+            return "Never connected once: {$bank['failed_authorizations']} authorization(s) rejected by the bank, "
+                ."from {$bank['affected_users']} user(s), and not a single session in {$bank['attempts']} attempt(s).";
+        }
+
+        if ($this->isFullyDown($bank)) {
+            $lastSync = $bank['newest_sync'] instanceof CarbonInterface
+                ? 'the newest sync of any of them is '.$bank['newest_sync']->diffForHumans()
+                : 'not one of them has ever synced';
+
+            return "All {$bank['failing']} of its {$bank['syncing']} live connection(s) have stopped syncing, across "
+                ."{$bank['failing_users']} user(s); {$lastSync}."
+                .($bank['rate_limited'] > 0 ? " {$bank['rate_limited']} further connection(s) are rate limited and left out." : '');
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  Collection<int, array<string, mixed>>  $banks
+     */
+    private function renderReport(Collection $banks): void
+    {
+        $this->table(
+            ['Bank', 'Country', 'Attempts', 'Rejected', 'Users', 'Connected', 'Live', 'Not syncing', 'Throttled', 'Newest sync', 'State'],
+            $banks->map(fn (array $bank): array => [
+                $bank['name'],
+                $bank['country'],
+                $bank['attempts'],
+                $bank['failed_authorizations'],
+                $bank['users'],
+                $bank['sessions'] > 0 ? 'yes' : 'no',
+                $bank['live'],
+                $bank['syncing'] > 0 ? "{$bank['failing']}/{$bank['syncing']}" : '-',
+                $bank['rate_limited'] ?: '-',
+                $bank['newest_sync'] instanceof CarbonInterface ? $bank['newest_sync']->diffForHumans() : 'never',
+                $bank['state'],
+            ])->all(),
+        );
+
+        $broken = $banks->whereNotNull('notify_command');
+
+        $this->info("{$banks->count()} bank(s) on record, {$broken->count()} broken for everyone who uses them.");
+    }
+
+    /**
+     * Email the owners about the banks that are broken for everyone, skipping any
+     * already alerted about inside the window.
+     *
+     * @param  Collection<int, array<string, mixed>>  $banks
+     */
+    private function sendAlert(Collection $banks): int
+    {
+        /** @var array<int, string> $recipients */
+        $recipients = config('mail.report_recipients');
+
+        if ($recipients === []) {
+            $this->error('REPORT_RECIPIENTS is not configured. Skipping the bank health alert.');
+
+            return self::FAILURE;
+        }
+
+        $broken = $banks->whereNotNull('notify_command');
+
+        if ($broken->isEmpty()) {
+            $this->info('No bank is broken for everyone. Nothing to alert about.');
+
+            return self::SUCCESS;
+        }
+
+        $fresh = $broken->reject(fn (array $bank): bool => Cache::has($this->alertKey($bank)))->values();
+
+        if ($fresh->isEmpty()) {
+            $this->info("All {$broken->count()} broken bank(s) were already alerted about in the last {$this->repeatAfter()} day(s).");
+
+            return self::SUCCESS;
+        }
+
+        Mail::to($recipients)->send(new BankHealthAlertEmail($fresh->all(), $this->repeatAfter()));
+
+        $this->suppressUntilWindowElapses($fresh);
+
+        $this->warn("Alerted about {$fresh->count()} bank(s): ".$fresh->pluck('display_name')->implode(', ').'.');
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Remember what has just been reported, so tomorrow's run stays quiet about
+     * it. Four Spanish banks have been broken since before this command existed;
+     * without this the daily alert would be noise from its first run.
+     *
+     * The cache is the whole ledger — the entry expires the window away on its own
+     * — and it is written only once the email is out, because an alert lost to a
+     * mail failure is worse than a second copy of one.
+     *
+     * @param  Collection<int, array<string, mixed>>  $banks
+     */
+    private function suppressUntilWindowElapses(Collection $banks): void
+    {
+        foreach ($banks as $bank) {
+            Cache::put($this->alertKey($bank), now()->toIso8601String(), now()->addDays($this->repeatAfter()));
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $bank
+     */
+    private function alertKey(array $bank): string
+    {
+        return "banking-health-alert:{$bank['key']}";
+    }
+
+    /**
+     * Days of silence after a bank has been alerted about. Zero would alert every
+     * day, which is what the window exists to prevent.
+     */
+    private function repeatAfter(): int
+    {
+        return max(1, (int) $this->option('repeat-after'));
+    }
+
+    private function staleHours(): int
+    {
+        return max(1, (int) $this->option('stale-hours'));
+    }
+}

--- a/app/Console/Commands/BankHealthCommand.php
+++ b/app/Console/Commands/BankHealthCommand.php
@@ -43,6 +43,7 @@ class BankHealthCommand extends Command
         'failing' => 0,
         'failing_users' => 0,
         'newest_sync' => null,
+        'newest_failing_sync' => null,
     ];
 
     /**
@@ -98,7 +99,7 @@ class BankHealthCommand extends Command
             ->map(fn (array $bank, string $key) => $this->summarise([
                 ...$bank,
                 ...($failures->get($key) ?? ['failed_authorizations' => 0, 'affected_users' => 0]),
-                ...($sync->get($key) ?? self::NO_LIVE_CONNECTIONS),
+                ...($sync[$key] ?? self::NO_LIVE_CONNECTIONS),
             ]))
             ->sortBy([['severity', 'desc'], ['failing', 'desc'], ['users', 'desc'], ['name', 'asc']])
             ->values();
@@ -160,9 +161,9 @@ class BankHealthCommand extends Command
      * which keeps the two states below readable instead of hidden in conditional
      * SQL aggregates.
      *
-     * @return Collection<string, array<string, mixed>>
+     * @return array<array-key, array{live: int, live_users: int, rate_limited: int, syncing: int, failing: int, failing_users: int, newest_sync: CarbonInterface|null, newest_failing_sync: CarbonInterface|null}>
      */
-    private function syncHealth(): Collection
+    private function syncHealth(): array
     {
         return BankingConnection::query()
             ->tap($this->matchesOutage($this->matchesEnableBanking()))
@@ -171,12 +172,13 @@ class BankHealthCommand extends Command
                 (string) $connection->aspsp_name,
                 (string) $connection->aspsp_country,
             ))
-            ->map(fn (Collection $connections): array => $this->summariseSync($connections));
+            ->map(fn (Collection $connections): array => $this->summariseSync($connections))
+            ->all();
     }
 
     /**
      * @param  Collection<int, BankingConnection>  $connections
-     * @return array{live: int, live_users: int, rate_limited: int, syncing: int, failing: int, failing_users: int, newest_sync: CarbonInterface|null}
+     * @return array{live: int, live_users: int, rate_limited: int, syncing: int, failing: int, failing_users: int, newest_sync: CarbonInterface|null, newest_failing_sync: CarbonInterface|null}
      */
     private function summariseSync(Collection $connections): array
     {
@@ -191,6 +193,10 @@ class BankHealthCommand extends Command
             'failing' => $failing->count(),
             'failing_users' => $failing->unique('user_id')->count(),
             'newest_sync' => $connections->max('last_synced_at'),
+            // Separate from the column above on purpose: a throttled connection
+            // syncing an hour ago says nothing about the ones that are down, and
+            // quoting it would make the alert read better than the truth.
+            'newest_failing_sync' => $failing->max('last_synced_at'),
         ];
     }
 
@@ -387,13 +393,13 @@ class BankHealthCommand extends Command
         }
 
         if ($this->isFullyDown($bank)) {
-            $lastSync = $bank['newest_sync'] instanceof CarbonInterface
-                ? 'the newest sync of any of them is '.$bank['newest_sync']->diffForHumans()
+            $lastSync = $bank['newest_failing_sync'] instanceof CarbonInterface
+                ? 'the most recent of them synced '.$bank['newest_failing_sync']->diffForHumans()
                 : 'not one of them has ever synced';
 
-            return "All {$bank['failing']} of its {$bank['syncing']} live connection(s) have stopped syncing, across "
+            return "All {$bank['failing']} of its {$bank['syncing']} connection(s) that should be syncing have stopped, across "
                 ."{$bank['failing_users']} user(s); {$lastSync}."
-                .($bank['rate_limited'] > 0 ? " {$bank['rate_limited']} further connection(s) are rate limited and left out." : '');
+                .($bank['rate_limited'] > 0 ? " A further {$bank['rate_limited']} are rate limited and left out of that count." : '');
         }
 
         return null;
@@ -405,7 +411,7 @@ class BankHealthCommand extends Command
     private function renderReport(Collection $banks): void
     {
         $this->table(
-            ['Bank', 'Country', 'Attempts', 'Rejected', 'Users', 'Connected', 'Live', 'Not syncing', 'Throttled', 'Newest sync', 'State'],
+            ['Bank', 'Country', 'Attempts', 'Failed auth', 'Users', 'Connected', 'Live', 'Not syncing', 'Throttled', 'Newest sync', 'State'],
             $banks->map(fn (array $bank): array => [
                 $bank['name'],
                 $bank['country'],
@@ -459,13 +465,39 @@ class BankHealthCommand extends Command
             return self::SUCCESS;
         }
 
-        Mail::to($recipients)->send(new BankHealthAlertEmail($fresh->all(), $this->repeatAfter()));
+        Mail::to($recipients)->send(new BankHealthAlertEmail(
+            $fresh->all(),
+            $this->repeatAfter(),
+            $this->looksLikeProviderOutage($banks, $broken),
+        ));
 
         $this->suppressUntilWindowElapses($fresh);
 
         $this->warn("Alerted about {$fresh->count()} bank(s): ".$fresh->pluck('display_name')->implode(', ').'.');
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Whether this many banks failing at once is better explained by Enable
+     * Banking than by the banks themselves.
+     *
+     * It matters because of what the email asks for: every notify command in it
+     * tells that bank's users their bank is broken. If the provider is down, that
+     * diagnosis is wrong for all of them at once, and the outage notice is the one
+     * mistake here that cannot be taken back.
+     *
+     * @param  Collection<int, array<string, mixed>>  $banks
+     * @param  Collection<int, array<string, mixed>>  $broken
+     */
+    private function looksLikeProviderOutage(Collection $banks, Collection $broken): bool
+    {
+        $connected = $banks->where('live', '>', 0)->count();
+        $down = $broken->where('live', '>', 0)->count();
+
+        // Half of everything that has a live connection, and never on the two or
+        // three banks that are simply always broken.
+        return $down >= 3 && $down * 2 > $connected;
     }
 
     /**

--- a/app/Console/Commands/Concerns/NotifiesBankUsers.php
+++ b/app/Console/Commands/Concerns/NotifiesBankUsers.php
@@ -2,7 +2,6 @@
 
 namespace App\Console\Commands\Concerns;
 
-use App\Enums\BankingProvider;
 use App\Enums\DripEmailType;
 use App\Models\BankingConnection;
 use App\Models\User;
@@ -22,10 +21,8 @@ use Illuminate\Support\Str;
  * review the recipients, email one message per user, and never mail the same
  * user twice for the same bank.
  *
- * A bank is identified by `aspsp_name` + `aspsp_country`, which is also how
- * Enable Banking identifies an ASPSP: `banking_connections` has no bank_id, and
- * the `banks` table is per-user, so a bank UUID means nothing outside the one
- * account it belongs to.
+ * The definitions of a broken bank, and how one is identified, are in
+ * {@see QueriesBankFailures}.
  *
  * A command using this must declare all four shared options in its signature —
  * `--country`, `--dry-run`, `--force` and `--resend` — because the helpers here
@@ -35,6 +32,8 @@ use Illuminate\Support\Str;
  */
 trait NotifiesBankUsers
 {
+    use QueriesBankFailures;
+
     /**
      * The withCount alias the recipient tables read.
      */
@@ -46,17 +45,6 @@ trait NotifiesBankUsers
     protected function countryOption(): ?string
     {
         return $this->option('country') ? Str::upper((string) $this->option('country')) : null;
-    }
-
-    /**
-     * Every Enable Banking connection to the bank the operator named.
-     */
-    protected function matchesBank(string $aspsp, ?string $country): Closure
-    {
-        return fn (Builder $query) => $query
-            ->where('provider', BankingProvider::EnableBanking)
-            ->where('aspsp_name', $aspsp)
-            ->when($country, fn (Builder $query) => $query->where('aspsp_country', $country));
     }
 
     /**
@@ -96,14 +84,6 @@ trait NotifiesBankUsers
         }
 
         return $country ?? (string) $countries->first();
-    }
-
-    /**
-     * The ledger key for one bank's notice, stable across re-runs.
-     */
-    protected function bankIdentifier(string $bankName, string $country): string
-    {
-        return Str::slug("{$bankName}-{$country}");
     }
 
     /**
@@ -189,7 +169,7 @@ trait NotifiesBankUsers
         // The usual mistake is the right name with the wrong country, so say
         // where that bank does exist before offering other names.
         $countries = BankingConnection::withTrashed()
-            ->where('provider', BankingProvider::EnableBanking)
+            ->tap($this->matchesEnableBanking())
             ->where('aspsp_name', $aspsp)
             ->distinct()
             ->orderBy('aspsp_country')
@@ -202,7 +182,7 @@ trait NotifiesBankUsers
         }
 
         $similar = BankingConnection::withTrashed()
-            ->where('provider', BankingProvider::EnableBanking)
+            ->tap($this->matchesEnableBanking())
             ->where('aspsp_name', 'like', '%'.$aspsp.'%')
             ->where('aspsp_name', '!=', $aspsp)
             ->distinct()

--- a/app/Console/Commands/Concerns/QueriesBankFailures.php
+++ b/app/Console/Commands/Concerns/QueriesBankFailures.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Console\Commands\Concerns;
+
+use App\Enums\BankingConnectionStatus;
+use App\Enums\BankingProvider;
+use App\Jobs\SyncBankingConnectionJob;
+use Closure;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Illuminate\Support\Str;
+
+/**
+ * What "this bank is broken" means, in one place.
+ *
+ * There is one definition per failure mode: a bank whose authorization never
+ * completes for anybody, and a bank whose working connections stopped answering.
+ * They live here because two kinds of command read them — the ones that email
+ * the affected users, and the one that reports which banks are in that state —
+ * and a report that measured something subtly different from what the notice
+ * claims would be worse than no report.
+ *
+ * A bank is identified by `aspsp_name` + `aspsp_country`: `banking_connections`
+ * has no bank_id and the `banks` table is per-user, so a bank UUID means nothing
+ * outside the one account it belongs to.
+ */
+trait QueriesBankFailures
+{
+    /**
+     * How many distinct people must have hit the bank before its failure can be
+     * called the bank's. One user cancelling twice at their bank leaves the same
+     * trace as a broken connector.
+     */
+    protected const MIN_AFFECTED_USERS = 2;
+
+    /**
+     * Every connection made through Enable Banking, which is the only provider
+     * where a bank can break for everyone at once: the rest are API keys we hold
+     * per user.
+     */
+    protected function matchesEnableBanking(): Closure
+    {
+        return fn (Builder $query) => $query->where('provider', BankingProvider::EnableBanking);
+    }
+
+    /**
+     * Every Enable Banking connection to the bank the operator named.
+     */
+    protected function matchesBank(string $aspsp, ?string $country): Closure
+    {
+        return fn (Builder $query) => $query
+            ->tap($this->matchesEnableBanking())
+            ->where('aspsp_name', $aspsp)
+            ->when($country, fn (Builder $query) => $query->where('aspsp_country', $country));
+    }
+
+    /**
+     * Attempts the bank itself sent back as an error.
+     *
+     * A soft-deleted `pending` row is the fingerprint: AuthorizationController::
+     * handleAuthorizationError() is the only path that deletes a connection while
+     * it is still pending, and a manual disconnect sets Revoked before deleting.
+     * A `pending` row that is *not* deleted means the user simply never came back
+     * from the bank, which is not something to apologise for.
+     */
+    protected function failedAuthorizations(Closure $matchesBank): Closure
+    {
+        return fn (Builder $query) => $query
+            ->tap($matchesBank)
+            // Only the soft-deleted rows: a rejected callback deletes the
+            // connection, so every attempt worth reporting is trashed. The column
+            // is qualified because this also runs as a subquery against `users`,
+            // which has a `deleted_at` of its own.
+            ->withoutGlobalScope(SoftDeletingScope::class)
+            ->whereNotNull('banking_connections.deleted_at')
+            ->where('status', BankingConnectionStatus::Pending);
+    }
+
+    /**
+     * The connections an outage at the bank actually explains: the ones the
+     * scheduler will keep retrying, mirroring SyncAllBankingConnectionsJob.
+     *
+     * This is what keeps a claim about the bank honest. An expired, revoked or
+     * retry-capped connection is stuck for its own reason and its owner does have
+     * to reconnect, which is the opposite of a bank-side outage.
+     */
+    protected function matchesOutage(Closure $matchesBank): Closure
+    {
+        return fn (Builder $query) => $query
+            ->tap($matchesBank)
+            ->where(fn (Builder $query) => $query
+                ->where('status', BankingConnectionStatus::Active)
+                ->orWhere(fn (Builder $query) => $query
+                    ->where('status', BankingConnectionStatus::Error)
+                    ->where('consecutive_sync_failures', '<', SyncBankingConnectionJob::MAX_SCHEDULED_RETRIES)))
+            ->where(fn (Builder $query) => $query
+                ->whereNull('valid_until')
+                ->orWhere('valid_until', '>', now()));
+    }
+
+    /**
+     * The ledger key for one bank, stable across re-runs.
+     */
+    protected function bankIdentifier(string $bankName, string $country): string
+    {
+        return Str::slug("{$bankName}-{$country}");
+    }
+}

--- a/app/Console/Commands/NotifyBankConnectFailureCommand.php
+++ b/app/Console/Commands/NotifyBankConnectFailureCommand.php
@@ -3,7 +3,6 @@
 namespace App\Console\Commands;
 
 use App\Console\Commands\Concerns\NotifiesBankUsers;
-use App\Enums\BankingConnectionStatus;
 use App\Enums\DripEmailType;
 use App\Mail\BankConnectFailedEmail;
 use App\Models\BankingConnection;
@@ -13,7 +12,6 @@ use Closure;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\Isolatable;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Support\Collection;
 
 /**
@@ -28,13 +26,6 @@ use Illuminate\Support\Collection;
 class NotifyBankConnectFailureCommand extends Command implements Isolatable
 {
     use NotifiesBankUsers;
-
-    /**
-     * How many distinct people must have hit the bank before the copy's claim
-     * that it fails for everyone can be defended. One user cancelling twice at
-     * their bank leaves the same trace as a broken connector.
-     */
-    private const MIN_AFFECTED_USERS = 2;
 
     /**
      * The name and signature of the console command.
@@ -107,28 +98,6 @@ class NotifyBankConnectFailureCommand extends Command implements Isolatable
         );
 
         return self::SUCCESS;
-    }
-
-    /**
-     * Attempts the bank itself sent back as an error.
-     *
-     * A soft-deleted `pending` row is the fingerprint: AuthorizationController::
-     * handleAuthorizationError() is the only path that deletes a connection while
-     * it is still pending, and a manual disconnect sets Revoked before deleting.
-     * A `pending` row that is *not* deleted means the user simply never came back
-     * from the bank, which is not something to apologise for.
-     */
-    private function failedAuthorizations(Closure $matchesBank): Closure
-    {
-        return fn (Builder $query) => $query
-            ->tap($matchesBank)
-            // Only the soft-deleted rows: a rejected callback deletes the
-            // connection, so every attempt worth reporting is trashed. The column
-            // is qualified because this also runs as a subquery against `users`,
-            // which has a `deleted_at` of its own.
-            ->withoutGlobalScope(SoftDeletingScope::class)
-            ->whereNotNull('banking_connections.deleted_at')
-            ->where('status', BankingConnectionStatus::Pending);
     }
 
     /**

--- a/app/Console/Commands/NotifyBankOutageCommand.php
+++ b/app/Console/Commands/NotifyBankOutageCommand.php
@@ -3,16 +3,13 @@
 namespace App\Console\Commands;
 
 use App\Console\Commands\Concerns\NotifiesBankUsers;
-use App\Enums\BankingConnectionStatus;
 use App\Enums\DripEmailType;
-use App\Jobs\SyncBankingConnectionJob;
 use App\Mail\BankOutageEmail;
 use App\Models\BankingConnection;
 use App\Models\User;
 use Closure;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\Isolatable;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 
 /**
@@ -92,28 +89,6 @@ class NotifyBankOutageCommand extends Command implements Isolatable
         );
 
         return self::SUCCESS;
-    }
-
-    /**
-     * The connections an outage at the bank actually explains: the ones the
-     * scheduler will keep retrying, mirroring SyncAllBankingConnectionsJob.
-     *
-     * This is what makes the email honest. An expired, revoked or retry-capped
-     * connection is stuck for its own reason and its owner does have to
-     * reconnect — the exact opposite of what this notice tells them.
-     */
-    private function matchesOutage(Closure $matchesBank): Closure
-    {
-        return fn (Builder $query) => $query
-            ->tap($matchesBank)
-            ->where(fn (Builder $query) => $query
-                ->where('status', BankingConnectionStatus::Active)
-                ->orWhere(fn (Builder $query) => $query
-                    ->where('status', BankingConnectionStatus::Error)
-                    ->where('consecutive_sync_failures', '<', SyncBankingConnectionJob::MAX_SCHEDULED_RETRIES)))
-            ->where(fn (Builder $query) => $query
-                ->whereNull('valid_until')
-                ->orWhere('valid_until', '>', now()));
     }
 
     /**

--- a/app/Mail/BankHealthAlertEmail.php
+++ b/app/Mail/BankHealthAlertEmail.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Attachment;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Tells the owners which banks have stopped working for everyone who uses them,
+ * and hands over the exact command that notifies those users.
+ *
+ * Internal: this goes to REPORT_RECIPIENTS, never to a customer, which is why
+ * nothing in it is translated.
+ */
+class BankHealthAlertEmail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * @param  array<int, array<string, mixed>>  $banks
+     * @param  int  $repeatAfterDays  Days before the same bank is reported again
+     */
+    public function __construct(
+        public array $banks,
+        public int $repeatAfterDays,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        $count = count($this->banks);
+
+        return new Envelope(
+            subject: $count === 1
+                ? "Bank connection alert: {$this->banks[0]['display_name']} is broken for everyone"
+                : "Bank connection alert: {$count} banks are broken for everyone",
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'mail.bank-health-alert',
+            with: [
+                'banks' => $this->banks,
+                'repeatAfterDays' => $this->repeatAfterDays,
+            ],
+        );
+    }
+
+    /**
+     * @return array<int, Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/app/Mail/BankHealthAlertEmail.php
+++ b/app/Mail/BankHealthAlertEmail.php
@@ -23,10 +23,12 @@ class BankHealthAlertEmail extends Mailable
     /**
      * @param  array<int, array<string, mixed>>  $banks
      * @param  int  $repeatAfterDays  Days before the same bank is reported again
+     * @param  bool  $looksLikeProviderOutage  Too many banks at once to blame the banks
      */
     public function __construct(
         public array $banks,
         public int $repeatAfterDays,
+        public bool $looksLikeProviderOutage = false,
     ) {}
 
     public function envelope(): Envelope
@@ -47,6 +49,7 @@ class BankHealthAlertEmail extends Mailable
             with: [
                 'banks' => $this->banks,
                 'repeatAfterDays' => $this->repeatAfterDays,
+                'looksLikeProviderOutage' => $this->looksLikeProviderOutage,
             ],
         );
     }

--- a/resources/views/mail/bank-health-alert.blade.php
+++ b/resources/views/mail/bank-health-alert.blade.php
@@ -1,0 +1,28 @@
+<x-mail::message>
+# {{ count($banks) }} bank(s) broken for everyone
+
+Every connection to the bank(s) below is failing, so nobody using them is getting
+data. Each one has a command that tells its users, ready to paste — it runs as a
+dry run, so it only lists who would be emailed. Drop `--dry-run` from the end to
+actually send it, and it will ask for confirmation first.
+
+@foreach ($banks as $bank)
+## {{ $bank['display_name'] }}
+
+{{ $bank['reason'] }}
+
+{{-- Unescaped on purpose: Blade would turn the quotes around the bank name
+into &quot;, which the markdown renderer escapes a second time, and the
+operator would paste &amp;quot; into a shell. CommonMark escapes the code
+block's contents itself, so the raw string is what reaches the reader. --}}
+```
+{!! $bank['notify_command'] !!} --dry-run
+```
+
+@endforeach
+These bank(s) will not be reported again for {{ $repeatAfterDays }} day(s), whether or not you send anything.
+Run `php artisan banking:health` for the full table, including the banks that are only partly broken.
+
+Thanks,<br>
+{{ config('app.name') }}
+</x-mail::message>

--- a/resources/views/mail/bank-health-alert.blade.php
+++ b/resources/views/mail/bank-health-alert.blade.php
@@ -6,6 +6,13 @@ data. Each one has a command that tells its users, ready to paste — it runs as
 dry run, so it only lists who would be emailed. Drop `--dry-run` from the end to
 actually send it, and it will ask for confirmation first.
 
+@if ($looksLikeProviderOutage)
+**Check Enable Banking first.** This is most of the banks we have a live
+connection to, which one bank being down cannot explain. If the provider is the
+one that is failing, every command below would tell those users something untrue
+about their own bank.
+
+@endif
 @foreach ($banks as $bank)
 ## {{ $bank['display_name'] }}
 

--- a/routes/console.php
+++ b/routes/console.php
@@ -11,6 +11,7 @@ Schedule::command('loans:generate-balances')->monthlyOn(1, '00:00');
 Schedule::command('email:paywall-follow-up')->dailyAt('10:00')->timezone('Europe/Madrid');
 Schedule::command('email:ai-consent-follow-up')->dailyAt('10:15')->timezone('Europe/Madrid');
 Schedule::command('email:user-emails-report')->monthlyOn(1, '09:05')->timezone('Europe/Madrid');
+Schedule::command('banking:health --email')->dailyAt('09:30')->timezone('Europe/Madrid');
 Schedule::command('stats:daily-report')->dailyAt('09:00')->timezone('Europe/Madrid');
 Schedule::command('stats:ai-cohort-report')->monthlyOn(1, '09:00')->timezone('Europe/Madrid');
 Schedule::command('stats:subscription-funnel')->weekly()->mondays()->at('09:15')->timezone('Europe/Madrid');

--- a/tests/Feature/Console/BankHealthCommandTest.php
+++ b/tests/Feature/Console/BankHealthCommandTest.php
@@ -1,0 +1,294 @@
+<?php
+
+use App\Enums\BankingConnectionStatus;
+use App\Jobs\SyncBankingConnectionJob;
+use App\Mail\BankHealthAlertEmail;
+use App\Models\BankingConnection;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Mail;
+
+use function Pest\Laravel\artisan;
+
+beforeEach(function () {
+    Mail::fake();
+    Cache::flush();
+    config(['mail.report_recipients' => ['owner@example.com']]);
+});
+
+/**
+ * One connection to a named bank, owned by its own user.
+ *
+ * @param  array<string, mixed>  $attributes
+ */
+function healthConnection(string $bank, array $attributes = []): BankingConnection
+{
+    return BankingConnection::factory()->for(User::factory())->create([
+        'aspsp_name' => $bank,
+        'aspsp_country' => 'ES',
+        ...$attributes,
+    ]);
+}
+
+/**
+ * An attempt the bank's own authorization rejected: pending, no session, and
+ * soft-deleted by the error callback.
+ */
+function rejectedAuthorization(string $bank): BankingConnection
+{
+    $connection = BankingConnection::factory()->for(User::factory())->pending()->create([
+        'aspsp_name' => $bank,
+        'aspsp_country' => 'ES',
+    ]);
+
+    $connection->delete();
+
+    return $connection;
+}
+
+/**
+ * A live connection that has not synced for long enough to count as failing.
+ */
+function stalledConnection(string $bank): BankingConnection
+{
+    return healthConnection($bank, ['last_synced_at' => now()->subDays(5)]);
+}
+
+/**
+ * The banks the last `--email` run reported, as the mailable received them.
+ *
+ * @return array<int, array<string, mixed>>
+ */
+function alertedBanks(): array
+{
+    $banks = [];
+
+    Mail::assertSent(BankHealthAlertEmail::class, function (BankHealthAlertEmail $mail) use (&$banks) {
+        $banks = $mail->banks;
+
+        return true;
+    });
+
+    return $banks;
+}
+
+test('reports a bank whose connections are all syncing as healthy', function () {
+    healthConnection('Working Bank');
+    healthConnection('Working Bank');
+
+    artisan('banking:health')
+        ->expectsOutputToContain('1 bank(s) on record, 0 broken for everyone who uses them.')
+        ->assertSuccessful();
+
+    Mail::assertNothingOutgoing();
+});
+
+test('alerts about a bank that has never let anybody in', function () {
+    rejectedAuthorization('Never Works Bank');
+    rejectedAuthorization('Never Works Bank');
+
+    artisan('banking:health', ['--email' => true])
+        ->expectsOutputToContain('Alerted about 1 bank(s): Never Works Bank (ES).')
+        ->assertSuccessful();
+
+    expect(alertedBanks())->toHaveCount(1)
+        ->and(alertedBanks()[0]['notify_command'])
+        ->toBe('php artisan banking:notify-connect-failure "Never Works Bank" --country=ES')
+        ->and(alertedBanks()[0]['reason'])->toContain('Never connected once: 2 authorization(s) rejected');
+});
+
+test('alerts about a bank whose every live connection has stopped syncing', function () {
+    stalledConnection('Dead Bank');
+    stalledConnection('Dead Bank');
+
+    artisan('banking:health', ['--email' => true])
+        ->expectsOutputToContain('Alerted about 1 bank(s): Dead Bank (ES).')
+        ->assertSuccessful();
+
+    expect(alertedBanks()[0]['notify_command'])
+        ->toBe('php artisan banking:notify-outage "Dead Bank" --country=ES')
+        ->and(alertedBanks()[0]['reason'])->toContain('All 2 of its 2 live connection(s) have stopped syncing');
+});
+
+test('counts a connection stuck on an error as failing, however fresh its clock', function () {
+    healthConnection('Erroring Bank', ['status' => BankingConnectionStatus::Error]);
+    healthConnection('Erroring Bank', ['status' => BankingConnectionStatus::Error]);
+
+    artisan('banking:health', ['--email' => true])->assertSuccessful();
+
+    expect(alertedBanks()[0]['display_name'])->toBe('Erroring Bank (ES)');
+});
+
+test('leaves a bank alone while only some of its connections are failing', function () {
+    stalledConnection('Flaky Bank');
+    stalledConnection('Flaky Bank');
+    healthConnection('Flaky Bank');
+
+    artisan('banking:health', ['--email' => true])
+        ->expectsOutputToContain('No bank is broken for everyone. Nothing to alert about.')
+        ->assertSuccessful();
+
+    Mail::assertNothingOutgoing();
+});
+
+test('will not call a bank broken on one person\'s evidence alone', function () {
+    $user = User::factory()->create();
+
+    foreach (range(1, 3) as $ignored) {
+        BankingConnection::factory()->for($user)->create([
+            'aspsp_name' => 'One User Bank',
+            'aspsp_country' => 'ES',
+            'last_synced_at' => now()->subDays(5),
+        ]);
+    }
+
+    artisan('banking:health', ['--email' => true])
+        ->expectsOutputToContain('No bank is broken for everyone. Nothing to alert about.')
+        ->assertSuccessful();
+
+    Mail::assertNothingOutgoing();
+});
+
+test('does not read a rate limited connection as a bank-side outage', function () {
+    // The 429 lands after the transactions import and the discarded run never
+    // writes last_synced_at, so these look permanently stale while working fine.
+    healthConnection('Trade Republic', [
+        'last_synced_at' => null,
+        'rate_limited_until' => now()->addHour(),
+    ]);
+    healthConnection('Trade Republic', [
+        'last_synced_at' => null,
+        'rate_limited_until' => now()->addHour(),
+    ]);
+
+    artisan('banking:health', ['--email' => true])
+        ->expectsOutputToContain('No bank is broken for everyone. Nothing to alert about.')
+        ->assertSuccessful();
+
+    Mail::assertNothingOutgoing();
+});
+
+test('still alerts when a throttled connection sits beside connections that are genuinely down', function () {
+    stalledConnection('Half Throttled Bank');
+    stalledConnection('Half Throttled Bank');
+    healthConnection('Half Throttled Bank', [
+        'last_synced_at' => null,
+        'rate_limited_until' => now()->addHour(),
+    ]);
+
+    artisan('banking:health', ['--email' => true])->assertSuccessful();
+
+    expect(alertedBanks()[0]['reason'])
+        ->toContain('All 2 of its 2 live connection(s) have stopped syncing')
+        ->toContain('1 further connection(s) are rate limited and left out');
+});
+
+test('ignores connections the user has to reconnect themselves', function () {
+    healthConnection('Expired Bank', ['status' => BankingConnectionStatus::Expired, 'valid_until' => now()->subDay()]);
+    healthConnection('Expired Bank', ['status' => BankingConnectionStatus::Revoked]);
+    healthConnection('Expired Bank', [
+        'status' => BankingConnectionStatus::Error,
+        'consecutive_sync_failures' => SyncBankingConnectionJob::MAX_SCHEDULED_RETRIES,
+    ]);
+
+    artisan('banking:health', ['--email' => true])
+        ->expectsOutputToContain('No bank is broken for everyone. Nothing to alert about.')
+        ->assertSuccessful();
+
+    Mail::assertNothingOutgoing();
+});
+
+test('stays quiet about a bank it has already reported inside the window', function () {
+    stalledConnection('Dead Bank');
+    stalledConnection('Dead Bank');
+
+    artisan('banking:health', ['--email' => true])->assertSuccessful();
+    Mail::assertSent(BankHealthAlertEmail::class, 1);
+
+    artisan('banking:health', ['--email' => true])
+        ->expectsOutputToContain('All 1 broken bank(s) were already alerted about in the last 7 day(s).')
+        ->assertSuccessful();
+
+    Mail::assertSent(BankHealthAlertEmail::class, 1);
+});
+
+test('reports the same bank again once the window has elapsed', function () {
+    stalledConnection('Dead Bank');
+    stalledConnection('Dead Bank');
+
+    artisan('banking:health', ['--email' => true, '--repeat-after' => 2])->assertSuccessful();
+
+    $this->travel(3)->days();
+
+    artisan('banking:health', ['--email' => true, '--repeat-after' => 2])->assertSuccessful();
+
+    Mail::assertSent(BankHealthAlertEmail::class, 2);
+});
+
+test('the staleness window decides how long a quiet connection gets', function () {
+    healthConnection('Slow Bank', ['last_synced_at' => now()->subHours(6)]);
+    healthConnection('Slow Bank', ['last_synced_at' => now()->subHours(6)]);
+
+    artisan('banking:health', ['--email' => true])
+        ->expectsOutputToContain('No bank is broken for everyone.')
+        ->assertSuccessful();
+
+    artisan('banking:health', ['--email' => true, '--stale-hours' => 4])->assertSuccessful();
+
+    expect(alertedBanks()[0]['display_name'])->toBe('Slow Bank (ES)');
+});
+
+test('renders the report without sending anything when --email is left off', function () {
+    stalledConnection('Dead Bank');
+    stalledConnection('Dead Bank');
+
+    artisan('banking:health')
+        ->expectsOutputToContain('1 bank(s) on record, 1 broken for everyone who uses them.')
+        ->assertSuccessful();
+
+    Mail::assertNothingOutgoing();
+});
+
+test('refuses to alert with no recipients configured', function () {
+    config(['mail.report_recipients' => []]);
+    stalledConnection('Dead Bank');
+    stalledConnection('Dead Bank');
+
+    artisan('banking:health', ['--email' => true])
+        ->expectsOutputToContain('REPORT_RECIPIENTS is not configured.')
+        ->assertFailed();
+
+    Mail::assertNothingOutgoing();
+});
+
+test('says so when there is no Enable Banking connection at all', function () {
+    BankingConnection::factory()->for(User::factory())->indexaCapital()->create();
+
+    artisan('banking:health', ['--email' => true])
+        ->expectsOutputToContain('No Enable Banking connection on record.')
+        ->assertSuccessful();
+
+    Mail::assertNothingOutgoing();
+});
+
+test('escapes a bank name a shell would otherwise expand', function () {
+    rejectedAuthorization('Bank "$HOME"');
+    rejectedAuthorization('Bank "$HOME"');
+
+    artisan('banking:health', ['--email' => true])->assertSuccessful();
+
+    expect(alertedBanks()[0]['notify_command'])
+        ->toBe('php artisan banking:notify-connect-failure "Bank \\"\\$HOME\\"" --country=ES');
+});
+
+test('a bank that connects for others is not broken for the users it rejected', function () {
+    healthConnection('Cancelled At Bank');
+    rejectedAuthorization('Cancelled At Bank');
+    rejectedAuthorization('Cancelled At Bank');
+
+    artisan('banking:health', ['--email' => true])
+        ->expectsOutputToContain('No bank is broken for everyone. Nothing to alert about.')
+        ->assertSuccessful();
+
+    Mail::assertNothingOutgoing();
+});

--- a/tests/Feature/Console/BankHealthCommandTest.php
+++ b/tests/Feature/Console/BankHealthCommandTest.php
@@ -107,7 +107,7 @@ test('alerts about a bank whose every live connection has stopped syncing', func
 
     expect(alertedBanks()[0]['notify_command'])
         ->toBe('php artisan banking:notify-outage "Dead Bank" --country=ES')
-        ->and(alertedBanks()[0]['reason'])->toContain('All 2 of its 2 live connection(s) have stopped syncing');
+        ->and(alertedBanks()[0]['reason'])->toContain('All 2 of its 2 connection(s) that should be syncing have stopped');
 });
 
 test('counts a connection stuck on an error as failing, however fresh its clock', function () {
@@ -169,18 +169,23 @@ test('does not read a rate limited connection as a bank-side outage', function (
 });
 
 test('still alerts when a throttled connection sits beside connections that are genuinely down', function () {
-    stalledConnection('Half Throttled Bank');
-    stalledConnection('Half Throttled Bank');
+    healthConnection('Half Throttled Bank', ['last_synced_at' => null]);
+    healthConnection('Half Throttled Bank', ['last_synced_at' => null]);
+    // Throttled, and the only connection to this bank with a recent sync.
     healthConnection('Half Throttled Bank', [
-        'last_synced_at' => null,
+        'last_synced_at' => now()->subHour(),
         'rate_limited_until' => now()->addHour(),
     ]);
 
     artisan('banking:health', ['--email' => true])->assertSuccessful();
 
     expect(alertedBanks()[0]['reason'])
-        ->toContain('All 2 of its 2 live connection(s) have stopped syncing')
-        ->toContain('1 further connection(s) are rate limited and left out');
+        ->toContain('All 2 of its 2 connection(s) that should be syncing have stopped')
+        ->toContain('A further 1 are rate limited and left out of that count')
+        // The throttled connection is the one that synced an hour ago. Quoting it
+        // here would make the alert read better than the failing set really is.
+        ->toContain('not one of them has ever synced')
+        ->not->toContain('1 hour ago');
 });
 
 test('ignores connections the user has to reconnect themselves', function () {
@@ -291,4 +296,26 @@ test('a bank that connects for others is not broken for the users it rejected', 
         ->assertSuccessful();
 
     Mail::assertNothingOutgoing();
+});
+
+test('names the provider when too many banks fail at once to blame the banks', function () {
+    foreach (['Bank A', 'Bank B', 'Bank C'] as $bank) {
+        stalledConnection($bank);
+        stalledConnection($bank);
+    }
+
+    artisan('banking:health', ['--email' => true])->assertSuccessful();
+
+    Mail::assertSent(BankHealthAlertEmail::class, fn (BankHealthAlertEmail $mail) => $mail->looksLikeProviderOutage);
+});
+
+test('blames the bank when it is the only one failing', function () {
+    stalledConnection('Dead Bank');
+    stalledConnection('Dead Bank');
+    healthConnection('Healthy Bank');
+    healthConnection('Another Healthy Bank');
+
+    artisan('banking:health', ['--email' => true])->assertSuccessful();
+
+    Mail::assertSent(BankHealthAlertEmail::class, fn (BankHealthAlertEmail $mail) => ! $mail->looksLikeProviderOutage);
 });


### PR DESCRIPTION
Adds `banking:health`: one internal command that reports how every Enable Banking
bank is doing, and with `--email` writes to `REPORT_RECIPIENTS` about the banks
that are broken for everyone who uses them. Scheduled daily at 09:30
Europe/Madrid. Nothing user-facing — no route, no page, no copy a customer sees.

## The metric

One row per bank (`aspsp_name` + `aspsp_country`), worst first, covering both
funnels so the table answers which connections work and which don't:

| | |
|---|---|
| authorization | attempts, failed auth, distinct users, ever connected |
| sync | live connections, how many are not syncing, how many are throttled, newest sync |

The `State` column carries the verdict. Only `BROKEN` gets an email; anything one
bar short of it says which bar it missed (`unproven: 3/3 not syncing, 1 user(s)`)
rather than reading as a milder problem.

## The alert

Two failure modes, because we have a command to notify users for each:

- **The bank never authorizes anyone** → `banking:notify-connect-failure`
- **Connections that used to work stopped** → `banking:notify-outage`

The email names why each bank is listed and carries the matching command ready to
paste, as a dry run:

```
php artisan banking:notify-outage "Openbank" --country=ES --dry-run
```

Both definitions of broken require at least 2 distinct affected users. One person
cancelling twice at their bank leaves the same trace as a broken connector.

## Where the definitions live

`NotifyBankConnectFailureCommand` and `NotifyBankOutageCommand` each already
encoded one half of what "this bank is broken" means. Rather than copy those
query builders — which `bun run dry` would have failed anyway — they moved into a
shared `QueriesBankFailures` concern that `NotifiesBankUsers` now composes. The
report cannot drift from the notice it tells you to send. Neither notify command
changed behaviour; their 40 tests pass untouched.

## Measuring around the rate-limit bug

Trade Republic is responsible for most of our rate limits. Its 429 lands on
`getBalances` *after* the transactions import, and the syncer rethrows so the job
can set a backoff — which discards the whole run, so `last_synced_at` is never
written. A connection can be importing data perfectly and still look permanently
dead.

Throttled connections are therefore held out of the failing count and shown as
their own state. Without that, this report would have asked us to email Trade
Republic's users an outage notice while their data was arriving fine. The sync
bug itself is untouched here.

`consecutive_sync_failures` is deliberately not the staleness signal: it is 0 on
every live connection in production, because it is only written on the path that
also caps the retries — and passing the cap takes the connection out of the
population entirely. What is left is the status the last run wrote and the sync
clock, with a configurable `--stale-hours` (default 48, or eight consecutive
missed six-hourly syncs).

## Repeat suppression

Four Spanish banks have been broken since long before this existed, so a daily
alert would be noise from its first run. A bank that has been alerted about is
not alerted again for `--repeat-after` days (default 7). The ledger is the cache —
no table, no migration — and it is written only once the email is out, because an
alert lost to a mail failure is worse than a second copy of one.

## Verified against production

Read-only queries against the prod database, so the thresholds are set on real
data rather than guesses. Today the alert would fire for exactly five banks: the
four that have never once authorized (MyInvestor Banco, Banco Cetelem, Banco
Mediolanum, Caja Rural de Navarra) and Openbank ES, whose five live connections
have all been silent for over a week. Trade Republic correctly does not fire.

## What review changed

- The fully-down sentence quoted `MAX(last_synced_at)` across every live
  connection, throttled ones included — so a bank could be reported as entirely
  stopped while the alert cited a fresh sync belonging to a connection it had
  just excluded. It now reads that timestamp off the failing set only.
- The table header said `Rejected` for what is really a failed authorization. The
  callback error code is not stored, so on a bank that does connect those rows
  are just as likely to be someone cancelling at their own bank.
- Every command in the email tells one bank's users that their bank is broken. If
  Enable Banking is the thing that is down, that is wrong for all of them at
  once, so a majority of connected banks failing together now says to check the
  provider first.

## Testing

19 feature tests, covering both failure modes, the ≥2-user bar, a partly failing
bank, a throttled connection that must not read as an outage, the suppression
window either side of its expiry, the `REPORT_RECIPIENTS` guard, and a bank name
a shell would otherwise expand.

QA'd as it is actually used: ran both modes against the local database, read the
rendered email in Mailhog (HTML and plain text) to confirm the pasteable command
survives escaping, checked the cache ledger keys, and confirmed the schedule
entry resolves to 09:30 Europe/Madrid.
