### PR TITLE
fix(banking): stop showing a spinner for a bank connection that will never sync

### DIFF
--- a/lang/es.json
+++ b/lang/es.json
@@ -2454,5 +2454,7 @@
     "Your plan has ended": "Tu plan ha terminado",
     "Your plan is active": "Tu plan está activo",
     "Your plan is on. Connected banks, AI suggestions and the AI assistant are all available now.": "Tu plan ya está activo. Los bancos conectados, las sugerencias de IA y el asistente de IA están disponibles.",
-    "The bank limited how often we can ask. Next attempt after :time.": "El banco ha limitado la frecuencia con la que podemos consultar. Pr\u00f3ximo intento a partir de las :time."
+    "The bank limited how often we can ask. We will not try again before :time.": "El banco ha limitado la frecuencia con la que podemos consultar. No volveremos a intentarlo antes de :time.",
+    "The bank limited how often we can ask. The next scheduled sync will try again.": "El banco ha limitado la frecuencia con la que podemos consultar. La próxima sincronización programada volverá a intentarlo.",
+    "Waiting to sync": "Esperando para sincronizar"
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -2453,5 +2453,6 @@
     "Your payment went through. If anything still looks locked, reload in a minute.": "Tu pago se ha completado. Si algo sigue bloqueado, recarga en un minuto.",
     "Your plan has ended": "Tu plan ha terminado",
     "Your plan is active": "Tu plan está activo",
-    "Your plan is on. Connected banks, AI suggestions and the AI assistant are all available now.": "Tu plan ya está activo. Los bancos conectados, las sugerencias de IA y el asistente de IA están disponibles."
+    "Your plan is on. Connected banks, AI suggestions and the AI assistant are all available now.": "Tu plan ya está activo. Los bancos conectados, las sugerencias de IA y el asistente de IA están disponibles.",
+    "The bank limited how often we can ask. Next attempt after :time.": "El banco ha limitado la frecuencia con la que podemos consultar. Pr\u00f3ximo intento a partir de las :time."
 }

--- a/resources/js/components/open-banking/connection-status-badge.tsx
+++ b/resources/js/components/open-banking/connection-status-badge.tsx
@@ -1,5 +1,9 @@
 import { Badge } from '@/components/ui/badge';
 import { Spinner } from '@/components/ui/spinner';
+import {
+    isFirstSyncInProgress,
+    isFirstSyncStalled,
+} from '@/lib/banking-connections';
 import type { BankingConnection } from '@/types/banking';
 import { __ } from '@/utils/i18n';
 
@@ -43,13 +47,16 @@ const statusConfig: Record<
 };
 
 export function ConnectionStatusBadge({
-    status,
-    lastSyncedAt,
+    connection,
 }: {
-    status: BankingConnection['status'];
-    lastSyncedAt?: string | null;
+    connection: BankingConnection;
 }) {
-    if (status === 'active' && !lastSyncedAt) {
+    const status = connection.status;
+
+    // Only a first sync that is actually running gets the spinner. A connection
+    // the bank has refused stays `active` with nothing synced, and saying
+    // "Syncing" over it is the whole reason a stalled connection looked healthy.
+    if (isFirstSyncInProgress(connection)) {
         return (
             <Badge
                 variant="secondary"
@@ -57,6 +64,14 @@ export function ConnectionStatusBadge({
             >
                 <Spinner className="size-3" />
                 {__('Syncing')}
+            </Badge>
+        );
+    }
+
+    if (isFirstSyncStalled(connection)) {
+        return (
+            <Badge variant="outline" className="dark:text-muted-foreground">
+                {__('Waiting to sync')}
             </Badge>
         );
     }

--- a/resources/js/lib/banking-connections.test.ts
+++ b/resources/js/lib/banking-connections.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
     alreadyConnectedBankNames,
     hasLiveConnectionForProvider,
+    isWaitingForBankQuota,
 } from './banking-connections';
 
 function connection(
@@ -17,6 +18,7 @@ function connection(
         valid_until: null,
         last_synced_at: null,
         error_message: null,
+        rate_limited_until: null,
         accounts_count: 1,
         created_at: '2026-01-01T00:00:00Z',
         updated_at: '2026-01-01T00:00:00Z',
@@ -78,5 +80,36 @@ describe('hasLiveConnectionForProvider', () => {
         expect(hasLiveConnectionForProvider(connections, 'coinbase')).toBe(
             false,
         );
+    });
+});
+
+describe('isWaitingForBankQuota', () => {
+    const now = new Date('2026-08-20T15:00:00Z');
+
+    it('is waiting while the bank has told us to come back later', () => {
+        expect(
+            isWaitingForBankQuota(
+                connection({ rate_limited_until: '2026-08-20T18:00:00Z' }),
+                now,
+            ),
+        ).toBe(true);
+    });
+
+    it('is not waiting once the window has passed', () => {
+        expect(
+            isWaitingForBankQuota(
+                connection({ rate_limited_until: '2026-08-20T14:59:00Z' }),
+                now,
+            ),
+        ).toBe(false);
+    });
+
+    it('is not waiting when the bank never limited us', () => {
+        expect(
+            isWaitingForBankQuota(
+                connection({ rate_limited_until: null }),
+                now,
+            ),
+        ).toBe(false);
     });
 });

--- a/resources/js/lib/banking-connections.test.ts
+++ b/resources/js/lib/banking-connections.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest';
 import {
     alreadyConnectedBankNames,
     hasLiveConnectionForProvider,
+    isFirstSyncInProgress,
+    isFirstSyncStalled,
     isWaitingForBankQuota,
 } from './banking-connections';
 
@@ -111,5 +113,60 @@ describe('isWaitingForBankQuota', () => {
                 now,
             ),
         ).toBe(false);
+    });
+
+    it('reads the clock itself when no now is passed, as both callers do', () => {
+        expect(
+            isWaitingForBankQuota(
+                connection({ rate_limited_until: '2099-01-01T00:00:00Z' }),
+            ),
+        ).toBe(true);
+        expect(
+            isWaitingForBankQuota(
+                connection({ rate_limited_until: '2020-01-01T00:00:00Z' }),
+            ),
+        ).toBe(false);
+    });
+});
+
+describe('isFirstSyncInProgress / isFirstSyncStalled', () => {
+    it('separates a running first sync from one that already failed', () => {
+        const running = connection({
+            last_synced_at: null,
+            error_message: null,
+        });
+        const stalled = connection({
+            last_synced_at: null,
+            error_message: 'Rate limit exceeded.',
+        });
+
+        expect(isFirstSyncInProgress(running)).toBe(true);
+        expect(isFirstSyncStalled(running)).toBe(false);
+        expect(isFirstSyncInProgress(stalled)).toBe(false);
+        expect(isFirstSyncStalled(stalled)).toBe(true);
+    });
+
+    it('says neither once a first sync has landed', () => {
+        // The population that would otherwise lose its "Last synced" line:
+        // throttled on the balance call only, transactions imported fine.
+        const throttledButWorking = connection({
+            last_synced_at: '2026-08-20T06:03:00Z',
+            error_message: 'Rate limit exceeded.',
+            rate_limited_until: '2099-01-01T00:00:00Z',
+        });
+
+        expect(isFirstSyncInProgress(throttledButWorking)).toBe(false);
+        expect(isFirstSyncStalled(throttledButWorking)).toBe(false);
+    });
+
+    it('ignores a connection that is not active', () => {
+        const expired = connection({
+            status: 'expired',
+            last_synced_at: null,
+            error_message: 'Session expired.',
+        });
+
+        expect(isFirstSyncInProgress(expired)).toBe(false);
+        expect(isFirstSyncStalled(expired)).toBe(false);
     });
 });

--- a/resources/js/lib/banking-connections.ts
+++ b/resources/js/lib/banking-connections.ts
@@ -45,3 +45,25 @@ export function hasLiveConnectionForProvider(
         (c) => c.provider === provider && isLiveConnection(c),
     );
 }
+
+/**
+ * Whether the bank has told us to come back later.
+ *
+ * A rate-limited connection stays `active` with its own sync parked until the
+ * quota resets, which can be the next hour or the next midnight. Without asking
+ * this, a connection that has never managed a first sync is indistinguishable
+ * from one that is still working: the page shows "Syncing transactions and
+ * balances…" and polls every 5 seconds for as long as it is open, and in
+ * production 11 connections have been in exactly that state - some with well
+ * over a hundred transactions already imported.
+ */
+export function isWaitingForBankQuota(
+    connection: BankingConnection,
+    now: Date = new Date(),
+): boolean {
+    if (connection.rate_limited_until === null) {
+        return false;
+    }
+
+    return new Date(connection.rate_limited_until) > now;
+}

--- a/resources/js/lib/banking-connections.ts
+++ b/resources/js/lib/banking-connections.ts
@@ -47,15 +47,47 @@ export function hasLiveConnectionForProvider(
 }
 
 /**
- * Whether the bank has told us to come back later.
+ * Whether a connection's first sync is genuinely still running.
  *
- * A rate-limited connection stays `active` with its own sync parked until the
- * quota resets, which can be the next hour or the next midnight. Without asking
- * this, a connection that has never managed a first sync is indistinguishable
- * from one that is still working: the page shows "Syncing transactions and
- * balances…" and polls every 5 seconds for as long as it is open, and in
- * production 11 connections have been in exactly that state - some with well
- * over a hundred transactions already imported.
+ * "Active with nothing synced yet" is not enough on its own, and that was the
+ * bug: a connection the bank has refused stays `active` with `last_synced_at`
+ * still null, so it was indistinguishable from one that had just been
+ * authorized. Fourteen connections in production sat in that state - twelve of
+ * them Trade Republic, one created a month ago and never synced once - each
+ * showing a spinner that would never resolve while the page asked the server
+ * for news every five seconds.
+ *
+ * The thing that separates them is whether an attempt has already failed.
+ * `error_message` holds that and survives the backoff window elapsing, unlike
+ * `rate_limited_until`: a bare "Too many requests" gets a one-hour park against
+ * a six-hourly schedule, so for five hours out of every six the park has lapsed
+ * while the connection is no closer to working.
+ */
+export function isFirstSyncInProgress(connection: BankingConnection): boolean {
+    return (
+        connection.status === 'active' &&
+        !connection.last_synced_at &&
+        connection.error_message === null
+    );
+}
+
+/**
+ * Whether a connection has never delivered anything and its last attempt failed.
+ */
+export function isFirstSyncStalled(connection: BankingConnection): boolean {
+    return (
+        connection.status === 'active' &&
+        !connection.last_synced_at &&
+        connection.error_message !== null
+    );
+}
+
+/**
+ * Whether the bank's own retry window is still open, so a time can be named.
+ *
+ * Only ever used to decide whether to print one. Whether a connection is stuck
+ * is `isFirstSyncStalled`'s question, because this one is false for most of the
+ * time a connection spends stuck.
  */
 export function isWaitingForBankQuota(
     connection: BankingConnection,

--- a/resources/js/pages/settings/connections.test.tsx
+++ b/resources/js/pages/settings/connections.test.tsx
@@ -31,9 +31,11 @@ vi.mock('@inertiajs/react', () => ({
             },
         },
     }),
-    usePoll: () => ({
-        start: mocks.pollStart,
-        stop: mocks.pollStop,
+    // Keyed by interval: the page runs two polls, a 5s one while a first sync is
+    // actually in flight and a 60s one for a connection parked on the bank.
+    usePoll: (interval: number) => ({
+        start: () => mocks.pollStart(interval),
+        stop: () => mocks.pollStop(interval),
     }),
 }));
 
@@ -61,12 +63,6 @@ vi.mock('@/components/subscription/upgrade-dialog', () => ({
     UpgradeDialog: () => null,
 }));
 
-vi.mock('@/components/open-banking/connection-status-badge', () => ({
-    ConnectionStatusBadge: ({ status }: { status: string }) => (
-        <span>{status}</span>
-    ),
-}));
-
 function makeConnection(
     overrides: Partial<BankingConnection> = {},
 ): BankingConnection {
@@ -79,6 +75,7 @@ function makeConnection(
         valid_until: null,
         last_synced_at: '2026-01-01T00:00:00.000000Z',
         error_message: null,
+        rate_limited_until: null,
         accounts_count: 1,
         created_at: '2026-01-01T00:00:00.000000Z',
         updated_at: '2026-01-01T00:00:00.000000Z',
@@ -112,5 +109,61 @@ describe('ConnectionsPage', () => {
         expect(
             screen.getAllByRole('button', { name: /reconnect/i }),
         ).toHaveLength(2);
+    });
+});
+
+describe('a first sync the bank has refused', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    const refused = () =>
+        makeConnection({
+            last_synced_at: null,
+            error_message: 'Rate limit exceeded.',
+            rate_limited_until: '2099-01-01T00:00:00.000000Z',
+        });
+
+    it('says what happened instead of spinning', () => {
+        render(<ConnectionsPage connections={[refused()]} />);
+
+        expect(
+            screen.getByText(/The bank limited how often we can ask/),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText('Syncing transactions and balances…'),
+        ).not.toBeInTheDocument();
+        // The badge is the most prominent thing on the card, so it must not
+        // still be claiming the connection is working.
+        expect(screen.queryByText('Syncing')).not.toBeInTheDocument();
+        expect(screen.getByText('Waiting to sync')).toBeInTheDocument();
+    });
+
+    it('drops to the slow poll instead of asking every five seconds', () => {
+        render(<ConnectionsPage connections={[refused()]} />);
+
+        expect(mocks.pollStart).not.toHaveBeenCalledWith(5000);
+        // Still polled, slowly: the next scheduled sync can fix it while the
+        // page is open, and before this the only thing that noticed was the
+        // five-second hammering.
+        expect(mocks.pollStart).toHaveBeenCalledWith(60_000);
+    });
+
+    it('still spins and polls while a first sync is genuinely running', () => {
+        render(
+            <ConnectionsPage
+                connections={[
+                    makeConnection({
+                        last_synced_at: null,
+                        error_message: null,
+                    }),
+                ]}
+            />,
+        );
+
+        expect(
+            screen.getByText('Syncing transactions and balances…'),
+        ).toBeInTheDocument();
+        expect(mocks.pollStart).toHaveBeenCalledWith(5000);
     });
 });

--- a/resources/js/pages/settings/connections.tsx
+++ b/resources/js/pages/settings/connections.tsx
@@ -21,7 +21,11 @@ import {
 import { Spinner } from '@/components/ui/spinner';
 import AppLayout from '@/layouts/app-layout';
 import SettingsLayout from '@/layouts/settings/layout';
-import { isWaitingForBankQuota } from '@/lib/banking-connections';
+import {
+    isFirstSyncInProgress,
+    isFirstSyncStalled,
+    isWaitingForBankQuota,
+} from '@/lib/banking-connections';
 import { CONNECT_PROVIDERS } from '@/lib/connect-providers';
 import { getCsrfToken } from '@/lib/csrf';
 import { leavePage } from '@/lib/leave-page';
@@ -58,18 +62,18 @@ export default function ConnectionsPage({ connections }: Props) {
         useState<BankingConnection | null>(null);
     const [reconnectingId, setReconnectingId] = useState<string | null>(null);
 
-    // A connection parked until the bank's quota resets is not going to change
-    // in the next five seconds, so it must not keep the poll alive - otherwise
-    // one that has never completed a first sync polls for as long as the page
-    // is open, forever.
-    const hasSyncing = connections.some(
-        (c) =>
-            c.status === 'active' &&
-            !c.last_synced_at &&
-            !isWaitingForBankQuota(c),
-    );
+    const hasSyncing = connections.some(isFirstSyncInProgress);
 
+    // A connection whose first sync already failed is not going to change in the
+    // next five seconds, but it can still come good on the next scheduled run -
+    // so it gets a slow poll instead of driving the fast one, and a page left
+    // open still notices when it recovers.
+    const hasStalled = connections.some(isFirstSyncStalled);
+
+    // Two instances on purpose: `usePoll` captures its interval on mount (its
+    // effect has an empty dependency list), so one hook cannot switch cadence.
     const { start, stop } = usePoll(5000, {}, { autoStart: false });
+    const slowPoll = usePoll(60_000, {}, { autoStart: false });
 
     useEffect(() => {
         if (flash?.error) {
@@ -87,6 +91,14 @@ export default function ConnectionsPage({ connections }: Props) {
             stop();
         }
     }, [hasSyncing, start, stop]);
+
+    useEffect(() => {
+        if (hasStalled && !hasSyncing) {
+            slowPoll.start();
+        } else {
+            slowPoll.stop();
+        }
+    }, [hasStalled, hasSyncing, slowPoll]);
 
     function handleSync(connection: BankingConnection) {
         router.post(`/settings/connections/${connection.id}/sync`);
@@ -171,6 +183,62 @@ export default function ConnectionsPage({ connections }: Props) {
         );
     }
 
+    /**
+     * What the card says about this connection's syncing, in one place.
+     *
+     * Was a four-arm nested ternary in the JSX. The arms are not
+     * interchangeable - a stalled first sync has to be told apart from one that
+     * is running, and both from a connection that simply synced a while ago - so
+     * early returns read better than indentation.
+     */
+    function syncStatusLine(connection: BankingConnection): React.ReactNode {
+        if (connection.status === 'awaiting_mapping') {
+            return (
+                <span>
+                    {__('Accounts need to be mapped before syncing can begin.')}
+                </span>
+            );
+        }
+
+        if (isFirstSyncStalled(connection)) {
+            return (
+                <span>
+                    {isWaitingForBankQuota(connection)
+                        ? __(
+                              'The bank limited how often we can ask. We will not try again before :time.',
+                              {
+                                  time: formatDate(
+                                      connection.rate_limited_until,
+                                  ),
+                              },
+                          )
+                        : __(
+                              'The bank limited how often we can ask. The next scheduled sync will try again.',
+                          )}
+                </span>
+            );
+        }
+
+        if (isFirstSyncInProgress(connection)) {
+            return (
+                <span className="flex items-center gap-1.5">
+                    <Spinner className="size-3" />
+                    {['indexacapital', 'interactivebrokers'].includes(
+                        connection.provider,
+                    )
+                        ? __('Syncing balances…')
+                        : __('Syncing transactions and balances…')}
+                </span>
+            );
+        }
+
+        return (
+            <span>
+                {__('Last synced')}: {formatDate(connection.last_synced_at)}
+            </span>
+        );
+    }
+
     function formatDate(dateString: string | null): string {
         if (!dateString) return __('Never');
         return new Date(dateString).toLocaleDateString(undefined, {
@@ -241,10 +309,7 @@ export default function ConnectionsPage({ connections }: Props) {
                                         </div>
                                         <div className="flex items-center gap-2">
                                             <ConnectionStatusBadge
-                                                status={connection.status}
-                                                lastSyncedAt={
-                                                    connection.last_synced_at
-                                                }
+                                                connection={connection}
                                             />
                                             {connection.status === 'expired' &&
                                                 canReconnect(connection) && (
@@ -382,54 +447,7 @@ export default function ConnectionsPage({ connections }: Props) {
                                     </CardHeader>
                                     <CardContent>
                                         <div className="flex gap-6 text-sm text-muted-foreground">
-                                            {connection.status ===
-                                            'awaiting_mapping' ? (
-                                                <span>
-                                                    {__(
-                                                        'Accounts need to be mapped before syncing can begin.',
-                                                    )}
-                                                </span>
-                                            ) : connection.status ===
-                                                  'active' &&
-                                              isWaitingForBankQuota(
-                                                  connection,
-                                              ) ? (
-                                                <span>
-                                                    {__(
-                                                        'The bank limited how often we can ask. Next attempt after :time.',
-                                                        {
-                                                            time: formatDate(
-                                                                connection.rate_limited_until,
-                                                            ),
-                                                        },
-                                                    )}
-                                                </span>
-                                            ) : connection.status ===
-                                                  'active' &&
-                                              !connection.last_synced_at ? (
-                                                <span className="flex items-center gap-1.5">
-                                                    <Spinner className="size-3" />
-                                                    {[
-                                                        'indexacapital',
-                                                        'interactivebrokers',
-                                                    ].includes(
-                                                        connection.provider,
-                                                    )
-                                                        ? __(
-                                                              'Syncing balances…',
-                                                          )
-                                                        : __(
-                                                              'Syncing transactions and balances…',
-                                                          )}
-                                                </span>
-                                            ) : (
-                                                <span>
-                                                    {__('Last synced')}:{' '}
-                                                    {formatDate(
-                                                        connection.last_synced_at,
-                                                    )}
-                                                </span>
-                                            )}
+                                            {syncStatusLine(connection)}
                                             {connection.valid_until && (
                                                 <span>
                                                     {__('Expires')}:{' '}

--- a/resources/js/pages/settings/connections.tsx
+++ b/resources/js/pages/settings/connections.tsx
@@ -21,6 +21,7 @@ import {
 import { Spinner } from '@/components/ui/spinner';
 import AppLayout from '@/layouts/app-layout';
 import SettingsLayout from '@/layouts/settings/layout';
+import { isWaitingForBankQuota } from '@/lib/banking-connections';
 import { CONNECT_PROVIDERS } from '@/lib/connect-providers';
 import { getCsrfToken } from '@/lib/csrf';
 import { leavePage } from '@/lib/leave-page';
@@ -57,8 +58,15 @@ export default function ConnectionsPage({ connections }: Props) {
         useState<BankingConnection | null>(null);
     const [reconnectingId, setReconnectingId] = useState<string | null>(null);
 
+    // A connection parked until the bank's quota resets is not going to change
+    // in the next five seconds, so it must not keep the poll alive - otherwise
+    // one that has never completed a first sync polls for as long as the page
+    // is open, forever.
     const hasSyncing = connections.some(
-        (c) => c.status === 'active' && !c.last_synced_at,
+        (c) =>
+            c.status === 'active' &&
+            !c.last_synced_at &&
+            !isWaitingForBankQuota(c),
     );
 
     const { start, stop } = usePoll(5000, {}, { autoStart: false });
@@ -379,6 +387,21 @@ export default function ConnectionsPage({ connections }: Props) {
                                                 <span>
                                                     {__(
                                                         'Accounts need to be mapped before syncing can begin.',
+                                                    )}
+                                                </span>
+                                            ) : connection.status ===
+                                                  'active' &&
+                                              isWaitingForBankQuota(
+                                                  connection,
+                                              ) ? (
+                                                <span>
+                                                    {__(
+                                                        'The bank limited how often we can ask. Next attempt after :time.',
+                                                        {
+                                                            time: formatDate(
+                                                                connection.rate_limited_until,
+                                                            ),
+                                                        },
                                                     )}
                                                 </span>
                                             ) : connection.status ===

--- a/resources/js/types/banking.ts
+++ b/resources/js/types/banking.ts
@@ -15,6 +15,7 @@ export interface BankingConnection {
     valid_until: string | null;
     last_synced_at: string | null;
     error_message: string | null;
+    rate_limited_until: string | null;
     accounts_count: number;
     has_pending_accounts?: boolean;
     created_at: string;


### PR DESCRIPTION
Fourteen bank connections in production are `active`, have **never** completed a sync, and show a spinner reading "Syncing transactions and balances…" that will never resolve. One was created on 24 July — a month ago — and has imported 249 transactions without ever finishing a run. Eleven of the fourteen have zero balance rows, so those users' balances and net worth read €0, which is presumably why they are on that page at all.

The page also polls the server every 5 seconds for as long as it stays open, asking about a state that cannot change until the bank's quota resets — which for a daily allowance is the next midnight.

## Why the spinner lies

When EnableBanking rate-limits a connection, `applyRateLimitBackoff` parks it: it writes `rate_limited_until` and an `error_message`, and deliberately leaves `status` as `active`. The page decided "this is syncing" from `status === 'active' && !last_synced_at`, which is exactly as true for a connection the bank has refused as for one that was authorized ten seconds ago.

`rate_limited_until` was already on the wire — the model doesn't hide it, the controller passes whole models — and simply unused. It wasn't even declared on the TypeScript type.

## What it says now

A connection that has never synced and whose last attempt failed says so, and names a time when there is an honest one to name. Everything else is unchanged: a genuinely-running first sync still spins, and a connection that synced this morning still shows "Last synced".

The rule lives once, in `lib/banking-connections.ts`, and the badge, the body line and the poll trigger all ask it.

## The two reviews caught two holes that each made the first attempt close to pointless

**The badge kept the spinner.** `connection-status-badge.tsx` carried its own copy of the same rule, so the first version rendered a green "◌ Syncing" badge directly above the new sentence explaining that the bank had told us to come back later — the more prominent of the two still saying the thing the change exists to stop saying.

**And the signal was wrong for 13 of the 14.** Keying on `rate_limited_until` being in the future sounds right and is true about one sixth of the time: a bare `Too many requests` — which is what Trade Republic sends, and 13 of the 14 are Trade Republic — gets a one-hour park against an `everySixHours()` schedule. So for five hours out of every six the park has lapsed while the connection is no closer to working, and the old spinner came straight back. What survives is `error_message`: an attempt has already failed. The window is now only consulted to decide whether a time can be printed.

`BankHealthCommand::isBackingOff` had already learned this the same way; its docblock says a window is needed "rather than `rate_limited_until` simply being in the future" because of that exact gap.

Also from the reviews: the note no longer competes with "Last synced" (5 of the 7 currently-parked connections synced fine this morning and are only throttled on their balance call — they would have lost that line), the four-arm nested ternary became a function with early returns, and the copy is a floor rather than a promise, because the real next attempt is the first scheduled run *after* the timestamp, not the timestamp.

## Tests

`connections.test.tsx` already had `pollStart`/`pollStop` wired into its `usePoll` mock and nobody had used them. Now keyed by interval, so the tests can tell the two cadences apart:

- says what happened instead of spinning, and the badge does not read "Syncing" (the badge is no longer mocked out, which is why this can catch it at all)
- drops to the slow poll instead of asking every five seconds
- still spins and polls at 5s while a first sync is genuinely running
- the predicates separate running from stalled, say neither for a connection that has synced, and ignore anything not `active`
- `isWaitingForBankQuota` reads the clock itself when no `now` is passed — the default both callers rely on, which no test covered

## Still not solved, and it is the thing those users actually care about

The €0 is unexplained. Those fourteen connections carry 249 / 174 / 172 / 164 / … transactions, and eleven have no `account_balances` rows at all, so the accounts read €0 and drag net worth down. Nothing in this page's props can say "your transactions arrived, the balance didn't" — that needs a count or a flag from `ConnectionController::index`. This PR stops the page lying about what is happening; it does not yet explain the number the user came to look at.

Two adjacent pre-existing bugs found while reading, each worth its own change:

- `AccountMappingController` and `ConnectionController::updateCredentials` clear `error_message` but not `rate_limited_until`, so the sync they dispatch is silently skipped while the flash message says it started.
- Manual Sync nulls `rate_limited_until` on purpose, so the user can press it forever: green toast, spinner, and within seconds the same message with a fresh one-hour stamp. It costs no allowance (a 429 is refused before access), but it is a loop, not a way out.
