### PR TITLE
fix(banking): log a metered bank quota as a warning, not an application error

### DIFF
--- a/app/Services/Banking/EnableBankingProvider.php
+++ b/app/Services/Banking/EnableBankingProvider.php
@@ -319,13 +319,20 @@ class EnableBankingProvider implements BankingProviderInterface
             ->acceptJson()
             ->throw(function ($response, RequestException $exception) {
                 // Expected outcomes of an unattended sync — a flaky bank connector,
-                // a consent the user has to renew, a period the bank won't serve —
-                // are the caller's to handle, so they log as warnings rather than
-                // as application errors.
+                // a consent the user has to renew, a period the bank won't serve,
+                // a quota the bank meters — are the caller's to handle, so they
+                // log as warnings rather than as application errors.
+                //
+                // 429 belongs on that list: the job already answers it by parking
+                // the connection until the quota resets and saying so in its own
+                // warning, and against a provider that meters access it is the
+                // routine outcome, not a defect. Reported as an error it was 120
+                // of the 134 error-level entries a day, which is enough to bury
+                // the ones that are real.
                 $isExpected = $this->isAspspError($exception)
                     || $this->requiresReconnect($exception)
                     || $this->isPsuActionRequired($exception)
-                    || $response->status() === 422;
+                    || in_array($response->status(), [422, 429], true);
 
                 Log::log($isExpected ? 'warning' : 'error', 'EnableBanking API error', [
                     'status' => $response->status(),

--- a/app/Services/Banking/EnableBankingProvider.php
+++ b/app/Services/Banking/EnableBankingProvider.php
@@ -224,6 +224,47 @@ class EnableBankingProvider implements BankingProviderInterface
         throw new BankingRequestException($e->response, $operation);
     }
 
+    /**
+     * Whether a failed request is one an unattended sync should expect.
+     *
+     * A flaky bank connector, a consent the user has to renew, a period the bank
+     * won't serve, a quota the bank meters: the caller handles all of these, so
+     * they belong in the log as warnings rather than as application errors.
+     * Reported as errors, the metered quota alone was 120 of the 134 error-level
+     * entries a day - enough to bury the ones that are real, as it did for three
+     * nights while a scheduled command was dying with nothing but one line in
+     * there to show for it.
+     *
+     * This is not a claim that a 429 is always handled well. The backoff that
+     * answers one is only partly effective, and deliberately so:
+     * `isExhaustedAccessAllowance` parks the connection until midnight for the
+     * daily-allowance wordings, while a bare "Too many requests" gets an hour
+     * against a six-hourly schedule, so that park usually expires unused.
+     * Widening the match to cover it was tried and dropped, because 1.7% of
+     * those retries do recover and a day-long park would forfeit them. The claim
+     * is only that a metered quota is never an application defect.
+     *
+     * An upstream 5xx is not on the list. That is the provider failing rather
+     * than the provider working as designed, and nothing here can answer it.
+     *
+     * Note this also covers the interactive paths - the bank picker and the
+     * authorization flow - where nothing parks anything and a user is watching.
+     * Those let the exception escape unwrapped, so it still reaches Sentry.
+     */
+    private function isExpectedProviderOutcome(RequestException $e): bool
+    {
+        return $this->isAspspError($e)
+            || $this->requiresReconnect($e)
+            || $this->isPsuActionRequired($e)
+            || $this->isRateLimited($e)
+            || $e->response->status() === 422;
+    }
+
+    private function isRateLimited(RequestException $e): bool
+    {
+        return $e->response->status() === 429;
+    }
+
     private function isAspspError(RequestException $e): bool
     {
         $body = $this->errorBody($e);
@@ -236,7 +277,10 @@ class EnableBankingProvider implements BankingProviderInterface
     {
         // Any upstream 5xx (EnableBanking itself or the ASPSP behind it) is a
         // transient server-side failure — same class as a ConnectionException,
-        // so retry/self-heal rather than report it as an app error.
+        // so retry and self-heal rather than fail the connection over it. Note
+        // that it does still log as an error, unlike the outcomes in
+        // `isExpectedProviderOutcome`: the caller recovering from a provider
+        // outage is not the same as the outage being expected.
         return $e->response->status() >= 500;
     }
 
@@ -318,23 +362,7 @@ class EnableBankingProvider implements BankingProviderInterface
             ->withToken($this->generateJwt())
             ->acceptJson()
             ->throw(function ($response, RequestException $exception) {
-                // Expected outcomes of an unattended sync — a flaky bank connector,
-                // a consent the user has to renew, a period the bank won't serve,
-                // a quota the bank meters — are the caller's to handle, so they
-                // log as warnings rather than as application errors.
-                //
-                // 429 belongs on that list: the job already answers it by parking
-                // the connection until the quota resets and saying so in its own
-                // warning, and against a provider that meters access it is the
-                // routine outcome, not a defect. Reported as an error it was 120
-                // of the 134 error-level entries a day, which is enough to bury
-                // the ones that are real.
-                $isExpected = $this->isAspspError($exception)
-                    || $this->requiresReconnect($exception)
-                    || $this->isPsuActionRequired($exception)
-                    || in_array($response->status(), [422, 429], true);
-
-                Log::log($isExpected ? 'warning' : 'error', 'EnableBanking API error', [
+                Log::log($this->isExpectedProviderOutcome($exception) ? 'warning' : 'error', 'EnableBanking API error', [
                     'status' => $response->status(),
                     // Which endpoint failed tells one bad account apart from a
                     // whole connection or a provider-wide wave.

--- a/app/Services/Banking/EnableBankingProvider.php
+++ b/app/Services/Banking/EnableBankingProvider.php
@@ -257,7 +257,12 @@ class EnableBankingProvider implements BankingProviderInterface
             || $this->requiresReconnect($e)
             || $this->isPsuActionRequired($e)
             || $this->isRateLimited($e)
-            || $e->response->status() === 422;
+            // Narrowed to the window refusal rather than every 422, because
+            // `isWrongPeriod` exists to let a genuine validation 422 - a
+            // malformed date, say - surface, and downgrading all of them here
+            // was quietly defeating that. Inert today: production has not seen a
+            // 422 from this provider in a fortnight.
+            || $this->isWrongPeriod($e);
     }
 
     private function isRateLimited(RequestException $e): bool

--- a/tests/Feature/OpenBanking/EnableBankingProviderTest.php
+++ b/tests/Feature/OpenBanking/EnableBankingProviderTest.php
@@ -11,6 +11,7 @@ use Illuminate\Http\Client\RequestException;
 use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 
 test('getTransactions wraps EnableBanking ASPSP errors as non-reportable transient errors', function () {
     Http::fake([
@@ -538,18 +539,15 @@ test('the API error log keeps the endpoint shape but not the bank identifiers', 
         ->and(json_encode($logged))->not->toContain('ext-secret-123');
 });
 
-test('a metered quota logs as a warning, an unexpected status as an error', function (int $status, string $level) {
+test('a metered quota logs as a warning, an unexpected status as an error', function (int $status, string $level, string $notLevel) {
     Http::fake([
         'api.enablebanking.com/accounts/ext-123/balances*' => Http::response([
             'code' => $status,
-            'message' => 'Too many requests',
+            'message' => 'Nope',
         ], $status),
     ]);
 
-    $levels = [];
-    Event::listen(MessageLogged::class, function (MessageLogged $event) use (&$levels): void {
-        $levels[] = $event->level;
-    });
+    Log::spy();
 
     try {
         enableBankingProviderForTest()->getBalances('ext-123');
@@ -557,10 +555,17 @@ test('a metered quota logs as a warning, an unexpected status as an error', func
         // What it throws is the caller's business; this is about what it logs.
     }
 
-    // A 429 is answered by parking the connection until the quota resets, so
-    // reporting it as an application error only buries the real ones.
-    expect($levels)->toContain($level);
+    // Asserting the absence too, because the point of the change is that the
+    // error-level entry stops being written - collecting levels and looking for
+    // the one you want passes just as well when both are there.
+    Log::shouldHaveReceived('log')->with($level, 'EnableBanking API error', Mockery::any())->once();
+    Log::shouldNotHaveReceived('log', [$notLevel, 'EnableBanking API error', Mockery::any()]);
 })->with([
-    [429, 'warning'],
-    [500, 'error'],
+    // A quota the bank meters, which the app answers with a backoff.
+    [429, 'warning', 'error'],
+    // Nothing recognises this one, so it stays an application error. Deliberately
+    // not a 5xx: `isTransientServerError` and `WiseClient` both read a 5xx as
+    // "not an app error", so pinning a level for it here would be taking a side
+    // in a disagreement this change has no business settling.
+    [404, 'error', 'warning'],
 ]);

--- a/tests/Feature/OpenBanking/EnableBankingProviderTest.php
+++ b/tests/Feature/OpenBanking/EnableBankingProviderTest.php
@@ -537,3 +537,30 @@ test('the API error log keeps the endpoint shape but not the bank identifiers', 
     expect($paths)->toContain('/accounts/{id}/balances')
         ->and(json_encode($logged))->not->toContain('ext-secret-123');
 });
+
+test('a metered quota logs as a warning, an unexpected status as an error', function (int $status, string $level) {
+    Http::fake([
+        'api.enablebanking.com/accounts/ext-123/balances*' => Http::response([
+            'code' => $status,
+            'message' => 'Too many requests',
+        ], $status),
+    ]);
+
+    $levels = [];
+    Event::listen(MessageLogged::class, function (MessageLogged $event) use (&$levels): void {
+        $levels[] = $event->level;
+    });
+
+    try {
+        enableBankingProviderForTest()->getBalances('ext-123');
+    } catch (Throwable) {
+        // What it throws is the caller's business; this is about what it logs.
+    }
+
+    // A 429 is answered by parking the connection until the quota resets, so
+    // reporting it as an application error only buries the real ones.
+    expect($levels)->toContain($level);
+})->with([
+    [429, 'warning'],
+    [500, 'error'],
+]);

--- a/tests/Feature/OpenBanking/EnableBankingProviderTest.php
+++ b/tests/Feature/OpenBanking/EnableBankingProviderTest.php
@@ -569,3 +569,26 @@ test('a metered quota logs as a warning, an unexpected status as an error', func
     // in a disagreement this change has no business settling.
     [404, 'error', 'warning'],
 ]);
+
+test('a 422 the bank did not raise about the period stays an application error', function () {
+    Http::fake([
+        'api.enablebanking.com/accounts/ext-123/transactions*' => Http::response([
+            'code' => 422,
+            'message' => 'Validation error',
+            'detail' => ['error_name' => 'ValidationError'],
+        ], 422),
+    ]);
+
+    Log::spy();
+
+    try {
+        enableBankingProviderForTest()->getTransactions('ext-123', 'not-a-date', 'not-a-date');
+    } catch (Throwable) {
+        // What it throws is the caller's business; this is about the level.
+    }
+
+    // `isWrongPeriod` narrows 422 to the window the bank refused, so that a
+    // genuine validation error still surfaces. Downgrading every 422 in the
+    // logging closure was quietly defeating that.
+    Log::shouldHaveReceived('log')->with('error', 'EnableBanking API error', Mockery::any())->once();
+});


### PR DESCRIPTION
`EnableBanking API error` at error severity was **120 of the 134 error-level log entries a day**. All of them are bank rate limits, in six different wordings — `Too many requests`, `[HUB046] Allowed number of accesses exceeded for consent`, `Maximum daily access exceeded`, `Access exceeded`, and two more. The other four entries in that bucket are the ones worth reading, which makes them 1-in-134 needles.

Last cycle a scheduled command had been dying every night for three days and its only trace was a single line in there.

## Why 429 belongs on the expected list

The file already sorts failures into "the caller's to handle" and "an application error": a flaky bank connector, a consent the user has to renew, a period the bank won't serve. A metered quota is the same kind of thing — the job answers it by parking the connection, records `rate_limited_until`, and logs its own `Banking connection rate limited, backing off` warning. Nothing about it is a defect in this code.

**What this does not claim is that a 429 is handled well.** The review measured it: for 115 of the last 258 production rate limits — Trade Republic 89, N26 22 — the bank sends a bare `Too many requests`, which `isExhaustedAccessAllowance` doesn't recognise, so they get a one-hour park against a six-hourly schedule and it expires unused. Widening that matcher was tried before and dropped on evidence (1.7% of those retries do recover, and a day-long park forfeits them), so the docblock now states the smaller, true claim rather than the comfortable one.

## Nothing is hidden

Both reviews went looking for a repeat of #723, where suppressing an exception created a real blind spot. There isn't one here:

- The entry still carries its status, redacted endpoint shape, capped body and exception class — only the level argument changes.
- Every occurrence is recorded in `banking_sync_logs` with its class and message, now tagged with the operation.
- The project has exactly one alert rule (the default high-priority *issue* alert) and zero metric alerts, and `dataset:errors query:EnableBanking` over 7d returns nothing — this log line has never created an issue or fired an alert. Nothing automated changes state because of this.
- The interactive paths — the bank picker and the authorization flow — let the exception escape unwrapped, so a 429 where a user is actually watching still reaches Sentry.

Plainly: this removes an eyeball cue, not a control. The control was already absent.

## Also in here, from the reviews

**The test could not fail for the thing being fixed.** The first version collected every logged level and looked for the one it wanted, which passes just as well when both are written. Proven by adding a second log call at the opposite level: all 27 tests stayed green. It now uses the assertion this repo already has for the question and asserts the absence too. The "unexpected status" case moved from 500 to 404, because `isTransientServerError` and `WiseClient` both read an upstream 5xx as "not an application error" while this closure logs it as one — pinning a level for it here would take a side in a disagreement this change has no business settling. That contradiction is now at least written down where both halves are.

**A validation 422 was being downgraded along with the rest.** `isWrongPeriod` narrows 422 to the window the bank refused precisely "so genuine validation 422s (e.g. malformed dates) still surface" — and the closure was downgrading all of them, defeating it. Inert today (no 422 from this provider in a fortnight), so it ships with a test rather than a repair.

**The rule now has a name.** It had grown into a boolean expression inside a logging closure, mixing typed predicates with bare status comparisons read off the wrong object.

## Worth your attention, not fixed here

- **`.env.production.example:29` sets `LOG_LEVEL=error`.** The live environment clearly isn't that file — production has 512 warn-level entries in 24h — but on a fresh deploy from the template this commit would turn a downgrade into total suppression.
- **14 bank connections have transactions and zero balance rows, and 11 of them have never completed a sync** (`last_synced_at` NULL, one with 174 transactions imported). Those users see their transactions while their balance and net worth read €0, behind an indefinite spinner that polls every 5s. #817 has not cleared them: today's 429s landed on transactions, so its balance-swallow never fired. This is the open half of the quota problem and it wants a design, not a patch.
- **`banking:health` cannot alert on this.** `isBackingOff` partitions rate-limited connections out of `failing`, so a provider rate-limiting every connection sends no email, and the daily schedule has no `emailOutputTo` — that output goes nowhere. Its own PR.
- **A rate-limited user is told nothing.** `applyRateLimitBackoff` writes `error_message` but leaves the status Active, and the connections page only renders that message when the status is `error`. The copy would also be wrong if it were shown: "Please wait a few minutes and try again" for a park that can run to midnight UTC.
