### PR TITLE
fix(banking): stop the third sync attempt burning the bank's daily allowance

### DIFF
--- a/app/Jobs/SyncBankingConnectionJob.php
+++ b/app/Jobs/SyncBankingConnectionJob.php
@@ -235,13 +235,20 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
         // connection this was written for is already parked in Error and stays
         // there: 68 failed jobs against 3 sync-log rows, and logging after the
         // guard would have added none of the missing 65.
-        $this->logSyncAttempt(
-            $connection,
-            BankingSyncLogStatus::Failed,
-            startTime: null,
-            error: $e,
-            metadata: ['reason' => 'job_died_outside_handle'],
-        );
+        //
+        // Only for a death handle() did not already record, though: a failure it
+        // classified is in the table with its duration and its real error, and
+        // repeating it here as `job_died_outside_handle` both doubles the row and
+        // misattributes the cause.
+        if (! $this->alreadyRecordedThisAttempt($connection)) {
+            $this->logSyncAttempt(
+                $connection,
+                BankingSyncLogStatus::Failed,
+                startTime: null,
+                error: $e,
+                metadata: ['reason' => 'job_died_outside_handle'],
+            );
+        }
 
         if ($connection->status === BankingConnectionStatus::Error || ! $this->isSyncableStatus($connection)) {
             return;
@@ -255,6 +262,26 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
             // the connection back up on its own.
             'error_message' => __('The sync did not finish. We will try again later.'),
         ]);
+    }
+
+    /**
+     * Whether the attempt that just died already recorded its own failure.
+     *
+     * It cannot be answered with a flag on the job: the queue unserializes a
+     * fresh instance of this class to call failed() on, so nothing handle() set
+     * survives the trip. The row it left behind does, and an in-band failure
+     * writes one moments before rethrowing - which is what brings us here - so a
+     * failed row for this same attempt, seconds old, is that row and not another
+     * cycle's. Scheduled cycles are hours apart, so there is nothing else it
+     * could be.
+     */
+    private function alreadyRecordedThisAttempt(BankingConnection $connection): bool
+    {
+        return $connection->syncLogs()
+            ->where('status', BankingSyncLogStatus::Failed)
+            ->where('attempt', $this->attempts())
+            ->where('created_at', '>=', now()->subMinute())
+            ->exists();
     }
 
     /**

--- a/app/Jobs/SyncBankingConnectionJob.php
+++ b/app/Jobs/SyncBankingConnectionJob.php
@@ -33,7 +33,20 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    public int $tries = 3;
+    /**
+     * Two attempts, not three.
+     *
+     * The third one recovered 2 of 176 runs over a fortnight in production
+     * (1.1%), and it is not free: an attempt re-syncs every account on the
+     * connection - transactions and balances - against a consent the bank meters
+     * at a couple of accesses a day, so it mostly spends the allowance the next
+     * scheduled cycle needs. The second attempt does earn its keep, at 58
+     * recoveries in 262 (22%), which is why this is 2 and not 1.
+     *
+     * A failure that outlives both attempts is not lost: the connection stays in
+     * the scheduled rotation and is tried again on the next cycle.
+     */
+    public int $tries = 2;
 
     public int $backoff = 30;
 

--- a/tests/Feature/OpenBanking/SyncRetryAndLoggingTest.php
+++ b/tests/Feature/OpenBanking/SyncRetryAndLoggingTest.php
@@ -76,6 +76,7 @@ test('the second attempt is the last one a failing sync gets', function () {
     $connection = BankingConnection::factory()->create([
         'user_id' => $user->id,
         'last_synced_at' => now()->subDay(),
+        'consecutive_sync_failures' => 0,
     ]);
     Account::factory()->connected()->create([
         'user_id' => $user->id,
@@ -223,7 +224,7 @@ test('temporary error on final attempt is logged', function () {
 
     Log::spy();
 
-    // Final attempt (3 of 3): the connection gives up, so it must be reported.
+    // Past the retry budget: the connection gives up, so it must be reported.
     $job = new SyncBankingConnectionJob($connection);
     $job->job = Mockery::mock(Job::class);
     $job->job->shouldReceive('attempts')->andReturn(3);
@@ -1025,6 +1026,94 @@ test('a second out-of-band death on an already errored connection changes nothin
     // written for happened - so dropping the log here would drop the whole point.
     $log = BankingSyncLog::where('banking_connection_id', $connection->id)->sole();
     expect($log->metadata['reason'])->toBe('job_died_outside_handle');
+});
+
+test('a failure handle() already recorded is not logged twice as a job death', function () {
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->create([
+        'user_id' => $user->id,
+        'last_synced_at' => now()->subDay(),
+        'consecutive_sync_failures' => 0,
+    ]);
+    Account::factory()->connected()->create([
+        'user_id' => $user->id,
+        'banking_connection_id' => $connection->id,
+        'external_account_id' => 'ext-123',
+    ]);
+
+    $failure = new TransientBankingProviderException(
+        'EnableBanking bank connector failed while fetching account transactions.',
+        provider: 'enablebanking',
+        statusCode: 400,
+        providerCode: 'ASPSP_ERROR',
+        operation: 'transactions',
+    );
+
+    $transactionSync = Mockery::mock(TransactionSyncService::class);
+    $transactionSync->shouldReceive('sync')->andThrow($failure);
+
+    $balanceSync = Mockery::mock(BalanceSyncService::class);
+
+    $job = new SyncBankingConnectionJob($connection);
+    $job->job = Mockery::mock(Job::class);
+    $job->job->shouldReceive('attempts')->andReturn(2);
+    $job->job->shouldReceive('isReleased')->andReturn(false);
+    $job->job->shouldReceive('isDeletedOrReleased')->andReturn(false);
+    $job->job->shouldReceive('hasFailed')->andReturn(false);
+
+    try {
+        runSync($job, $transactionSync, $balanceSync);
+    } catch (TransientBankingProviderException) {
+        // Expected: the rethrow is what makes the queue call failed() next.
+    }
+
+    // Which the queue does on a fresh instance of the job, unserialized from the
+    // payload - so nothing handle() left in memory is available here. Modelled
+    // that way on purpose: a check that only works on the same object would pass
+    // a test and do nothing in production.
+    $died = new SyncBankingConnectionJob($connection);
+    $died->job = Mockery::mock(Job::class);
+    $died->job->shouldReceive('attempts')->andReturn(2);
+    $died->failed($failure);
+
+    // One row, the one that knows what actually happened. Counting failures off
+    // this table used to see every classified failure twice.
+    $log = BankingSyncLog::where('banking_connection_id', $connection->id)->sole();
+    expect($log->status)->toBe(BankingSyncLogStatus::Failed);
+    expect($log->error_class)->toBe(TransientBankingProviderException::class);
+    expect($log->metadata)->not->toHaveKey('reason');
+    expect($log->duration_ms)->not->toBeNull();
+});
+
+test('a job death on a later attempt is still recorded after an earlier failure', function () {
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->create([
+        'user_id' => $user->id,
+        'consecutive_sync_failures' => 0,
+    ]);
+
+    // The first attempt failed in-band and said so. The second one is then killed
+    // from the outside, which is a different event and has to be recorded as one.
+    BankingSyncLog::create([
+        'banking_connection_id' => $connection->id,
+        'status' => BankingSyncLogStatus::Failed,
+        'attempt' => 1,
+        'error_class' => TransientBankingProviderException::class,
+        'duration_ms' => 1200,
+        'created_at' => now(),
+    ]);
+
+    $died = new SyncBankingConnectionJob($connection);
+    $died->job = Mockery::mock(Job::class);
+    $died->job->shouldReceive('attempts')->andReturn(2);
+    $died->failed(new TimeoutExceededException('App\\Jobs\\SyncBankingConnectionJob has timed out.'));
+
+    $logs = BankingSyncLog::where('banking_connection_id', $connection->id)
+        ->orderBy('attempt')
+        ->get();
+
+    expect($logs)->toHaveCount(2);
+    expect($logs->last()->metadata['reason'])->toBe('job_died_outside_handle');
 });
 
 test('an out-of-band job death is recorded in the connection history', function () {

--- a/tests/Feature/OpenBanking/SyncRetryAndLoggingTest.php
+++ b/tests/Feature/OpenBanking/SyncRetryAndLoggingTest.php
@@ -47,7 +47,7 @@ test('temporary error on non-final attempt does not set error status', function 
 
     $balanceSync = Mockery::mock(BalanceSyncService::class);
 
-    // Simulate attempt 1 of 3
+    // Simulate the first attempt, with one still to come
     $job = new SyncBankingConnectionJob($connection);
     $job->job = Mockery::mock(Job::class);
     $job->job->shouldReceive('attempts')->andReturn(1);
@@ -68,6 +68,54 @@ test('temporary error on non-final attempt does not set error status', function 
     $connection->refresh();
     expect($connection->status)->toBe(BankingConnectionStatus::Active);
     expect($connection->error_message)->toBeNull();
+    expect($connection->consecutive_sync_failures)->toBe(0);
+});
+
+test('the second attempt is the last one a failing sync gets', function () {
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->create([
+        'user_id' => $user->id,
+        'last_synced_at' => now()->subDay(),
+    ]);
+    Account::factory()->connected()->create([
+        'user_id' => $user->id,
+        'banking_connection_id' => $connection->id,
+        'external_account_id' => 'ext-123',
+    ]);
+
+    $transactionSync = Mockery::mock(TransactionSyncService::class);
+    $transactionSync->shouldReceive('sync')->andThrow(
+        new TransientBankingProviderException(
+            'EnableBanking bank connector failed while fetching account transactions.',
+            provider: 'enablebanking',
+            statusCode: 400,
+            providerCode: 'ASPSP_ERROR',
+            operation: 'transactions',
+        )
+    );
+
+    $balanceSync = Mockery::mock(BalanceSyncService::class);
+
+    $job = new SyncBankingConnectionJob($connection);
+    $job->job = Mockery::mock(Job::class);
+    $job->job->shouldReceive('attempts')->andReturn(2);
+    $job->job->shouldReceive('isReleased')->andReturn(false);
+    $job->job->shouldReceive('isDeletedOrReleased')->andReturn(false);
+    $job->job->shouldReceive('hasFailed')->andReturn(false);
+
+    try {
+        runSync($job, $transactionSync, $balanceSync);
+    } catch (TransientBankingProviderException) {
+        // Expected
+    }
+
+    // A third attempt would re-sync every account against a metered consent for a
+    // 1.1% chance of recovery, so the run gives up here and waits for the next
+    // scheduled cycle. The counter stays put: the outage is not the connection's
+    // fault, and spending it would drop the connection out of that rotation.
+    $connection->refresh();
+    expect($connection->status)->toBe(BankingConnectionStatus::Error);
+    expect($connection->error_message)->not->toBeNull();
     expect($connection->consecutive_sync_failures)->toBe(0);
 });
 
@@ -92,7 +140,7 @@ test('temporary error on final attempt sets error status and increments consecut
 
     $balanceSync = Mockery::mock(BalanceSyncService::class);
 
-    // Simulate final attempt (3 of 3)
+    // Simulate an attempt past the retry budget
     $job = new SyncBankingConnectionJob($connection);
     $job->job = Mockery::mock(Job::class);
     $job->job->shouldReceive('attempts')->andReturn(3);
@@ -711,7 +759,7 @@ test('sync log records attempt number', function () {
 
     $balanceSync = Mockery::mock(BalanceSyncService::class);
 
-    // Simulate attempt 2 of 3
+    // Simulate the second attempt
     $job = new SyncBankingConnectionJob($connection);
     $job->job = Mockery::mock(Job::class);
     $job->job->shouldReceive('attempts')->andReturn(2);


### PR DESCRIPTION
## What is wrong

A bank connection sync that fails is retried three times, 30 seconds apart, and
each attempt re-syncs **every account on the connection** — transactions and
balances — against a consent the bank meters at a couple of accesses a day. On a
connection whose bank is refusing, that turns 4 scheduled cycles a day into 12
full syncs a day, and the accesses it spends are the same ones the next cycle
needs.

Measured in production over the last fortnight (`banking_sync_logs`):

| attempt | runs | recovered | 
|---|---|---|
| 2 | 262 | 58 (22%) |
| 3 | 176 | 2 (1.1%) |

So the second attempt earns its keep and the third one essentially does not. Four
Openbank connections ran the 12-a-day pattern for nine days on
`400 ASPSP_ERROR` (`"Invalid status value"`), and 106 of the 108 entries in
`failed_jobs` for the last 7 days are this job.

Separately, and found while measuring the above: **every failure was being
recorded twice.** `handle()` classifies a failure, writes a `banking_sync_logs`
row with its duration and real error class, and rethrows so the queue marks the
job failed — which calls `failed()`, which wrote a second row for the same
failure labelled `job_died_outside_handle`. All **164** such rows in the last
fortnight have an in-band twin seconds earlier; there were no out-of-band deaths
at all in that window. Any failure count taken off that table was doubled, and
the row that names a cause named the wrong one.

## What this does

1. **Two attempts instead of three.** Nothing is lost when both fail: the
   connection stays in the scheduled rotation and is picked up on the next cycle.
   `MAX_SCHEDULED_RETRIES` is a different budget (scheduled *cycles*, not queue
   tries) and is untouched, so no connection gets stranded any sooner.
2. **`failed()` records only what the attempt did not record itself**, keeping the
   trace of a genuine out-of-band death (a worker timeout, a restart mid-sync),
   which is what that log line exists for.

The check in (2) is a query and not a flag on the job on purpose: the queue
unserializes a *fresh* instance of the job class to call `failed()` on, so
nothing `handle()` leaves in memory survives the trip. The first cut of this
patch used an instance flag; the architecture review caught that it would have
passed its test and done nothing in production, so the test now models the same
round trip the queue performs.

## User-visible effect

For the ~1.1% of runs that used to self-heal on the third attempt, the
connections page will show an error badge for that cycle instead of quietly
succeeding, and it clears on the next scheduled cycle. In exchange, the
connections that fail repeatedly stop spending three times the bank's daily
allowance per cycle — which is what leaves those users looking at stale data and
`0` balances.

## Testing

- New: the second attempt is the last one a failing sync gets (transient failure
  at attempt 2 lands the connection in Error without charging the cycle counter).
- New: a failure `handle()` already recorded is not logged twice, asserted across
  a fresh job instance.
- New: an out-of-band death on a *later* attempt is still recorded after an
  earlier attempt's in-band failure.
- `tests/Feature/OpenBanking` (396 tests) and `BankHealthCommandTest` pass
  locally; `php artisan crap --base=origin/main` clean; `bun run dry` unchanged.