### PR TITLE
fix(banking): a rate limited balance call no longer throws away the sync run

### DIFF
--- a/app/Console/Commands/BankHealthCommand.php
+++ b/app/Console/Commands/BankHealthCommand.php
@@ -210,9 +210,13 @@ class BankHealthCommand extends Command
      * the bank in this report's alert with an outage notice its users must not get.
      *
      * They used to look permanently stale too, because the rethrown 429 discarded
-     * the whole run and never wrote `last_synced_at`. That is fixed, so this now
-     * only holds them out of `syncing`: whether a connection that syncs while
-     * throttled belongs in that count is a question for the report, not for here.
+     * the whole run and never wrote `last_synced_at`. Now that such a run is kept,
+     * a backoff is written on *successful* runs as well, so this partition also
+     * holds connections that are throttled and completely up to date: `syncing`
+     * under-counts them and `rate_limited` counts them every day. Folding them
+     * back would mean one healthy connection could mask a bank whose others have
+     * all stopped, which is the masking this partition exists to prevent - so the
+     * count stays as it is and the report prints both numbers.
      *
      * The window, rather than `rate_limited_until` simply being in the future,
      * covers the gap between a backoff elapsing and the next scheduled sync

--- a/app/Console/Commands/BankHealthCommand.php
+++ b/app/Console/Commands/BankHealthCommand.php
@@ -205,11 +205,14 @@ class BankHealthCommand extends Command
      *
      * This is the one state the report has to hold apart by hand. Trade Republic
      * accounts for most of our rate limits and its 429 lands on the balances call,
-     * *after* the transactions import; the syncer rethrows so the job can set a
-     * backoff, which discards the whole run and never writes `last_synced_at`. So
-     * a connection can be importing data perfectly and still look permanently
-     * stale. Counted as failing it would put the bank in this report's alert with
-     * an outage notice its users must not get.
+     * *after* the transactions import, so these connections import data perfectly
+     * and back off daily on their balances alone. Counted as failing they would put
+     * the bank in this report's alert with an outage notice its users must not get.
+     *
+     * They used to look permanently stale too, because the rethrown 429 discarded
+     * the whole run and never wrote `last_synced_at`. That is fixed, so this now
+     * only holds them out of `syncing`: whether a connection that syncs while
+     * throttled belongs in that count is a question for the report, not for here.
      *
      * The window, rather than `rate_limited_until` simply being in the future,
      * covers the gap between a backoff elapsing and the next scheduled sync

--- a/app/Contracts/BankingConnectionSyncer.php
+++ b/app/Contracts/BankingConnectionSyncer.php
@@ -9,6 +9,11 @@ interface BankingConnectionSyncer
     /**
      * Sync every account belonging to the connection.
      *
+     * The one key the job acts on rather than just persisting is
+     * `balance_rate_limit`: `array{retry_after: string|null, message: string}`
+     * when the provider rate limited a balance call but the run is still worth
+     * keeping, and the job turns it into the connection's backoff window.
+     *
      * @return array<string, mixed> Metadata to persist on the sync log.
      */
     public function sync(BankingConnection $connection, bool $isFirstSync): array;

--- a/app/Jobs/SyncBankingConnectionJob.php
+++ b/app/Jobs/SyncBankingConnectionJob.php
@@ -134,7 +134,7 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
                 'status' => BankingConnectionStatus::Active,
                 'last_synced_at' => $syncedAt,
                 'error_message' => null,
-                'rate_limited_until' => null,
+                'rate_limited_until' => $this->balanceRateLimitBackoff($connection, $metadata),
                 'consecutive_sync_failures' => 0,
             ]);
 
@@ -516,21 +516,73 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
 
     private function resolveRateLimitBackoffUntil(\Throwable $e): Carbon
     {
+        if (! $e instanceof RequestException) {
+            return $this->rateLimitBackoffUntil(null, '');
+        }
+
+        $body = $e->response->json();
+
+        return $this->rateLimitBackoffUntil(
+            $e->response->header('Retry-After'),
+            is_array($body) ? (string) ($body['message'] ?? '') : '',
+        );
+    }
+
+    /**
+     * The backoff a *successful* run still has to carry, because the provider
+     * rate limited the balance call after the transactions had already been
+     * persisted. Null on every other run, which is what clears an old backoff.
+     *
+     * The exception cannot travel in the metadata - it is persisted as JSON on
+     * the sync log - so the syncer reports the two facts the policy keys on.
+     *
+     * @param  array<string, mixed>  $metadata
+     */
+    private function balanceRateLimitBackoff(BankingConnection $connection, array $metadata): ?Carbon
+    {
+        $rateLimit = $metadata['balance_rate_limit'] ?? null;
+
+        if (! is_array($rateLimit)) {
+            return null;
+        }
+
+        $retryAfter = $rateLimit['retry_after'] ?? null;
+        $until = $this->rateLimitBackoffUntil(
+            is_string($retryAfter) ? $retryAfter : null,
+            (string) ($rateLimit['message'] ?? ''),
+        );
+
+        // Same message as the failed-run path, which is what these get searched
+        // for. What the provider replied is already in the syncer's own warning
+        // and in the metadata of the sync log this run writes.
+        Log::warning('Banking connection rate limited, backing off', [
+            ...$connection->logContext(),
+            'operation' => 'balances',
+            'status_code' => 429,
+            'rate_limited_until' => $until->toIso8601String(),
+            'run_recorded_as' => BankingSyncLogStatus::Success->value,
+        ]);
+
+        return $until;
+    }
+
+    /**
+     * How long to stop asking the provider for, given what its 429 said.
+     *
+     * Shared by the failed run, which still has the exception in hand, and the
+     * run that succeeded with only its balance call rate limited, which has the
+     * JSON-safe facts the syncer put in the metadata.
+     */
+    private function rateLimitBackoffUntil(?string $retryAfter, string $message): Carbon
+    {
         $now = now();
 
-        if ($e instanceof RequestException) {
-            $retryAfter = $e->response->header('Retry-After');
+        if (is_numeric($retryAfter) && (int) $retryAfter > 0) {
+            return $now->copy()->addSeconds((int) $retryAfter);
+        }
 
-            if (is_numeric($retryAfter) && (int) $retryAfter > 0) {
-                return $now->copy()->addSeconds((int) $retryAfter);
-            }
-
-            $body = $e->response->json();
-            $message = is_array($body) ? (string) ($body['message'] ?? '') : '';
-
-            if ($this->isExhaustedAccessAllowance($message)) {
-                return $now->copy()->utc()->addDay()->startOfDay();
-            }
+        if ($this->isExhaustedAccessAllowance($message)) {
+            return $now->copy()->utc()->addDay()->startOfDay();
         }
 
         // Default: back off one hour for a burst limit we know nothing else about.

--- a/app/Jobs/SyncBankingConnectionJob.php
+++ b/app/Jobs/SyncBankingConnectionJob.php
@@ -129,12 +129,13 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
             $isFirstSync = ! $connection->last_synced_at || $this->fullSync;
 
             $metadata = $syncer->sync($connection, $isFirstSync);
+            $rateLimitedUntil = $this->balanceRateLimitBackoff($connection, $metadata);
 
             $connection->update([
                 'status' => BankingConnectionStatus::Active,
                 'last_synced_at' => $syncedAt,
                 'error_message' => null,
-                'rate_limited_until' => $this->balanceRateLimitBackoff($connection, $metadata),
+                'rate_limited_until' => $rateLimitedUntil,
                 'consecutive_sync_failures' => 0,
             ]);
 
@@ -517,12 +518,12 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
     private function resolveRateLimitBackoffUntil(\Throwable $e): Carbon
     {
         if (! $e instanceof RequestException) {
-            return $this->rateLimitBackoffUntil(null, '');
+            return $this->backoffUntil(null, '');
         }
 
         $body = $e->response->json();
 
-        return $this->rateLimitBackoffUntil(
+        return $this->backoffUntil(
             $e->response->header('Retry-After'),
             is_array($body) ? (string) ($body['message'] ?? '') : '',
         );
@@ -547,18 +548,20 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
         }
 
         $retryAfter = $rateLimit['retry_after'] ?? null;
-        $until = $this->rateLimitBackoffUntil(
-            is_string($retryAfter) ? $retryAfter : null,
-            (string) ($rateLimit['message'] ?? ''),
-        );
+        $message = (string) ($rateLimit['message'] ?? '');
+        $until = $this->backoffUntil(is_string($retryAfter) ? $retryAfter : null, $message);
 
         // Same message as the failed-run path, which is what these get searched
-        // for. What the provider replied is already in the syncer's own warning
-        // and in the metadata of the sync log this run writes.
+        // for. It carries what the failed path reads off the response - which of
+        // the two limits this is, and whether the wait is the provider's or our
+        // default - under different keys, because here they come from the
+        // metadata rather than from a response this class never sees.
         Log::warning('Banking connection rate limited, backing off', [
             ...$connection->logContext(),
             'operation' => 'balances',
             'status_code' => 429,
+            'provider_message' => $message,
+            'retry_after' => $retryAfter,
             'rate_limited_until' => $until->toIso8601String(),
             'run_recorded_as' => BankingSyncLogStatus::Success->value,
         ]);
@@ -573,7 +576,7 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
      * run that succeeded with only its balance call rate limited, which has the
      * JSON-safe facts the syncer put in the metadata.
      */
-    private function rateLimitBackoffUntil(?string $retryAfter, string $message): Carbon
+    private function backoffUntil(?string $retryAfter, string $message): Carbon
     {
         $now = now();
 

--- a/app/Services/Banking/Sync/EnableBankingSyncer.php
+++ b/app/Services/Banking/Sync/EnableBankingSyncer.php
@@ -15,6 +15,7 @@ use App\Services\Banking\BalanceSyncService;
 use App\Services\Banking\TransactionSyncService;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 
 class EnableBankingSyncer extends AbstractBankingConnectionSyncer
 {
@@ -110,11 +111,14 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
         // Outside the try on purpose: by here nothing was aborted mid-run, every
         // account was attempted, and the per-account failure is already logged.
         if ($transactionFailure !== null) {
-            // A balance rate limit has no channel once the run throws instead of
-            // returning its metadata, and the job would retry straight into an
-            // allowance it knows is spent. Handing it the 429 instead gets the
-            // backoff applied exactly as it was before the run was worth keeping.
-            throw $balanceRateLimitFailure ?? $transactionFailure;
+            // The balance rate limit has no channel here - the metadata only
+            // travels on the success path - so a run that dies like this loses its
+            // backoff and retries into an allowance it knows is spent. Throwing
+            // the 429 instead would buy the backoff at the price of the sync log
+            // blaming the balances endpoint for a run the transactions ended, so
+            // the abort is recorded with `balance_rate_limited` and the next
+            // attempt's own 429 is what applies the window.
+            throw $transactionFailure;
         }
 
         if ($isFirstSync) {
@@ -221,10 +225,17 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
             return false;
         }
 
+        // Read before the sync below writes today's row. The backfill used to be
+        // spent on the first sync alone, which was safe while a refused balance
+        // call discarded the whole run and left the next one a first sync too.
+        // Now that the run is kept, an account that has never had a balance is
+        // still owed it; the backfill only ever writes dates it has not written.
+        $backfillPending = $isFirstSync || $account->balances()->doesntExist();
+
         try {
             $this->balanceSync->sync($account);
 
-            if ($isFirstSync && ! $account->isLinked()) {
+            if ($backfillPending && ! $account->isLinked()) {
                 $this->balanceSync->calculateHistoricalBalances($account);
             }
 
@@ -301,7 +312,9 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
 
         return [
             'retry_after' => $e->response->header('Retry-After') ?: null,
-            'message' => is_array($body) ? (string) ($body['message'] ?? '') : '',
+            // Capped like the response body the job logs: a provider that answers
+            // an error with something enormous must not empty it into the row.
+            'message' => is_array($body) ? Str::limit((string) ($body['message'] ?? ''), 500) : '',
         ];
     }
 

--- a/app/Services/Banking/Sync/EnableBankingSyncer.php
+++ b/app/Services/Banking/Sync/EnableBankingSyncer.php
@@ -53,7 +53,7 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
 
         $transactionsPerBank = [];
         $balanceFailed = 0;
-        $balanceRateLimit = null;
+        $balanceRateLimitFailure = null;
         $transactionFailure = null;
 
         $accountsAttempted = 0;
@@ -84,15 +84,9 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
                     $transactionFailure ??= $this->recordAccountTransactionFailure($connection, $account, $e);
                 }
 
-                // Counted before the balances call, which is the one that throws
-                // most often: a tally taken after it would report zero imported
-                // for a run that had in fact just imported them.
-                if ($created > 0) {
-                    $bankName = $account->bank->name ?? __('Unknown Bank');
-                    $transactionsPerBank[$bankName] = ($transactionsPerBank[$bankName] ?? 0) + $created;
-                }
+                $transactionsPerBank = $this->tally($transactionsPerBank, $account, $created);
 
-                if (! $this->syncBalances($connection, $account, $isFirstSync, $balanceRateLimit)) {
+                if (! $this->syncBalances($connection, $account, $isFirstSync, $balanceRateLimitFailure)) {
                     $balanceFailed++;
                 }
             }
@@ -102,6 +96,7 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
                 'accounts_total' => $connection->accounts->count(),
                 'transactions_synced' => array_sum($transactionsPerBank),
                 'balance_failed' => $balanceFailed,
+                'balance_rate_limited' => $balanceRateLimitFailure !== null,
             ]);
 
             throw $e;
@@ -115,7 +110,11 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
         // Outside the try on purpose: by here nothing was aborted mid-run, every
         // account was attempted, and the per-account failure is already logged.
         if ($transactionFailure !== null) {
-            throw $transactionFailure;
+            // A balance rate limit has no channel once the run throws instead of
+            // returning its metadata, and the job would retry straight into an
+            // allowance it knows is spent. Handing it the 429 instead gets the
+            // backoff applied exactly as it was before the run was worth keeping.
+            throw $balanceRateLimitFailure ?? $transactionFailure;
         }
 
         if ($isFirstSync) {
@@ -128,7 +127,7 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
             'transactions_synced' => array_sum($transactionsPerBank),
             'transactions_per_bank' => $transactionsPerBank,
             'balance_failed' => $balanceFailed,
-            'balance_rate_limit' => $balanceRateLimit,
+            'balance_rate_limit' => $this->rateLimitFacts($balanceRateLimitFailure),
         ];
     }
 
@@ -139,7 +138,7 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
      * transactions and then the rate limit killed the run" was until now only
      * reconstructable by lining up timestamps across two tables.
      *
-     * @param  array<string, int>  $progress
+     * @param  array<string, bool|int>  $progress
      */
     private function logAbortedSync(BankingConnection $connection, \Throwable $e, array $progress): void
     {
@@ -207,21 +206,18 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
     /**
      * Sync one account's balances, tolerating a provider that will not serve them.
      *
-     * `$rateLimit` is filled in when the provider rate limited the call, so the
-     * caller can hand the job what its backoff policy needs. It travels in the
-     * metadata that gets persisted as JSON on the sync log, which is why it
-     * carries the facts of the 429 and not the exception itself.
+     * `$rateLimitFailure` is filled in with the 429 when the provider rate limited
+     * the call, so the caller can hand the job what its backoff policy needs.
      *
      * Arriving with it already filled in means an earlier account in the same run
      * was rate limited: the allowance is spent for the whole consent, so this call
      * is not made at all rather than burning what is left of it.
      *
-     * @param  array{retry_after: string|null, message: string}|null  $rateLimit
      * @return bool Whether the balances were synced
      */
-    private function syncBalances(BankingConnection $connection, Account $account, bool $isFirstSync, ?array &$rateLimit = null): bool
+    private function syncBalances(BankingConnection $connection, Account $account, bool $isFirstSync, ?RequestException &$rateLimitFailure): bool
     {
-        if ($rateLimit !== null) {
+        if ($rateLimitFailure !== null) {
             return false;
         }
 
@@ -246,7 +242,7 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
             // worth keeping, so it is reported instead of thrown: without it the
             // remaining scheduled runs keep burning the daily allowance.
             if ($e instanceof RequestException && $e->response->status() === 429) {
-                $rateLimit = $this->rateLimitFacts($e);
+                $rateLimitFailure = $e;
             }
 
             // No balance failure is worth losing the run over. Balances are a
@@ -258,7 +254,7 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
                 'operation' => 'balances',
                 'reason' => $e::class,
                 'status_code' => $e instanceof RequestException ? $e->response->status() : null,
-                'rate_limited' => $rateLimit !== null,
+                'rate_limited' => $rateLimitFailure !== null,
                 'error' => $e->getMessage(),
             ]);
 
@@ -267,13 +263,40 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
     }
 
     /**
-     * What the provider's 429 said, in the JSON-safe shape the job's backoff
-     * policy reads.
+     * Tally what one account imported, under the bank it came from.
      *
-     * @return array{retry_after: string|null, message: string}
+     * Counted before the balances call, which is the one that throws most often:
+     * a tally taken after it would report zero imported for a run that had in
+     * fact just imported them.
+     *
+     * @param  array<string, int>  $transactionsPerBank
+     * @return array<string, int>
      */
-    private function rateLimitFacts(RequestException $e): array
+    private function tally(array $transactionsPerBank, Account $account, int $created): array
     {
+        if ($created <= 0) {
+            return $transactionsPerBank;
+        }
+
+        $bankName = $account->bank->name ?? __('Unknown Bank');
+        $transactionsPerBank[$bankName] = ($transactionsPerBank[$bankName] ?? 0) + $created;
+
+        return $transactionsPerBank;
+    }
+
+    /**
+     * What the provider's 429 said, in the JSON-safe shape the job's backoff
+     * policy reads - the exception itself cannot go in the metadata, which is
+     * persisted as JSON on the sync log. Null when no balance call was limited.
+     *
+     * @return array{retry_after: string|null, message: string}|null
+     */
+    private function rateLimitFacts(?RequestException $e): ?array
+    {
+        if ($e === null) {
+            return null;
+        }
+
         $body = $e->response->json();
 
         return [

--- a/app/Services/Banking/Sync/EnableBankingSyncer.php
+++ b/app/Services/Banking/Sync/EnableBankingSyncer.php
@@ -53,6 +53,7 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
 
         $transactionsPerBank = [];
         $balanceFailed = 0;
+        $balanceRateLimit = null;
         $transactionFailure = null;
 
         $accountsAttempted = 0;
@@ -91,7 +92,7 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
                     $transactionsPerBank[$bankName] = ($transactionsPerBank[$bankName] ?? 0) + $created;
                 }
 
-                if (! $this->syncBalances($connection, $account, $isFirstSync)) {
+                if (! $this->syncBalances($connection, $account, $isFirstSync, $balanceRateLimit)) {
                     $balanceFailed++;
                 }
             }
@@ -127,6 +128,7 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
             'transactions_synced' => array_sum($transactionsPerBank),
             'transactions_per_bank' => $transactionsPerBank,
             'balance_failed' => $balanceFailed,
+            'balance_rate_limit' => $balanceRateLimit,
         ];
     }
 
@@ -205,10 +207,24 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
     /**
      * Sync one account's balances, tolerating a provider that will not serve them.
      *
+     * `$rateLimit` is filled in when the provider rate limited the call, so the
+     * caller can hand the job what its backoff policy needs. It travels in the
+     * metadata that gets persisted as JSON on the sync log, which is why it
+     * carries the facts of the 429 and not the exception itself.
+     *
+     * Arriving with it already filled in means an earlier account in the same run
+     * was rate limited: the allowance is spent for the whole consent, so this call
+     * is not made at all rather than burning what is left of it.
+     *
+     * @param  array{retry_after: string|null, message: string}|null  $rateLimit
      * @return bool Whether the balances were synced
      */
-    private function syncBalances(BankingConnection $connection, Account $account, bool $isFirstSync): bool
+    private function syncBalances(BankingConnection $connection, Account $account, bool $isFirstSync, ?array &$rateLimit = null): bool
     {
+        if ($rateLimit !== null) {
+            return false;
+        }
+
         try {
             $this->balanceSync->sync($account);
 
@@ -218,14 +234,22 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
 
             return true;
         } catch (\Throwable $e) {
-            // An expired consent needs the user to reconnect, and a rate limit has
-            // to reach the job so it applies the provider backoff: swallowing it
-            // would keep burning the remaining daily quota.
-            if ($e instanceof ExpiredBankingSessionException || $this->isRateLimit($e)) {
+            // An expired consent needs the user to reconnect, so it still has to
+            // reach the job.
+            if ($e instanceof ExpiredBankingSessionException) {
                 throw $e;
             }
 
-            // Anything else is not worth losing the run over. Balances are a
+            // A rate limit used to be rethrown so the job would apply the provider
+            // backoff, which threw away a run whose transactions were already
+            // persisted - and with them last_synced_at. The backoff is the part
+            // worth keeping, so it is reported instead of thrown: without it the
+            // remaining scheduled runs keep burning the daily allowance.
+            if ($e instanceof RequestException && $e->response->status() === 429) {
+                $rateLimit = $this->rateLimitFacts($e);
+            }
+
+            // No balance failure is worth losing the run over. Balances are a
             // nice-to-have next to the transactions we just persisted, and failing
             // here leaves last_synced_at unset.
             Log::warning('EnableBanking balance sync failed, continuing', [
@@ -233,11 +257,29 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
                 'account_id' => $account->id,
                 'operation' => 'balances',
                 'reason' => $e::class,
+                'status_code' => $e instanceof RequestException ? $e->response->status() : null,
+                'rate_limited' => $rateLimit !== null,
                 'error' => $e->getMessage(),
             ]);
 
             return false;
         }
+    }
+
+    /**
+     * What the provider's 429 said, in the JSON-safe shape the job's backoff
+     * policy reads.
+     *
+     * @return array{retry_after: string|null, message: string}
+     */
+    private function rateLimitFacts(RequestException $e): array
+    {
+        $body = $e->response->json();
+
+        return [
+            'retry_after' => $e->response->header('Retry-After') ?: null,
+            'message' => is_array($body) ? (string) ($body['message'] ?? '') : '',
+        ];
     }
 
     /**
@@ -269,10 +311,5 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
         $start = $watermark->toDateString() > $dateTo ? now() : $watermark;
 
         return $start->copy()->subDays(self::WATERMARK_OVERLAP_DAYS)->toDateString();
-    }
-
-    private function isRateLimit(\Throwable $e): bool
-    {
-        return $e instanceof RequestException && $e->response->status() === 429;
     }
 }

--- a/tests/Feature/Console/BankHealthCommandTest.php
+++ b/tests/Feature/Console/BankHealthCommandTest.php
@@ -150,8 +150,8 @@ test('will not call a bank broken on one person\'s evidence alone', function () 
 });
 
 test('does not read a rate limited connection as a bank-side outage', function () {
-    // The 429 lands after the transactions import and the discarded run never
-    // writes last_synced_at, so these look permanently stale while working fine.
+    // A connection whose every run 429s never writes last_synced_at, so it looks
+    // permanently stale while the transactions it did import are fine.
     healthConnection('Trade Republic', [
         'last_synced_at' => null,
         'rate_limited_until' => now()->addHour(),

--- a/tests/Feature/OpenBanking/BankingSyncTelemetryTest.php
+++ b/tests/Feature/OpenBanking/BankingSyncTelemetryTest.php
@@ -17,7 +17,7 @@ use Illuminate\Support\Facades\Http;
  * provider serves happily and balances it rate limits. Which of the two hits the
  * limit is the question the logs have never been able to answer.
  */
-function telemetryConnection(): BankingConnection
+function telemetryConnection(int $accounts = 1): BankingConnection
 {
     $user = User::factory()->onboarded()->create();
     $connection = BankingConnection::factory()->create([
@@ -27,11 +27,13 @@ function telemetryConnection(): BankingConnection
         'last_synced_at' => now()->subDay(),
     ]);
 
-    Account::factory()->connected()->create([
-        'user_id' => $user->id,
-        'banking_connection_id' => $connection->id,
-        'external_account_id' => 'ext-1',
-    ]);
+    for ($i = 1; $i <= $accounts; $i++) {
+        Account::factory()->connected()->create([
+            'user_id' => $user->id,
+            'banking_connection_id' => $connection->id,
+            'external_account_id' => "ext-{$i}",
+        ]);
+    }
 
     app()->instance(BankingProviderInterface::class, enableBankingProviderForTest());
 
@@ -123,21 +125,57 @@ function fakeRateLimitedBalances(string $message = 'Too many requests', array $h
     ]);
 }
 
-test('a rate limit on balances says so in the log the backoff writes', function () {
+/**
+ * The other way round: the limit lands on the transactions of `$account`, which
+ * is the shape that still costs the whole run.
+ */
+function fakeRateLimitedTransactions(string $account = 'ext-1', mixed $body = ['code' => 429, 'message' => 'Too many requests']): void
+{
+    Http::fake([
+        "api.enablebanking.com/accounts/{$account}/transactions*" => Http::response($body, 429),
+        'api.enablebanking.com/accounts/*/transactions*' => Http::response(telemetryTransactionsPayload()),
+        'api.enablebanking.com/accounts/*/balances*' => Http::response(['balances' => []]),
+    ]);
+}
+
+test('a rate limit on balances says so in the logs and still keeps the run', function () {
     $connection = telemetryConnection();
 
     fakeRateLimitedBalances('Maximum daily access exceeded', ['Retry-After' => '1800']);
 
     $logged = telemetryLogs(fn () => runSync(telemetryJob($connection)));
 
-    $context = telemetryLogContext($logged, 'Banking connection rate limited, backing off');
+    // The transactions were already persisted when the 429 arrived, so the run is
+    // no longer thrown away: the balance failure is reported and the run goes on.
+    $failure = telemetryLogContext($logged, 'EnableBanking balance sync failed, continuing');
 
-    expect($context['operation'])->toBe('balances')
-        ->and($context['status_code'])->toBe(429)
-        ->and($context['aspsp_name'])->toBe('Trade Republic')
-        ->and($context['aspsp_country'])->toBe('DE')
-        ->and($context['response_body'])->toContain('Maximum daily access exceeded')
-        ->and($context['rate_limit_headers'])->toBe(['Retry-After' => '1800']);
+    expect($failure['operation'])->toBe('balances')
+        ->and($failure['status_code'])->toBe(429)
+        ->and($failure['rate_limited'])->toBeTrue()
+        ->and($failure['aspsp_name'])->toBe('Trade Republic')
+        ->and($failure['aspsp_country'])->toBe('DE');
+
+    // The backoff the provider asked for is applied all the same.
+    $backoff = telemetryLogContext($logged, 'Banking connection rate limited, backing off');
+
+    expect($backoff['operation'])->toBe('balances')
+        ->and($backoff['status_code'])->toBe(429)
+        ->and($backoff['aspsp_name'])->toBe('Trade Republic');
+
+    $connection->refresh();
+    $log = BankingSyncLog::query()
+        ->where('banking_connection_id', $connection->id)
+        ->latest('created_at')
+        ->firstOrFail();
+
+    expect($connection->last_synced_at)->not->toBeNull()
+        ->and($connection->rate_limited_until->diffInMinutes(now(), true))->toBeGreaterThanOrEqual(29)
+        ->and($log->status)->toBe(BankingSyncLogStatus::Success)
+        // MySQL normalises the key order of a JSON column, hence toMatchArray.
+        ->and($log->metadata['balance_rate_limit'])->toMatchArray([
+            'retry_after' => '1800',
+            'message' => 'Maximum daily access exceeded',
+        ]);
 });
 
 test('a rate limit on transactions says so in the log the backoff writes', function () {
@@ -164,18 +202,20 @@ test('a rate limit on transactions says so in the log the backoff writes', funct
 });
 
 test('a run killed by the rate limit reports what it had already imported', function () {
-    $connection = telemetryConnection();
+    // Two accounts, and the limit lands on the second one's transactions: the run
+    // dies there, after the first account's transactions were already imported.
+    $connection = telemetryConnection(accounts: 2);
 
-    fakeRateLimitedBalances();
+    fakeRateLimitedTransactions('ext-2');
 
     $logged = telemetryLogs(fn () => runSync(telemetryJob($connection)));
 
     $context = telemetryLogContext($logged, 'EnableBanking sync aborted mid-run');
 
     expect($context['transactions_synced'])->toBe(2)
-        ->and($context['accounts_attempted'])->toBe(1)
-        ->and($context['accounts_total'])->toBe(1)
-        ->and($context['operation'])->toBe('balances')
+        ->and($context['accounts_attempted'])->toBe(2)
+        ->and($context['accounts_total'])->toBe(2)
+        ->and($context['operation'])->toBe('transactions')
         ->and($context['status_code'])->toBe(429)
         ->and($context['aspsp_name'])->toBe('Trade Republic');
 });
@@ -183,7 +223,7 @@ test('a run killed by the rate limit reports what it had already imported', func
 test('the failed sync log row carries the same context as the warning', function () {
     $connection = telemetryConnection();
 
-    fakeRateLimitedBalances();
+    fakeRateLimitedTransactions();
 
     runSync(telemetryJob($connection));
 
@@ -192,7 +232,7 @@ test('the failed sync log row carries the same context as the warning', function
         ->where('status', BankingSyncLogStatus::Failed)
         ->firstOrFail();
 
-    expect($log->metadata['operation'])->toBe('balances')
+    expect($log->metadata['operation'])->toBe('transactions')
         ->and($log->metadata['status_code'])->toBe(429)
         ->and($log->metadata['aspsp_name'])->toBe('Trade Republic');
 });
@@ -200,10 +240,7 @@ test('the failed sync log row carries the same context as the warning', function
 test('an oversized error body is truncated before it reaches the logs', function () {
     $connection = telemetryConnection();
 
-    Http::fake([
-        'api.enablebanking.com/accounts/ext-1/transactions*' => Http::response(telemetryTransactionsPayload()),
-        'api.enablebanking.com/accounts/ext-1/balances*' => Http::response(str_repeat('x', 5000), 429),
-    ]);
+    fakeRateLimitedTransactions('ext-1', str_repeat('x', 5000));
 
     $logged = telemetryLogs(fn () => runSync(telemetryJob($connection)));
 

--- a/tests/Feature/OpenBanking/BankingSyncTelemetryTest.php
+++ b/tests/Feature/OpenBanking/BankingSyncTelemetryTest.php
@@ -160,7 +160,12 @@ test('a rate limit on balances says so in the logs and still keeps the run', fun
 
     expect($backoff['operation'])->toBe('balances')
         ->and($backoff['status_code'])->toBe(429)
-        ->and($backoff['aspsp_name'])->toBe('Trade Republic');
+        ->and($backoff['aspsp_name'])->toBe('Trade Republic')
+        // Which of the two limits this is, and whether the wait is the provider's
+        // or our default: the same two questions the failed path answers with
+        // response_body and rate_limit_headers.
+        ->and($backoff['provider_message'])->toBe('Maximum daily access exceeded')
+        ->and($backoff['retry_after'])->toBe('1800');
 
     $connection->refresh();
     $log = BankingSyncLog::query()

--- a/tests/Feature/OpenBanking/EnableBankingPartialAccountFailureTest.php
+++ b/tests/Feature/OpenBanking/EnableBankingPartialAccountFailureTest.php
@@ -1,10 +1,12 @@
 <?php
 
 use App\Enums\BankingConnectionStatus;
+use App\Enums\BankingSyncLogStatus;
 use App\Exceptions\Banking\TransientBankingProviderException;
 use App\Jobs\SyncBankingConnectionJob;
 use App\Models\Account;
 use App\Models\BankingConnection;
+use App\Models\BankingSyncLog;
 use App\Models\User;
 use App\Services\Banking\BalanceSyncService;
 use App\Services\Banking\TransactionSyncService;
@@ -184,7 +186,7 @@ test('a rate limit still reaches the job instead of being swallowed per account'
     expect($connection->rate_limited_until)->not->toBeNull();
 });
 
-test('a balance rate limit still backs off when a later account fails the run', function () {
+test('a balance rate limit does not make a failed run blame the balances', function () {
     $connection = enableBankingConnectionWithAccounts(2);
     $refusedAccountId = $connection->accounts[1]->id;
 
@@ -197,9 +199,8 @@ test('a balance rate limit still backs off when a later account fails the run', 
         return 5;
     });
 
-    // Account 1's balances are rate limited, then account 2's transactions fail
-    // the run outright, so the metadata that carries the backoff is never
-    // returned.
+    // Account 1's balances are rate limited, then account 2's transactions end the
+    // run: two failures, and only one of them killed it.
     $balanceSync = Mockery::mock(BalanceSyncService::class);
     $balanceSync->shouldReceive('sync')->once()->andThrow(
         new RequestException(new Illuminate\Http\Client\Response(
@@ -209,15 +210,22 @@ test('a balance rate limit still backs off when a later account fails the run', 
 
     try {
         runSync(finalAttemptJobFor($connection), $transactionSync, $balanceSync);
-    } catch (RequestException|TransientBankingProviderException) {
-        // Either type means the run failed. Which of the two the job is handed is
-        // the whole point, and rate_limited_until below is the proof.
+    } catch (TransientBankingProviderException) {
+        // Expected: the transactions failure is what the job is handed.
     }
 
     $connection->refresh();
+    $log = BankingSyncLog::query()
+        ->where('banking_connection_id', $connection->id)
+        ->where('status', BankingSyncLogStatus::Failed)
+        ->firstOrFail();
 
-    // Without it the job retries twice more, straight into an allowance it already
-    // knows is spent.
-    expect($connection->rate_limited_until)->not->toBeNull()
-        ->and($connection->rate_limited_until->equalTo(now()->utc()->addDay()->startOfDay()))->toBeTrue();
+    // Handing the job the 429 instead would buy a backoff at the price of the log
+    // blaming the balances endpoint, and of the connection sitting Active with a
+    // persistent per-account failure nobody is told about.
+    expect($log->error_class)->toBe(TransientBankingProviderException::class)
+        ->and($connection->status)->toBe(BankingConnectionStatus::Error)
+        // The known cost, recorded on the aborted-run warning instead: this run
+        // takes no backoff with it, and the next attempt's own 429 applies one.
+        ->and($connection->rate_limited_until)->toBeNull();
 });

--- a/tests/Feature/OpenBanking/EnableBankingPartialAccountFailureTest.php
+++ b/tests/Feature/OpenBanking/EnableBankingPartialAccountFailureTest.php
@@ -183,3 +183,41 @@ test('a rate limit still reaches the job instead of being swallowed per account'
     $connection->refresh();
     expect($connection->rate_limited_until)->not->toBeNull();
 });
+
+test('a balance rate limit still backs off when a later account fails the run', function () {
+    $connection = enableBankingConnectionWithAccounts(2);
+    $refusedAccountId = $connection->accounts[1]->id;
+
+    $transactionSync = Mockery::mock(TransactionSyncService::class);
+    $transactionSync->shouldReceive('sync')->andReturnUsing(function ($account) use ($refusedAccountId) {
+        if ($account->id === $refusedAccountId) {
+            throw aspspError();
+        }
+
+        return 5;
+    });
+
+    // Account 1's balances are rate limited, then account 2's transactions fail
+    // the run outright, so the metadata that carries the backoff is never
+    // returned.
+    $balanceSync = Mockery::mock(BalanceSyncService::class);
+    $balanceSync->shouldReceive('sync')->once()->andThrow(
+        new RequestException(new Illuminate\Http\Client\Response(
+            new Response(429, [], json_encode(['code' => 429, 'message' => 'Maximum daily access exceeded']))
+        ))
+    );
+
+    try {
+        runSync(finalAttemptJobFor($connection), $transactionSync, $balanceSync);
+    } catch (RequestException|TransientBankingProviderException) {
+        // Either type means the run failed. Which of the two the job is handed is
+        // the whole point, and rate_limited_until below is the proof.
+    }
+
+    $connection->refresh();
+
+    // Without it the job retries twice more, straight into an allowance it already
+    // knows is spent.
+    expect($connection->rate_limited_until)->not->toBeNull()
+        ->and($connection->rate_limited_until->equalTo(now()->utc()->addDay()->startOfDay()))->toBeTrue();
+});

--- a/tests/Feature/OpenBanking/SyncBankingConnectionJobTest.php
+++ b/tests/Feature/OpenBanking/SyncBankingConnectionJobTest.php
@@ -331,13 +331,59 @@ test('a rate limited balance call keeps the transactions and still backs off', f
     runSync($job, $transactionSync, $balanceSync);
 
     $connection->refresh();
+    $log = BankingSyncLog::query()->latest('created_at')->first();
 
-    // The quota is per consent: swallowing the 429 here would keep the next
-    // scheduled runs burning what is left of it.
+    // The transactions were already persisted when the 429 arrived, so the run is
+    // the success it was and last_synced_at gets set. The backoff survives on its
+    // own: the quota is per consent, and without it the next scheduled runs would
+    // keep burning what is left of it.
     expect($connection->status)->toBe(BankingConnectionStatus::Active)
+        ->and($connection->last_synced_at)->not->toBeNull()
         ->and($connection->rate_limited_until)->not->toBeNull()
         ->and($connection->rate_limited_until->isFuture())->toBeTrue()
-        ->and($account->transactions()->count())->toBe(1);
+        ->and($account->transactions()->count())->toBe(1)
+        ->and($log->status)->toBe(BankingSyncLogStatus::Success)
+        ->and($log->metadata['balance_failed'])->toBe(1);
+});
+
+test('a rate limited balance call stops asking for the remaining accounts', function () {
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->create([
+        'user_id' => $user->id,
+        'last_synced_at' => null,
+    ]);
+
+    foreach (['ext-1', 'ext-2'] as $externalId) {
+        Account::factory()->connected()->create([
+            'user_id' => $user->id,
+            'banking_connection_id' => $connection->id,
+            'external_account_id' => $externalId,
+        ]);
+    }
+
+    $transactionSync = Mockery::mock(TransactionSyncService::class);
+    $transactionSync->shouldReceive('sync')->twice()->andReturn(2);
+
+    // Exactly once: the allowance is spent for the whole consent, so the second
+    // account's balances are not even asked for.
+    $balanceSync = Mockery::mock(BalanceSyncService::class);
+    $balanceSync->shouldReceive('sync')->once()->andThrow(
+        new RequestException(new Illuminate\Http\Client\Response(new Response(429)))
+    );
+    $balanceSync->shouldNotReceive('calculateHistoricalBalances');
+
+    $job = new SyncBankingConnectionJob($connection);
+    runSync($job, $transactionSync, $balanceSync);
+
+    $connection->refresh();
+    $log = BankingSyncLog::query()->latest('created_at')->first();
+
+    expect($connection->status)->toBe(BankingConnectionStatus::Active)
+        ->and($connection->last_synced_at)->not->toBeNull()
+        ->and($connection->rate_limited_until->isFuture())->toBeTrue()
+        ->and($log->status)->toBe(BankingSyncLogStatus::Success)
+        ->and($log->metadata['transactions_synced'])->toBe(4)
+        ->and($log->metadata['balance_failed'])->toBe(2);
 });
 
 test('an expired session during the balance call is not swallowed', function () {

--- a/tests/Feature/OpenBanking/SyncBankingConnectionJobTest.php
+++ b/tests/Feature/OpenBanking/SyncBankingConnectionJobTest.php
@@ -11,6 +11,7 @@ use App\Jobs\SyncBinanceHistoricalBalancesJob;
 use App\Mail\BankingConnectionAuthFailedEmail;
 use App\Mail\BankTransactionsSyncedEmail;
 use App\Models\Account;
+use App\Models\AccountBalance;
 use App\Models\Bank;
 use App\Models\BankingConnection;
 use App\Models\BankingSyncLog;
@@ -98,6 +99,12 @@ test('subsequent syncs do not calculate historical balances', function () {
         'user_id' => $user->id,
         'banking_connection_id' => $connection->id,
         'external_account_id' => 'ext-123',
+    ]);
+    // The backfill already landed once, which is what makes it a routine sync
+    // rather than one still owed a balance to walk back from.
+    AccountBalance::factory()->create([
+        'account_id' => $account->id,
+        'balance_date' => now()->subDay()->toDateString(),
     ]);
 
     $transactionSync = Mockery::mock(TransactionSyncService::class);
@@ -297,7 +304,10 @@ test('a failing balance call does not fail the whole sync', function () {
         ->and($connection->last_synced_at)->not->toBeNull()
         ->and($account->transactions()->count())->toBe(1)
         ->and($log->status)->toBe(BankingSyncLogStatus::Success)
-        ->and($log->metadata['balance_failed'])->toBe(1);
+        ->and($log->metadata['balance_failed'])->toBe(1)
+        // What makes the daily bank-transactions email start working at all: the
+        // first kept run sets the cutoff, so nothing already imported is mailed.
+        ->and($connection->bank_transactions_email_cutoff_at)->not->toBeNull();
 });
 
 test('a rate limited balance call keeps the transactions and still backs off', function () {
@@ -343,7 +353,10 @@ test('a rate limited balance call keeps the transactions and still backs off', f
         ->and($connection->rate_limited_until->isFuture())->toBeTrue()
         ->and($account->transactions()->count())->toBe(1)
         ->and($log->status)->toBe(BankingSyncLogStatus::Success)
-        ->and($log->metadata['balance_failed'])->toBe(1);
+        ->and($log->metadata['balance_failed'])->toBe(1)
+        // What makes the daily bank-transactions email start working at all: the
+        // first kept run sets the cutoff, so nothing already imported is mailed.
+        ->and($connection->bank_transactions_email_cutoff_at)->not->toBeNull();
 });
 
 test('a rate limited balance call stops asking for the remaining accounts', function () {
@@ -1862,4 +1875,31 @@ test('still reports MaxAttemptsExceededException raised for other jobs', functio
     $exception = MaxAttemptsExceededException::forJob($queueJob);
 
     expect(app(ExceptionHandler::class)->shouldReport($exception))->toBeTrue();
+});
+
+test('a first sync that could not read balances is still owed its history', function () {
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->create([
+        'user_id' => $user->id,
+        // The first sync already happened: it kept its transactions and set this,
+        // and its balance call was the one the provider refused.
+        'last_synced_at' => now()->subDay(),
+    ]);
+    Account::factory()->connected()->create([
+        'user_id' => $user->id,
+        'banking_connection_id' => $connection->id,
+        'external_account_id' => 'ext-123',
+    ]);
+
+    $transactionSync = Mockery::mock(TransactionSyncService::class);
+    $transactionSync->shouldReceive('sync')->once()->andReturn(0);
+
+    // Not a first sync any more, so the historical balances would have been lost
+    // for good: the account has never had a balance to walk back from.
+    $balanceSync = Mockery::mock(BalanceSyncService::class);
+    $balanceSync->shouldReceive('sync')->once();
+    $balanceSync->shouldReceive('calculateHistoricalBalances')->once();
+
+    $job = new SyncBankingConnectionJob($connection);
+    runSync($job, $transactionSync, $balanceSync);
 });


### PR DESCRIPTION
A rate-limited *balance* call used to throw away the whole sync run, including
the transactions that same run had already persisted.

Trade Republic grants roughly 1-2 unattended accesses per day per consent. The
first scheduled run after UTC midnight spends the allowance on `getTransactions`,
which succeeds and saves its rows; `getBalances` then returns 429,
`EnableBankingSyncer::syncBalances` rethrew it, and the job's rate-limit branch
returned early — so `last_synced_at` was never set. Every later run that day 429s
on transactions outright.

## Prod evidence

Transaction rows land 1-13 seconds *before* the `failed` sync log of the same
run, i.e. the transactions were fetched and saved and the 429 arrived afterwards:

| connection | transaction row created | its `failed` log |
|---|---|---|
| 019fa7f0-757c-716c-97ac-9f754292557e | 2026-08-19 00:21:02 | 00:21:15 |
| 019fac9a-33b9-733d-8a8e-e0ad6c60a247 | 2026-08-19 00:21:24 | 00:21:27 |
| 019fda09-034c-722e-a823-b2142d96f58c | 2026-08-19 06:07:55 | 06:07:56 |

`last_synced_at` staying NULL is what the affected users actually feel: the
connections page shows an indefinite spinner and polls every 5s while it is open,
`bank_transactions_email_cutoff_at` is never set so the daily bank-transactions
email never works, and the account shows no balance. 0 of 27 Trade Republic
connections in prod have ever recorded a successful sync that touched the
provider.

**Both failure modes are on the same connections, and this PR fixes the one that
can set `last_synced_at`.** Querying only the window where #812's `operation` tag
has been populating (since 2026-08-20 00:18, about two scheduler cycles) shows 23
failures on `transactions` and 1 on `balances` — because those are the *later*
runs of the day, which 429 before they fetch anything. The first run of the day is
the one that gets its transactions through and dies on balances, and it is the
only run that could ever mark the connection synced. A 429 that arrives mid-way
through transaction pagination still costs the whole run; that is a separate
change and not this one.

## What changes

- `EnableBankingSyncer::syncBalances()` no longer rethrows a 429. It records what
  the provider replied and returns false, exactly like every other balance
  failure it already tolerated. The expired-session rethrow is untouched.
- The backoff was the real reason for the rethrow, so it is reported instead of
  thrown. The syncer holds the 429 and returns two JSON-safe facts next to the
  existing `balance_failed` — the `Retry-After` header and the response body's
  `message` — because the metadata is persisted as JSON on the sync log and the
  exception object cannot go there.
- The policy moves out of `resolveRateLimitBackoffUntil(\Throwable)` into a shared
  `backoffUntil(?string $retryAfter, string $message)`. Both paths call it, so
  there is one implementation of "honour Retry-After, else back off to the day
  boundary for a spent allowance, else an hour".
- The job's success path turns those facts into `rate_limited_until` in one small
  private method, so `handle()` gains no branching.
- Once one account's balances have been rate limited, the remaining accounts'
  balances are not requested at all — that allowance is already gone.
- The historical balance backfill is no longer spent on a run that got no
  balance. It only ran on a first sync, which was safe while a refused balance
  call discarded the run and left the next one a first sync too; now it is also
  attempted while an account has no balance to walk back from. It is idempotent
  and only ever writes dates it has not written, so this is at most one extra
  aggregate per account.
- `sync()`'s per-bank tally moved into a method of its own. It was three of the
  branches in the method the complexity check measures, and the fix needed the
  room.

Net effect: the run is recorded as `Success`, `last_synced_at` gets set, the
transactions are kept, and the connection still backs off until the provider
quota resets.

## QA

Ran the real job through the real provider and sync services against a faked
EnableBanking that serves transactions and 429s balances, two accounts, inside a
rolled-back transaction:

| | before (`origin/main`) | after |
|---|---|---|
| sync log | `failed` | `success` |
| `last_synced_at` | NULL | set |
| `bank_transactions_email_cutoff_at` | NULL | set |
| transactions requests | 1 (account 2 never reached) | 2 |
| balances requests | 1 | 1 (account 2 skipped) |
| transactions stored | 2 | 4 |
| `rate_limited_until` | +30 min | +30 min |

With the same 429 but no `Retry-After`, the backoff resolves to
`2026-08-21T00:00:00Z` — the spent-allowance policy travels intact through the
JSON-safe metadata. `isRateLimited()` is true afterwards, so the next scheduled
run still skips the connection.

## The daily email starts working

This is what makes the daily bank-transactions email start working for
connections whose `last_synced_at` was stuck at NULL. The first successful run is
a first sync, so it sets `bank_transactions_email_cutoff_at` and sends nothing —
no backfill blast — and the cutoff excludes every transaction created before it.
The run after that is the one that emails, with only the newly imported rows.

## Known residuals, deliberately left

- **A multi-account connection whose remaining accounts' *transactions* also 429
  still loses the run.** Skipping those too would mean a run reporting success
  with accounts it never synced, which is the partial-success shape that has been
  turned down before.
- **A run that dies on a later account's transaction failure takes no backoff with
  it.** Throwing the stored 429 instead would buy one at the price of the sync log
  blaming the balances endpoint for a run the transactions ended, and of a
  persistent per-account failure sitting `Active` with nothing surfaced. The
  aborted-run warning records `balance_rate_limited` and the next attempt's own
  429 applies the window.
- **`banking:health` now counts a throttled-but-current connection under
  `rate_limited` rather than `syncing`**, because a backoff is written on
  successful runs too. Folding them back would let one healthy connection mask a
  bank whose others have all stopped — the masking that partition exists to
  prevent — so the count stays and the docblock explains what it holds.
- **The balances backoff line carries `provider_message`/`retry_after` where the
  failed path carries `response_body`/`rate_limit_headers`.** Same facts, and both
  #812 questions stay answerable, but a saved search on those key names needs the
  balances variant adding. `run_recorded_as` tells the two apart.
- **`balance_failed` counts accounts whose balances we skipped**, which is what
  "balances we do not have" means; `balance_rate_limit` in the same metadata says
  why.

## Not in this PR

- Adding `'too many requests'` to `isExhaustedAccessAllowance()` so Trade
  Republic's other 429 wording backs off to the day boundary instead of one hour.
- The connections page not showing the rate-limit message to the user.
- No repair migration: the affected connections are `active` with
  `consecutive_sync_failures = 0` and a `rate_limited_until` in the past, so the
  next scheduled run picks them up on its own.
- The €0 balance itself. Trade Republic balances may simply never fit inside the
  daily allowance; what to show instead of €0 is a separate conversation.

## Tests

- `'a rate limited balance call keeps the transactions and still backs off'` now
  asserts the run is logged as `Success`, `last_synced_at` and the email cutoff are
  set, and `rate_limited_until` is still in the future.
- New: `'a rate limited balance call stops asking for the remaining accounts'`,
  `'a first sync that could not read balances is still owed its history'`, and
  `'a balance rate limit does not make a failed run blame the balances'`.
- `BankingSyncTelemetryTest`: the balances-429 cases were written against the old
  "the run dies here" behaviour. The balances case now asserts the new pair of log
  lines plus the `Success` row and its `balance_rate_limit` metadata; the
  aborted-mid-run, failed-log-row and body-truncation cases were retargeted to a
  429 on *transactions*, which is the shape that still costs the whole run.
- `'subsequent syncs do not calculate historical balances'` now gives the account
  the balance row that makes it a routine sync, so it still guards the intent.
- The policy tests (`Retry-After`, the day-boundary dataset) pass untouched.
