### PR TITLE
feat(currencies): add the Kuwaiti dinar (KWD)

### DIFF
--- a/config/currencies.php
+++ b/config/currencies.php
@@ -141,6 +141,12 @@ return [
             'allows_account' => true,
         ],
         [
+            'code' => 'KWD',
+            'name' => 'Kuwaiti Dinar',
+            'allows_primary' => true,
+            'allows_account' => true,
+        ],
+        [
             'code' => 'BTC',
             'name' => 'Bitcoin',
             'allows_primary' => false,

--- a/lang/es.json
+++ b/lang/es.json
@@ -1596,6 +1596,7 @@
     "Brazilian Real": "Real brasileño",
     "Dominican Peso": "Peso dominicano",
     "Saudi Riyal": "Riyal saudí",
+    "Kuwaiti Dinar": "Dinar kuwaití",
     "Guatemalan Quetzal": "Quetzal guatemalteco",
     "Hong Kong Dollar": "Dólar de Hong Kong",
     "Take control of your finances with privacy-first money tracking. Let's set up your account in just a few minutes.": "Toma el control de tus finanzas con un seguimiento privado de tu dinero. Vamos a configurar tu cuenta en pocos minutos.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1511,6 +1511,7 @@
     "Brazilian Real": "Réal brésilien",
     "Dominican Peso": "Peso dominicain",
     "Saudi Riyal": "Riyal saoudien",
+    "Kuwaiti Dinar": "Dinar koweïtien",
     "Guatemalan Quetzal": "Quetzal guatémaltèque",
     "Hong Kong Dollar": "Dollar de Hong Kong",
     "Take control of your finances with privacy-first money tracking. Let's set up your account in just a few minutes.": "Prenez le contrôle de vos finances grâce au suivi de l'argent privé. Nous créerons votre compte dans quelques minutes.",


### PR DESCRIPTION
## Why

A user wrote in from Kuwait: they cannot use Whisper Money at all because KWD is not
in the currency list, so they can pick it neither as their profile currency nor for an
account.

## What

Adds `KWD` to `config/currencies.php` with `allows_primary` and `allows_account`, plus
the `es` translation (enforced by `LocalizationTest`) and the `fr` one (optional locale,
added while here).

## Notes

- The rate source, `@fawazahmed0/currency-api`, already publishes KWD, so conversion
  needs no change.
- KWD is a three-decimal currency. The app stores and formats every currency on a fixed
  two-decimal "cents" scale (`resources/js/utils/currency.ts` divides by 100 with
  `minimumFractionDigits: 2`), so a KWD amount shows two decimals rather than three.
  That is the same treatment JPY already gets in the opposite direction, and it is
  internally consistent — amounts round-trip and convert correctly. Giving currencies
  their real minor units is a separate change and is deliberately not in scope here.
- No frontend symbol added: `getCurrencySymbol` falls back to the code, which is what
  SAR, RSD and the other recent additions do.

Draft for review.