### PR TITLE
fix(budgets): stop a biweekly budget counting the same spend twice

### DIFF
--- a/app/Http/Controllers/BudgetController.php
+++ b/app/Http/Controllers/BudgetController.php
@@ -32,8 +32,13 @@ class BudgetController extends Controller
         $budgets = $user
             ->budgets()
             ->with(['categories', 'labels', 'periods' => function ($query) {
+                // Same ordering as Budget::getCurrentPeriod, for the same
+                // reason: the card reads `periods[0]`, and where two periods
+                // cover today the earliest-starting one is the one the user
+                // never configured.
                 $query->where('start_date', '<=', today())
                     ->where('end_date', '>=', today())
+                    ->orderByDesc('start_date')
                     ->with(['budgetTransactions']);
             }])
             ->get();

--- a/app/Models/Budget.php
+++ b/app/Models/Budget.php
@@ -77,11 +77,26 @@ class Budget extends Model
         return $this->hasMany(BudgetPeriod::class);
     }
 
+    /**
+     * The period covering today, if there is one.
+     *
+     * Ordered because more than one can cover today. Overlapping periods are
+     * not hypothetical - every biweekly budget created before the fix to
+     * `generatePreviousPeriod` has a pair, and a monthly budget anchored past
+     * the 28th can still produce one - and an unordered `first()` resolves to
+     * whatever MySQL returns first, which on the `(budget_id, start_date)`
+     * index is the *earliest* starting window. That is the wrong one: it is the
+     * period the user did not configure, and `BudgetController::show` cannot
+     * navigate out of it because its previous/next queries are strict
+     * comparisons that step over an overlapping sibling. Taking the latest
+     * start picks the period the chain actually continues from.
+     */
     public function getCurrentPeriod(): ?BudgetPeriod
     {
         return $this->periods()
             ->where('start_date', '<=', today())
             ->where('end_date', '>=', today())
+            ->orderByDesc('start_date')
             ->first();
     }
 

--- a/app/Services/BudgetPeriodService.php
+++ b/app/Services/BudgetPeriodService.php
@@ -50,9 +50,9 @@ class BudgetPeriodService
      * what this used to do, but a biweekly period is rewound to a *weekday* -
      * a seven-day grid under a fourteen-day window - so that day lands in the
      * middle of the previous fortnight and the two periods overlap by a week.
-     * All 14 live biweekly budgets in production are shaped that way, and since
-     * both periods are handed to `AssignHistoricalTransactionsToBudget`, 17
-     * transactions across 9 budgets are counted twice.
+     * 12 of the 13 live biweekly budgets in production are shaped that way, and
+     * since both periods are handed to `AssignHistoricalTransactionsToBudget`,
+     * 16 transactions across 8 budgets hold two rows for one spend.
      */
     public function generatePreviousPeriod(Budget $budget, BudgetPeriod $period, ?int $allocatedAmount = null, bool $processHistorical = false): BudgetPeriod
     {
@@ -64,10 +64,21 @@ class BudgetPeriodService
     /**
      * One period back from where this one starts.
      *
-     * Mirrors the step each branch of `calculatePeriodDates` takes forward, which
-     * is the only thing that knows how long a period of this type is. Counting
-     * days instead looks generic and is wrong twice over: it keeps the biweekly
-     * bug, and 31 days back from 1 March is January, skipping February entirely.
+     * Counting days is not it: 31 days back from 1 March is January, so February
+     * disappears. Nor is reusing the forward step of `calculatePeriodDates` for
+     * every type - **Monthly deliberately does not mirror it**. Forward it uses
+     * `addMonth()`, which overflows, and that overflow is load-bearing for the
+     * windows budgets anchored past the 28th already have (see
+     * `startDayOfMonth`). Backward the same overflow would land inside the
+     * current period: for a budget anchored on the 29th, on 2026-03-29,
+     * `subMonth()` gives a previous period of 03-01..03-31 that overlaps the
+     * current 03-29..04-28 by three days - the very bug this method exists to
+     * stop, reappearing in another type.
+     *
+     * Measured over three years of reference dates per anchor, no-overflow
+     * backward removes every overlap for anchors 29 and 30 and most for 31,
+     * while making both directions no-overflow would collapse anchor 31 from
+     * 636 adjacent results to 6. The asymmetry is the point, not drift.
      */
     private function onePeriodEarlier(Budget $budget, BudgetPeriod $period): Carbon
     {

--- a/app/Services/BudgetPeriodService.php
+++ b/app/Services/BudgetPeriodService.php
@@ -43,11 +43,42 @@ class BudgetPeriodService
         );
     }
 
+    /**
+     * The period immediately before a given one.
+     *
+     * "The day before this one started" reads like the obvious reference and is
+     * what this used to do, but a biweekly period is rewound to a *weekday* -
+     * a seven-day grid under a fourteen-day window - so that day lands in the
+     * middle of the previous fortnight and the two periods overlap by a week.
+     * All 14 live biweekly budgets in production are shaped that way, and since
+     * both periods are handed to `AssignHistoricalTransactionsToBudget`, 17
+     * transactions across 9 budgets are counted twice.
+     */
     public function generatePreviousPeriod(Budget $budget, BudgetPeriod $period, ?int $allocatedAmount = null, bool $processHistorical = false): BudgetPeriod
     {
-        $referenceDate = $period->start_date->copy()->subDay();
+        $referenceDate = $this->onePeriodEarlier($budget, $period);
 
         return $this->generatePeriod($budget, $allocatedAmount ?? $period->allocated_amount, $referenceDate, $processHistorical);
+    }
+
+    /**
+     * One period back from where this one starts.
+     *
+     * Mirrors the step each branch of `calculatePeriodDates` takes forward, which
+     * is the only thing that knows how long a period of this type is. Counting
+     * days instead looks generic and is wrong twice over: it keeps the biweekly
+     * bug, and 31 days back from 1 March is January, skipping February entirely.
+     */
+    private function onePeriodEarlier(Budget $budget, BudgetPeriod $period): Carbon
+    {
+        $start = $period->start_date->copy();
+
+        return match ($budget->period_type) {
+            BudgetPeriodType::Weekly => $start->subWeek(),
+            BudgetPeriodType::Biweekly => $start->subWeeks(2),
+            BudgetPeriodType::Yearly => $start->subYear(),
+            BudgetPeriodType::Monthly => $start->subMonthNoOverflow(),
+        };
     }
 
     /**

--- a/database/migrations/2026_08_21_050014_deduplicate_budget_transactions_from_overlapping_created_periods.php
+++ b/database/migrations/2026_08_21_050014_deduplicate_budget_transactions_from_overlapping_created_periods.php
@@ -1,0 +1,73 @@
+<?php
+
+use App\Models\BudgetTransaction;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Drop the second copy of a spend that two overlapping periods both claim.
+     *
+     * Until the fix that ships with this migration, `generatePreviousPeriod`
+     * derived a biweekly budget's previous period from the day before the
+     * current one started, which lands mid-fortnight - so budget creation
+     * produced two periods overlapping by a week and handed both to
+     * `AssignHistoricalTransactionsToBudget`. Anything spent in the shared week
+     * got a row against each. Production: 12 of the 13 live biweekly budgets,
+     * 16 transactions across 8 budgets.
+     *
+     * Only the pair born in the same `BudgetService::create` call is touched,
+     * matched on the two periods sharing a `created_at`. That is what separates
+     * this bug's spurious period from a genuine mid-chain overlap left by the
+     * old `period_start_day = 0` monthly bug, where the earlier row is real
+     * history with real transactions - one such row exists in production and
+     * must survive. If the two inserts happened to straddle a second boundary
+     * the pair is simply skipped, which is the safe direction.
+     *
+     * The row deleted is always the one on the earlier-starting period: the
+     * window the fixed algorithm would never produce, and the one the UI cannot
+     * reach. The periods themselves are left alone - the spurious one also holds
+     * genuine history from before the budget existed, and deleting it would
+     * cascade that away.
+     */
+    public function up(): void
+    {
+        $this->pairsBornTogether()->each(function (object $pair): void {
+            $keptTransactionIds = BudgetTransaction::query()
+                ->where('budget_period_id', $pair->kept_period_id)
+                ->pluck('transaction_id');
+
+            BudgetTransaction::query()
+                ->where('budget_period_id', $pair->spurious_period_id)
+                ->whereIn('transaction_id', $keptTransactionIds)
+                ->delete();
+        });
+    }
+
+    public function down(): void
+    {
+        // One-off repair. The rows it removes were written by a bug and say
+        // nothing the surviving row does not.
+    }
+
+    /**
+     * Overlapping period pairs created in the same breath, spurious one first.
+     *
+     * @return Collection<int, object>
+     */
+    private function pairsBornTogether(): Collection
+    {
+        return DB::table('budget_periods as spurious')
+            ->join('budget_periods as kept', function ($join): void {
+                $join->on('kept.budget_id', '=', 'spurious.budget_id')
+                    ->whereColumn('kept.id', '!=', 'spurious.id')
+                    ->whereColumn('kept.start_date', '>', 'spurious.start_date')
+                    ->whereColumn('kept.start_date', '<=', 'spurious.end_date')
+                    ->whereColumn('kept.created_at', '=', 'spurious.created_at');
+            })
+            ->select('spurious.id as spurious_period_id', 'kept.id as kept_period_id')
+            ->get();
+    }
+};

--- a/tests/Feature/BudgetHistoricalAssignmentTest.php
+++ b/tests/Feature/BudgetHistoricalAssignmentTest.php
@@ -6,6 +6,7 @@ use App\Models\Category;
 use App\Models\Label;
 use App\Models\Transaction;
 use App\Models\User;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Queue;
 
 use function Pest\Laravel\assertDatabaseHas;
@@ -404,4 +405,46 @@ test('multiple budgets assign independently', function () {
         'transaction_id' => $transaction2->id,
         'budget_period_id' => $period1->id,
     ]);
+});
+
+test('a biweekly budget counts a spend in its previous period once, not twice', function () {
+    Carbon::setTestNow(Carbon::parse('2026-08-20 09:00:00'));
+
+    $category = Category::factory()->create(['user_id' => $this->user->id]);
+
+    // Dated in the week the current period and its predecessor used to share:
+    // the current fortnight opens 2026-08-16, and the old reference date put the
+    // predecessor at 08-09..08-22.
+    $transaction = Transaction::factory()->create([
+        'user_id' => $this->user->id,
+        'category_id' => $category->id,
+        'transaction_date' => '2026-08-18',
+        'amount' => -5000,
+    ]);
+
+    $this->actingAs($this->user)->post('/budgets', [
+        'name' => 'Fortnightly',
+        'period_type' => 'biweekly',
+        'period_start_day' => 0,
+        'category_ids' => [$category->id],
+        'rollover_type' => 'reset',
+        'allocated_amount' => 100000,
+    ])->assertRedirect();
+
+    $this->artisan('queue:work --stop-when-empty');
+
+    // Scoped to the budget rather than to one period: the existing duplicate
+    // test counts within a single `budget_period_id`, which is exactly why a
+    // transaction sitting in two overlapping periods of the same budget went
+    // unnoticed. `BudgetService::create` hands both periods to the backfill.
+    $rows = BudgetTransaction::where('transaction_id', $transaction->id)
+        ->whereIn(
+            'budget_period_id',
+            $this->user->budgets()->first()->periods()->pluck('id'),
+        )
+        ->count();
+
+    expect($rows)->toBe(1);
+
+    Carbon::setTestNow();
 });

--- a/tests/Feature/BudgetPeriodServiceTest.php
+++ b/tests/Feature/BudgetPeriodServiceTest.php
@@ -394,3 +394,34 @@ test('generatePreviousPeriod hands back the period immediately before', function
     'monthly across a year boundary' => [BudgetPeriodType::Monthly, 1, '2026-01-15', '2025-12-01', '2025-12-31'],
     'yearly' => [BudgetPeriodType::Yearly, 1, '2026-08-20', '2025-01-01', '2025-12-31'],
 ]);
+
+test('getCurrentPeriod picks the on-grid window when two periods cover today', function () {
+    Carbon::setTestNow(Carbon::parse('2026-08-20 09:00:00'));
+
+    $budget = Budget::factory()->create([
+        'user_id' => User::factory()->create(['onboarded_at' => now()])->id,
+        'period_type' => BudgetPeriodType::Biweekly,
+        'period_start_day' => 0,
+    ]);
+
+    // The shape every biweekly budget created before this fix carries: a
+    // spurious period starting a week early, overlapping the real one.
+    $spurious = BudgetPeriod::factory()->create([
+        'budget_id' => $budget->id,
+        'start_date' => '2026-08-09',
+        'end_date' => '2026-08-22',
+        'allocated_amount' => 10000,
+    ]);
+    $onGrid = BudgetPeriod::factory()->create([
+        'budget_id' => $budget->id,
+        'start_date' => '2026-08-16',
+        'end_date' => '2026-08-29',
+        'allocated_amount' => 10000,
+    ]);
+
+    // Unordered, MySQL hands back the earliest start first - the window the
+    // user never configured, and one `BudgetController::show` cannot navigate
+    // out of.
+    expect($budget->getCurrentPeriod()->id)->toBe($onGrid->id)
+        ->and($budget->getCurrentPeriod()->id)->not->toBe($spurious->id);
+});

--- a/tests/Feature/BudgetPeriodServiceTest.php
+++ b/tests/Feature/BudgetPeriodServiceTest.php
@@ -425,3 +425,26 @@ test('getCurrentPeriod picks the on-grid window when two periods cover today', f
     expect($budget->getCurrentPeriod()->id)->toBe($onGrid->id)
         ->and($budget->getCurrentPeriod()->id)->not->toBe($spurious->id);
 });
+
+test('generatePreviousPeriod does not overlap a budget anchored past the 28th', function () {
+    Carbon::setTestNow(Carbon::parse('2026-03-29 09:00:00'));
+
+    $budget = Budget::factory()->create([
+        'user_id' => User::factory()->create(['onboarded_at' => now()])->id,
+        'period_type' => BudgetPeriodType::Monthly,
+        'period_start_day' => 29,
+    ]);
+
+    $service = app(BudgetPeriodService::class);
+    $current = $service->generatePeriod($budget, 10000, Carbon::parse('2026-03-29'));
+    $previous = $service->generatePreviousPeriod($budget, $current);
+
+    // Its own test rather than a row in the adjacency dataset: the gap here is
+    // real and owned by the separate `startDayOfMonth` ceiling bug. What matters
+    // is that it does not overlap - stepping back with an overflowing
+    // `subMonth()` would return 03-01..03-31 over a current 03-29..04-28.
+    expect($current->start_date->toDateString())->toBe('2026-03-29')
+        ->and($previous->start_date->toDateString())->toBe('2026-02-01')
+        ->and($previous->end_date->toDateString())->toBe('2026-02-28')
+        ->and($previous->end_date->lt($current->start_date))->toBeTrue();
+});

--- a/tests/Feature/BudgetPeriodServiceTest.php
+++ b/tests/Feature/BudgetPeriodServiceTest.php
@@ -355,3 +355,42 @@ test('closePeriod finds a successor that starts on the closed period last day', 
         ->and($ended->fresh()->carried_over_amount)->toBe(0)
         ->and(BudgetPeriod::where('budget_id', $budget->id)->count())->toBe(2);
 });
+
+test('generatePreviousPeriod hands back the period immediately before', function (
+    BudgetPeriodType $type,
+    int $startDay,
+    string $today,
+    string $expectedStart,
+    string $expectedEnd,
+) {
+    Carbon::setTestNow(Carbon::parse("{$today} 09:00:00"));
+
+    $budget = Budget::factory()->create([
+        'user_id' => User::factory()->create(['onboarded_at' => now()])->id,
+        'period_type' => $type,
+        'period_start_day' => $startDay,
+    ]);
+
+    $service = app(BudgetPeriodService::class);
+    $current = $service->generatePeriod($budget, 10000, Carbon::parse($today));
+    $previous = $service->generatePreviousPeriod($budget, $current);
+
+    expect($previous->start_date->toDateString())->toBe($expectedStart)
+        ->and($previous->end_date->toDateString())->toBe($expectedEnd)
+        // The point of the whole thing: the two must meet, not overlap. Both are
+        // handed to AssignHistoricalTransactionsToBudget, so a shared day is a
+        // transaction counted twice.
+        ->and($previous->end_date->copy()->addDay()->toDateString())
+        ->toBe($current->start_date->toDateString());
+})->with([
+    // A fortnight rewound to a weekday lands mid-fortnight: every one of the 14
+    // live biweekly budgets in production overlaps its predecessor by a week.
+    'biweekly' => [BudgetPeriodType::Biweekly, 0, '2026-08-20', '2026-08-02', '2026-08-15'],
+    'weekly' => [BudgetPeriodType::Weekly, 0, '2026-08-20', '2026-08-09', '2026-08-15'],
+    // March is the month that breaks any day-counting version of this: 31 days
+    // back from 1 March is January, and February disappears.
+    'monthly across a short month' => [BudgetPeriodType::Monthly, 1, '2026-03-15', '2026-02-01', '2026-02-28'],
+    'monthly across a 30-day month' => [BudgetPeriodType::Monthly, 1, '2026-05-15', '2026-04-01', '2026-04-30'],
+    'monthly across a year boundary' => [BudgetPeriodType::Monthly, 1, '2026-01-15', '2025-12-01', '2025-12-31'],
+    'yearly' => [BudgetPeriodType::Yearly, 1, '2026-08-20', '2025-01-01', '2025-12-31'],
+]);

--- a/tests/Feature/DeduplicateBudgetTransactionsMigrationTest.php
+++ b/tests/Feature/DeduplicateBudgetTransactionsMigrationTest.php
@@ -1,0 +1,145 @@
+<?php
+
+use App\Enums\BudgetPeriodType;
+use App\Models\Budget;
+use App\Models\BudgetPeriod;
+use App\Models\BudgetTransaction;
+use App\Models\Transaction;
+use App\Models\User;
+use Carbon\Carbon;
+
+afterEach(function () {
+    Carbon::setTestNow();
+});
+
+function runDeduplicateBudgetTransactionsMigration(): void
+{
+    $migration = require database_path('migrations/2026_08_21_050014_deduplicate_budget_transactions_from_overlapping_created_periods.php');
+    $migration->up();
+}
+
+/**
+ * The pair budget creation used to produce: two periods a week apart, born in
+ * the same call, with the spend in the week they share written against both.
+ */
+function overlappingPair(Budget $budget, string $createdAt): array
+{
+    $spurious = BudgetPeriod::factory()->create([
+        'budget_id' => $budget->id,
+        'start_date' => '2026-08-09',
+        'end_date' => '2026-08-22',
+        'allocated_amount' => 10000,
+        'created_at' => $createdAt,
+    ]);
+    $kept = BudgetPeriod::factory()->create([
+        'budget_id' => $budget->id,
+        'start_date' => '2026-08-16',
+        'end_date' => '2026-08-29',
+        'allocated_amount' => 10000,
+        'created_at' => $createdAt,
+    ]);
+
+    return [$spurious, $kept];
+}
+
+function biweeklyBudget(): Budget
+{
+    return Budget::factory()->create([
+        'user_id' => User::factory()->create(['onboarded_at' => now()])->id,
+        'period_type' => BudgetPeriodType::Biweekly,
+        'period_start_day' => 0,
+    ]);
+}
+
+it('keeps the row on the on-grid period and drops the other', function () {
+    Carbon::setTestNow(Carbon::parse('2026-08-20 09:00:00'));
+
+    $budget = biweeklyBudget();
+    [$spurious, $kept] = overlappingPair($budget, '2026-08-16 10:00:00');
+
+    $transaction = Transaction::factory()->create([
+        'user_id' => $budget->user_id,
+        'transaction_date' => '2026-08-18',
+        'amount' => -5000,
+    ]);
+    $droppedRow = BudgetTransaction::factory()->create([
+        'transaction_id' => $transaction->id,
+        'budget_period_id' => $spurious->id,
+        'amount' => 5000,
+    ]);
+    $keptRow = BudgetTransaction::factory()->create([
+        'transaction_id' => $transaction->id,
+        'budget_period_id' => $kept->id,
+        'amount' => 5000,
+    ]);
+
+    runDeduplicateBudgetTransactionsMigration();
+
+    expect(BudgetTransaction::find($droppedRow->id))->toBeNull()
+        ->and(BudgetTransaction::find($keptRow->id))->not->toBeNull();
+});
+
+it('leaves history the spurious period holds on its own', function () {
+    Carbon::setTestNow(Carbon::parse('2026-08-20 09:00:00'));
+
+    $budget = biweeklyBudget();
+    [$spurious] = overlappingPair($budget, '2026-08-16 10:00:00');
+
+    // Dated before the budget existed and claimed by nothing else: the backfill
+    // picked it up and it is the only record of it.
+    $onlyHere = BudgetTransaction::factory()->create([
+        'transaction_id' => Transaction::factory()->create([
+            'user_id' => $budget->user_id,
+            'transaction_date' => '2026-08-10',
+            'amount' => -2500,
+        ])->id,
+        'budget_period_id' => $spurious->id,
+        'amount' => 2500,
+    ]);
+
+    runDeduplicateBudgetTransactionsMigration();
+
+    expect(BudgetTransaction::find($onlyHere->id))->not->toBeNull();
+});
+
+it('does not touch an overlap the periods were not born together in', function () {
+    Carbon::setTestNow(Carbon::parse('2026-08-20 09:00:00'));
+
+    $budget = biweeklyBudget();
+    $earlier = BudgetPeriod::factory()->create([
+        'budget_id' => $budget->id,
+        'start_date' => '2026-08-09',
+        'end_date' => '2026-08-22',
+        'allocated_amount' => 10000,
+        'created_at' => '2026-07-01 10:00:00',
+    ]);
+    $later = BudgetPeriod::factory()->create([
+        'budget_id' => $budget->id,
+        'start_date' => '2026-08-16',
+        'end_date' => '2026-08-29',
+        'allocated_amount' => 10000,
+        // A month apart: a genuine mid-chain overlap, where the earlier period
+        // is real history rather than this bug's artefact.
+        'created_at' => '2026-08-01 10:00:00',
+    ]);
+
+    $transaction = Transaction::factory()->create([
+        'user_id' => $budget->user_id,
+        'transaction_date' => '2026-08-18',
+        'amount' => -5000,
+    ]);
+    $earlierRow = BudgetTransaction::factory()->create([
+        'transaction_id' => $transaction->id,
+        'budget_period_id' => $earlier->id,
+        'amount' => 5000,
+    ]);
+    BudgetTransaction::factory()->create([
+        'transaction_id' => $transaction->id,
+        'budget_period_id' => $later->id,
+        'amount' => 5000,
+    ]);
+
+    runDeduplicateBudgetTransactionsMigration();
+
+    expect(BudgetTransaction::find($earlierRow->id))->not->toBeNull();
+});


### PR DESCRIPTION
Creating a biweekly budget produced two periods overlapping by a week, and assigned every spend in that shared week to both.

`BudgetService::create` builds the current period and the one before it, and hands **both** to `AssignHistoricalTransactionsToBudget`. `generatePreviousPeriod` derived that predecessor from the day before the current period started — which is fine for every type whose window can be reconstructed from any date inside it, and wrong for a fortnight: `rewindToDayOfWeek` snaps to a *weekday*, a 7-day grid under a 14-day window, so "the day before" lands in the middle of the previous fortnight.

Production: **12 of the 13 live biweekly budgets** are shaped this way, holding **16 doubled transactions across 8 budgets**.

## What it costs the user

Not an inflated total — I got that wrong at first and the review corrected it. `budget_transactions` holds one row per (transaction, period) and `spentAmount()` sums a single period, so each window's own figure is right. The damage is elsewhere and worse:

**The wrong fortnight is shown as current.** `getCurrentPeriod()` and the index eager-load both took an unordered `first()`, and on the `(budget_id, start_date)` index MySQL returns the earliest-starting window — the spurious one. A real case from production: a user configures a biweekly budget to start on Saturdays, creates it on 13 August, and their first screen reads **"Aug 1 – Aug 14"** with **both navigation arrows disabled**, because `show` picks previous and next with strict comparisons that step straight over an overlapping sibling. The period they configured was unreachable.

**Duplicate over-limit emails**, with receipts in production: both halves of a pair carry `over_limit_notified = 1`, so one user got two *"Auto" is over its limit* emails with identical figures and different date ranges. `BudgetNotificationService`'s own docblock promises at most one email per budget; an overlap breaks that by construction.

**And a win that was being paid for and never delivered:** the previous period that `BudgetService::create` exists to populate for the chart's comparison line never matched `show`'s `end_date < start_date` filter, because it ended *after* the current period began. Every biweekly budget paid for that backfill and got an empty comparison and a dead ← arrow. Now it works.

## The fix

**Step back by one period of the budget's own type** — `subWeek` / `subWeeks(2)` / `subYear` / `subMonthNoOverflow`.

I first wrote this as a generic "subtract the period length in days" and it was wrong twice over: it keeps the biweekly bug on some anchors, and **31 days back from 1 March is January**, so February disappears. Three months of twelve broke, and the first case I spot-checked happened to be one of the nine that work.

**Monthly deliberately does not mirror the forward step.** Forward is an overflowing `addMonth()`, and that overflow is load-bearing for the windows budgets anchored past the 28th already have. Backward, the same overflow lands *inside* the current period: for a budget anchored on the 29th, on 2026-03-29, `subMonth()` returns 03-01..03-31 against a current 03-29..04-28. The review measured all four combinations over three years of reference dates per anchor — no-overflow backward removes every overlap for anchors 29 and 30, while making both directions no-overflow collapses anchor 31 from 636 adjacent results to 6. The asymmetry is the point, and the docblock now says so instead of claiming the opposite.

**Order the two current-period lookups.** One line each, and it is what stops an overlap putting the wrong period on screen. It still matters after this fix, because 12 live budgets keep their pair and a monthly budget anchored past the 28th can still produce one.

**Delete the second copy.** I had deferred this as "a decision about someone else's money"; both reviews pushed back and were right. The spurious row always sits on the earlier-starting period of a pair born in the same `create()` call, matched on the two periods sharing a `created_at` — which is precisely what separates this bug from a genuine mid-chain overlap left by the old day-0 monthly bug, where the earlier row is real history. One such row exists in production and survives. Rows are deleted, never periods: the spurious period also holds genuine pre-budget history the backfill picked up, and the foreign key cascades.

## Tests

- Six dataset rows for adjacency across a fortnight, a week, a year and three monthly shapes. Only the biweekly row fails on `main` — the other five are regression guards, not mechanism pins, and the commit says so.
- The `subMonthNoOverflow` step gets its own test, because all four monthly dataset rows use start day 1 where both variants are identical, so that mutant survived the whole suite.
- `getCurrentPeriod()` picks the on-grid window when two periods cover today.
- **The harm itself**, which nothing tested: create a biweekly budget over HTTP, drain the queue, count the rows for a spend dated inside the shared week — **2 before, 1 after**. The file's existing "duplicate assignments are prevented" test counts within a single `budget_period_id`, so it never could have caught a transaction sitting in two periods of one budget; the unique key has the same shape. Getting the date right took two attempts, since 08-12 sits only in the predecessor and proved nothing.
- Three migration tests, including one that fails if the `created_at` guard is dropped.

## Left alone on purpose

- **`startDayOfMonth`'s missing ceiling is now the only remaining source of new overlapping periods** — a monthly budget anchored past the 28th. It needs a clamp *and* non-overflowing month arithmetic, which moves windows that currently work, so it wants its own change and its own repair.
- `Budget::periodFollowing`'s inclusive comparison and `GenerateBudgetPeriods`' oldest-first ordering were both built to tolerate these overlaps and stay correct. They should not be "cleaned up" while any pair remains.
- The duplicate-email guard in `BudgetNotificationService::handleAssignment`. The invariant is genuinely broken, but with no new overlaps created and every existing shared window closed (the latest ended 14 August), it cannot fire again.
