### PR TITLE
fix(automation-rules): step the amount condition in both directions

### DIFF
--- a/resources/js/components/automation-rules/rule-builder.test.tsx
+++ b/resources/js/components/automation-rules/rule-builder.test.tsx
@@ -37,38 +37,47 @@ function amountValueOf(structure: RuleStructure): string {
     return structure.groups[0].conditions[0].value;
 }
 
+function typeAmount(typed: string): string {
+    const onChange = vi.fn();
+    render(<RuleBuilder value={amountStructure('')} onChange={onChange} />);
+
+    const input = screen.getByPlaceholderText('Value');
+    fireEvent.focus(input);
+    if (typed !== '') {
+        fireEvent.change(input, { target: { value: typed } });
+    }
+    fireEvent.blur(input);
+
+    return amountValueOf(onChange.mock.lastCall![0]);
+}
+
 describe('RuleBuilder amount field', () => {
-    it('shows a stored negative amount, which is kept in currency units', () => {
+    it.each([
+        ['-21.99', '-21.99'],
+        ['1250', '1,250.00'],
+    ])('shows a stored amount of %s', (stored, displayed) => {
         render(
-            <RuleBuilder
-                value={amountStructure('-21.99')}
-                onChange={vi.fn()}
-            />,
+            <RuleBuilder value={amountStructure(stored)} onChange={vi.fn()} />,
         );
 
-        expect(screen.getByPlaceholderText('Value')).toHaveValue('-21.99');
+        expect(screen.getByPlaceholderText('Value')).toHaveValue(displayed);
     });
 
-    it('stores what the user types in currency units, not in cents', () => {
-        const onChange = vi.fn();
-        render(<RuleBuilder value={amountStructure('')} onChange={onChange} />);
+    it.each([
+        ['-5', '-5'],
+        ['-21,99', '-21.99'],
+        ['12.50', '12.5'],
+    ])('stores %s in currency units, not in cents', (typed, stored) => {
+        expect(typeAmount(typed)).toBe(stored);
+    });
 
-        const input = screen.getByPlaceholderText('Value');
-        fireEvent.focus(input);
-        fireEvent.change(input, { target: { value: '-5' } });
-        fireEvent.blur(input);
-
-        expect(amountValueOf(onChange.mock.lastCall![0])).toBe('-5');
+    // `amount < 0` is how you match every expense, so a typed zero has to
+    // survive even though AmountInput reports it as 0 cents like an empty field.
+    it('keeps a typed zero instead of blanking the condition', () => {
+        expect(typeAmount('0')).toBe('0');
     });
 
     it('leaves an untouched amount field empty instead of storing a zero', () => {
-        const onChange = vi.fn();
-        render(<RuleBuilder value={amountStructure('')} onChange={onChange} />);
-
-        const input = screen.getByPlaceholderText('Value');
-        fireEvent.focus(input);
-        fireEvent.blur(input);
-
-        expect(amountValueOf(onChange.mock.lastCall![0])).toBe('');
+        expect(typeAmount('')).toBe('');
     });
 });

--- a/resources/js/components/automation-rules/rule-builder.test.tsx
+++ b/resources/js/components/automation-rules/rule-builder.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { type RuleStructure } from '@/lib/rule-builder-utils';
+import { RuleBuilder } from './rule-builder';
+
+vi.mock('@inertiajs/react', () => ({
+    usePage: () => ({
+        props: {
+            locale: 'en-US',
+            auth: { user: { currency_code: 'EUR' } },
+        },
+    }),
+}));
+
+function amountStructure(value: string): RuleStructure {
+    return {
+        groups: [
+            {
+                id: 'group-1',
+                operator: 'and',
+                conditions: [
+                    {
+                        id: 'condition-1',
+                        field: 'amount',
+                        operator: 'less_than',
+                        value,
+                    },
+                ],
+            },
+        ],
+        groupOperator: 'and',
+    };
+}
+
+function amountValueOf(structure: RuleStructure): string {
+    return structure.groups[0].conditions[0].value;
+}
+
+describe('RuleBuilder amount field', () => {
+    it('shows a stored negative amount, which is kept in currency units', () => {
+        render(
+            <RuleBuilder
+                value={amountStructure('-21.99')}
+                onChange={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByPlaceholderText('Value')).toHaveValue('-21.99');
+    });
+
+    it('stores what the user types in currency units, not in cents', () => {
+        const onChange = vi.fn();
+        render(<RuleBuilder value={amountStructure('')} onChange={onChange} />);
+
+        const input = screen.getByPlaceholderText('Value');
+        fireEvent.focus(input);
+        fireEvent.change(input, { target: { value: '-5' } });
+        fireEvent.blur(input);
+
+        expect(amountValueOf(onChange.mock.lastCall![0])).toBe('-5');
+    });
+
+    it('leaves an untouched amount field empty instead of storing a zero', () => {
+        const onChange = vi.fn();
+        render(<RuleBuilder value={amountStructure('')} onChange={onChange} />);
+
+        const input = screen.getByPlaceholderText('Value');
+        fireEvent.focus(input);
+        fireEvent.blur(input);
+
+        expect(amountValueOf(onChange.mock.lastCall![0])).toBe('');
+    });
+});

--- a/resources/js/components/automation-rules/rule-builder.tsx
+++ b/resources/js/components/automation-rules/rule-builder.tsx
@@ -1,4 +1,5 @@
 import InputError from '@/components/input-error';
+import { AmountInput } from '@/components/ui/amount-input';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -20,7 +21,9 @@ import {
     OPERATOR_LABELS,
     type RuleStructure,
 } from '@/lib/rule-builder-utils';
+import type { SharedData } from '@/types';
 import { __ } from '@/utils/i18n';
+import { usePage } from '@inertiajs/react';
 import { ChevronDown, Plus, Trash2, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
@@ -231,6 +234,15 @@ export function RuleBuilder({ value, onChange, error }: RuleBuilderProps) {
     );
 }
 
+/**
+ * `condition.value` is stored as a string in currency units ("-21.99") because
+ * that is what `buildJsonLogic` and the backend expect, while `AmountInput`
+ * speaks cents.
+ */
+function unitsToCents(value: string): number {
+    return Math.round(parseFloat(value) * 100) || 0;
+}
+
 interface ConditionRowProps {
     condition: Condition;
     onChange: (condition: Condition) => void;
@@ -246,6 +258,8 @@ function ConditionRow({
 }: ConditionRowProps) {
     const fieldConfig = FIELD_CONFIG[condition.field];
     const availableOperators = fieldConfig?.operators || [];
+    const currencyCode =
+        usePage<SharedData>().props.auth.user.currency_code || 'USD';
 
     const handleFieldChange = (field: string) => {
         const newFieldConfig = FIELD_CONFIG[field];
@@ -273,9 +287,9 @@ function ConditionRow({
         condition.operator !== 'is_empty' &&
         condition.operator !== 'is_not_empty';
 
-    const inputType = fieldConfig?.type === 'number' ? 'number' : 'text';
+    const isAmountField = fieldConfig?.type === 'number';
 
-    const showAmountHint = showValueInput && inputType === 'number';
+    const showAmountHint = showValueInput && isAmountField;
 
     return (
         <div className="flex flex-col gap-1">
@@ -312,16 +326,39 @@ function ConditionRow({
                     </SelectContent>
                 </Select>
 
-                {showValueInput && (
+                {showValueInput && isAmountField && (
+                    <div className="w-full sm:flex-1">
+                        <AmountInput
+                            value={unitsToCents(condition.value)}
+                            onChange={(valueInCents) =>
+                                onChange({
+                                    ...condition,
+                                    // AmountInput renders 0 as an empty field, so
+                                    // 0 maps back to an empty value: a field the
+                                    // user never filled in must stay incomplete.
+                                    value:
+                                        valueInCents === 0
+                                            ? ''
+                                            : String(valueInCents / 100),
+                                })
+                            }
+                            currencyCode={currencyCode}
+                            placeholder={__('Value')}
+                            className="w-full"
+                            allowNegative
+                        />
+                    </div>
+                )}
+
+                {showValueInput && !isAmountField && (
                     <Input
-                        type={inputType}
+                        type="text"
                         value={condition.value}
                         onChange={(e) =>
                             onChange({ ...condition, value: e.target.value })
                         }
                         placeholder={__('Value')}
                         className="w-full sm:flex-1"
-                        step={inputType === 'number' ? 'any' : undefined}
                     />
                 )}
 

--- a/resources/js/components/automation-rules/rule-builder.tsx
+++ b/resources/js/components/automation-rules/rule-builder.tsx
@@ -239,8 +239,10 @@ export function RuleBuilder({ value, onChange, error }: RuleBuilderProps) {
  * that is what `buildJsonLogic` and the backend expect, while `AmountInput`
  * speaks cents.
  */
-function unitsToCents(value: string): number {
-    return Math.round(parseFloat(value) * 100) || 0;
+function currencyUnitsToCents(value: string): number {
+    const cents = Math.round(parseFloat(value) * 100);
+
+    return Number.isNaN(cents) ? 0 : cents;
 }
 
 interface ConditionRowProps {
@@ -258,8 +260,7 @@ function ConditionRow({
 }: ConditionRowProps) {
     const fieldConfig = FIELD_CONFIG[condition.field];
     const availableOperators = fieldConfig?.operators || [];
-    const currencyCode =
-        usePage<SharedData>().props.auth.user.currency_code || 'USD';
+    const currencyCode = usePage<SharedData>().props.auth.user.currency_code;
 
     const handleFieldChange = (field: string) => {
         const newFieldConfig = FIELD_CONFIG[field];
@@ -326,33 +327,31 @@ function ConditionRow({
                     </SelectContent>
                 </Select>
 
-                {showValueInput && isAmountField && (
+                {!showValueInput ? (
+                    <div className="hidden sm:flex sm:flex-1" />
+                ) : isAmountField ? (
                     <div className="w-full sm:flex-1">
                         <AmountInput
-                            value={unitsToCents(condition.value)}
-                            onChange={(valueInCents) =>
+                            value={currencyUnitsToCents(condition.value)}
+                            onChange={(valueInCents, isEmpty) =>
                                 onChange({
                                     ...condition,
-                                    // AmountInput renders 0 as an empty field, so
-                                    // 0 maps back to an empty value: a field the
-                                    // user never filled in must stay incomplete.
-                                    value:
-                                        valueInCents === 0
-                                            ? ''
-                                            : String(valueInCents / 100),
+                                    // A cleared field and a typed 0 both resolve
+                                    // to 0 cents; only the cleared one may blank
+                                    // the condition, or `amount < 0` would be
+                                    // impossible to express.
+                                    value: isEmpty
+                                        ? ''
+                                        : String(valueInCents / 100),
                                 })
                             }
                             currencyCode={currencyCode}
                             placeholder={__('Value')}
-                            className="w-full"
                             allowNegative
                         />
                     </div>
-                )}
-
-                {showValueInput && !isAmountField && (
+                ) : (
                     <Input
-                        type="text"
                         value={condition.value}
                         onChange={(e) =>
                             onChange({ ...condition, value: e.target.value })
@@ -360,10 +359,6 @@ function ConditionRow({
                         placeholder={__('Value')}
                         className="w-full sm:flex-1"
                     />
-                )}
-
-                {!showValueInput && (
-                    <div className="hidden sm:flex sm:flex-1" />
                 )}
 
                 <Button

--- a/resources/js/components/ui/amount-input.test.tsx
+++ b/resources/js/components/ui/amount-input.test.tsx
@@ -31,7 +31,7 @@ describe('AmountInput sign toggle', () => {
 
         fireEvent.click(screen.getByRole('button'));
 
-        expect(onChange).toHaveBeenCalledWith(-2500);
+        expect(onChange).toHaveBeenCalledWith(-2500, false);
     });
 
     it('flips a negative amount back to positive', () => {
@@ -46,7 +46,24 @@ describe('AmountInput sign toggle', () => {
 
         fireEvent.click(screen.getByRole('button'));
 
-        expect(onChange).toHaveBeenLastCalledWith(2500);
+        expect(onChange).toHaveBeenLastCalledWith(2500, false);
+    });
+
+    it('reports an empty field and a typed zero differently', () => {
+        const onChange = vi.fn();
+        render(
+            <AmountInput value={0} onChange={onChange} currencyCode="USD" />,
+        );
+
+        const input = screen.getByRole('textbox');
+        fireEvent.focus(input);
+        fireEvent.blur(input);
+        expect(onChange).toHaveBeenLastCalledWith(0, true);
+
+        fireEvent.focus(input);
+        fireEvent.change(input, { target: { value: '0' } });
+        fireEvent.blur(input);
+        expect(onChange).toHaveBeenLastCalledWith(0, false);
     });
 
     it('keeps the negative sign when focusing after toggling an empty field', () => {

--- a/resources/js/components/ui/amount-input.tsx
+++ b/resources/js/components/ui/amount-input.tsx
@@ -7,7 +7,11 @@ import { __ } from '@/utils/i18n';
 
 interface AmountInputProps {
     value: number;
-    onChange: (valueInCents: number) => void;
+    /**
+     * `isEmpty` tells apart "the user cleared the field" from "the user typed a
+     * zero": both resolve to 0 cents, and some call sites need the difference.
+     */
+    onChange: (valueInCents: number, isEmpty: boolean) => void;
     currencyCode: string;
     disabled?: boolean;
     required?: boolean;
@@ -198,9 +202,13 @@ export const AmountInput = React.forwardRef<HTMLInputElement, AmountInputProps>(
             }
         };
 
+        const commit = (text: string) => {
+            onChange(resolveCents(text), text.trim() === '');
+        };
+
         const handleBlur = () => {
             setIsFocused(false);
-            onChange(resolveCents(displayValue));
+            commit(displayValue);
         };
 
         const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -209,7 +217,7 @@ export const AmountInput = React.forwardRef<HTMLInputElement, AmountInputProps>(
 
         const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
             if (e.key === 'Enter') {
-                onChange(resolveCents(displayValue));
+                commit(displayValue);
             }
         };
 
@@ -222,7 +230,7 @@ export const AmountInput = React.forwardRef<HTMLInputElement, AmountInputProps>(
                 ? displayValue.replace('-', '')
                 : `-${displayValue}`;
             setDisplayValue(next);
-            onChange(resolveCents(next));
+            commit(next);
         };
 
         const isNegative = displayValue.trim().startsWith('-');

--- a/tests/Browser/AutomationRuleBuilderTest.php
+++ b/tests/Browser/AutomationRuleBuilderTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\AutomationRule;
 use App\Models\User;
 use Illuminate\Support\Facades\Notification;
 
@@ -139,8 +140,8 @@ it('can select different field types and operators', function () {
         ->wait(0.5)
         ->click('[role="option"]:has-text("Amount")')
         ->wait(1)
-        // After selecting Amount, the value input changes to number type
-        ->fill('input[type="number"][placeholder="Value"]', '100')
+        // After selecting Amount, the value input becomes the masked AmountInput
+        ->fill('input[placeholder="Value"]', '-5')
         ->click('[data-testid="action-category-select"]')
         ->wait(0.5)
         ->click('Bills')
@@ -152,10 +153,11 @@ it('can select different field types and operators', function () {
     $page->assertSee('Amount Rule')
         ->assertNoJavascriptErrors();
 
-    $this->assertDatabaseHas('automation_rules', [
-        'user_id' => $user->id,
-        'title' => 'Amount Rule',
-    ]);
+    $rule = AutomationRule::where('user_id', $user->id)->sole();
+
+    // AmountInput speaks cents, the rule stores currency units: -5, not -500.
+    expect(json_encode($rule->rules_json))->toContain('"amount"', '-5')
+        ->not->toContain('-500');
 });
 
 it('can edit an existing rule with visual builder', function () {

--- a/tests/Browser/AutomationRuleBuilderTest.php
+++ b/tests/Browser/AutomationRuleBuilderTest.php
@@ -156,7 +156,10 @@ it('can select different field types and operators', function () {
     $rule = AutomationRule::where('user_id', $user->id)->sole();
 
     // AmountInput speaks cents, the rule stores currency units: -5, not -500.
-    expect($rule->rules_json)->toBe(['<' => [['var' => 'amount'], -5]]);
+    // `rules_json` is persisted as a JSON string, and `equals` is the default
+    // operator for Amount since this test only changes the field.
+    expect(json_decode($rule->rules_json, true))
+        ->toBe(['==' => [['var' => 'amount'], -5]]);
 });
 
 it('can edit an existing rule with visual builder', function () {

--- a/tests/Browser/AutomationRuleBuilderTest.php
+++ b/tests/Browser/AutomationRuleBuilderTest.php
@@ -156,8 +156,7 @@ it('can select different field types and operators', function () {
     $rule = AutomationRule::where('user_id', $user->id)->sole();
 
     // AmountInput speaks cents, the rule stores currency units: -5, not -500.
-    expect(json_encode($rule->rules_json))->toContain('"amount"', '-5')
-        ->not->toContain('-500');
+    expect($rule->rules_json)->toBe(['<' => [['var' => 'amount'], -5]]);
 });
 
 it('can edit an existing rule with visual builder', function () {


### PR DESCRIPTION
A user reported that in the automation-rule builder (`Amount` / `less than` / `-5`),
scrolling the mouse wheel **down** over the value field made the number more negative
while scrolling **up** did nothing.

## Root cause

Reproduced in the running app. The value field was a plain
`<input type="number" step="any">` — the only `step="any"` left in the repo — and the
rule builder always renders inside a Radix dialog. Radix's scroll lock
(`react-remove-scroll`) attaches a non-passive `wheel` listener on `document` and calls
`preventDefault()` whenever the wheel would scroll past the edge of the locked
container. Cancelling the wheel's default action also cancels the browser's native
number-input step.

Measured on the pre-fix build, dialog at `scrollTop: 0` with 313px of room below:

| interaction | value | wheel `defaultPrevented` |
|---|---|---|
| wheel **down** | `-5` → `-6` | `false` |
| wheel **up** | `-6` → `-6` (nothing) | **`true`** |
| ArrowUp / ArrowDown | `-5` → `-4` → `-5` | — |

So it was wheel-only and inherently asymmetric: at the top of a dialog there is nothing
above to scroll into, so upward wheels are always cancelled while downward ones pass
through. The keyboard arrows were never broken.

The window height decides how it presents, which is worth knowing for anyone trying to
reproduce it: the dialog has to *overflow* for the downward wheel to work. In a tall
window it does not overflow, `locationCouldBeScrolled` finds no scrollable ancestor, and
`shouldCancelEvent` returns `true` straight away — so the spinner is dead in **both**
directions. The reporter's half-working spinner is the shorter-window case.

Ruled out along the way: `step="any"` on its own (a bare input steps both ways in
Chromium, controlled-React loop included), and the `RuleBuilder` local-state /
`useEffect` echo through `AutomationRuleForm`.

## Fix

Rather than fight the scroll lock with a custom wheel handler, the numeric condition now
uses the shared **`AmountInput`** — the same masked, locale-aware amount field as the
create/edit transaction form. It is a `type="text" inputMode="decimal"` input with no
spinner, so there is no native step for `preventDefault()` to cancel and the asymmetry
disappears at the root. It also brings comma decimals (`-21,99`), math expressions
(`-10*2`), a `+/−` toggle for keyboards without a minus key, and consistency with every
other money field in the app.

`condition.value` stays a **string in currency units** (`"-21.99"`), which is what
`buildJsonLogic`, the backend evaluator (`prepareTransactionData` divides by 100) and
`rule-builder-utils.test.ts` all expect. `AmountInput` speaks cents, so the conversion
happens at the boundary only.

### The zero problem, and why `AmountInput` gained one argument

`AmountInput` resolves both a cleared field and a typed `"0"` to `0` cents. Mapping
`0 → ""` would have made `amount < 0` — the canonical "match every expense" condition,
documented in `app/Mcp/Tools/CreateAutomationRule.php` and exercised in
`AutomationRuleEvaluationTest` — impossible to express, and would have let an existing
rule storing `0` silently lose its condition on re-save (`parseFloat("")` → `NaN` →
`null` in the saved jsonLogic, which the PHP evaluator treats as never matching).

So `onChange` now reports `(valueInCents, isEmpty)`. The extra argument is
backwards-compatible — every other call site takes one parameter or is a `useState`
setter — and the rule builder blanks the condition only for a genuinely empty field.

## Verified in the browser

Both surfaces (Settings → Automation rules, and the "Automatize Categorization" dialog
the report came from): no `input[type="number"]` left, and the wheel now does nothing in
**either** direction.

Round-trip — typed, saved, reopened, and the persisted jsonLogic:

| typed | shown | reopened | stored |
|---|---|---|---|
| `-5` | `-5.00` | `-5.00` | `{"<":[{"var":"amount"},-5]}` |
| `-21,99` | `-21.99` | `-21.99` | `{"<":[{"var":"amount"},-21.99]}` |
| `21.99` | `21.99` | `21.99` | `{"<":[{"var":"amount"},21.99]}` |
| `-10*2` | `-20.00` | `-20.00` | `{"<":[{"var":"amount"},-20]}` |
| `0` | *(blank)* | *(blank)* | `{"<":[{"var":"amount"},0]}` |

Plain numbers, never cents. Focusing and leaving the field without typing still leaves
the condition incomplete ("At least one valid condition is required"). A seeded
`-21.99` transaction was auto-categorized by the rule created through the UI.

## Demo

Recorded at a 1280x620 viewport so the dialog overflows (`scrollHeight` 698 >
`clientHeight` 587, `scrollTop` 0) — that is the state the report came from.

**Before** — wheel down steps `-5` → `-6`, wheel up twice does nothing, arrow keys work
both ways:

<!-- DEMO PLACEHOLDER: drag amount-stepper-before.mp4 here -->

**After** — the field no longer responds to the wheel in *either* direction, because
`AmountInput` has no spinner. Symmetry by removing the stepper, which is what this
approach means: the arrow keys stop stepping too, and the value is typed instead.

<!-- DEMO PLACEHOLDER: drag amount-stepper-after.mp4 here -->

## Tests

- `rule-builder.test.tsx` (new): the units/cents round-trip in both directions, comma
  decimals, a typed zero surviving, and an untouched field staying empty. Mutation-checked
  — leaking cents fails one test, dropping the `isEmpty` guard fails another.
- `amount-input.test.tsx`: covers the new flag; the two sign-toggle assertions now assert
  both arguments.
- `AutomationRuleBuilderTest.php`: the amount case types `-5` (the reported value) and
  asserts the exact persisted structure instead of only the title.

## Known limitations, not addressed here

- A stored `0` renders as a blank field, because `AmountInput` formats `0` as an empty
  string. It round-trips correctly as long as the user does not focus and leave it, and
  it is the same behaviour as every other amount field in the app. Fixing it properly
  means giving `AmountInput` a nullable value, which touches budgets, transactions and
  accounts — too wide for this PR.
- `buildJsonLogic` still emits `null` for a condition whose value is empty while a
  sibling condition is valid (`isValidRuleStructure` uses `.some()`). Pre-existing, and
  the JS and PHP engines disagree on `amount < null`. Worth its own PR.
- The currency symbol comes from the user's profile currency, but the evaluator compares
  raw numbers with no FX conversion, so for a multi-currency user the symbol implies a
  conversion that does not happen. Pre-existing.
- The same wheel asymmetry is live on the other `type="number"` inputs inside dialogs and
  popovers (closest: the Min/Max amount filters in `transaction-filters.tsx`). Left out
  deliberately — this PR is scoped to the reported field.
