### PR TITLE
feat(observability): make an EnableBanking 429 say which endpoint it came from

### DIFF
--- a/app/Exceptions/Banking/BankingRequestException.php
+++ b/app/Exceptions/Banking/BankingRequestException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Exceptions\Banking;
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
+
+/**
+ * A provider request that matched none of the classified failures, re-raised
+ * carrying the operation it came from.
+ *
+ * It extends RequestException on purpose. A 429 matches no branch of the
+ * provider's error ladder and the job keys its rate-limit handling on
+ * `instanceof RequestException`, so subclassing leaves that path byte for byte
+ * as it was while giving the logs the one thing they were missing: whether it
+ * was the balances or the transactions endpoint that hit the limit.
+ */
+class BankingRequestException extends RequestException
+{
+    public function __construct(Response $response, public readonly string $operation)
+    {
+        parent::__construct($response);
+    }
+}

--- a/app/Exceptions/Banking/BankingRequestException.php
+++ b/app/Exceptions/Banking/BankingRequestException.php
@@ -15,7 +15,7 @@ use Illuminate\Http\Client\Response;
  * as it was while giving the logs the one thing they were missing: whether it
  * was the balances or the transactions endpoint that hit the limit.
  */
-class BankingRequestException extends RequestException
+class BankingRequestException extends RequestException implements CarriesBankingOperation
 {
     public function __construct(Response $response, public readonly string $operation)
     {

--- a/app/Exceptions/Banking/CarriesBankingOperation.php
+++ b/app/Exceptions/Banking/CarriesBankingOperation.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Exceptions\Banking;
+
+/**
+ * A banking failure that knows which provider endpoint produced it.
+ *
+ * The two exceptions carrying it already expose the property, so this only
+ * gives the logs one type to ask instead of a cascade repeated per call site.
+ */
+interface CarriesBankingOperation
+{
+    public ?string $operation { get; }
+}

--- a/app/Exceptions/Banking/TransientBankingProviderException.php
+++ b/app/Exceptions/Banking/TransientBankingProviderException.php
@@ -6,7 +6,7 @@ use Exception;
 use Illuminate\Contracts\Debug\ShouldntReport;
 use Throwable;
 
-class TransientBankingProviderException extends Exception implements ShouldntReport
+class TransientBankingProviderException extends Exception implements CarriesBankingOperation, ShouldntReport
 {
     public function __construct(
         string $message,

--- a/app/Exceptions/Banking/TransientBankingProviderException.php
+++ b/app/Exceptions/Banking/TransientBankingProviderException.php
@@ -13,6 +13,7 @@ class TransientBankingProviderException extends Exception implements ShouldntRep
         public readonly ?string $provider = null,
         public readonly ?int $statusCode = null,
         public readonly ?string $providerCode = null,
+        public readonly ?string $operation = null,
         ?Throwable $previous = null,
     ) {
         parent::__construct($message, 0, $previous);

--- a/app/Jobs/SyncBankingConnectionJob.php
+++ b/app/Jobs/SyncBankingConnectionJob.php
@@ -5,6 +5,7 @@ namespace App\Jobs;
 use App\Contracts\BankingConnectionSyncer;
 use App\Enums\BankingConnectionStatus;
 use App\Enums\BankingSyncLogStatus;
+use App\Exceptions\Banking\BankingRequestException;
 use App\Exceptions\Banking\ExpiredBankingSessionException;
 use App\Exceptions\Banking\TransientBankingProviderException;
 use App\Mail\BankingConnectionAuthFailedEmail;
@@ -17,6 +18,7 @@ use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Carbon;
@@ -51,6 +53,22 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
      * a connection in Error state before requiring manual intervention.
      */
     public const int MAX_SCHEDULED_RETRIES = 3;
+
+    /**
+     * Response headers logged verbatim on a failure, so that "the provider told
+     * us to wait N" is distinguishable from "we defaulted to an hour".
+     *
+     * @var list<string>
+     */
+    private const array RATE_LIMIT_HEADERS = [
+        'Retry-After',
+        'RateLimit-Limit',
+        'RateLimit-Remaining',
+        'RateLimit-Reset',
+        'X-RateLimit-Limit',
+        'X-RateLimit-Remaining',
+        'X-RateLimit-Reset',
+    ];
 
     public function __construct(
         public BankingConnection $bankingConnection,
@@ -126,42 +144,45 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
 
             return;
         } catch (\Throwable $e) {
-            $context = [
-                'connection_id' => $connection->id,
-                'error' => $e->getMessage(),
-                'attempt' => $this->attempts(),
-            ];
-
-            if ($e instanceof TransientBankingProviderException) {
-                $context['provider'] = $e->provider;
-                $context['status_code'] = $e->statusCode;
-                $context['provider_code'] = $e->providerCode;
-            }
-
-            // Only report once the connection actually gives up. Transient errors on a
-            // non-final attempt are recovered by the retry and would otherwise spam one
-            // warning per scheduled cycle for connections that ultimately sync fine.
-            if ($this->attempts() >= $this->tries || $this->isAuthError($e)) {
-                Log::log($e instanceof TransientBankingProviderException ? 'warning' : 'error', 'Banking sync failed', $context);
-            }
-
-            if ($this->isRateLimitError($e)) {
-                $this->applyRateLimitBackoff($connection, $e);
-                $this->logSyncAttempt($connection, BankingSyncLogStatus::Failed, $startTime, $e);
-
-                return;
-            }
-
-            $this->logSyncAttempt($connection, BankingSyncLogStatus::Failed, $startTime, $e);
-
-            if ($this->isAuthError($e)) {
-                $this->handlePermanentError($connection, $syncer, $e);
-
-                return;
-            }
-
-            $this->handleTemporaryError($connection, $e);
+            $this->handleSyncFailure($connection, $syncer, $e, $startTime);
         }
+    }
+
+    /**
+     * Classify a failed run, record it, and leave the connection in the state
+     * that classification calls for.
+     */
+    private function handleSyncFailure(
+        BankingConnection $connection,
+        BankingConnectionSyncer $syncer,
+        \Throwable $e,
+        float $startTime,
+    ): void {
+        $context = $this->failureContext($connection, $e);
+
+        // Only report once the connection actually gives up. Transient errors on a
+        // non-final attempt are recovered by the retry and would otherwise spam one
+        // warning per scheduled cycle for connections that ultimately sync fine.
+        if ($this->attempts() >= $this->tries || $this->isAuthError($e)) {
+            Log::log($e instanceof TransientBankingProviderException ? 'warning' : 'error', 'Banking sync failed', $context);
+        }
+
+        if ($this->isRateLimitError($e)) {
+            $this->applyRateLimitBackoff($connection, $e, $context);
+            $this->logSyncAttempt($connection, BankingSyncLogStatus::Failed, $startTime, $e, $context);
+
+            return;
+        }
+
+        $this->logSyncAttempt($connection, BankingSyncLogStatus::Failed, $startTime, $e, $context);
+
+        if ($this->isAuthError($e)) {
+            $this->handlePermanentError($connection, $syncer, $e);
+
+            return;
+        }
+
+        $this->handleTemporaryError($connection, $e);
     }
 
     /**
@@ -358,6 +379,111 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
         ]);
     }
 
+    /**
+     * Everything worth knowing about a failed sync, shared by the warning that
+     * reaches Sentry and the sync-log row that stays in the database.
+     *
+     * @return array<string, mixed>
+     */
+    private function failureContext(BankingConnection $connection, \Throwable $e): array
+    {
+        $context = [
+            'connection_id' => $connection->id,
+            // Without the bank there is no way to tell a provider-wide wave from
+            // one connector misbehaving, which is the first question every one of
+            // these investigations starts with.
+            'aspsp_name' => $connection->aspsp_name,
+            'aspsp_country' => $connection->aspsp_country,
+            'operation' => $this->resolveOperation($e),
+            'error' => $e->getMessage(),
+            'error_class' => $e::class,
+            'attempt' => $this->attempts(),
+        ];
+
+        if ($e instanceof TransientBankingProviderException) {
+            $context['provider'] = $e->provider;
+            $context['status_code'] = $e->statusCode;
+            $context['provider_code'] = $e->providerCode;
+        }
+
+        return [...$context, ...$this->responseContext($e)];
+    }
+
+    /**
+     * Which endpoint the provider was serving when it failed, when the provider
+     * bothered to say.
+     */
+    private function resolveOperation(\Throwable $e): ?string
+    {
+        return match (true) {
+            $e instanceof BankingRequestException => $e->operation,
+            $e instanceof TransientBankingProviderException => $e->operation,
+            default => null,
+        };
+    }
+
+    /**
+     * What the provider actually replied, for the failures that got a reply.
+     *
+     * @return array<string, mixed>
+     */
+    private function responseContext(\Throwable $e): array
+    {
+        $failure = $this->requestFailure($e);
+
+        if ($failure === null) {
+            return [];
+        }
+
+        return [
+            'status_code' => $failure->response->status(),
+            // Error bodies only - a RequestException never carries a successful
+            // payload - and truncated, so that a provider which starts answering
+            // with account data on an error status cannot empty it into the logs.
+            'response_body' => Str::limit($failure->response->body(), 500),
+            'rate_limit_headers' => $this->rateLimitHeaders($failure->response),
+        ];
+    }
+
+    /**
+     * The HTTP failure behind an exception, whether it is the exception itself
+     * or the one the provider wrapped.
+     */
+    private function requestFailure(\Throwable $e): ?RequestException
+    {
+        if ($e instanceof RequestException) {
+            return $e;
+        }
+
+        $previous = $e->getPrevious();
+
+        return $previous instanceof RequestException ? $previous : null;
+    }
+
+    /**
+     * The provider's own account of the limit it is enforcing.
+     *
+     * Allow-listed rather than dumped wholesale: response headers are the one
+     * place a token or a cookie could ride along into a log this project keeps
+     * in public.
+     *
+     * @return array<string, string>
+     */
+    private function rateLimitHeaders(Response $response): array
+    {
+        $headers = [];
+
+        foreach (self::RATE_LIMIT_HEADERS as $name) {
+            $value = $response->header($name);
+
+            if ($value !== '') {
+                $headers[$name] = $value;
+            }
+        }
+
+        return $headers;
+    }
+
     private function friendlyErrorMessage(\Throwable $e): string
     {
         if ($e instanceof TransientBankingProviderException) {
@@ -387,7 +513,10 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
      * Persist a backoff window so the scheduler stops re-dispatching
      * the same connection until the provider quota resets.
      */
-    private function applyRateLimitBackoff(BankingConnection $connection, \Throwable $e): void
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    private function applyRateLimitBackoff(BankingConnection $connection, \Throwable $e, array $context): void
     {
         $until = $this->resolveRateLimitBackoffUntil($e);
 
@@ -396,8 +525,11 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
             'error_message' => $this->friendlyErrorMessage($e),
         ]);
 
+        // The line above this one only fires on the final attempt, so for a rate
+        // limit this is usually the only record that reaches the logs. It carries
+        // the full context for that reason.
         Log::warning('Banking connection rate limited, backing off', [
-            'connection_id' => $connection->id,
+            ...$context,
             'rate_limited_until' => $until->toIso8601String(),
         ]);
     }

--- a/app/Jobs/SyncBankingConnectionJob.php
+++ b/app/Jobs/SyncBankingConnectionJob.php
@@ -5,7 +5,7 @@ namespace App\Jobs;
 use App\Contracts\BankingConnectionSyncer;
 use App\Enums\BankingConnectionStatus;
 use App\Enums\BankingSyncLogStatus;
-use App\Exceptions\Banking\BankingRequestException;
+use App\Exceptions\Banking\CarriesBankingOperation;
 use App\Exceptions\Banking\ExpiredBankingSessionException;
 use App\Exceptions\Banking\TransientBankingProviderException;
 use App\Mail\BankingConnectionAuthFailedEmail;
@@ -388,13 +388,8 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
     private function failureContext(BankingConnection $connection, \Throwable $e): array
     {
         $context = [
-            'connection_id' => $connection->id,
-            // Without the bank there is no way to tell a provider-wide wave from
-            // one connector misbehaving, which is the first question every one of
-            // these investigations starts with.
-            'aspsp_name' => $connection->aspsp_name,
-            'aspsp_country' => $connection->aspsp_country,
-            'operation' => $this->resolveOperation($e),
+            ...$connection->logContext(),
+            'operation' => $e instanceof CarriesBankingOperation ? $e->operation : null,
             'error' => $e->getMessage(),
             'error_class' => $e::class,
             'attempt' => $this->attempts(),
@@ -402,24 +397,10 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
 
         if ($e instanceof TransientBankingProviderException) {
             $context['provider'] = $e->provider;
-            $context['status_code'] = $e->statusCode;
             $context['provider_code'] = $e->providerCode;
         }
 
         return [...$context, ...$this->responseContext($e)];
-    }
-
-    /**
-     * Which endpoint the provider was serving when it failed, when the provider
-     * bothered to say.
-     */
-    private function resolveOperation(\Throwable $e): ?string
-    {
-        return match (true) {
-            $e instanceof BankingRequestException => $e->operation,
-            $e instanceof TransientBankingProviderException => $e->operation,
-            default => null,
-        };
     }
 
     /**
@@ -512,8 +493,7 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
     /**
      * Persist a backoff window so the scheduler stops re-dispatching
      * the same connection until the provider quota resets.
-     */
-    /**
+     *
      * @param  array<string, mixed>  $context
      */
     private function applyRateLimitBackoff(BankingConnection $connection, \Throwable $e, array $context): void

--- a/app/Models/BankingConnection.php
+++ b/app/Models/BankingConnection.php
@@ -17,6 +17,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
  * @property bool $has_pending_accounts
+ * @property string|null $aspsp_name
+ * @property string|null $aspsp_country
  * @property BankingProvider $provider
  * @property BankingConnectionStatus $status
  * @property Carbon|null $valid_until
@@ -62,6 +64,24 @@ class BankingConnection extends Model
         'state_token',
         'session_id',
     ];
+
+    /**
+     * How this connection identifies itself in a log line.
+     *
+     * Which bank it is decides whether a wave of failures is one connector
+     * misbehaving or the provider as a whole, and that is the first question
+     * every sync investigation starts with.
+     *
+     * @return array<string, string|null>
+     */
+    public function logContext(): array
+    {
+        return [
+            'connection_id' => $this->id,
+            'aspsp_name' => $this->aspsp_name,
+            'aspsp_country' => $this->aspsp_country,
+        ];
+    }
 
     protected function casts(): array
     {

--- a/app/Services/Banking/EnableBankingProvider.php
+++ b/app/Services/Banking/EnableBankingProvider.php
@@ -3,6 +3,7 @@
 namespace App\Services\Banking;
 
 use App\Contracts\BankingProviderInterface;
+use App\Exceptions\Banking\BankingRequestException;
 use App\Exceptions\Banking\ExpiredBankingSessionException;
 use App\Exceptions\Banking\InaccessibleBankAccountException;
 use App\Exceptions\Banking\TransientBankingProviderException;
@@ -103,23 +104,10 @@ class EnableBankingProvider implements BankingProviderInterface
             throw new TransientBankingProviderException(
                 'EnableBanking did not respond while fetching account transactions.',
                 provider: 'enablebanking',
+                operation: 'transactions',
                 previous: $e,
             );
         } catch (RequestException $e) {
-            if ($this->requiresReconnect($e)) {
-                throw new ExpiredBankingSessionException(
-                    'EnableBanking needs the user to reconnect before it will serve account transactions.',
-                    previous: $e,
-                );
-            }
-
-            if ($this->isInaccessibleAccount($e)) {
-                throw new InaccessibleBankAccountException(
-                    'EnableBanking account is no longer accessible while fetching transactions.',
-                    previous: $e,
-                );
-            }
-
             if ($this->isWrongPeriod($e)) {
                 throw new WrongTransactionsPeriodException(
                     'EnableBanking rejected the requested transactions period as too wide.',
@@ -127,30 +115,7 @@ class EnableBankingProvider implements BankingProviderInterface
                 );
             }
 
-            if ($this->isTransientServerError($e) || $this->isPsuActionRequired($e)) {
-                throw new TransientBankingProviderException(
-                    'EnableBanking could not serve account transactions right now.',
-                    provider: 'enablebanking',
-                    statusCode: $e->response->status(),
-                    providerCode: $this->detailErrorName($e),
-                    previous: $e,
-                );
-            }
-
-            if (! $this->isAspspError($e)) {
-                throw $e;
-            }
-
-            $body = $this->errorBody($e);
-            $providerCode = $body['error'] ?? null;
-
-            throw new TransientBankingProviderException(
-                'EnableBanking bank connector failed while fetching account transactions.',
-                provider: 'enablebanking',
-                statusCode: $e->response->status(),
-                providerCode: is_string($providerCode) ? $providerCode : null,
-                previous: $e,
-            );
+            $this->rethrowRequestFailure($e, 'transactions');
         }
 
         $data = $response->json();
@@ -171,47 +136,11 @@ class EnableBankingProvider implements BankingProviderInterface
             throw new TransientBankingProviderException(
                 'EnableBanking did not respond while fetching account balances.',
                 provider: 'enablebanking',
+                operation: 'balances',
                 previous: $e,
             );
         } catch (RequestException $e) {
-            if ($this->requiresReconnect($e)) {
-                throw new ExpiredBankingSessionException(
-                    'EnableBanking needs the user to reconnect before it will serve account balances.',
-                    previous: $e,
-                );
-            }
-
-            if ($this->isInaccessibleAccount($e)) {
-                throw new InaccessibleBankAccountException(
-                    'EnableBanking account is no longer accessible while fetching balances.',
-                    previous: $e,
-                );
-            }
-
-            if ($this->isTransientServerError($e) || $this->isPsuActionRequired($e)) {
-                throw new TransientBankingProviderException(
-                    'EnableBanking could not serve account balances right now.',
-                    provider: 'enablebanking',
-                    statusCode: $e->response->status(),
-                    providerCode: $this->detailErrorName($e),
-                    previous: $e,
-                );
-            }
-
-            if (! $this->isAspspError($e)) {
-                throw $e;
-            }
-
-            $body = $this->errorBody($e);
-            $providerCode = $body['error'] ?? null;
-
-            throw new TransientBankingProviderException(
-                'EnableBanking bank connector failed while fetching account balances.',
-                provider: 'enablebanking',
-                statusCode: $e->response->status(),
-                providerCode: is_string($providerCode) ? $providerCode : null,
-                previous: $e,
-            );
+            $this->rethrowRequestFailure($e, 'balances');
         }
 
         return $response->json();
@@ -240,6 +169,58 @@ class EnableBankingProvider implements BankingProviderInterface
         $response = $this->client()->delete("/sessions/{$sessionId}");
 
         $response->throw();
+    }
+
+    /**
+     * Re-raise a failed EnableBanking request as the classified exception the
+     * caller expects, tagged with the operation it came from.
+     *
+     * The tag is the whole point. A 429 matches none of the branches below and
+     * leaves as a plain request failure, which is why nothing downstream has
+     * ever been able to say whether it is balances or transactions that hits
+     * the limit.
+     */
+    private function rethrowRequestFailure(RequestException $e, string $operation): never
+    {
+        if ($this->requiresReconnect($e)) {
+            throw new ExpiredBankingSessionException(
+                "EnableBanking needs the user to reconnect before it will serve account {$operation}.",
+                previous: $e,
+            );
+        }
+
+        if ($this->isInaccessibleAccount($e)) {
+            throw new InaccessibleBankAccountException(
+                "EnableBanking account is no longer accessible while fetching {$operation}.",
+                previous: $e,
+            );
+        }
+
+        if ($this->isTransientServerError($e) || $this->isPsuActionRequired($e)) {
+            throw new TransientBankingProviderException(
+                "EnableBanking could not serve account {$operation} right now.",
+                provider: 'enablebanking',
+                statusCode: $e->response->status(),
+                providerCode: $this->detailErrorName($e),
+                operation: $operation,
+                previous: $e,
+            );
+        }
+
+        if ($this->isAspspError($e)) {
+            $providerCode = $this->errorBody($e)['error'] ?? null;
+
+            throw new TransientBankingProviderException(
+                "EnableBanking bank connector failed while fetching account {$operation}.",
+                provider: 'enablebanking',
+                statusCode: $e->response->status(),
+                providerCode: is_string($providerCode) ? $providerCode : null,
+                operation: $operation,
+                previous: $e,
+            );
+        }
+
+        throw new BankingRequestException($e->response, $operation);
     }
 
     private function isAspspError(RequestException $e): bool
@@ -349,11 +330,27 @@ class EnableBankingProvider implements BankingProviderInterface
                     'status' => $response->status(),
                     // Which endpoint failed tells one bad account apart from a
                     // whole connection or a provider-wide wave.
-                    'path' => $response->effectiveUri()?->getPath(),
+                    'path' => $this->redactedPath($response->effectiveUri()?->getPath()),
                     'body' => $response->json(),
                     'exception' => get_class($exception),
                 ]);
             });
+    }
+
+    /**
+     * The endpoint that failed, with the bank's own identifiers stripped out.
+     *
+     * The shape of the path is what has diagnostic value; the account and
+     * session ids in it are a bank's handle on a real person's account, and
+     * these logs leave the building. Keep the shape, drop the ids.
+     */
+    private function redactedPath(?string $path): ?string
+    {
+        if ($path === null) {
+            return null;
+        }
+
+        return preg_replace('#/(accounts|sessions)/[^/]+#', '/$1/{id}', $path);
     }
 
     private function generateJwt(): string

--- a/app/Services/Banking/EnableBankingProvider.php
+++ b/app/Services/Banking/EnableBankingProvider.php
@@ -14,6 +14,7 @@ use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 
 class EnableBankingProvider implements BankingProviderInterface
 {
@@ -331,7 +332,10 @@ class EnableBankingProvider implements BankingProviderInterface
                     // Which endpoint failed tells one bad account apart from a
                     // whole connection or a provider-wide wave.
                     'path' => $this->redactedPath($response->effectiveUri()?->getPath()),
-                    'body' => $response->json(),
+                    // Capped like every other body this project logs: an error
+                    // body is provider boilerplate today, but nothing guarantees
+                    // a bank will not answer with account data on an error status.
+                    'body' => Str::limit($response->body(), 500),
                     'exception' => get_class($exception),
                 ]);
             });

--- a/app/Services/Banking/Sync/EnableBankingSyncer.php
+++ b/app/Services/Banking/Sync/EnableBankingSyncer.php
@@ -3,6 +3,7 @@
 namespace App\Services\Banking\Sync;
 
 use App\Enums\TransactionSource;
+use App\Exceptions\Banking\BankingRequestException;
 use App\Exceptions\Banking\ExpiredBankingSessionException;
 use App\Exceptions\Banking\InaccessibleBankAccountException;
 use App\Exceptions\Banking\TransientBankingProviderException;
@@ -54,46 +55,63 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
         $balanceFailed = 0;
         $transactionFailure = null;
 
+        $accountsAttempted = 0;
+
         $connection->load('accounts.bank');
 
-        foreach ($connection->accounts as $account) {
-            $created = 0;
-            [$dateFrom, $strategy] = $this->resolveWindow($connection, $account, $dateTo, $isFirstSync);
+        try {
+            foreach ($connection->accounts as $account) {
+                $created = 0;
+                $accountsAttempted++;
+                [$dateFrom, $strategy] = $this->resolveWindow($connection, $account, $dateTo, $isFirstSync);
 
-            try {
-                $created = $this->transactionSync->sync($account, $dateFrom, $dateTo, $strategy, saveDailyBalances: ! $account->isLinked());
-            } catch (InaccessibleBankAccountException|WrongTransactionsPeriodException $e) {
-                // A single account the bank no longer exposes, or whose history
-                // window it refuses even after narrowing, must not break the
-                // whole connection sync. Skip it; the user can stop syncing it
-                // from the manage-accounts screen.
-                Log::warning('Skipping unsyncable EnableBanking account during sync', [
-                    'connection_id' => $connection->id,
-                    'account_id' => $account->id,
-                    'reason' => $e::class,
-                ]);
+                try {
+                    $created = $this->transactionSync->sync($account, $dateFrom, $dateTo, $strategy, saveDailyBalances: ! $account->isLinked());
+                } catch (InaccessibleBankAccountException|WrongTransactionsPeriodException $e) {
+                    // A single account the bank no longer exposes, or whose history
+                    // window it refuses even after narrowing, must not break the
+                    // whole connection sync. Skip it; the user can stop syncing it
+                    // from the manage-accounts screen.
+                    Log::warning('Skipping unsyncable EnableBanking account during sync', [
+                        ...$this->bankContext($connection),
+                        'account_id' => $account->id,
+                        'reason' => $e::class,
+                    ]);
 
-                continue;
-            } catch (TransientBankingProviderException $e) {
-                $transactionFailure ??= $this->recordAccountTransactionFailure($account, $e);
+                    continue;
+                } catch (TransientBankingProviderException $e) {
+                    $transactionFailure ??= $this->recordAccountTransactionFailure($connection, $account, $e);
+                }
+
+                // Counted before the balances call, which is the one that throws
+                // most often: a tally taken after it would report zero imported
+                // for a run that had in fact just imported them.
+                if ($created > 0) {
+                    $bankName = $account->bank->name ?? __('Unknown Bank');
+                    $transactionsPerBank[$bankName] = ($transactionsPerBank[$bankName] ?? 0) + $created;
+                }
+
+                if (! $this->syncBalances($connection, $account, $isFirstSync)) {
+                    $balanceFailed++;
+                }
             }
 
-            if (! $this->syncBalances($account, $isFirstSync)) {
-                $balanceFailed++;
+            // Report the failure only once every account has had its turn. The run
+            // still fails, so the connection keeps its Error state, its retries and its
+            // unset last_synced_at exactly as before - the one thing that changes is
+            // that the accounts behind the failing one were attempted at all.
+            if ($transactionFailure !== null) {
+                throw $transactionFailure;
             }
+        } catch (\Throwable $e) {
+            $this->logAbortedSync($connection, $e, [
+                'accounts_attempted' => $accountsAttempted,
+                'accounts_total' => $connection->accounts->count(),
+                'transactions_synced' => array_sum($transactionsPerBank),
+                'balance_failed' => $balanceFailed,
+            ]);
 
-            if ($created > 0) {
-                $bankName = $account->bank->name ?? __('Unknown Bank');
-                $transactionsPerBank[$bankName] = ($transactionsPerBank[$bankName] ?? 0) + $created;
-            }
-        }
-
-        // Report the failure only once every account has had its turn. The run
-        // still fails, so the connection keeps its Error state, its retries and its
-        // unset last_synced_at exactly as before - the one thing that changes is
-        // that the accounts behind the failing one were attempted at all.
-        if ($transactionFailure !== null) {
-            throw $transactionFailure;
+            throw $e;
         }
 
         if ($isFirstSync) {
@@ -107,6 +125,53 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
             'transactions_per_bank' => $transactionsPerBank,
             'balance_failed' => $balanceFailed,
         ];
+    }
+
+    /**
+     * The connection and the bank behind it, on every log this syncer writes.
+     *
+     * Which bank it is decides whether a wave of failures is one connector
+     * misbehaving or the provider as a whole, and until now none of these lines
+     * carried it.
+     *
+     * @return array<string, string|null>
+     */
+    private function bankContext(BankingConnection $connection): array
+    {
+        return [
+            'connection_id' => $connection->id,
+            'aspsp_name' => $connection->aspsp_name,
+            'aspsp_country' => $connection->aspsp_country,
+        ];
+    }
+
+    /**
+     * Record what the run had already got done when it died.
+     *
+     * A throwing run returns no metadata, so "this connection imported six
+     * transactions and then the rate limit killed the run" was until now only
+     * reconstructable by lining up timestamps across two tables.
+     *
+     * @param  array<string, int>  $progress
+     */
+    private function logAbortedSync(BankingConnection $connection, \Throwable $e, array $progress): void
+    {
+        // A consent that lapsed mid-run is a lifecycle event the job already
+        // records, not a failure worth a second warning.
+        if ($e instanceof ExpiredBankingSessionException) {
+            return;
+        }
+
+        Log::warning('EnableBanking sync aborted mid-run', [
+            ...$this->bankContext($connection),
+            ...$progress,
+            'operation' => $e instanceof TransientBankingProviderException || $e instanceof BankingRequestException
+                ? $e->operation
+                : null,
+            'status_code' => $e instanceof RequestException ? $e->response->status() : null,
+            'reason' => $e::class,
+            'error' => $e->getMessage(),
+        ]);
     }
 
     /**
@@ -136,17 +201,18 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
      * path. Only a reply that came back with a status says something about *this*
      * account: the ConnectionException path is the one that leaves statusCode null.
      */
-    private function recordAccountTransactionFailure(Account $account, TransientBankingProviderException $e): TransientBankingProviderException
+    private function recordAccountTransactionFailure(BankingConnection $connection, Account $account, TransientBankingProviderException $e): TransientBankingProviderException
     {
         if ($e->statusCode === null) {
             throw $e;
         }
 
         Log::warning('EnableBanking transaction sync failed for one account, continuing', [
-            'connection_id' => $account->banking_connection_id,
+            ...$this->bankContext($connection),
             'account_id' => $account->id,
             'status_code' => $e->statusCode,
             'provider_code' => $e->providerCode,
+            'operation' => $e->operation,
             'error' => $e->getMessage(),
         ]);
 
@@ -158,7 +224,7 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
      *
      * @return bool Whether the balances were synced
      */
-    private function syncBalances(Account $account, bool $isFirstSync): bool
+    private function syncBalances(BankingConnection $connection, Account $account, bool $isFirstSync): bool
     {
         try {
             $this->balanceSync->sync($account);
@@ -180,7 +246,7 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
             // nice-to-have next to the transactions we just persisted, and failing
             // here leaves last_synced_at unset.
             Log::warning('EnableBanking balance sync failed, continuing', [
-                'connection_id' => $account->banking_connection_id,
+                ...$this->bankContext($connection),
                 'account_id' => $account->id,
                 'reason' => $e::class,
                 'error' => $e->getMessage(),

--- a/app/Services/Banking/Sync/EnableBankingSyncer.php
+++ b/app/Services/Banking/Sync/EnableBankingSyncer.php
@@ -3,7 +3,7 @@
 namespace App\Services\Banking\Sync;
 
 use App\Enums\TransactionSource;
-use App\Exceptions\Banking\BankingRequestException;
+use App\Exceptions\Banking\CarriesBankingOperation;
 use App\Exceptions\Banking\ExpiredBankingSessionException;
 use App\Exceptions\Banking\InaccessibleBankAccountException;
 use App\Exceptions\Banking\TransientBankingProviderException;
@@ -73,7 +73,7 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
                     // whole connection sync. Skip it; the user can stop syncing it
                     // from the manage-accounts screen.
                     Log::warning('Skipping unsyncable EnableBanking account during sync', [
-                        ...$this->bankContext($connection),
+                        ...$connection->logContext(),
                         'account_id' => $account->id,
                         'reason' => $e::class,
                     ]);
@@ -95,14 +95,6 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
                     $balanceFailed++;
                 }
             }
-
-            // Report the failure only once every account has had its turn. The run
-            // still fails, so the connection keeps its Error state, its retries and its
-            // unset last_synced_at exactly as before - the one thing that changes is
-            // that the accounts behind the failing one were attempted at all.
-            if ($transactionFailure !== null) {
-                throw $transactionFailure;
-            }
         } catch (\Throwable $e) {
             $this->logAbortedSync($connection, $e, [
                 'accounts_attempted' => $accountsAttempted,
@@ -112,6 +104,17 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
             ]);
 
             throw $e;
+        }
+
+        // Report the failure only once every account has had its turn. The run
+        // still fails, so the connection keeps its Error state, its retries and its
+        // unset last_synced_at exactly as before - the one thing that changes is
+        // that the accounts behind the failing one were attempted at all.
+        //
+        // Outside the try on purpose: by here nothing was aborted mid-run, every
+        // account was attempted, and the per-account failure is already logged.
+        if ($transactionFailure !== null) {
+            throw $transactionFailure;
         }
 
         if ($isFirstSync) {
@@ -124,24 +127,6 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
             'transactions_synced' => array_sum($transactionsPerBank),
             'transactions_per_bank' => $transactionsPerBank,
             'balance_failed' => $balanceFailed,
-        ];
-    }
-
-    /**
-     * The connection and the bank behind it, on every log this syncer writes.
-     *
-     * Which bank it is decides whether a wave of failures is one connector
-     * misbehaving or the provider as a whole, and until now none of these lines
-     * carried it.
-     *
-     * @return array<string, string|null>
-     */
-    private function bankContext(BankingConnection $connection): array
-    {
-        return [
-            'connection_id' => $connection->id,
-            'aspsp_name' => $connection->aspsp_name,
-            'aspsp_country' => $connection->aspsp_country,
         ];
     }
 
@@ -163,11 +148,9 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
         }
 
         Log::warning('EnableBanking sync aborted mid-run', [
-            ...$this->bankContext($connection),
+            ...$connection->logContext(),
             ...$progress,
-            'operation' => $e instanceof TransientBankingProviderException || $e instanceof BankingRequestException
-                ? $e->operation
-                : null,
+            'operation' => $e instanceof CarriesBankingOperation ? $e->operation : null,
             'status_code' => $e instanceof RequestException ? $e->response->status() : null,
             'reason' => $e::class,
             'error' => $e->getMessage(),
@@ -208,7 +191,7 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
         }
 
         Log::warning('EnableBanking transaction sync failed for one account, continuing', [
-            ...$this->bankContext($connection),
+            ...$connection->logContext(),
             'account_id' => $account->id,
             'status_code' => $e->statusCode,
             'provider_code' => $e->providerCode,
@@ -246,8 +229,9 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
             // nice-to-have next to the transactions we just persisted, and failing
             // here leaves last_synced_at unset.
             Log::warning('EnableBanking balance sync failed, continuing', [
-                ...$this->bankContext($connection),
+                ...$connection->logContext(),
                 'account_id' => $account->id,
+                'operation' => 'balances',
                 'reason' => $e::class,
                 'error' => $e->getMessage(),
             ]);

--- a/tests/Feature/OpenBanking/BankingSyncTelemetryTest.php
+++ b/tests/Feature/OpenBanking/BankingSyncTelemetryTest.php
@@ -1,0 +1,239 @@
+<?php
+
+use App\Contracts\BankingProviderInterface;
+use App\Enums\BankingSyncLogStatus;
+use App\Jobs\SyncBankingConnectionJob;
+use App\Models\Account;
+use App\Models\BankingConnection;
+use App\Models\BankingSyncLog;
+use App\Models\User;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * The shape production keeps producing: one bank, one account, transactions the
+ * provider serves happily and balances it rate limits. Which of the two hits the
+ * limit is the question the logs have never been able to answer.
+ */
+function telemetryConnection(): BankingConnection
+{
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->create([
+        'user_id' => $user->id,
+        'aspsp_name' => 'Trade Republic',
+        'aspsp_country' => 'DE',
+        'last_synced_at' => now()->subDay(),
+    ]);
+
+    Account::factory()->connected()->create([
+        'user_id' => $user->id,
+        'banking_connection_id' => $connection->id,
+        'external_account_id' => 'ext-1',
+    ]);
+
+    app()->instance(BankingProviderInterface::class, enableBankingProviderForTest());
+
+    return $connection;
+}
+
+/**
+ * On its final attempt, so the reporting gate in the job is open.
+ */
+function telemetryJob(BankingConnection $connection): SyncBankingConnectionJob
+{
+    $job = new SyncBankingConnectionJob($connection);
+    $job->job = Mockery::mock(Job::class);
+    $job->job->shouldReceive('attempts')->andReturn(3);
+    $job->job->shouldReceive('isReleased')->andReturn(false);
+    $job->job->shouldReceive('isDeletedOrReleased')->andReturn(false);
+    $job->job->shouldReceive('hasFailed')->andReturn(false);
+
+    return $job;
+}
+
+/**
+ * Every line written during the callback, as [message, context] pairs.
+ *
+ * @return array<int, array{0: string, 1: array<string, mixed>}>
+ */
+function captureLogs(callable $callback): array
+{
+    $logged = [];
+
+    Event::listen(MessageLogged::class, function (MessageLogged $event) use (&$logged): void {
+        $logged[] = [$event->message, $event->context];
+    });
+
+    $callback();
+
+    return $logged;
+}
+
+/**
+ * @param  array<int, array{0: string, 1: array<string, mixed>}>  $logged
+ * @return array<string, mixed>
+ */
+function logContext(array $logged, string $message): array
+{
+    foreach ($logged as [$loggedMessage, $context]) {
+        if ($loggedMessage === $message) {
+            return $context;
+        }
+    }
+
+    test()->fail("No log line with message \"{$message}\".");
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function transactionsPayload(int $count = 2): array
+{
+    $transactions = [];
+
+    for ($i = 1; $i <= $count; $i++) {
+        $transactions[] = [
+            'transaction_id' => "txn-{$i}",
+            'transaction_amount' => ['amount' => '10.00', 'currency' => 'EUR'],
+            'credit_debit_indicator' => 'DBIT',
+            'booking_date' => now()->toDateString(),
+            'remittance_information' => ['Coffee'],
+        ];
+    }
+
+    return ['transactions' => $transactions, 'continuation_key' => null];
+}
+
+test('a rate limit on balances says so in the log the backoff writes', function () {
+    $connection = telemetryConnection();
+
+    Http::fake([
+        'api.enablebanking.com/accounts/ext-1/transactions*' => Http::response(transactionsPayload()),
+        'api.enablebanking.com/accounts/ext-1/balances*' => Http::response([
+            'code' => 429,
+            'message' => 'Maximum daily access exceeded',
+        ], 429, ['Retry-After' => '1800']),
+    ]);
+
+    $logged = captureLogs(fn () => runSync(telemetryJob($connection)));
+
+    $context = logContext($logged, 'Banking connection rate limited, backing off');
+
+    expect($context['operation'])->toBe('balances')
+        ->and($context['status_code'])->toBe(429)
+        ->and($context['aspsp_name'])->toBe('Trade Republic')
+        ->and($context['aspsp_country'])->toBe('DE')
+        ->and($context['response_body'])->toContain('Maximum daily access exceeded')
+        ->and($context['rate_limit_headers'])->toBe(['Retry-After' => '1800']);
+});
+
+test('a rate limit on transactions says so in the log the backoff writes', function () {
+    $connection = telemetryConnection();
+
+    Http::fake([
+        'api.enablebanking.com/accounts/ext-1/transactions*' => Http::response([
+            'code' => 429,
+            'message' => 'Too many requests',
+        ], 429),
+        'api.enablebanking.com/accounts/ext-1/balances*' => Http::response(['balances' => []]),
+    ]);
+
+    $logged = captureLogs(fn () => runSync(telemetryJob($connection)));
+
+    $context = logContext($logged, 'Banking connection rate limited, backing off');
+
+    expect($context['operation'])->toBe('transactions')
+        ->and($context['status_code'])->toBe(429)
+        ->and($context['aspsp_name'])->toBe('Trade Republic')
+        ->and($context['response_body'])->toContain('Too many requests')
+        // Nothing told us how long to wait, so the hour is ours, not the bank's.
+        ->and($context['rate_limit_headers'])->toBe([]);
+});
+
+test('a run killed by the rate limit reports what it had already imported', function () {
+    $connection = telemetryConnection();
+
+    Http::fake([
+        'api.enablebanking.com/accounts/ext-1/transactions*' => Http::response(transactionsPayload(2)),
+        'api.enablebanking.com/accounts/ext-1/balances*' => Http::response([
+            'code' => 429,
+            'message' => 'Too many requests',
+        ], 429),
+    ]);
+
+    $logged = captureLogs(fn () => runSync(telemetryJob($connection)));
+
+    $context = logContext($logged, 'EnableBanking sync aborted mid-run');
+
+    expect($context['transactions_synced'])->toBe(2)
+        ->and($context['accounts_attempted'])->toBe(1)
+        ->and($context['accounts_total'])->toBe(1)
+        ->and($context['operation'])->toBe('balances')
+        ->and($context['status_code'])->toBe(429)
+        ->and($context['aspsp_name'])->toBe('Trade Republic');
+});
+
+test('the failed sync log row carries the same context as the warning', function () {
+    $connection = telemetryConnection();
+
+    Http::fake([
+        'api.enablebanking.com/accounts/ext-1/transactions*' => Http::response(transactionsPayload()),
+        'api.enablebanking.com/accounts/ext-1/balances*' => Http::response([
+            'code' => 429,
+            'message' => 'Too many requests',
+        ], 429),
+    ]);
+
+    runSync(telemetryJob($connection));
+
+    $log = BankingSyncLog::query()
+        ->where('banking_connection_id', $connection->id)
+        ->where('status', BankingSyncLogStatus::Failed)
+        ->firstOrFail();
+
+    expect($log->metadata['operation'])->toBe('balances')
+        ->and($log->metadata['status_code'])->toBe(429)
+        ->and($log->metadata['aspsp_name'])->toBe('Trade Republic');
+});
+
+test('an oversized error body is truncated before it reaches the logs', function () {
+    $connection = telemetryConnection();
+
+    Http::fake([
+        'api.enablebanking.com/accounts/ext-1/transactions*' => Http::response(transactionsPayload()),
+        'api.enablebanking.com/accounts/ext-1/balances*' => Http::response(str_repeat('x', 5000), 429),
+    ]);
+
+    $logged = captureLogs(fn () => runSync(telemetryJob($connection)));
+
+    $context = logContext($logged, 'Banking connection rate limited, backing off');
+
+    // Str::limit keeps 500 characters and appends an ellipsis.
+    expect(strlen($context['response_body']))->toBeLessThanOrEqual(510);
+});
+
+test('a successful payload never reaches the logs', function () {
+    $connection = telemetryConnection();
+
+    Http::fake([
+        'api.enablebanking.com/accounts/ext-1/transactions*' => Http::response(transactionsPayload()),
+        'api.enablebanking.com/accounts/ext-1/balances*' => Http::response(['balances' => [[
+            'balance_amount' => ['amount' => '1234.56', 'currency' => 'EUR'],
+            'balance_type' => 'CLBD',
+            'reference_date' => now()->toDateString(),
+            'account_reference' => ['iban' => 'DE89370400440532013000'],
+        ]]]),
+    ]);
+
+    $logged = captureLogs(fn () => runSync(telemetryJob($connection)));
+
+    $connection->refresh();
+    expect($connection->last_synced_at)->not->toBeNull();
+
+    $serialized = json_encode($logged, JSON_PARTIAL_OUTPUT_ON_ERROR);
+
+    expect($serialized)->not->toContain('DE89370400440532013000')
+        ->and($serialized)->not->toContain('response_body');
+});

--- a/tests/Feature/OpenBanking/BankingSyncTelemetryTest.php
+++ b/tests/Feature/OpenBanking/BankingSyncTelemetryTest.php
@@ -58,7 +58,7 @@ function telemetryJob(BankingConnection $connection): SyncBankingConnectionJob
  *
  * @return array<int, array{0: string, 1: array<string, mixed>}>
  */
-function captureLogs(callable $callback): array
+function telemetryLogs(callable $callback): array
 {
     $logged = [];
 
@@ -75,7 +75,7 @@ function captureLogs(callable $callback): array
  * @param  array<int, array{0: string, 1: array<string, mixed>}>  $logged
  * @return array<string, mixed>
  */
-function logContext(array $logged, string $message): array
+function telemetryLogContext(array $logged, string $message): array
 {
     foreach ($logged as [$loggedMessage, $context]) {
         if ($loggedMessage === $message) {
@@ -89,7 +89,7 @@ function logContext(array $logged, string $message): array
 /**
  * @return array<string, mixed>
  */
-function transactionsPayload(int $count = 2): array
+function telemetryTransactionsPayload(int $count = 2): array
 {
     $transactions = [];
 
@@ -106,20 +106,31 @@ function transactionsPayload(int $count = 2): array
     return ['transactions' => $transactions, 'continuation_key' => null];
 }
 
+/**
+ * Transactions the bank serves, balances it rate limits: the shape the whole
+ * investigation is about.
+ *
+ * @param  array<string, string>  $headers
+ */
+function fakeRateLimitedBalances(string $message = 'Too many requests', array $headers = []): void
+{
+    Http::fake([
+        'api.enablebanking.com/accounts/ext-1/transactions*' => Http::response(telemetryTransactionsPayload()),
+        'api.enablebanking.com/accounts/ext-1/balances*' => Http::response([
+            'code' => 429,
+            'message' => $message,
+        ], 429, $headers),
+    ]);
+}
+
 test('a rate limit on balances says so in the log the backoff writes', function () {
     $connection = telemetryConnection();
 
-    Http::fake([
-        'api.enablebanking.com/accounts/ext-1/transactions*' => Http::response(transactionsPayload()),
-        'api.enablebanking.com/accounts/ext-1/balances*' => Http::response([
-            'code' => 429,
-            'message' => 'Maximum daily access exceeded',
-        ], 429, ['Retry-After' => '1800']),
-    ]);
+    fakeRateLimitedBalances('Maximum daily access exceeded', ['Retry-After' => '1800']);
 
-    $logged = captureLogs(fn () => runSync(telemetryJob($connection)));
+    $logged = telemetryLogs(fn () => runSync(telemetryJob($connection)));
 
-    $context = logContext($logged, 'Banking connection rate limited, backing off');
+    $context = telemetryLogContext($logged, 'Banking connection rate limited, backing off');
 
     expect($context['operation'])->toBe('balances')
         ->and($context['status_code'])->toBe(429)
@@ -140,9 +151,9 @@ test('a rate limit on transactions says so in the log the backoff writes', funct
         'api.enablebanking.com/accounts/ext-1/balances*' => Http::response(['balances' => []]),
     ]);
 
-    $logged = captureLogs(fn () => runSync(telemetryJob($connection)));
+    $logged = telemetryLogs(fn () => runSync(telemetryJob($connection)));
 
-    $context = logContext($logged, 'Banking connection rate limited, backing off');
+    $context = telemetryLogContext($logged, 'Banking connection rate limited, backing off');
 
     expect($context['operation'])->toBe('transactions')
         ->and($context['status_code'])->toBe(429)
@@ -155,17 +166,11 @@ test('a rate limit on transactions says so in the log the backoff writes', funct
 test('a run killed by the rate limit reports what it had already imported', function () {
     $connection = telemetryConnection();
 
-    Http::fake([
-        'api.enablebanking.com/accounts/ext-1/transactions*' => Http::response(transactionsPayload(2)),
-        'api.enablebanking.com/accounts/ext-1/balances*' => Http::response([
-            'code' => 429,
-            'message' => 'Too many requests',
-        ], 429),
-    ]);
+    fakeRateLimitedBalances();
 
-    $logged = captureLogs(fn () => runSync(telemetryJob($connection)));
+    $logged = telemetryLogs(fn () => runSync(telemetryJob($connection)));
 
-    $context = logContext($logged, 'EnableBanking sync aborted mid-run');
+    $context = telemetryLogContext($logged, 'EnableBanking sync aborted mid-run');
 
     expect($context['transactions_synced'])->toBe(2)
         ->and($context['accounts_attempted'])->toBe(1)
@@ -178,13 +183,7 @@ test('a run killed by the rate limit reports what it had already imported', func
 test('the failed sync log row carries the same context as the warning', function () {
     $connection = telemetryConnection();
 
-    Http::fake([
-        'api.enablebanking.com/accounts/ext-1/transactions*' => Http::response(transactionsPayload()),
-        'api.enablebanking.com/accounts/ext-1/balances*' => Http::response([
-            'code' => 429,
-            'message' => 'Too many requests',
-        ], 429),
-    ]);
+    fakeRateLimitedBalances();
 
     runSync(telemetryJob($connection));
 
@@ -202,13 +201,13 @@ test('an oversized error body is truncated before it reaches the logs', function
     $connection = telemetryConnection();
 
     Http::fake([
-        'api.enablebanking.com/accounts/ext-1/transactions*' => Http::response(transactionsPayload()),
+        'api.enablebanking.com/accounts/ext-1/transactions*' => Http::response(telemetryTransactionsPayload()),
         'api.enablebanking.com/accounts/ext-1/balances*' => Http::response(str_repeat('x', 5000), 429),
     ]);
 
-    $logged = captureLogs(fn () => runSync(telemetryJob($connection)));
+    $logged = telemetryLogs(fn () => runSync(telemetryJob($connection)));
 
-    $context = logContext($logged, 'Banking connection rate limited, backing off');
+    $context = telemetryLogContext($logged, 'Banking connection rate limited, backing off');
 
     // Str::limit keeps 500 characters and appends an ellipsis.
     expect(strlen($context['response_body']))->toBeLessThanOrEqual(510);
@@ -218,7 +217,7 @@ test('a successful payload never reaches the logs', function () {
     $connection = telemetryConnection();
 
     Http::fake([
-        'api.enablebanking.com/accounts/ext-1/transactions*' => Http::response(transactionsPayload()),
+        'api.enablebanking.com/accounts/ext-1/transactions*' => Http::response(telemetryTransactionsPayload()),
         'api.enablebanking.com/accounts/ext-1/balances*' => Http::response(['balances' => [[
             'balance_amount' => ['amount' => '1234.56', 'currency' => 'EUR'],
             'balance_type' => 'CLBD',
@@ -227,7 +226,7 @@ test('a successful payload never reaches the logs', function () {
         ]]]),
     ]);
 
-    $logged = captureLogs(fn () => runSync(telemetryJob($connection)));
+    $logged = telemetryLogs(fn () => runSync(telemetryJob($connection)));
 
     $connection->refresh();
     expect($connection->last_synced_at)->not->toBeNull();

--- a/tests/Feature/OpenBanking/EnableBankingProviderTest.php
+++ b/tests/Feature/OpenBanking/EnableBankingProviderTest.php
@@ -1,13 +1,15 @@
 <?php
 
+use App\Exceptions\Banking\BankingRequestException;
 use App\Exceptions\Banking\ExpiredBankingSessionException;
 use App\Exceptions\Banking\InaccessibleBankAccountException;
 use App\Exceptions\Banking\TransientBankingProviderException;
 use App\Exceptions\Banking\WrongTransactionsPeriodException;
-use App\Services\Banking\EnableBankingProvider;
 use Illuminate\Contracts\Debug\ShouldntReport;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
+use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 
 test('getTransactions wraps EnableBanking ASPSP errors as non-reportable transient errors', function () {
@@ -324,45 +326,6 @@ test('getBalances keeps non-ASPSP client errors reportable', function () {
         ->toThrow(RequestException::class);
 });
 
-function enableBankingProviderForTest(): EnableBankingProvider
-{
-    $privateKey = <<<'PEM'
------BEGIN PRIVATE KEY-----
-MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDWoizjYmPaLQqn
-uGJQxJCl18MxlJmTgoDzITt/hIW2CEFegbuKuynz7HCFM7xdAg6WRmHfOevLXVuq
-+erPk9gcqC1ePLWzwzmNLIIPpPrO4pkFTZF91T46kJY9/J6QclzbrbI4wB9l3SKA
-14h0O2R2sh1DubnSN5H7JeHyZtIal+aJe7jxuLyKxKkWY80a/jq7rGIzQFJFCFFV
-zLcRKyqs80l4nGLT00lubmlJj1y2/p0OH7B8ZLwxr2LrH+NAPw9L6/e8jEhHSxHs
-LLgOeCEIHO3f7tAfWN6dld08I9puT5JtXp8c5OpkrciDD5C3HvOGjQFNj/W7EmRg
-GVIBeDf7AgMBAAECggEAAJOXLJWl9T70krfCfztGFx3MNtmv/P8GF0OPFp/KnsU1
-SoMenxzkb8OkyPYyMPxhi0PemEdAvlByTnk6EwxvgEoNDNa2rXb5gy1zUCPUWMrq
-806Ur9AI3Muj7/s57LvJ6HMnalyb58BBvEbwjLNgmiEsRhrML8pA9hd4sGam/vq/
-Xb1BoT8FRPVlmz32w9RFrcQaZ4tO/r8rRNlWFtEV0iOdocK+4NizJvJvCyPYesck
-F8+wAoPrHARSOhmzWfzYXXFwJdXcpkuMshQ+COzD2TTZnTZbRn8tWMcL32Bb9b55
-E1CKVPUB99eE182oCHaWNE7HO+2VbMFqExU9oZU+fQKBgQD8HjrFlP234WDChook
-ED5btDxJqSpGuHvzgP083Ej8sOLtWcpVJOFEsLiKRzUqBm6wjFrfk8yq+Vk3OgoA
-CDV6owfQGwn0Jj7yhYPDlMUf1mqytbeFSrziIaFs8YcV1nxykXbJCQyDIAhjOlXf
-je9SifsrBDxOv6re2ky8mzzp1QKBgQDZ8DF64aEntI78SP6CW72fUrQkA9HOnV5s
-dZLE/RbybTG/oozjJzJ0OTHiwtz14UVxTXTCEkF4nsrv9W19pw5E/C4wLqq7tdDn
-gXxS0CAQ1zCBqQAMrgeMA+mmNc3j7rp/TthMQ+Z+wStOqptkIvigv6EZ/9+jzdSA
-C5O5nq4yjwKBgEzhpwhze79kIg6P2nZO4cUzPCM2S+cPAPVrg03Y2wT7p+e7NuEq
-AuvgfBXmywaKuZxq4JdHSeVlblhSAZSq7Cv+pTZH2Iw0UYPBRUISDt67kwP2OAWU
-me7XVJOVP51gL8j8JN3/PWqLDSO9OUyXysA/xXEDtKRK/H9C0J2/NR8VAoGASr4B
-ei8fYcqerw8pmfN0mMt4VFGrBr0ZwQChkUVrNUEVqq9Iui6bMxjabvZ9aSYU9sKl
-pFk2cvOijaESJ+G/FxGVlZirnSzBtGPIC26tUJk8XXtkNPUKSY6d9w7EycL52udj
-buRqjFYbUCNan4EO27JcwdnrDPZuRmuyAhrViykCgYEA4pLCByU4uISinHpFKWD4
-TMGRZNdyFw1UWET/t3UgYA05iFzgrlaz5WtWy27LVHGIpDZqmR/pqw43tsOX67qi
-r6aIG0QnM0a0BlAPUi+7BBZL76TatYBoYlqbvLOaRRaYsL4s4jGph+KUS4Sr/JmK
-+Y9QVqKpHPmUKWPRdA7INQ0=
------END PRIVATE KEY-----
-PEM;
-
-    $path = sys_get_temp_dir().'/enablebanking-test-key.pem';
-    file_put_contents($path, $privateKey);
-
-    return new EnableBankingProvider('test-app-id', $path);
-}
-
 test('getTransactions treats a PSU-action-required 403 as transient rather than expiring the connection', function () {
     // Payload shape from PHP-LARAVEL-3J. Expiring a connection is a one-way
     // door, so a single one of these must leave it schedulable and self-healing.
@@ -492,4 +455,85 @@ test('a 403 whose detail is not an object is not mistaken for a known code', fun
 
     expect(fn () => $provider->getTransactions('ext-123', now()->toDateString(), now()->toDateString()))
         ->toThrow(RequestException::class);
+});
+
+test('a rate limit names the endpoint it came from', function (string $operation, string $path) {
+    Http::fake([
+        "api.enablebanking.com/accounts/ext-123/{$path}*" => Http::response([
+            'code' => 429,
+            'message' => 'Too many requests',
+        ], 429),
+    ]);
+
+    $provider = enableBankingProviderForTest();
+
+    try {
+        $operation === 'balances'
+            ? $provider->getBalances('ext-123')
+            : $provider->getTransactions('ext-123', now()->toDateString(), now()->toDateString());
+    } catch (BankingRequestException $e) {
+        // Still a RequestException, so the job's rate-limit handling is untouched.
+        expect($e)->toBeInstanceOf(RequestException::class)
+            ->and($e->operation)->toBe($operation)
+            ->and($e->response->status())->toBe(429);
+
+        return;
+    }
+
+    test()->fail('Expected a banking request exception naming the operation.');
+})->with([
+    ['balances', 'balances'],
+    ['transactions', 'transactions'],
+]);
+
+test('a wrapped failure names the endpoint it came from', function (string $operation, string $path) {
+    Http::fake([
+        "api.enablebanking.com/accounts/ext-123/{$path}*" => Http::response([
+            'code' => 400,
+            'message' => 'Error interacting with ASPSP',
+            'error' => 'ASPSP_ERROR',
+        ], 400),
+    ]);
+
+    $provider = enableBankingProviderForTest();
+
+    try {
+        $operation === 'balances'
+            ? $provider->getBalances('ext-123')
+            : $provider->getTransactions('ext-123', now()->toDateString(), now()->toDateString());
+    } catch (TransientBankingProviderException $e) {
+        expect($e->operation)->toBe($operation);
+
+        return;
+    }
+
+    test()->fail('Expected a transient banking provider exception naming the operation.');
+})->with([
+    ['balances', 'balances'],
+    ['transactions', 'transactions'],
+]);
+
+test('the API error log keeps the endpoint shape but not the bank identifiers', function () {
+    Http::fake([
+        'api.enablebanking.com/accounts/ext-secret-123/balances*' => Http::response([
+            'code' => 429,
+            'message' => 'Too many requests',
+        ], 429),
+    ]);
+
+    $logged = [];
+    Event::listen(MessageLogged::class, function (MessageLogged $event) use (&$logged): void {
+        $logged[] = $event->context;
+    });
+
+    try {
+        enableBankingProviderForTest()->getBalances('ext-secret-123');
+    } catch (RequestException) {
+        // Expected
+    }
+
+    $paths = array_column($logged, 'path');
+
+    expect($paths)->toContain('/accounts/{id}/balances')
+        ->and(json_encode($logged))->not->toContain('ext-secret-123');
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -10,6 +10,7 @@ use App\Models\Label;
 use App\Models\Transaction;
 use App\Models\User;
 use App\Services\Banking\BalanceSyncService;
+use App\Services\Banking\EnableBankingProvider;
 use App\Services\Banking\Sync\BankingConnectionSyncerFactory;
 use App\Services\Banking\TransactionSyncService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -289,6 +290,49 @@ function createAccountViaUI($page, string $displayName, string $bankName, string
  * EnableBanking sync-service mocks the test provides so the resolved syncer
  * uses them instead of the container defaults.
  */
+/**
+ * An EnableBankingProvider signing with a throwaway key, for tests that drive
+ * the real provider against a faked HTTP layer.
+ */
+function enableBankingProviderForTest(): EnableBankingProvider
+{
+    $privateKey = <<<'PEM'
+-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDWoizjYmPaLQqn
+uGJQxJCl18MxlJmTgoDzITt/hIW2CEFegbuKuynz7HCFM7xdAg6WRmHfOevLXVuq
++erPk9gcqC1ePLWzwzmNLIIPpPrO4pkFTZF91T46kJY9/J6QclzbrbI4wB9l3SKA
+14h0O2R2sh1DubnSN5H7JeHyZtIal+aJe7jxuLyKxKkWY80a/jq7rGIzQFJFCFFV
+zLcRKyqs80l4nGLT00lubmlJj1y2/p0OH7B8ZLwxr2LrH+NAPw9L6/e8jEhHSxHs
+LLgOeCEIHO3f7tAfWN6dld08I9puT5JtXp8c5OpkrciDD5C3HvOGjQFNj/W7EmRg
+GVIBeDf7AgMBAAECggEAAJOXLJWl9T70krfCfztGFx3MNtmv/P8GF0OPFp/KnsU1
+SoMenxzkb8OkyPYyMPxhi0PemEdAvlByTnk6EwxvgEoNDNa2rXb5gy1zUCPUWMrq
+806Ur9AI3Muj7/s57LvJ6HMnalyb58BBvEbwjLNgmiEsRhrML8pA9hd4sGam/vq/
+Xb1BoT8FRPVlmz32w9RFrcQaZ4tO/r8rRNlWFtEV0iOdocK+4NizJvJvCyPYesck
+F8+wAoPrHARSOhmzWfzYXXFwJdXcpkuMshQ+COzD2TTZnTZbRn8tWMcL32Bb9b55
+E1CKVPUB99eE182oCHaWNE7HO+2VbMFqExU9oZU+fQKBgQD8HjrFlP234WDChook
+ED5btDxJqSpGuHvzgP083Ej8sOLtWcpVJOFEsLiKRzUqBm6wjFrfk8yq+Vk3OgoA
+CDV6owfQGwn0Jj7yhYPDlMUf1mqytbeFSrziIaFs8YcV1nxykXbJCQyDIAhjOlXf
+je9SifsrBDxOv6re2ky8mzzp1QKBgQDZ8DF64aEntI78SP6CW72fUrQkA9HOnV5s
+dZLE/RbybTG/oozjJzJ0OTHiwtz14UVxTXTCEkF4nsrv9W19pw5E/C4wLqq7tdDn
+gXxS0CAQ1zCBqQAMrgeMA+mmNc3j7rp/TthMQ+Z+wStOqptkIvigv6EZ/9+jzdSA
+C5O5nq4yjwKBgEzhpwhze79kIg6P2nZO4cUzPCM2S+cPAPVrg03Y2wT7p+e7NuEq
+AuvgfBXmywaKuZxq4JdHSeVlblhSAZSq7Cv+pTZH2Iw0UYPBRUISDt67kwP2OAWU
+me7XVJOVP51gL8j8JN3/PWqLDSO9OUyXysA/xXEDtKRK/H9C0J2/NR8VAoGASr4B
+ei8fYcqerw8pmfN0mMt4VFGrBr0ZwQChkUVrNUEVqq9Iui6bMxjabvZ9aSYU9sKl
+pFk2cvOijaESJ+G/FxGVlZirnSzBtGPIC26tUJk8XXtkNPUKSY6d9w7EycL52udj
+buRqjFYbUCNan4EO27JcwdnrDPZuRmuyAhrViykCgYEA4pLCByU4uISinHpFKWD4
+TMGRZNdyFw1UWET/t3UgYA05iFzgrlaz5WtWy27LVHGIpDZqmR/pqw43tsOX67qi
+r6aIG0QnM0a0BlAPUi+7BBZL76TatYBoYlqbvLOaRRaYsL4s4jGph+KUS4Sr/JmK
++Y9QVqKpHPmUKWPRdA7INQ0=
+-----END PRIVATE KEY-----
+PEM;
+
+    $path = sys_get_temp_dir().'/enablebanking-test-key.pem';
+    file_put_contents($path, $privateKey);
+
+    return new EnableBankingProvider('test-app-id', $path);
+}
+
 function runSync(
     SyncBankingConnectionJob $job,
     ?object $transactionSync = null,

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -286,53 +286,34 @@ function createAccountViaUI($page, string $displayName, string $bankName, string
 }
 
 /**
- * Run the banking sync job through the real syncer factory, binding any
- * EnableBanking sync-service mocks the test provides so the resolved syncer
- * uses them instead of the container defaults.
- */
-/**
  * An EnableBankingProvider signing with a throwaway key, for tests that drive
  * the real provider against a faked HTTP layer.
  */
 function enableBankingProviderForTest(): EnableBankingProvider
 {
-    $privateKey = <<<'PEM'
------BEGIN PRIVATE KEY-----
-MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDWoizjYmPaLQqn
-uGJQxJCl18MxlJmTgoDzITt/hIW2CEFegbuKuynz7HCFM7xdAg6WRmHfOevLXVuq
-+erPk9gcqC1ePLWzwzmNLIIPpPrO4pkFTZF91T46kJY9/J6QclzbrbI4wB9l3SKA
-14h0O2R2sh1DubnSN5H7JeHyZtIal+aJe7jxuLyKxKkWY80a/jq7rGIzQFJFCFFV
-zLcRKyqs80l4nGLT00lubmlJj1y2/p0OH7B8ZLwxr2LrH+NAPw9L6/e8jEhHSxHs
-LLgOeCEIHO3f7tAfWN6dld08I9puT5JtXp8c5OpkrciDD5C3HvOGjQFNj/W7EmRg
-GVIBeDf7AgMBAAECggEAAJOXLJWl9T70krfCfztGFx3MNtmv/P8GF0OPFp/KnsU1
-SoMenxzkb8OkyPYyMPxhi0PemEdAvlByTnk6EwxvgEoNDNa2rXb5gy1zUCPUWMrq
-806Ur9AI3Muj7/s57LvJ6HMnalyb58BBvEbwjLNgmiEsRhrML8pA9hd4sGam/vq/
-Xb1BoT8FRPVlmz32w9RFrcQaZ4tO/r8rRNlWFtEV0iOdocK+4NizJvJvCyPYesck
-F8+wAoPrHARSOhmzWfzYXXFwJdXcpkuMshQ+COzD2TTZnTZbRn8tWMcL32Bb9b55
-E1CKVPUB99eE182oCHaWNE7HO+2VbMFqExU9oZU+fQKBgQD8HjrFlP234WDChook
-ED5btDxJqSpGuHvzgP083Ej8sOLtWcpVJOFEsLiKRzUqBm6wjFrfk8yq+Vk3OgoA
-CDV6owfQGwn0Jj7yhYPDlMUf1mqytbeFSrziIaFs8YcV1nxykXbJCQyDIAhjOlXf
-je9SifsrBDxOv6re2ky8mzzp1QKBgQDZ8DF64aEntI78SP6CW72fUrQkA9HOnV5s
-dZLE/RbybTG/oozjJzJ0OTHiwtz14UVxTXTCEkF4nsrv9W19pw5E/C4wLqq7tdDn
-gXxS0CAQ1zCBqQAMrgeMA+mmNc3j7rp/TthMQ+Z+wStOqptkIvigv6EZ/9+jzdSA
-C5O5nq4yjwKBgEzhpwhze79kIg6P2nZO4cUzPCM2S+cPAPVrg03Y2wT7p+e7NuEq
-AuvgfBXmywaKuZxq4JdHSeVlblhSAZSq7Cv+pTZH2Iw0UYPBRUISDt67kwP2OAWU
-me7XVJOVP51gL8j8JN3/PWqLDSO9OUyXysA/xXEDtKRK/H9C0J2/NR8VAoGASr4B
-ei8fYcqerw8pmfN0mMt4VFGrBr0ZwQChkUVrNUEVqq9Iui6bMxjabvZ9aSYU9sKl
-pFk2cvOijaESJ+G/FxGVlZirnSzBtGPIC26tUJk8XXtkNPUKSY6d9w7EycL52udj
-buRqjFYbUCNan4EO27JcwdnrDPZuRmuyAhrViykCgYEA4pLCByU4uISinHpFKWD4
-TMGRZNdyFw1UWET/t3UgYA05iFzgrlaz5WtWy27LVHGIpDZqmR/pqw43tsOX67qi
-r6aIG0QnM0a0BlAPUi+7BBZL76TatYBoYlqbvLOaRRaYsL4s4jGph+KUS4Sr/JmK
-+Y9QVqKpHPmUKWPRdA7INQ0=
------END PRIVATE KEY-----
-PEM;
+    // Generated once per process rather than committed: a working RSA key in a
+    // public repo is a bad pattern to keep, and the signature is never verified
+    // by anything but the faked HTTP layer.
+    static $path = null;
 
-    $path = sys_get_temp_dir().'/enablebanking-test-key.pem';
-    file_put_contents($path, $privateKey);
+    if ($path === null) {
+        openssl_pkey_export(openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]), $privateKey);
+
+        $path = tempnam(sys_get_temp_dir(), 'enablebanking-test-key');
+        file_put_contents($path, $privateKey);
+    }
 
     return new EnableBankingProvider('test-app-id', $path);
 }
 
+/**
+ * Run the banking sync job through the real syncer factory, binding any
+ * EnableBanking sync-service mocks the test provides so the resolved syncer
+ * uses them instead of the container defaults.
+ */
 function runSync(
     SyncBankingConnectionJob $job,
     ?object $transactionSync = null,


### PR DESCRIPTION
Instrumentation only. No change to sync behaviour, retries, backoff, error
classification, or what marks a run successful. Log messages are byte-identical;
only attributes were added.

## The query to run after the next scheduled sync

In Sentry Logs:

```
message:"Banking connection rate limited, backing off" aspsp_name:"Trade Republic"
```

Read the `operation` attribute: `balances` or `transactions`. That is the answer.
To get the split directly, run the two counts:

```
message:"Banking connection rate limited, backing off" operation:"balances"
message:"Banking connection rate limited, backing off" operation:"transactions"
```

That line is the right one to key on because it fires on every rate-limited run.
`Banking sync failed` is gated on `attempts() >= tries`, and a 429 returns without
retrying, so it usually never fires for one.

Two attributes on the same line settle the follow-ups: `response_body` separates
`"Too many requests"` (a burst limit) from `"Maximum daily access exceeded"` (a
spent PSD2 allowance), and `rate_limit_headers` tells "the provider told us to
wait N" from "we defaulted to an hour".

## You can probably answer this today, without waiting

The premise in the brief is not quite right. `EnableBankingProvider::client()`'s
throw callback fires on every failed response and has logged the endpoint since
#742 (2026-08-09, on main):

```
message:"EnableBanking API error" status:429
```

`path` on that line already reads `/accounts/<id>/balances` or
`/accounts/<id>/transactions`, at error level, for roughly the last ten days of
the fourteen you analysed. I verified the callback fires for a 429 rather than
assuming it — there is a test pinning it.

What this PR adds on top is that you no longer have to correlate that line with a
different one by timestamp: `operation` lands on the job's own rate-limit warning,
next to the bank, the body, the headers and the run's progress. It also makes
`path` groupable, since it was previously one distinct value per account.

## The seven gaps

1. **`status_code` for any `RequestException`**, not only the wrapped transient ones.
2. **`aspsp_name` / `aspsp_country`** on every banking log in the job and the syncer, via a new `BankingConnection::logContext()`.
3. **The rate-limit warning gets the full context.** It is the line that actually fires for a 429.
4. **The error response body**, truncated to 500 characters.
5. **Rate-limit headers**, allow-listed rather than dumped, so no auth header can ride along.
6. **Which endpoint failed.** This was the point. A 429 matched no branch of the provider's error ladder and left as a bare `RequestException` with no provenance. Both ladders now share one re-raise helper that tags every classified exception, and the fall-through case throws `BankingRequestException`, which **extends** `RequestException` — so the job's `instanceof RequestException` rate-limit path is untouched.
7. **What the run had already done when it died.** A new `EnableBanking sync aborted mid-run` line carries `transactions_synced`, `accounts_attempted`, `accounts_total`, `balance_failed`; `banking_sync_logs.metadata`, previously null on every failed row, now carries the failure context.

## Verified by running it, not only by tests

Driving a real 429 through the job with a faked HTTP layer:

```
WARNING  Banking connection rate limited, backing off
  operation: "balances"
  status_code: 429
  aspsp_name: "Trade Republic"
  response_body: "{\"code\":429,\"message\":\"Maximum daily access exceeded\"}"
  rate_limit_headers: {"Retry-After":"3600","X-RateLimit-Remaining":"0"}

WARNING  EnableBanking sync aborted mid-run
  transactions_synced: 2
```

Connection afterwards: `status: active`, `rate_limited_until` set, `last_synced_at`
**unchanged**. The run still fails. This is not #797.

## Things a reviewer should look at on purpose

- **The exception class for an unclassified failure changed.** A 429 now arrives as `App\Exceptions\Banking\BankingRequestException` instead of `Illuminate\Http\Client\RequestException`. Sentry groups issues by class, so any saved filter on `error.type:RequestException` needs updating. `error_class` in the log context reports the new name too. (In practice a 429 is caught and never reported as an issue; this bites for other unclassified statuses.)
- **The syncer's sync loop was restructured**, which is the largest hunk in a diff billed as instrumentation. The loop is wrapped in a try/catch, and the `$transactionsPerBank` tally moved above the `syncBalances()` call. The reorder is behaviour-neutral — on the throwing path the return array is discarded, on the success path the totals are identical — but without it a run killed by balances reports `transactions_synced: 0` for a run that had just imported them, which is the exact false conclusion this PR exists to prevent.
- **Two log lines per failed run.** The syncer's line is the only record when the job's own reporting gate is closed (attempts 1 and 2); the job's line is the one to query. After moving the collected transaction failure outside the try, a failure the retry recovers no longer writes the syncer line at all.

## Also in here

- `path` in `EnableBanking API error` is redacted to `/accounts/{id}/balances`. It was logging the bank's `external_account_id`, which the brief's PII rules forbid, and the redacted form groups.
- That log's `body` is capped at 500 characters. It was the one unbounded body left, in the same call as the path.
- The test signing key is generated at runtime instead of sitting in the tree as a working RSA private key.

## Not in scope

The 429 itself, the backoff, and making a partly-failed run count as a success.

## Noticed while in here, not touched

- `BalanceSyncService` logs `'balance' => $amount` on every **successful** balance sync — a real balance in cents. Predates this work and is off the 429 path.
- The user-facing 429 copy says "Please wait a few minutes and try again", but `resolveRateLimitBackoffUntil` can back off a full day on a spent allowance.

## Checks

PHPStan 0 errors · Pint clean · `bun run dry` under threshold (this diff *reduces*
PHP duplication by collapsing the two identical error ladders) · `php artisan crap`
none above 10 — `handle()` was at **16 before this branch** and is now under the
threshold, by extracting the catch body as a pure move · 382 `tests/Feature/OpenBanking`
green, including 12 new ones.
