### PR TITLE
fix(banking): stop a rate limited connection sitting on "Syncing" forever

### DIFF
--- a/app/Http/Controllers/OpenBanking/ConnectionController.php
+++ b/app/Http/Controllers/OpenBanking/ConnectionController.php
@@ -18,6 +18,10 @@ use App\Services\Banking\CoinbaseClient;
 use App\Services\Banking\IndexaCapitalClient;
 use App\Services\Banking\InteractiveBrokersClient;
 use App\Services\Banking\WiseClient;
+use Carbon\Carbon;
+use Illuminate\Console\Scheduling\Event;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
@@ -38,17 +42,42 @@ class ConnectionController extends Controller
         /** @var User $user */
         $user = Auth::user();
 
+        $nextScheduledSync = $this->nextScheduledSyncAt();
+
         $connections = $user->bankingConnections()
             ->withCount('accounts')
             ->orderByDesc('created_at')
             ->get()
-            ->each(function ($connection) {
+            ->each(function (BankingConnection $connection) use ($nextScheduledSync) {
                 $connection->has_pending_accounts = $connection->hasPendingAccounts();
+                $connection->can_sync_manually = ! $connection->isRateLimited();
+                $connection->next_sync_attempt_at = $nextScheduledSync?->max($connection->rate_limited_until);
             });
 
         return Inertia::render('settings/connections', [
             'connections' => $connections,
         ]);
+    }
+
+    /**
+     * When the scheduler will next reach this connection.
+     *
+     * A rate limit backoff is an hour by default while the sweep runs every six,
+     * so `rate_limited_until` on its own promises an attempt that will not happen
+     * and, once it lapses, promises nothing at all. Whichever comes later is the
+     * only figure that is true.
+     */
+    private function nextScheduledSyncAt(): ?Carbon
+    {
+        // routes/console.php is only read when the console kernel boots, which a
+        // web request never does on its own. Without this the schedule is empty
+        // here and the user is told nothing about when we will try again.
+        app(ConsoleKernel::class)->bootstrap();
+
+        $event = collect(app(Schedule::class)->events())
+            ->first(fn (Event $event): bool => str_contains($event->command ?? '', 'banking:sync'));
+
+        return $event ? Carbon::instance($event->nextRunDate()) : null;
     }
 
     /**
@@ -68,16 +97,23 @@ class ConnectionController extends Controller
             return back()->with('error', 'Connection is not active.');
         }
 
+        // A live backoff is the bank having told us to stop. Spending an access
+        // call anyway buys another refusal and burns the scheduled run, and the
+        // card already tells the user when we will try again. Only the healthy
+        // path is refused: a connection in Error is one the scheduler has given
+        // up on, so a manual retry is its only way back.
+        if ($connection->isActive() && $connection->isRateLimited()) {
+            return back()->with('error', __('Your bank limits how often we can fetch your data. We will retry automatically.'));
+        }
+
         $connection->update([
             'status' => BankingConnectionStatus::Active,
             'error_message' => null,
             'consecutive_sync_failures' => 0,
-            // The backoff exists to keep the *scheduler* off a provider that asked
-            // us to stop. A person asking for their own connection is the request
-            // to honour, and PSD2 budgets access with the user present separately
-            // from unattended access. Leaving it set meant the job returned early
-            // while this flashed "sync started" and nothing happened - for as long
-            // as the window had left.
+            // Only a stranded connection reaches this with a backoff still set,
+            // and there the retry is the way back. Leaving it would make the job
+            // return early while this flashed "sync started" and nothing
+            // happened, for as long as the window had left.
             'rate_limited_until' => null,
         ]);
 

--- a/app/Jobs/SyncBankingConnectionJob.php
+++ b/app/Jobs/SyncBankingConnectionJob.php
@@ -495,6 +495,12 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
      * Persist a backoff window so the scheduler stops re-dispatching
      * the same connection until the provider quota resets.
      *
+     * This is the only failure path that records a message while leaving the
+     * status Active, and the connections page relies on that: an active,
+     * never-synced connection carrying a message is rendered as waiting for the
+     * bank, with copy that names a rate limit. A second path that stored a
+     * message without flipping the status would tell users the wrong story.
+     *
      * @param  array<string, mixed>  $context
      */
     private function applyRateLimitBackoff(BankingConnection $connection, \Throwable $e, array $context): void

--- a/app/Models/BankingConnection.php
+++ b/app/Models/BankingConnection.php
@@ -17,6 +17,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
  * @property bool $has_pending_accounts
+ * @property bool $can_sync_manually
+ * @property Carbon|null $next_sync_attempt_at
  * @property string|null $aspsp_name
  * @property string|null $aspsp_country
  * @property BankingProvider $provider

--- a/lang/es.json
+++ b/lang/es.json
@@ -2453,5 +2453,8 @@
     "Your payment went through. If anything still looks locked, reload in a minute.": "Tu pago se ha completado. Si algo sigue bloqueado, recarga en un minuto.",
     "Your plan has ended": "Tu plan ha terminado",
     "Your plan is active": "Tu plan está activo",
-    "Your plan is on. Connected banks, AI suggestions and the AI assistant are all available now.": "Tu plan ya está activo. Los bancos conectados, las sugerencias de IA y el asistente de IA están disponibles."
+    "Your plan is on. Connected banks, AI suggestions and the AI assistant are all available now.": "Tu plan ya está activo. Los bancos conectados, las sugerencias de IA y el asistente de IA están disponibles.",
+    "Waiting for the bank": "Esperando al banco",
+    "Your bank limits how often we can fetch your data. We will retry automatically.": "Tu banco limita la frecuencia con la que podemos consultar tus datos. Lo reintentaremos automáticamente.",
+    "Next attempt": "Próximo intento"
 }

--- a/resources/js/components/open-banking/connection-status-badge.tsx
+++ b/resources/js/components/open-banking/connection-status-badge.tsx
@@ -1,7 +1,12 @@
 import { Badge } from '@/components/ui/badge';
 import { Spinner } from '@/components/ui/spinner';
+import { isWaitingForBank } from '@/lib/banking-connections';
 import type { BankingConnection } from '@/types/banking';
 import { __ } from '@/utils/i18n';
+
+/** Matches the amber callout the waiting state renders below the card. */
+const AMBER_BADGE =
+    'border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-300';
 
 const statusConfig: Record<
     BankingConnection['status'],
@@ -43,23 +48,15 @@ const statusConfig: Record<
 };
 
 export function ConnectionStatusBadge({
-    status,
-    lastSyncedAt,
-    errorMessage,
+    connection,
 }: {
-    status: BankingConnection['status'];
-    lastSyncedAt?: string | null;
-    errorMessage?: string | null;
+    connection: BankingConnection;
 }) {
-    // An active connection that never synced *and* already recorded an error is
-    // not syncing: the bank refused us and the job stopped. Only the message is
-    // stored, so last_synced_at stays null forever and the spinner would too.
-    if (status === 'active' && !lastSyncedAt && errorMessage) {
+    const { status, last_synced_at: lastSyncedAt } = connection;
+
+    if (isWaitingForBank(connection)) {
         return (
-            <Badge
-                variant="secondary"
-                className={statusConfig.pending.className}
-            >
+            <Badge variant="secondary" className={AMBER_BADGE}>
                 {__('Waiting for the bank')}
             </Badge>
         );

--- a/resources/js/components/open-banking/connection-status-badge.tsx
+++ b/resources/js/components/open-banking/connection-status-badge.tsx
@@ -45,10 +45,26 @@ const statusConfig: Record<
 export function ConnectionStatusBadge({
     status,
     lastSyncedAt,
+    errorMessage,
 }: {
     status: BankingConnection['status'];
     lastSyncedAt?: string | null;
+    errorMessage?: string | null;
 }) {
+    // An active connection that never synced *and* already recorded an error is
+    // not syncing: the bank refused us and the job stopped. Only the message is
+    // stored, so last_synced_at stays null forever and the spinner would too.
+    if (status === 'active' && !lastSyncedAt && errorMessage) {
+        return (
+            <Badge
+                variant="secondary"
+                className={statusConfig.pending.className}
+            >
+                {__('Waiting for the bank')}
+            </Badge>
+        );
+    }
+
     if (status === 'active' && !lastSyncedAt) {
         return (
             <Badge

--- a/resources/js/lib/banking-connections.ts
+++ b/resources/js/lib/banking-connections.ts
@@ -45,3 +45,41 @@ export function hasLiveConnectionForProvider(
         (c) => c.provider === provider && isLiveConnection(c),
     );
 }
+
+/**
+ * Whether a first sync is genuinely still running.
+ *
+ * A connection only gets a `last_synced_at` once a run finishes, so a
+ * never-synced active connection normally means "syncing". Not once it has
+ * recorded an error: a rate limit leaves the status Active and stores only the
+ * message, so `last_synced_at` would stay null forever and the spinner with it.
+ */
+export function isFirstSyncRunning(connection: BankingConnection): boolean {
+    return (
+        connection.status === 'active' &&
+        !connection.last_synced_at &&
+        !connection.error_message
+    );
+}
+
+/**
+ * The other half of {@link isFirstSyncRunning}: the bank refused the first sync.
+ * Not an error state - the transactions do import - only a wait for the access
+ * window to reopen.
+ */
+export function isWaitingForBank(connection: BankingConnection): boolean {
+    return (
+        connection.status === 'active' &&
+        !connection.last_synced_at &&
+        !!connection.error_message
+    );
+}
+
+/**
+ * Whether the user may spend an access call on demand. Computed server-side from
+ * the backoff, which is the enforcing side too; the flag is only present on the
+ * connections page payload.
+ */
+export function canSyncManually(connection: BankingConnection): boolean {
+    return connection.can_sync_manually !== false;
+}

--- a/resources/js/pages/settings/connections.test.tsx
+++ b/resources/js/pages/settings/connections.test.tsx
@@ -94,7 +94,6 @@ function makeConnection(
         valid_until: null,
         last_synced_at: '2026-01-01T00:00:00.000000Z',
         error_message: null,
-        rate_limited_until: null,
         accounts_count: 1,
         created_at: '2026-01-01T00:00:00.000000Z',
         updated_at: '2026-01-01T00:00:00.000000Z',
@@ -150,7 +149,7 @@ describe('ConnectionsPage', () => {
                     makeConnection({
                         last_synced_at: null,
                         error_message: 'Rate limit exceeded.',
-                        rate_limited_until: '2999-01-01T12:00:00.000000Z',
+                        next_sync_attempt_at: '2999-01-01T12:00:00.000000Z',
                     }),
                 ]}
             />,
@@ -167,14 +166,14 @@ describe('ConnectionsPage', () => {
         expect(mocks.pollStart).not.toHaveBeenCalled();
     });
 
-    it('drops the next attempt line when the backoff window has already passed', () => {
+    it('drops the next attempt line when the server could not name one', () => {
         render(
             <ConnectionsPage
                 connections={[
                     makeConnection({
                         last_synced_at: null,
                         error_message: 'Rate limit exceeded.',
-                        rate_limited_until: '2020-01-01T12:00:00.000000Z',
+                        next_sync_attempt_at: null,
                     }),
                 ]}
             />,
@@ -182,5 +181,53 @@ describe('ConnectionsPage', () => {
 
         expect(screen.getByText(/waiting for the bank/i)).toBeInTheDocument();
         expect(screen.queryByText(/next attempt/i)).not.toBeInTheDocument();
+    });
+
+    it('hides the manual sync while the bank has told us to back off', () => {
+        render(
+            <ConnectionsPage
+                connections={[makeConnection({ can_sync_manually: false })]}
+            />,
+        );
+
+        expect(
+            screen.queryByRole('menuitem', { name: /sync now/i }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.getByRole('menuitem', { name: /disconnect/i }),
+        ).toBeInTheDocument();
+    });
+
+    it('keeps Retry on an errored connection even while a backoff is set', () => {
+        render(
+            <ConnectionsPage
+                connections={[
+                    makeConnection({
+                        status: 'error',
+                        error_message: 'Something went wrong.',
+                        can_sync_manually: false,
+                    }),
+                ]}
+            />,
+        );
+
+        expect(
+            screen.getByRole('menuitem', { name: /retry/i }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: /retry/i }),
+        ).toBeInTheDocument();
+    });
+
+    it('keeps the manual sync when no backoff is in the way', () => {
+        render(
+            <ConnectionsPage
+                connections={[makeConnection({ can_sync_manually: true })]}
+            />,
+        );
+
+        expect(
+            screen.getByRole('menuitem', { name: /sync now/i }),
+        ).toBeInTheDocument();
     });
 });

--- a/resources/js/pages/settings/connections.test.tsx
+++ b/resources/js/pages/settings/connections.test.tsx
@@ -37,6 +37,27 @@ vi.mock('@inertiajs/react', () => ({
     }),
 }));
 
+vi.mock('@/components/ui/dropdown-menu', () => ({
+    DropdownMenu: ({ children }: { children: React.ReactNode }) => (
+        <div>{children}</div>
+    ),
+    DropdownMenuTrigger: () => null,
+    DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+        <div>{children}</div>
+    ),
+    DropdownMenuItem: ({
+        children,
+        onClick,
+    }: {
+        children: React.ReactNode;
+        onClick?: () => void;
+    }) => (
+        <div role="menuitem" onClick={onClick}>
+            {children}
+        </div>
+    ),
+}));
+
 vi.mock('@/layouts/app-layout', () => ({
     default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
@@ -61,12 +82,6 @@ vi.mock('@/components/subscription/upgrade-dialog', () => ({
     UpgradeDialog: () => null,
 }));
 
-vi.mock('@/components/open-banking/connection-status-badge', () => ({
-    ConnectionStatusBadge: ({ status }: { status: string }) => (
-        <span>{status}</span>
-    ),
-}));
-
 function makeConnection(
     overrides: Partial<BankingConnection> = {},
 ): BankingConnection {
@@ -79,6 +94,7 @@ function makeConnection(
         valid_until: null,
         last_synced_at: '2026-01-01T00:00:00.000000Z',
         error_message: null,
+        rate_limited_until: null,
         accounts_count: 1,
         created_at: '2026-01-01T00:00:00.000000Z',
         updated_at: '2026-01-01T00:00:00.000000Z',
@@ -112,5 +128,59 @@ describe('ConnectionsPage', () => {
         expect(
             screen.getAllByRole('button', { name: /reconnect/i }),
         ).toHaveLength(2);
+    });
+
+    it('polls and spins while a first sync is genuinely running', () => {
+        render(
+            <ConnectionsPage
+                connections={[makeConnection({ last_synced_at: null })]}
+            />,
+        );
+
+        expect(
+            screen.getByText(/syncing transactions and balances/i),
+        ).toBeInTheDocument();
+        expect(mocks.pollStart).toHaveBeenCalled();
+    });
+
+    it('shows a waiting state instead of an endless spinner once the bank refused us', () => {
+        render(
+            <ConnectionsPage
+                connections={[
+                    makeConnection({
+                        last_synced_at: null,
+                        error_message: 'Rate limit exceeded.',
+                        rate_limited_until: '2999-01-01T12:00:00.000000Z',
+                    }),
+                ]}
+            />,
+        );
+
+        expect(screen.getByText(/waiting for the bank/i)).toBeInTheDocument();
+        expect(
+            screen.getByText(/your bank limits how often/i),
+        ).toBeInTheDocument();
+        expect(screen.getByText(/next attempt/i)).toBeInTheDocument();
+        expect(
+            screen.queryByText(/syncing transactions and balances/i),
+        ).not.toBeInTheDocument();
+        expect(mocks.pollStart).not.toHaveBeenCalled();
+    });
+
+    it('drops the next attempt line when the backoff window has already passed', () => {
+        render(
+            <ConnectionsPage
+                connections={[
+                    makeConnection({
+                        last_synced_at: null,
+                        error_message: 'Rate limit exceeded.',
+                        rate_limited_until: '2020-01-01T12:00:00.000000Z',
+                    }),
+                ]}
+            />,
+        );
+
+        expect(screen.getByText(/waiting for the bank/i)).toBeInTheDocument();
+        expect(screen.queryByText(/next attempt/i)).not.toBeInTheDocument();
     });
 });

--- a/resources/js/pages/settings/connections.tsx
+++ b/resources/js/pages/settings/connections.tsx
@@ -58,7 +58,7 @@ export default function ConnectionsPage({ connections }: Props) {
     const [reconnectingId, setReconnectingId] = useState<string | null>(null);
 
     const hasSyncing = connections.some(
-        (c) => c.status === 'active' && !c.last_synced_at,
+        (c) => c.status === 'active' && !c.last_synced_at && !c.error_message,
     );
 
     const { start, stop } = usePoll(5000, {}, { autoStart: false });
@@ -156,6 +156,25 @@ export default function ConnectionsPage({ connections }: Props) {
         );
     }
 
+    /**
+     * The bank refused the very first sync, so last_synced_at will never be set and
+     * the spinner would run forever. The connection is not broken - transactions do
+     * import - it is only waiting for the access window to reopen.
+     */
+    function isWaitingForBank(connection: BankingConnection): boolean {
+        return (
+            connection.status === 'active' &&
+            !connection.last_synced_at &&
+            !!connection.error_message
+        );
+    }
+
+    function nextSyncAttempt(connection: BankingConnection): string | null {
+        const at = connection.rate_limited_until;
+
+        return at && new Date(at) > new Date() ? at : null;
+    }
+
     function canManageAccounts(connection: BankingConnection): boolean {
         return (
             connection.provider === 'enablebanking' &&
@@ -236,6 +255,9 @@ export default function ConnectionsPage({ connections }: Props) {
                                                 status={connection.status}
                                                 lastSyncedAt={
                                                     connection.last_synced_at
+                                                }
+                                                errorMessage={
+                                                    connection.error_message
                                                 }
                                             />
                                             {connection.status === 'expired' &&
@@ -381,7 +403,9 @@ export default function ConnectionsPage({ connections }: Props) {
                                                         'Accounts need to be mapped before syncing can begin.',
                                                     )}
                                                 </span>
-                                            ) : connection.status ===
+                                            ) : isWaitingForBank(
+                                                  connection,
+                                              ) ? null : connection.status ===
                                                   'active' &&
                                               !connection.last_synced_at ? (
                                                 <span className="flex items-center gap-1.5">
@@ -416,6 +440,27 @@ export default function ConnectionsPage({ connections }: Props) {
                                                 </span>
                                             )}
                                         </div>
+                                        {isWaitingForBank(connection) && (
+                                            <div className="mt-3 space-y-1 rounded-lg border border-amber-500/20 bg-amber-500/10 p-3 text-sm text-amber-700 dark:text-amber-300">
+                                                <p>
+                                                    {__(
+                                                        'Your bank limits how often we can fetch your data. We will retry automatically.',
+                                                    )}
+                                                </p>
+                                                {nextSyncAttempt(
+                                                    connection,
+                                                ) && (
+                                                    <p>
+                                                        {__('Next attempt')}:{' '}
+                                                        {formatDate(
+                                                            nextSyncAttempt(
+                                                                connection,
+                                                            ),
+                                                        )}
+                                                    </p>
+                                                )}
+                                            </div>
+                                        )}
                                         {connection.status === 'error' && (
                                             <div className="mt-3 rounded-lg border border-destructive/30 bg-destructive/5 p-3 dark:bg-destructive/10">
                                                 <div className="flex items-start gap-2">

--- a/resources/js/pages/settings/connections.tsx
+++ b/resources/js/pages/settings/connections.tsx
@@ -3,6 +3,7 @@ import { ConnectionStatusBadge } from '@/components/open-banking/connection-stat
 import { DisconnectDialog } from '@/components/open-banking/disconnect-dialog';
 import { UpdateCredentialsDialog } from '@/components/open-banking/update-credentials-dialog';
 import { UpgradeDialog } from '@/components/subscription/upgrade-dialog';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import {
     Card,
@@ -21,6 +22,11 @@ import {
 import { Spinner } from '@/components/ui/spinner';
 import AppLayout from '@/layouts/app-layout';
 import SettingsLayout from '@/layouts/settings/layout';
+import {
+    canSyncManually,
+    isFirstSyncRunning,
+    isWaitingForBank,
+} from '@/lib/banking-connections';
 import { CONNECT_PROVIDERS } from '@/lib/connect-providers';
 import { getCsrfToken } from '@/lib/csrf';
 import { leavePage } from '@/lib/leave-page';
@@ -31,6 +37,7 @@ import { Head, router, usePage, usePoll } from '@inertiajs/react';
 import {
     AlertCircle,
     ArrowRight,
+    Clock,
     KeyRound,
     MoreHorizontal,
     RefreshCw,
@@ -57,9 +64,7 @@ export default function ConnectionsPage({ connections }: Props) {
         useState<BankingConnection | null>(null);
     const [reconnectingId, setReconnectingId] = useState<string | null>(null);
 
-    const hasSyncing = connections.some(
-        (c) => c.status === 'active' && !c.last_synced_at && !c.error_message,
-    );
+    const hasSyncing = connections.some(isFirstSyncRunning);
 
     const { start, stop } = usePoll(5000, {}, { autoStart: false });
 
@@ -156,25 +161,6 @@ export default function ConnectionsPage({ connections }: Props) {
         );
     }
 
-    /**
-     * The bank refused the very first sync, so last_synced_at will never be set and
-     * the spinner would run forever. The connection is not broken - transactions do
-     * import - it is only waiting for the access window to reopen.
-     */
-    function isWaitingForBank(connection: BankingConnection): boolean {
-        return (
-            connection.status === 'active' &&
-            !connection.last_synced_at &&
-            !!connection.error_message
-        );
-    }
-
-    function nextSyncAttempt(connection: BankingConnection): string | null {
-        const at = connection.rate_limited_until;
-
-        return at && new Date(at) > new Date() ? at : null;
-    }
-
     function canManageAccounts(connection: BankingConnection): boolean {
         return (
             connection.provider === 'enablebanking' &&
@@ -252,13 +238,7 @@ export default function ConnectionsPage({ connections }: Props) {
                                         </div>
                                         <div className="flex items-center gap-2">
                                             <ConnectionStatusBadge
-                                                status={connection.status}
-                                                lastSyncedAt={
-                                                    connection.last_synced_at
-                                                }
-                                                errorMessage={
-                                                    connection.error_message
-                                                }
+                                                connection={connection}
                                             />
                                             {connection.status === 'expired' &&
                                                 canReconnect(connection) && (
@@ -356,8 +336,11 @@ export default function ConnectionsPage({ connections }: Props) {
                                                             {__('Reconnect')}
                                                         </DropdownMenuItem>
                                                     )}
-                                                    {(connection.status ===
-                                                        'active' ||
+                                                    {((connection.status ===
+                                                        'active' &&
+                                                        canSyncManually(
+                                                            connection,
+                                                        )) ||
                                                         (connection.status ===
                                                             'error' &&
                                                             !isEnableBankingAuthError(
@@ -403,11 +386,9 @@ export default function ConnectionsPage({ connections }: Props) {
                                                         'Accounts need to be mapped before syncing can begin.',
                                                     )}
                                                 </span>
-                                            ) : isWaitingForBank(
+                                            ) : isFirstSyncRunning(
                                                   connection,
-                                              ) ? null : connection.status ===
-                                                  'active' &&
-                                              !connection.last_synced_at ? (
+                                              ) ? (
                                                 <span className="flex items-center gap-1.5">
                                                     <Spinner className="size-3" />
                                                     {[
@@ -423,7 +404,9 @@ export default function ConnectionsPage({ connections }: Props) {
                                                               'Syncing transactions and balances…',
                                                           )}
                                                 </span>
-                                            ) : (
+                                            ) : isWaitingForBank(
+                                                  connection,
+                                              ) ? null : (
                                                 <span>
                                                     {__('Last synced')}:{' '}
                                                     {formatDate(
@@ -441,25 +424,25 @@ export default function ConnectionsPage({ connections }: Props) {
                                             )}
                                         </div>
                                         {isWaitingForBank(connection) && (
-                                            <div className="mt-3 space-y-1 rounded-lg border border-amber-500/20 bg-amber-500/10 p-3 text-sm text-amber-700 dark:text-amber-300">
-                                                <p>
-                                                    {__(
-                                                        'Your bank limits how often we can fetch your data. We will retry automatically.',
-                                                    )}
-                                                </p>
-                                                {nextSyncAttempt(
-                                                    connection,
-                                                ) && (
+                                            <Alert className="mt-3 border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-300">
+                                                <Clock />
+                                                <AlertDescription className="text-amber-700 dark:text-amber-300">
                                                     <p>
-                                                        {__('Next attempt')}:{' '}
-                                                        {formatDate(
-                                                            nextSyncAttempt(
-                                                                connection,
-                                                            ),
+                                                        {__(
+                                                            'Your bank limits how often we can fetch your data. We will retry automatically.',
                                                         )}
                                                     </p>
-                                                )}
-                                            </div>
+                                                    {connection.next_sync_attempt_at && (
+                                                        <p>
+                                                            {__('Next attempt')}
+                                                            :{' '}
+                                                            {formatDate(
+                                                                connection.next_sync_attempt_at,
+                                                            )}
+                                                        </p>
+                                                    )}
+                                                </AlertDescription>
+                                            </Alert>
                                         )}
                                         {connection.status === 'error' && (
                                             <div className="mt-3 rounded-lg border border-destructive/30 bg-destructive/5 p-3 dark:bg-destructive/10">

--- a/resources/js/types/banking.ts
+++ b/resources/js/types/banking.ts
@@ -15,6 +15,7 @@ export interface BankingConnection {
     valid_until: string | null;
     last_synced_at: string | null;
     error_message: string | null;
+    rate_limited_until: string | null;
     accounts_count: number;
     has_pending_accounts?: boolean;
     created_at: string;

--- a/resources/js/types/banking.ts
+++ b/resources/js/types/banking.ts
@@ -15,9 +15,10 @@ export interface BankingConnection {
     valid_until: string | null;
     last_synced_at: string | null;
     error_message: string | null;
-    rate_limited_until: string | null;
     accounts_count: number;
     has_pending_accounts?: boolean;
+    next_sync_attempt_at?: string | null;
+    can_sync_manually?: boolean;
     created_at: string;
     updated_at: string;
 }

--- a/tests/Feature/OpenBanking/ConnectionControllerTest.php
+++ b/tests/Feature/OpenBanking/ConnectionControllerTest.php
@@ -2,11 +2,13 @@
 
 use App\Contracts\BankingProviderInterface;
 use App\Enums\BankingConnectionStatus;
+use App\Jobs\SyncBankingConnectionJob;
 use App\Models\Account;
 use App\Models\AccountBalance;
 use App\Models\BankingConnection;
 use App\Models\Transaction;
 use App\Models\User;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Queue;
 
 beforeEach(function () {
@@ -205,6 +207,113 @@ test('disconnecting indexa capital connection does not revoke session', function
     $account->refresh();
     expect($account->banking_connection_id)->toBeNull();
     expect($account->external_account_id)->toBeNull();
+});
+
+test('users cannot manually sync a connection the bank has told us to back off from', function () {
+    Queue::fake();
+
+    $backoff = now()->addHour();
+
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->create([
+        'user_id' => $user->id,
+        'status' => BankingConnectionStatus::Active,
+        'rate_limited_until' => $backoff,
+    ]);
+
+    $response = $this->actingAs($user)->post("/settings/connections/{$connection->id}/sync");
+
+    $response->assertRedirect();
+    $response->assertSessionHas('error');
+
+    Queue::assertNotPushed(SyncBankingConnectionJob::class);
+
+    expect($connection->refresh()->rate_limited_until->toDateTimeString())
+        ->toBe($backoff->toDateTimeString());
+});
+
+test('a lapsed backoff does not block a manual sync', function () {
+    Queue::fake();
+
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->create([
+        'user_id' => $user->id,
+        'status' => BankingConnectionStatus::Active,
+        'rate_limited_until' => now()->subHour(),
+    ]);
+
+    $response = $this->actingAs($user)->post("/settings/connections/{$connection->id}/sync");
+
+    $response->assertSessionHas('success');
+
+    Queue::assertPushed(SyncBankingConnectionJob::class);
+});
+
+test('a stranded connection can still be retried while a backoff is set', function () {
+    Queue::fake();
+
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->create([
+        'user_id' => $user->id,
+        'status' => BankingConnectionStatus::Error,
+        'rate_limited_until' => now()->addHour(),
+        'consecutive_sync_failures' => 3,
+    ]);
+
+    $response = $this->actingAs($user)->post("/settings/connections/{$connection->id}/sync");
+
+    $response->assertSessionHas('success');
+
+    Queue::assertPushed(SyncBankingConnectionJob::class);
+    expect($connection->refresh()->rate_limited_until)->toBeNull();
+});
+
+test('connections page reports whether each connection can be synced on demand', function () {
+    $user = User::factory()->onboarded()->create();
+    BankingConnection::factory()->create([
+        'user_id' => $user->id,
+        'aspsp_name' => 'Backed off bank',
+        'rate_limited_until' => now()->addHour(),
+        'created_at' => now(),
+    ]);
+    BankingConnection::factory()->create([
+        'user_id' => $user->id,
+        'aspsp_name' => 'Healthy bank',
+        'rate_limited_until' => null,
+        'created_at' => now()->subDay(),
+    ]);
+
+    $response = $this->actingAs($user)->get('/settings/connections');
+
+    $response->assertInertia(fn ($page) => $page
+        ->where('connections.0.aspsp_name', 'Backed off bank')
+        ->where('connections.0.can_sync_manually', false)
+        ->where('connections.1.aspsp_name', 'Healthy bank')
+        ->where('connections.1.can_sync_manually', true)
+    );
+});
+
+test('the next attempt shown to the user is never sooner than the scheduled sync', function () {
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->create([
+        'user_id' => $user->id,
+        'status' => BankingConnectionStatus::Active,
+        'last_synced_at' => null,
+        'error_message' => 'Rate limit exceeded.',
+        // A backoff that has already lapsed, which is how these connections
+        // spend most of their life: the window is an hour, the sweep is six.
+        'rate_limited_until' => now()->subHours(2),
+    ]);
+
+    $response = $this->actingAs($user)->get('/settings/connections');
+
+    $response->assertInertia(fn ($page) => $page
+        ->where('connections.0.id', $connection->id)
+        ->where(
+            'connections.0.next_sync_attempt_at',
+            fn ($at) => $at !== null && Carbon::parse($at)->isFuture()
+        )
+    );
 });
 
 test('users cannot sync expired connection', function () {

--- a/tests/Feature/OpenBanking/SyncRetryAndLoggingTest.php
+++ b/tests/Feature/OpenBanking/SyncRetryAndLoggingTest.php
@@ -885,26 +885,31 @@ test('manual sync resets consecutive sync failures', function () {
     expect($connection->error_message)->toBeNull();
 });
 
-test('manual sync clears the rate limit backoff so it is not silently swallowed', function () {
+test('manual sync is refused under a live backoff rather than silently swallowed', function () {
     $user = User::factory()->onboarded()->create();
 
-    // The scheduler is meant to stay off a provider that asked us to stop; a person
-    // asking for their own connection is a different request. Leaving the window in
-    // place meant the job returned early while the UI said "sync started".
+    // Manual sync used to clear the window, on the theory that a person asking for
+    // their own connection is a different request from the scheduler's. On a bank
+    // with a small per-consent allowance that only bought another refusal and burnt
+    // the scheduled run, so the request is now declined out loud instead - which
+    // answers the same complaint the other way: the UI no longer says "sync
+    // started" while the job returns early and nothing happens.
+    $until = now()->addHours(20);
     $connection = BankingConnection::factory()->create([
         'user_id' => $user->id,
-        'rate_limited_until' => now()->addHours(20),
+        'rate_limited_until' => $until,
     ]);
 
     Queue::fake(SyncBankingConnectionJob::class);
 
     $this->actingAs($user)
         ->post(route('settings.connections.sync', $connection))
-        ->assertRedirect();
+        ->assertRedirect()
+        ->assertSessionHas('error');
 
     $connection->refresh();
-    expect($connection->rate_limited_until)->toBeNull();
-    Queue::assertPushed(SyncBankingConnectionJob::class);
+    expect($connection->rate_limited_until->toDateTimeString())->toBe($until->toDateTimeString());
+    Queue::assertNotPushed(SyncBankingConnectionJob::class);
 });
 
 // --- Job-Level Failure Tests ---


### PR DESCRIPTION
A Trade Republic user reported a connection stuck on "Syncing transactions and
balances…" for over 15 minutes, retried the next day from scratch, still
spinning — while some transactions had in fact imported.

**This makes the UI tell the truth. It does not make the sync succeed.**

## What was happening

Enable Banking 429s the *transactions* call after ~94s of pagination. The job
classifies it as a rate limit, stores `error_message` and `rate_limited_until`,
and returns — never writing `last_synced_at` and deliberately leaving the status
`Active`, because the transactions really did import. The page reads
`active && !last_synced_at` as "syncing", in the card body *and* in the status
badge, and starts a 5s poll behind it. Nothing ever clears that condition, so
the spinner and the poll run forever.

Verified on production: **every** connection currently stuck this way (13 Trade
Republic + 1 Openbank) has both an `error_message` and a `rate_limited_until`.
There is no population spinning for any other reason — a non-rate-limit failure
moves the connection to `Error`, which already renders the red box.

## What changes

**1. An honest waiting state instead of an endless spinner.**
An active, never-synced connection that has already recorded an error is not
syncing — the bank refused us. It gets an amber "Waiting for the bank" badge and
an informational (not destructive) callout, and `hasSyncing` excludes it so the
poll stops. The status stays `Active`; painting it as broken would be wrong when
its transactions import. This keys on `error_message`, the same signal
`OnboardingController::syncStatus` already uses for exactly this problem.

The stored message ("Please wait a few minutes and try again") is deliberately
not shown: a PSD2 daily allowance is not minutes, and it points at a button we
are removing.

**2. No manual sync while the bank has told us to back off.**
`ConnectionController::sync` used to clear `rate_limited_until`, reasoning that a
person present is the request to honour. On a bank with a small per-consent
allowance that is backwards — each press spends a call the scheduler needed,
earns another 429, and resets the window. It is now refused server-side while
the backoff is live, and the page hides the menu item via `can_sync_manually`.
The rule is generic: no bank names anywhere.

A connection in `Error` is exempt. `SyncAllBankingConnectionsJob` skips those
once `consecutive_sync_failures >= 3`, so there is no scheduled run left to
protect and Retry is the only way back.

**3. "Next attempt" is a time the scheduler will actually honour.**
The backoff is an hour by default; `banking:sync` runs every six. Showing
`rate_limited_until` alone would name an attempt that will not happen, and once
it lapses — which is the state 13 of the 14 affected rows are in — name nothing
at all. The payload now carries the later of the two.

## Knowingly left out

- **The €0.00 balance.** Separate problem, separate answer.
- **The Trade Republic backoff window.** A longer backoff is a real lever and it
  is yours to decide; with the current 1h-vs-6h gap, a Trade Republic user whose
  window has lapsed can still press Sync Now.
- **What counts as a successful sync.** Not revisited.
- No explanatory line on cards whose Sync Now disappeared — hiding over
  disabling was the call, but a user who used that button last week gets no
  signal. Say the word and it is one muted line.
- Connections that are rate-limited but *have* synced before (6 in prod) still
  show a plain "Active" badge with no callout. Real, but not this bug.

## Testing

`resources/js/pages/settings/connections.test.tsx` — waiting state renders and
does not start the poll; a genuine first sync still spins and does poll; the
next-attempt line is dropped when the server cannot name one; the manual sync
disappears under a backoff and survives without one; Retry stays on an errored
connection.

`tests/Feature/OpenBanking/ConnectionControllerTest.php` — a backed-off
connection is refused and keeps its window; a lapsed backoff does not block; a
stranded `Error` connection still retries; the payload carries
`can_sync_manually` and a future `next_sync_attempt_at`.

## QA

Browser pass against a seeded connection set in light and dark: the waiting card
renders as designed, the poll stops, the menu item is gone, the errored Trade
Republic card keeps Retry, and `POST /settings/connections/{id}/sync` returns the
refusal flash, queues no job and leaves `rate_limited_until` untouched.

## Demo

<!-- PLACEHOLDER: drag the recorded QA video in here -->
