### PR TITLE
fix(onboarding): let the last step be retried when its request dies on the network

### DIFF
--- a/resources/js/components/onboarding/step-complete.test.tsx
+++ b/resources/js/components/onboarding/step-complete.test.tsx
@@ -1,0 +1,45 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { StepComplete } from './step-complete';
+
+const post = vi.fn();
+
+vi.mock('@inertiajs/react', () => ({
+    router: { post: (...args: unknown[]) => post(...args) },
+}));
+
+type VisitCallbacks = {
+    onError?: () => void;
+    onFinish?: () => void;
+    onNetworkError?: (error: Error) => void;
+};
+
+/**
+ * What Inertia does to a visit whose request never reached the server: it
+ * reports the transport failure and settles the chain. `onError` is not part of
+ * it — that only runs for a response Inertia could read.
+ */
+function failOnTheNetwork(callbacks: VisitCallbacks): void {
+    callbacks.onNetworkError?.(new Error('Network error'));
+    callbacks.onFinish?.();
+}
+
+describe('StepComplete', () => {
+    it('lets the user try again when the request never reaches the server', async () => {
+        render(<StepComplete />);
+
+        fireEvent.click(screen.getByRole('button'));
+
+        expect(screen.getByRole('button')).toBeDisabled();
+
+        const callbacks = post.mock.calls[0]?.[2] as VisitCallbacks;
+
+        await act(async () => {
+            failOnTheNetwork(callbacks);
+        });
+
+        // StepButton disables itself while loading, so staying in that state
+        // leaves the last step of onboarding behind a dead button.
+        expect(screen.getByRole('button')).toBeEnabled();
+    });
+});

--- a/resources/js/components/onboarding/step-complete.test.tsx
+++ b/resources/js/components/onboarding/step-complete.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { StepComplete } from './step-complete';
 
 const post = vi.fn();
@@ -15,31 +15,55 @@ type VisitCallbacks = {
 };
 
 /**
- * What Inertia does to a visit whose request never reached the server: it
- * reports the transport failure and settles the chain. `onError` is not part of
- * it — that only runs for a response Inertia could read.
+ * Every way `POST /onboarding/complete` can end without moving the user on.
+ * Only the first of them reaches `onError`, which is why resetting the button
+ * from there left the last step of onboarding behind a dead, spinning button.
  */
-function failOnTheNetwork(callbacks: VisitCallbacks): void {
-    callbacks.onNetworkError?.(new Error('Network error'));
-    callbacks.onFinish?.();
-}
+const failures: Array<[string, (callbacks: VisitCallbacks) => void]> = [
+    [
+        'the server rejects the request',
+        (callbacks) => {
+            callbacks.onError?.();
+            callbacks.onFinish?.();
+        },
+    ],
+    [
+        'the request never reaches the server',
+        (callbacks) => {
+            callbacks.onNetworkError?.(new Error('Network error'));
+            callbacks.onFinish?.();
+        },
+    ],
+    [
+        'the answer is one Inertia cannot read',
+        (callbacks) => {
+            callbacks.onFinish?.();
+        },
+    ],
+];
 
 describe('StepComplete', () => {
-    it('lets the user try again when the request never reaches the server', async () => {
-        render(<StepComplete />);
-
-        fireEvent.click(screen.getByRole('button'));
-
-        expect(screen.getByRole('button')).toBeDisabled();
-
-        const callbacks = post.mock.calls[0]?.[2] as VisitCallbacks;
-
-        await act(async () => {
-            failOnTheNetwork(callbacks);
-        });
-
-        // StepButton disables itself while loading, so staying in that state
-        // leaves the last step of onboarding behind a dead button.
-        expect(screen.getByRole('button')).toBeEnabled();
+    afterEach(() => {
+        post.mockReset();
     });
+
+    it.each(failures)(
+        'lets the user try again when %s',
+        async (_failure, settle) => {
+            render(<StepComplete />);
+
+            fireEvent.click(screen.getByRole('button'));
+
+            expect(post).toHaveBeenCalledOnce();
+            expect(screen.getByRole('button')).toBeDisabled();
+
+            await act(async () => {
+                settle(post.mock.calls[0][2] as VisitCallbacks);
+            });
+
+            // StepButton disables itself while loading, so staying in that
+            // state is a one-way door out of onboarding.
+            expect(screen.getByRole('button')).toBeEnabled();
+        },
+    );
 });

--- a/resources/js/components/onboarding/step-complete.tsx
+++ b/resources/js/components/onboarding/step-complete.tsx
@@ -15,7 +15,13 @@ export function StepComplete() {
             complete.url(),
             {},
             {
-                onError: () => {
+                // `onError` only fires for a response Inertia could read, so a
+                // request that died on the network left the last step of
+                // onboarding behind a spinning, disabled button with no way out
+                // but a page reload. `onFinish` runs on every outcome, so the
+                // toast that already explains the failure comes with a button
+                // the user can press again.
+                onFinish: () => {
                     setIsRedirecting(false);
                 },
             },


### PR DESCRIPTION
Closes PHP-LARAVEL-5C — `HttpNetworkError: Network error (https://whisper.money/onboarding/complete)`, 10 events / 8 users in 6 days, every one of them on a phone.

## What was happening

The last onboarding screen sets `isRedirecting` and posts `/onboarding/complete`. It reset that flag from Inertia's `onError`, which only runs for a response Inertia could parse. A request that died on the network never reaches it — and `StepButton` renders `disabled={disabled || loading}`, so eight users tapped "Go to Dashboard" on a flaky mobile connection and were left staring at a disabled, spinning button at the very end of onboarding. A page reload was the only way out.

`onFinish` runs on every outcome, which is what the other twenty mutation call sites in the app already do (`create-budget-dialog`, `map-accounts`, `update-credentials-dialog`, `Accounts/Show`, …). `StepComplete` was the only one left resetting from `onError`.

The fix is wider than the reported symptom: a `419` or a proxy's HTML `500` — the same conditions that produce the transport failures — also skip `onError` (`@inertiajs/core` routes them to the error dialog), so the button hung for those too.

The user was already being told what happened: `installFailedNavigationToast` shows "We could not reach the server. Check your connection." on Inertia's `networkError` event, and it fires before the button re-enables. What was missing was a button to press afterwards.

## Retrying is safe

`EnsureOnboardingComplete` matches `onboarding.*`, so if the first attempt actually reached the server and only the response was lost, the retry is redirected to the dashboard and never re-enters `OnboardingController::complete` — no second `CategorizeOnboardingTransactionsJob`. And the job only touches uncategorized transactions anyway.

## Tests

`step-complete.test.tsx` tables the three endings Inertia distinguishes — rejected (`onError`), never arrived (`onNetworkError`), unreadable answer (neither) — and asserts the button comes back for all of them. Verified by mutation: the old `onError` version fails two of the three, and an `onNetworkError`-only version fails a different two.

## Deliberately not in this PR

- `failed-navigation-toast.ts` has no `isLeavingPage()` guard, unlike its sibling in `sentry.ts`. Tapping a bank on the create-account step aborts the 4s poll, so "We could not reach the server" can flash when nothing failed — visible on iOS PWA, where the page stays alive after handing the redirect to Safari.
- Worth a glance during QA at 375×667: sonner's bottom-center toast sits in the same strip as this button on a short viewport, so the first retry tap could land on the toast for its 4s life. Cosmetic, and unrelated to the stuck state.
