### PR TITLE
feat(emails): re-engage dormant users who never connected a bank

### DIFF
--- a/app/Console/Commands/SendInactiveNoBankEmailsCommand.php
+++ b/app/Console/Commands/SendInactiveNoBankEmailsCommand.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\DripEmailType;
+use App\Jobs\Drip\SendInactiveNoBankEmailJob;
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Collection;
+
+class SendInactiveNoBankEmailsCommand extends Command
+{
+    protected $signature = 'email:inactive-no-bank';
+
+    protected $description = 'Queue the re-engagement email for onboarded users with no bank connected who last used the app a week ago';
+
+    /**
+     * A user is treated as dormant once this many days have passed since their
+     * last visit. The match is on that exact day, so each dormancy episode
+     * triggers a single email.
+     */
+    private const INACTIVE_DAYS = 7;
+
+    public function handle(): int
+    {
+        if (! config('mail.drip_emails_enabled')) {
+            $this->info('Drip emails are disabled. Nothing to do.');
+
+            return self::SUCCESS;
+        }
+
+        $dormantOn = today()->subDays(self::INACTIVE_DAYS)->toDateString();
+
+        $queued = 0;
+
+        User::query()
+            ->whereNotNull('onboarded_at')
+            ->whereDate('last_active_at', $dormantOn)
+            ->whereDoesntHave('bankingConnections')
+            ->whereDoesntHave('mailLogs', function ($query) use ($dormantOn): void {
+                $query->where('email_type', DripEmailType::InactiveNoBank)
+                    ->where('email_identifier', $dormantOn);
+            })
+            ->chunkById(100, function (Collection $users) use ($dormantOn, &$queued): void {
+                foreach ($users as $user) {
+                    SendInactiveNoBankEmailJob::dispatch($user, $dormantOn);
+                    $queued++;
+                }
+            });
+
+        $this->info("Queued {$queued} inactive-no-bank email(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/SendTestEmails.php
+++ b/app/Console/Commands/SendTestEmails.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use App\Mail\Drip\FeedbackEmail;
 use App\Mail\Drip\ImportHelpEmail;
+use App\Mail\Drip\InactiveNoBankEmail;
 use App\Mail\Drip\OnboardingReminderEmail;
 use App\Mail\Drip\PromoCodeEmail;
 use App\Mail\Drip\WelcomeEmail;
@@ -44,6 +45,7 @@ class SendTestEmails extends Command
             'Import Help Email' => new ImportHelpEmail($user),
             'Onboarding Reminder Email' => new OnboardingReminderEmail($user),
             'Promo Code Email' => new PromoCodeEmail($user),
+            'Inactive No Bank Email' => new InactiveNoBankEmail($user),
         ];
 
         foreach ($emails as $name => $mailable) {

--- a/app/Enums/DripEmailType.php
+++ b/app/Enums/DripEmailType.php
@@ -16,4 +16,5 @@ enum DripEmailType: string
     case Update = 'update';
     case BankOutage = 'bank_outage';
     case BankConnectFailed = 'bank_connect_failed';
+    case InactiveNoBank = 'inactive_no_bank';
 }

--- a/app/Jobs/Drip/SendDripEmailJob.php
+++ b/app/Jobs/Drip/SendDripEmailJob.php
@@ -27,6 +27,16 @@ abstract class SendDripEmailJob implements ShouldQueue
     abstract protected function buildMail(): Mailable;
 
     /**
+     * Dedupe key stored alongside the email type. Emails that may legitimately
+     * be sent to the same user more than once override this with a per-send
+     * value (e.g. a date); the default makes them one-per-user-ever.
+     */
+    protected function emailIdentifier(): string
+    {
+        return $this->emailType()->value;
+    }
+
+    /**
      * Per-email eligibility checks beyond the shared "can receive" and
      * "not already sent" guards.
      */
@@ -41,7 +51,7 @@ abstract class SendDripEmailJob implements ShouldQueue
             return;
         }
 
-        if ($this->user->hasReceivedEmail($this->emailType())) {
+        if ($this->hasAlreadyBeenSent()) {
             return;
         }
 
@@ -54,8 +64,16 @@ abstract class SendDripEmailJob implements ShouldQueue
         UserMailLog::create([
             'user_id' => $this->user->id,
             'email_type' => $this->emailType(),
-            'email_identifier' => $this->emailType()->value,
+            'email_identifier' => $this->emailIdentifier(),
             'sent_at' => now(),
         ]);
+    }
+
+    private function hasAlreadyBeenSent(): bool
+    {
+        return $this->user->mailLogs()
+            ->where('email_type', $this->emailType())
+            ->where('email_identifier', $this->emailIdentifier())
+            ->exists();
     }
 }

--- a/app/Jobs/Drip/SendInactiveNoBankEmailJob.php
+++ b/app/Jobs/Drip/SendInactiveNoBankEmailJob.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Jobs\Drip;
+
+use App\Enums\DripEmailType;
+use App\Mail\Drip\InactiveNoBankEmail;
+use App\Models\User;
+use Illuminate\Mail\Mailable;
+
+class SendInactiveNoBankEmailJob extends SendDripEmailJob
+{
+    /**
+     * @param  string  $dormantOn  The Y-m-d the user was last active, i.e. the
+     *                             dormancy episode this email belongs to.
+     */
+    public function __construct(User $user, public string $dormantOn)
+    {
+        parent::__construct($user);
+    }
+
+    protected function emailType(): DripEmailType
+    {
+        return DripEmailType::InactiveNoBank;
+    }
+
+    protected function buildMail(): Mailable
+    {
+        return new InactiveNoBankEmail($this->user);
+    }
+
+    /**
+     * Keyed on the episode rather than the type, so the user gets one email per
+     * dormancy episode instead of one ever.
+     */
+    protected function emailIdentifier(): string
+    {
+        return $this->dormantOn;
+    }
+
+    protected function shouldSend(): bool
+    {
+        return $this->user->last_active_at?->toDateString() === $this->dormantOn
+            && ! $this->user->bankingConnections()->exists();
+    }
+}

--- a/app/Mail/Drip/DripMail.php
+++ b/app/Mail/Drip/DripMail.php
@@ -50,6 +50,22 @@ abstract class DripMail extends Mailable implements ShouldQueue
     }
 
     /**
+     * UTM parameters for every link in a drip email, so PostHog attributes the
+     * landing pageview to the email that produced it. Merge in a `utm_content`
+     * at the call site when a mail carries more than one link.
+     *
+     * @return array<string, string>
+     */
+    protected function utmParameters(): array
+    {
+        return [
+            'utm_source' => 'drip',
+            'utm_medium' => 'email',
+            'utm_campaign' => str($this->template())->afterLast('.')->value(),
+        ];
+    }
+
+    /**
      * Whether replies should route back to the drip sender address.
      */
     protected function repliesToSender(): bool
@@ -77,6 +93,7 @@ abstract class DripMail extends Mailable implements ShouldQueue
             markdown: $this->template(),
             with: [
                 'userName' => $this->user->name,
+                'emailUtm' => $this->utmParameters(),
                 ...$this->contentData(),
             ],
         );

--- a/app/Mail/Drip/InactiveNoBankEmail.php
+++ b/app/Mail/Drip/InactiveNoBankEmail.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Mail\Drip;
+
+class InactiveNoBankEmail extends DripMail
+{
+    protected function dripSubject(): string
+    {
+        return __('Your accounts have not been updated in a week');
+    }
+
+    protected function template(): string
+    {
+        return 'mail.drip.inactive-no-bank';
+    }
+
+    protected function repliesToSender(): bool
+    {
+        return true;
+    }
+}

--- a/lang/es.json
+++ b/lang/es.json
@@ -2461,10 +2461,10 @@
     "Your numbers are a week out of date, :name": "Tus números llevan una semana sin actualizarse, :name",
     "Hi! It's Víctor and Álvaro, the founders of Whisper Money. It's been a week since you last stopped by, and nothing has arrived on its own in the meantime: you have no bank connected, so nothing syncs in the background. Whatever Whisper Money is showing you right now is a week old.": "¡Hola! Somos Víctor y Álvaro, los fundadores de Whisper Money. Ha pasado una semana desde la última vez que entraste y desde entonces no ha llegado nada por su cuenta: no tienes ningún banco conectado, así que no se sincroniza nada en segundo plano. Lo que Whisper Money te muestra ahora mismo tiene una semana de retraso.",
     "Your transactions then arrive on their own, every day, and we email you a summary when they do.": "Tus transacciones llegarán solas, cada día, y te enviamos un resumen por email cuando lo hagan.",
-    "Export the transactions from your bank and upload the file. We map the columns for you, and it works with most banks.": "Exporta las transacciones de tu banco y sube el archivo. Nosotros mapeamos las columnas por ti y funciona con la mayoría de bancos.",
+    "Import a CSV": "Importa un CSV",
+    "Export the transactions from your bank, then upload the file from your dashboard. We map the columns for you, and it works with most banks.": "Exporta las transacciones de tu banco y sube el archivo desde tu panel. Nosotros mapeamos las columnas por ti y funciona con la mayoría de bancos.",
+    "Or connect your bank": "O conecta tu banco",
     "There are two ways to fix that, and both take a couple of minutes.": "Hay dos formas de arreglarlo y las dos te llevan un par de minutos.",
-    "Connect your bank": "Conecta tu banco",
-    "Or import a CSV": "O importa un CSV",
     "Connect a bank": "Conectar un banco",
     "If something got in the way, your bank is missing, the import failed, or Whisper Money just is not what you were looking for, reply to this email and tell us. We read every reply ourselves.": "Si algo se ha puesto por medio, falta tu banco, la importación ha fallado o simplemente Whisper Money no es lo que buscabas, responde a este email y cuéntanoslo. Leemos todas las respuestas personalmente."
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -2456,5 +2456,15 @@
     "Your plan is on. Connected banks, AI suggestions and the AI assistant are all available now.": "Tu plan ya está activo. Los bancos conectados, las sugerencias de IA y el asistente de IA están disponibles.",
     "Waiting for the bank": "Esperando al banco",
     "Your bank limits how often we can fetch your data. We will retry automatically.": "Tu banco limita la frecuencia con la que podemos consultar tus datos. Lo reintentaremos automáticamente.",
-    "Next attempt": "Próximo intento"
+    "Next attempt": "Próximo intento",
+    "Your accounts have not been updated in a week": "Tus cuentas llevan una semana sin actualizarse",
+    "Your numbers are a week out of date, :name": "Tus números llevan una semana sin actualizarse, :name",
+    "Hi! It's Víctor and Álvaro, the founders of Whisper Money. It's been a week since you last stopped by, and nothing has arrived on its own in the meantime: you have no bank connected, so nothing syncs in the background. Whatever Whisper Money is showing you right now is a week old.": "¡Hola! Somos Víctor y Álvaro, los fundadores de Whisper Money. Ha pasado una semana desde la última vez que entraste y desde entonces no ha llegado nada por su cuenta: no tienes ningún banco conectado, así que no se sincroniza nada en segundo plano. Lo que Whisper Money te muestra ahora mismo tiene una semana de retraso.",
+    "Your transactions then arrive on their own, every day, and we email you a summary when they do.": "Tus transacciones llegarán solas, cada día, y te enviamos un resumen por email cuando lo hagan.",
+    "Export the transactions from your bank and upload the file. We map the columns for you, and it works with most banks.": "Exporta las transacciones de tu banco y sube el archivo. Nosotros mapeamos las columnas por ti y funciona con la mayoría de bancos.",
+    "There are two ways to fix that, and both take a couple of minutes.": "Hay dos formas de arreglarlo y las dos te llevan un par de minutos.",
+    "Connect your bank": "Conecta tu banco",
+    "Or import a CSV": "O importa un CSV",
+    "Connect a bank": "Conectar un banco",
+    "If something got in the way, your bank is missing, the import failed, or Whisper Money just is not what you were looking for, reply to this email and tell us. We read every reply ourselves.": "Si algo se ha puesto por medio, falta tu banco, la importación ha fallado o simplemente Whisper Money no es lo que buscabas, responde a este email y cuéntanoslo. Leemos todas las respuestas personalmente."
 }

--- a/resources/views/mail/drip/inactive-no-bank.blade.php
+++ b/resources/views/mail/drip/inactive-no-bank.blade.php
@@ -5,14 +5,14 @@
 
 {{ __('There are two ways to fix that, and both take a couple of minutes.') }}
 
-**{{ __('Connect your bank') }}**
-{{ __('Your transactions then arrive on their own, every day, and we email you a summary when they do.') }}
+**{{ __('Import a CSV') }}**
+{{ __('Export the transactions from your bank, then upload the file from your dashboard. We map the columns for you, and it works with most banks.') }}
 
-**{{ __('Or import a CSV') }}**
-{{ __('Export the transactions from your bank and upload the file. We map the columns for you, and it works with most banks.') }}
+**{{ __('Or connect your bank') }}**
+{{ __('Your transactions then arrive on their own, every day, and we email you a summary when they do.') }} [{{ __('Connect a bank') }}]({!! route('settings.connections.index', $emailUtm + ['utm_content' => 'connect-bank']) !!})
 
-<x-mail::button :url="route('settings.connections.index', $emailUtm)">
-{{ __('Connect a bank') }}
+<x-mail::button :url="route('dashboard', $emailUtm + ['utm_content' => 'dashboard'])">
+{{ __('Go to Dashboard') }}
 </x-mail::button>
 
 {{ __("If something got in the way, your bank is missing, the import failed, or Whisper Money just is not what you were looking for, reply to this email and tell us. We read every reply ourselves.") }}

--- a/resources/views/mail/drip/inactive-no-bank.blade.php
+++ b/resources/views/mail/drip/inactive-no-bank.blade.php
@@ -1,0 +1,23 @@
+<x-mail::message>
+# {{ __('Your numbers are a week out of date, :name', ['name' => $userName]) }}
+
+{{ __("Hi! It's Víctor and Álvaro, the founders of Whisper Money. It's been a week since you last stopped by, and nothing has arrived on its own in the meantime: you have no bank connected, so nothing syncs in the background. Whatever Whisper Money is showing you right now is a week old.") }}
+
+{{ __('There are two ways to fix that, and both take a couple of minutes.') }}
+
+**{{ __('Connect your bank') }}**
+{{ __('Your transactions then arrive on their own, every day, and we email you a summary when they do.') }}
+
+**{{ __('Or import a CSV') }}**
+{{ __('Export the transactions from your bank and upload the file. We map the columns for you, and it works with most banks.') }}
+
+<x-mail::button :url="route('settings.connections.index')">
+{{ __('Connect a bank') }}
+</x-mail::button>
+
+{{ __("If something got in the way, your bank is missing, the import failed, or Whisper Money just is not what you were looking for, reply to this email and tell us. We read every reply ourselves.") }}
+
+{{ __('Best,') }}<br>
+{{ __('Víctor & Álvaro') }}<br>
+{{ __('Founders of Whisper Money') }}
+</x-mail::message>

--- a/resources/views/mail/drip/inactive-no-bank.blade.php
+++ b/resources/views/mail/drip/inactive-no-bank.blade.php
@@ -11,7 +11,7 @@
 **{{ __('Or import a CSV') }}**
 {{ __('Export the transactions from your bank and upload the file. We map the columns for you, and it works with most banks.') }}
 
-<x-mail::button :url="route('settings.connections.index')">
+<x-mail::button :url="route('settings.connections.index', $emailUtm)">
 {{ __('Connect a bank') }}
 </x-mail::button>
 

--- a/routes/console.php
+++ b/routes/console.php
@@ -10,6 +10,7 @@ Schedule::command('real-estate:apply-revaluation')->monthlyOn(1, '00:00');
 Schedule::command('loans:generate-balances')->monthlyOn(1, '00:00');
 Schedule::command('email:paywall-follow-up')->dailyAt('10:00')->timezone('Europe/Madrid');
 Schedule::command('email:ai-consent-follow-up')->dailyAt('10:15')->timezone('Europe/Madrid');
+Schedule::command('email:inactive-no-bank')->dailyAt('09:45')->timezone('Europe/Madrid');
 Schedule::command('email:user-emails-report')->monthlyOn(1, '09:05')->timezone('Europe/Madrid');
 Schedule::command('banking:health --email')->dailyAt('09:30')->timezone('Europe/Madrid');
 Schedule::command('stats:daily-report')->dailyAt('09:00')->timezone('Europe/Madrid');

--- a/tests/Feature/Console/SendInactiveNoBankEmailsCommandTest.php
+++ b/tests/Feature/Console/SendInactiveNoBankEmailsCommandTest.php
@@ -1,0 +1,171 @@
+<?php
+
+use App\Enums\DripEmailType;
+use App\Jobs\Drip\SendInactiveNoBankEmailJob;
+use App\Mail\Drip\InactiveNoBankEmail;
+use App\Models\BankingConnection;
+use App\Models\User;
+use App\Models\UserMailLog;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Mail;
+
+// Freeze time so the day-relative timestamps below cannot straddle midnight and
+// fall outside the command's exact-day match.
+beforeEach(fn () => $this->freezeTime());
+
+/**
+ * Creates an onboarded user whose last activity was $inactiveDaysAgo days ago.
+ */
+function dormantUser(int $inactiveDaysAgo = 7): User
+{
+    return User::factory()->onboarded()->create([
+        'last_active_at' => now()->subDays($inactiveDaysAgo),
+    ]);
+}
+
+it('queues the email for an onboarded user with no bank who went quiet a week ago', function () {
+    Bus::fake();
+
+    $user = dormantUser();
+
+    $this->artisan('email:inactive-no-bank')->assertSuccessful();
+
+    Bus::assertDispatched(
+        SendInactiveNoBankEmailJob::class,
+        fn (SendInactiveNoBankEmailJob $job): bool => $job->user->is($user)
+            && $job->dormantOn === $user->last_active_at->toDateString(),
+    );
+});
+
+it('skips users who have a bank connected', function () {
+    Bus::fake();
+
+    BankingConnection::factory()->for(dormantUser())->create();
+
+    $this->artisan('email:inactive-no-bank')->assertSuccessful();
+
+    Bus::assertNotDispatched(SendInactiveNoBankEmailJob::class);
+});
+
+it('skips users who were active within the last week', function () {
+    Bus::fake();
+
+    dormantUser(inactiveDaysAgo: 2);
+    dormantUser(inactiveDaysAgo: 6);
+
+    $this->artisan('email:inactive-no-bank')->assertSuccessful();
+
+    Bus::assertNotDispatched(SendInactiveNoBankEmailJob::class);
+});
+
+it('skips users who never finished onboarding', function () {
+    Bus::fake();
+
+    User::factory()->notOnboarded()->create(['last_active_at' => now()->subDays(7)]);
+
+    $this->artisan('email:inactive-no-bank')->assertSuccessful();
+
+    Bus::assertNotDispatched(SendInactiveNoBankEmailJob::class);
+});
+
+it('skips users whose activity was never recorded', function () {
+    Bus::fake();
+
+    User::factory()->onboarded()->create(['last_active_at' => null]);
+
+    $this->artisan('email:inactive-no-bank')->assertSuccessful();
+
+    Bus::assertNotDispatched(SendInactiveNoBankEmailJob::class);
+});
+
+it('does nothing when drip emails are disabled', function () {
+    config(['mail.drip_emails_enabled' => false]);
+    Bus::fake();
+
+    dormantUser();
+
+    $this->artisan('email:inactive-no-bank')->assertSuccessful();
+
+    Bus::assertNotDispatched(SendInactiveNoBankEmailJob::class);
+});
+
+it('does not queue again on a same-day re-run', function () {
+    Mail::fake();
+
+    $user = dormantUser();
+
+    $this->artisan('email:inactive-no-bank')->assertSuccessful();
+    $this->artisan('email:inactive-no-bank')->assertSuccessful();
+
+    Mail::assertQueuedCount(1);
+    expect(UserMailLog::where('user_id', $user->id)->count())->toBe(1);
+});
+
+it('sends the email and records a mail log keyed on the dormancy date', function () {
+    Mail::fake();
+
+    $user = dormantUser();
+    $dormantOn = $user->last_active_at->toDateString();
+
+    (new SendInactiveNoBankEmailJob($user, $dormantOn))->handle();
+
+    Mail::assertQueued(InactiveNoBankEmail::class);
+    expect(UserMailLog::where('user_id', $user->id)->value('email_identifier'))->toBe($dormantOn);
+    expect(UserMailLog::where('user_id', $user->id)->value('email_type'))
+        ->toBe(DripEmailType::InactiveNoBank);
+});
+
+it('sends again for a later dormancy episode', function () {
+    Mail::fake();
+
+    $user = dormantUser();
+    (new SendInactiveNoBankEmailJob($user, $user->last_active_at->toDateString()))->handle();
+
+    // The user came back and went quiet again: a new episode, so a new email.
+    $user->last_active_at = now()->subDays(3);
+    $user->save();
+
+    (new SendInactiveNoBankEmailJob($user, $user->last_active_at->toDateString()))->handle();
+
+    Mail::assertQueuedCount(2);
+    expect(UserMailLog::where('user_id', $user->id)->count())->toBe(2);
+});
+
+it('does not send once the user has connected a bank', function () {
+    Mail::fake();
+
+    $user = dormantUser();
+    BankingConnection::factory()->for($user)->create();
+
+    (new SendInactiveNoBankEmailJob($user, $user->last_active_at->toDateString()))->handle();
+
+    Mail::assertNothingQueued();
+});
+
+it('does not send once the user has come back', function () {
+    Mail::fake();
+
+    $user = dormantUser();
+    $dormantOn = $user->last_active_at->toDateString();
+
+    // The user opened the app between the command queueing this and it running.
+    $user->last_active_at = now();
+    $user->save();
+
+    (new SendInactiveNoBankEmailJob($user, $dormantOn))->handle();
+
+    Mail::assertNothingQueued();
+    expect(UserMailLog::where('user_id', $user->id)->count())->toBe(0);
+});
+
+it('renders the email in the user locale', function () {
+    app()->setLocale('es');
+
+    $user = User::factory()->make(['name' => 'Ada']);
+    $html = (new InactiveNoBankEmail($user))->render();
+
+    app()->setLocale('en');
+
+    expect($html)->toContain('Tus números llevan una semana sin actualizarse, Ada');
+    expect($html)->toContain('Conectar un banco');
+});

--- a/tests/Feature/Console/SendInactiveNoBankEmailsCommandTest.php
+++ b/tests/Feature/Console/SendInactiveNoBankEmailsCommandTest.php
@@ -168,13 +168,22 @@ it('renders the email in the user locale', function () {
     }
 
     expect($html)->toContain('Tus números llevan una semana sin actualizarse, Ada');
-    expect($html)->toContain('Conectar un banco');
+    expect($html)->toContain('Ir al Panel');
 });
 
-it('tags its link so the click is attributable in PostHog', function () {
+it('points its button at the dashboard and offers connecting a bank as a link', function () {
+    $html = (new InactiveNoBankEmail(User::factory()->make()))->render();
+
+    expect($html)->toContain(route('dashboard').'?')
+        ->toContain(route('settings.connections.index').'?');
+});
+
+it('tags both links so the clicks are attributable in PostHog', function () {
     $html = (new InactiveNoBankEmail(User::factory()->make()))->render();
 
     expect($html)->toContain('utm_source=drip')
         ->toContain('utm_medium=email')
-        ->toContain('utm_campaign=inactive-no-bank');
+        ->toContain('utm_campaign=inactive-no-bank')
+        ->toContain('utm_content=dashboard')
+        ->toContain('utm_content=connect-bank');
 });

--- a/tests/Feature/Console/SendInactiveNoBankEmailsCommandTest.php
+++ b/tests/Feature/Console/SendInactiveNoBankEmailsCommandTest.php
@@ -161,11 +161,20 @@ it('does not send once the user has come back', function () {
 it('renders the email in the user locale', function () {
     app()->setLocale('es');
 
-    $user = User::factory()->make(['name' => 'Ada']);
-    $html = (new InactiveNoBankEmail($user))->render();
-
-    app()->setLocale('en');
+    try {
+        $html = (new InactiveNoBankEmail(User::factory()->make(['name' => 'Ada'])))->render();
+    } finally {
+        app()->setLocale('en');
+    }
 
     expect($html)->toContain('Tus números llevan una semana sin actualizarse, Ada');
     expect($html)->toContain('Conectar un banco');
+});
+
+it('tags its link so the click is attributable in PostHog', function () {
+    $html = (new InactiveNoBankEmail(User::factory()->make()))->render();
+
+    expect($html)->toContain('utm_source=drip')
+        ->toContain('utm_medium=email')
+        ->toContain('utm_campaign=inactive-no-bank');
 });

--- a/tests/Feature/MailSenderTest.php
+++ b/tests/Feature/MailSenderTest.php
@@ -119,7 +119,18 @@ test('promo code email adds the founder promo code to its view data', function (
     $user = User::factory()->create();
 
     expect((new PromoCodeEmail($user))->content()->with)
-        ->toEqual(['userName' => $user->name, 'promoCode' => 'FOUNDER']);
+        ->toMatchArray(['userName' => $user->name, 'promoCode' => 'FOUNDER']);
+});
+
+test('drip mailables hand their template UTM parameters for PostHog attribution', function () {
+    $user = User::factory()->create();
+
+    expect((new PromoCodeEmail($user))->content()->with['emailUtm'])
+        ->toBe([
+            'utm_source' => 'drip',
+            'utm_medium' => 'email',
+            'utm_campaign' => 'promo-code',
+        ]);
 });
 
 test('default sender is used for active non-drip mailables', function (string $mailableClass) {


### PR DESCRIPTION
## Why

Users with a bank connection keep hearing from us: the daily "new transactions
synced" email lands in their inbox whenever their bank sends something. Users
with **no bank connected** get nothing at all after the day-one onboarding
drip, so they quietly drift away.

This adds the missing email for them.

## Who gets it

Onboarded users with **zero banking connections** whose `users.last_active_at`
was **exactly 7 days ago**.

- `whereNotNull('onboarded_at')` — never-onboarded signups already get
  `OnboardingReminder` + `ImportHelp` on day one; a third email is noise.
- `whereDoesntHave('bankingConnections')` — no bank of any status.
- The exact-day match naturally fires **once per dormancy episode**, so this is
  not a recurring every-7-days nag. Users with a null `last_active_at` are
  excluded by `whereDate()`, which is deliberate: the column landed on
  2026-06-10, so matching nulls would blast every ancient dormant account.

On production this is **17–45 users a day** (mean ≈ 26 over the last three
weeks), comfortably inside the `emails` rate limiter.

## The one wrinkle: dedupe

`SendDripEmailJob` deduped on `email_type` alone, which makes every drip email
once-per-user-ever — wrong for an email that should fire again on the next
dormancy episode. So the base job gains an `emailIdentifier()` hook, the same
mechanism `SendDailyBankTransactionsSyncedEmailJob` and `SendUpdateEmailJob`
already use, and the guard now matches on `(email_type, email_identifier)`.

The default identifier stays `email_type->value`, so **nothing changes for the
other eight drip emails**. Verified against production `user_mail_logs`: every
type that flows through this base class has zero rows where
`email_identifier <> email_type` (welcome 4187, feedback 3540,
onboarding_reminder 2200, import_help 1161, ai_consent_follow_up 74,
paywall_follow_up 22, promo_code 21, subscription_cancelled 6). The existing
`user_mail_logs_unique` index on `(user_id, email_type, email_identifier)`
already backs the new key.

This email keys on the dormancy date, which the command passes into the job
rather than the job re-deriving it. That matters: a user who opens the app
between the command queueing at 09:45 and the job running would otherwise be
told they had been away a week, *and* have their mail log written against the
new date, silently suppressing the real episode seven days later. The job
re-checks both audience conditions before sending, so that user simply gets
nothing and stays eligible.

## Copy

First person, from Álvaro and Víctor, in the tone of the existing onboarding
drip. It says their numbers are a week out of date and that nothing syncs
because no bank is connected, then offers the two ways out.

**The button goes to the dashboard, not to the bank connection page.**
Connecting a bank needs a paid plan and this audience almost never has one — of
726 users matching it over 30 days, 15 have an active subscription, and a
typical daily cohort has none. Sending them to `/settings/connections` would
land nearly everyone on a page whose only action is an upgrade dialog. So the
copy leads with the CSV path, the button goes to the dashboard where the
importer lives, and connecting a bank stays an inline text link for the few it
applies to.

It deliberately does **not** claim they have never imported a transaction —
39% of audience-shaped users on production already have transactions, so that
claim would be false for a good chunk of the recipients.

## Tracking

A send nobody can measure is a send we can't decide about, so both links are
tagged: `utm_source=drip`, `utm_medium=email`,
`utm_campaign=inactive-no-bank`, plus a per-link `utm_content`
(`dashboard` / `connect-bank`) so the readout says which of the two paths they
took. PostHog needs no new code for this — it is
initialized with the default `capture_pageview` and `person_profiles: 'always'`
(`resources/js/lib/posthog.ts`), so it reads `utm_*` off the landing URL into
the `$pageview` event and `$initial_utm_*` on the person profile. A click from
this email is now distinguishable from an in-app visit to the same page.

The tagging lives on `DripMail`, not in this Blade: every drip mailable now gets
an `$emailUtm` array whose campaign is derived from its own template name, so
future drip emails inherit it by writing
`route('...', $emailUtm)` and nothing else. Add a `utm_content` at the call site
when a mail carries more than one link.

The eight pre-existing drip Blades are still untagged. Retrofitting them is a
follow-up rather than part of this PR, to keep the blast radius here to one
email.

## QA

Ran against a local database with five seeded users and Mailhog:

- `email:inactive-no-bank` queued **exactly the 2** dormant-no-bank onboarded
  users. Correctly skipped the user with a bank connection, the user active two
  days ago, and the never-onboarded user.
- Both emails rendered correctly in English and Spanish (locale comes from
  `preferredLocale()`), with the right From/Reply-To, the name interpolated and
  the CTA resolving to `/settings/connections`. No template leakage, no
  double-escaped entities.
- Same-day re-run queued 0; mail logs stayed at 2, Mailhog stayed at 2.
- Moving `last_active_at` to a later date and re-running sent a second email
  with a distinct identifier, confirming one-per-episode rather than one-ever.
- The delivered links read `/dashboard?...&utm_content=dashboard` and
  `/settings/connections?...&utm_content=connect-bank` in both locales, correct
  in the HTML part and the plain-text part alike.
- `php artisan schedule:list` shows `45 7 * * *` (09:45 Europe/Madrid), no
  collision with the existing email slots.

Checks: 14 new tests pass; the 252 tests across the drip/mail suites pass
unchanged; PHPStan clean; `crap --base=origin/main` reports nothing above
complexity 10; `bun run dry` at 4.45% against a 5.4% threshold.
