### PR TITLE
feat(banking): record which trigger dispatched every bank sync

### DIFF
--- a/app/Console/Commands/SyncBankingConnections.php
+++ b/app/Console/Commands/SyncBankingConnections.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use App\Enums\BankingConnectionStatus;
 use App\Enums\BankingProvider;
+use App\Enums\BankingSyncTrigger;
 use App\Jobs\SyncAllBankingConnectionsJob;
 use App\Jobs\SyncBankingConnectionJob;
 use App\Models\BankingConnection;
@@ -94,10 +95,10 @@ class SyncBankingConnections extends Command
         $connections->each(function (BankingConnection $connection) use ($sync, $fullSync) {
             if ($sync) {
                 $this->info("Syncing {$connection->provider->value} connection {$connection->id}...");
-                SyncBankingConnectionJob::dispatchSync($connection, $fullSync);
+                SyncBankingConnectionJob::dispatchSync($connection, $fullSync, BankingSyncTrigger::Command);
                 $this->info("Finished syncing {$connection->provider->value} connection {$connection->id}.");
             } else {
-                SyncBankingConnectionJob::dispatch($connection, $fullSync);
+                SyncBankingConnectionJob::dispatch($connection, $fullSync, BankingSyncTrigger::Command);
             }
         });
 

--- a/app/Enums/BankingSyncTrigger.php
+++ b/app/Enums/BankingSyncTrigger.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * What asked for a banking sync, recorded as `metadata['trigger']` on every
+ * banking_sync_logs row so "how many manual syncs per user per day" is a query
+ * rather than a guess.
+ *
+ * Scheduled is also the default on the job, so a dispatch site added later and
+ * left unlabelled lands in the scheduled bucket rather than inflating whichever
+ * on-demand trigger someone is sizing a limit against.
+ */
+enum BankingSyncTrigger: string
+{
+    /** The six-hourly sweep, and anything that forgot to say otherwise. */
+    case Scheduled = 'scheduled';
+
+    /** The Sync button on the connections page. */
+    case Manual = 'manual';
+
+    /** A bank connected for the first time. */
+    case Connect = 'connect';
+
+    /** An expired or revoked connection re-authorized by the user. */
+    case Reconnect = 'reconnect';
+
+    /** The user finished mapping the bank's accounts onto ours. */
+    case AccountMapping = 'account_mapping';
+
+    /** A single account linked to an existing connection. */
+    case AccountLinked = 'account_linked';
+
+    /** New API credentials saved for a key-based provider. */
+    case CredentialsUpdated = 'credentials_updated';
+
+    /** `banking:sync` run by hand against specific users or connections. */
+    case Command = 'command';
+}

--- a/app/Http/Controllers/OpenBanking/AccountMappingController.php
+++ b/app/Http/Controllers/OpenBanking/AccountMappingController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\OpenBanking;
 
 use App\Enums\BankingConnectionStatus;
+use App\Enums\BankingSyncTrigger;
 use App\Http\Controllers\Controller;
 use App\Http\Controllers\OpenBanking\Concerns\CreatesAccountsFromPending;
 use App\Http\Requests\OpenBanking\MapAccountsRequest;
@@ -36,7 +37,7 @@ class AccountMappingController extends Controller
         // During onboarding, skip the mapping UI — auto-create all accounts directly
         if (! $user->isOnboarded()) {
             $this->createAccountsFromPending($user, $connection, $accountUserCurrencyService);
-            SyncBankingConnectionJob::dispatch($connection);
+            SyncBankingConnectionJob::dispatch($connection, trigger: BankingSyncTrigger::Connect);
 
             return redirect()->route('onboarding', ['step' => 'create-account'])
                 ->with('success', 'Bank account connected successfully.');
@@ -143,7 +144,7 @@ class AccountMappingController extends Controller
             'consecutive_sync_failures' => 0,
         ]);
 
-        SyncBankingConnectionJob::dispatch($connection);
+        SyncBankingConnectionJob::dispatch($connection, trigger: BankingSyncTrigger::AccountMapping);
 
         $successRedirect = $user->isOnboarded() ? 'settings.connections.index' : 'onboarding';
         $redirectParams = $user->isOnboarded() ? [] : ['step' => 'create-account'];

--- a/app/Http/Controllers/OpenBanking/AuthorizationController.php
+++ b/app/Http/Controllers/OpenBanking/AuthorizationController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\OpenBanking;
 use App\Contracts\BankingProviderInterface;
 use App\Enums\BankingConnectionStatus;
 use App\Enums\BankingProvider;
+use App\Enums\BankingSyncTrigger;
 use App\Http\Controllers\Controller;
 use App\Http\Controllers\OpenBanking\Concerns\CreatesAccountsFromPending;
 use App\Http\Controllers\OpenBanking\Concerns\HandlesSubscriptionGate;
@@ -240,7 +241,7 @@ class AuthorizationController extends Controller
 
         $this->refreshAccountIds($connection, $sessionData['accounts']);
 
-        SyncBankingConnectionJob::dispatch($connection);
+        SyncBankingConnectionJob::dispatch($connection, trigger: BankingSyncTrigger::Reconnect);
 
         return $this->finishRedirect('settings.connections.index', [], 'success', __('Bank account reconnected successfully.'));
     }
@@ -265,7 +266,7 @@ class AuthorizationController extends Controller
 
         if (! $user->isOnboarded()) {
             $this->createAccountsFromPending($user, $connection, $accountUserCurrencyService);
-            SyncBankingConnectionJob::dispatch($connection);
+            SyncBankingConnectionJob::dispatch($connection, trigger: BankingSyncTrigger::Connect);
 
             return $this->finishRedirect('onboarding', ['step' => 'create-account'], 'success', 'Bank account connected successfully.');
         }

--- a/app/Http/Controllers/OpenBanking/ConnectionAccountController.php
+++ b/app/Http/Controllers/OpenBanking/ConnectionAccountController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\OpenBanking;
 
 use App\Contracts\BankingProviderInterface;
+use App\Enums\BankingSyncTrigger;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\OpenBanking\MapConnectionAccountRequest;
 use App\Jobs\SyncBankingConnectionJob;
@@ -97,7 +98,7 @@ class ConnectionAccountController extends Controller
 
         $accountUserCurrencyService->syncFromFirstAccount($account);
 
-        SyncBankingConnectionJob::dispatch($connection);
+        SyncBankingConnectionJob::dispatch($connection, trigger: BankingSyncTrigger::AccountLinked);
 
         return back()->with('success', __('Account synced. Transactions will be updated shortly.'));
     }

--- a/app/Http/Controllers/OpenBanking/ConnectionController.php
+++ b/app/Http/Controllers/OpenBanking/ConnectionController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\OpenBanking;
 use App\Actions\OpenBanking\DisconnectBankingConnection;
 use App\Enums\BankingConnectionStatus;
 use App\Enums\BankingProvider;
+use App\Enums\BankingSyncTrigger;
 use App\Http\Controllers\Controller;
 use App\Http\Controllers\OpenBanking\Concerns\HandlesSubscriptionGate;
 use App\Http\Requests\OpenBanking\DestroyConnectionRequest;
@@ -117,7 +118,7 @@ class ConnectionController extends Controller
             'rate_limited_until' => null,
         ]);
 
-        SyncBankingConnectionJob::dispatch($connection);
+        SyncBankingConnectionJob::dispatch($connection, trigger: BankingSyncTrigger::Manual);
 
         return back()->with('success', 'Sync started. Transactions will be updated shortly.');
     }
@@ -146,7 +147,7 @@ class ConnectionController extends Controller
             'consecutive_sync_failures' => 0,
         ]);
 
-        SyncBankingConnectionJob::dispatch($connection);
+        SyncBankingConnectionJob::dispatch($connection, trigger: BankingSyncTrigger::CredentialsUpdated);
 
         return back()->with('success', __('Credentials updated. Sync started.'));
     }

--- a/app/Http/Controllers/OpenBanking/OpenBankingConnectController.php
+++ b/app/Http/Controllers/OpenBanking/OpenBankingConnectController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\OpenBanking;
 
 use App\Enums\BankingConnectionStatus;
 use App\Enums\BankingProvider;
+use App\Enums\BankingSyncTrigger;
 use App\Http\Controllers\Controller;
 use App\Http\Controllers\OpenBanking\Concerns\CreatesAccountsFromPending;
 use App\Http\Controllers\OpenBanking\Concerns\HandlesSubscriptionGate;
@@ -115,7 +116,7 @@ abstract class OpenBankingConnectController extends Controller
     {
         if (! $user->isOnboarded()) {
             $this->createAccountsFromPending($user, $connection, $accountUserCurrencyService);
-            SyncBankingConnectionJob::dispatch($connection);
+            SyncBankingConnectionJob::dispatch($connection, trigger: BankingSyncTrigger::Connect);
 
             return response()->json([
                 'redirect_url' => route('onboarding', ['step' => 'create-account']),

--- a/app/Http/Controllers/OpenBanking/WiseController.php
+++ b/app/Http/Controllers/OpenBanking/WiseController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\OpenBanking;
 
 use App\Enums\BankingConnectionStatus;
 use App\Enums\BankingProvider;
+use App\Enums\BankingSyncTrigger;
 use App\Http\Controllers\Controller;
 use App\Http\Controllers\OpenBanking\Concerns\CreatesAccountsFromPending;
 use App\Http\Controllers\OpenBanking\Concerns\HandlesSubscriptionGate;
@@ -70,7 +71,7 @@ class WiseController extends Controller
 
         if (! $user->isOnboarded()) {
             $this->createAccountsFromPending($user, $connection, $accountUserCurrencyService);
-            SyncBankingConnectionJob::dispatch($connection);
+            SyncBankingConnectionJob::dispatch($connection, trigger: BankingSyncTrigger::Connect);
 
             return response()->json([
                 'redirect_url' => route('onboarding', ['step' => 'create-account']),

--- a/app/Jobs/SyncAllBankingConnectionsJob.php
+++ b/app/Jobs/SyncAllBankingConnectionsJob.php
@@ -4,6 +4,7 @@ namespace App\Jobs;
 
 use App\Enums\BankingConnectionStatus;
 use App\Enums\BankingProvider;
+use App\Enums\BankingSyncTrigger;
 use App\Models\BankingConnection;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -47,7 +48,7 @@ class SyncAllBankingConnectionsJob implements ShouldQueue
                     ->orWhere('rate_limited_until', '<=', now());
             })
             ->each(function (BankingConnection $connection) {
-                SyncBankingConnectionJob::dispatch($connection, $this->fullSync);
+                SyncBankingConnectionJob::dispatch($connection, $this->fullSync, BankingSyncTrigger::Scheduled);
             });
     }
 }

--- a/app/Jobs/SyncBankingConnectionJob.php
+++ b/app/Jobs/SyncBankingConnectionJob.php
@@ -5,6 +5,7 @@ namespace App\Jobs;
 use App\Contracts\BankingConnectionSyncer;
 use App\Enums\BankingConnectionStatus;
 use App\Enums\BankingSyncLogStatus;
+use App\Enums\BankingSyncTrigger;
 use App\Exceptions\Banking\CarriesBankingOperation;
 use App\Exceptions\Banking\ExpiredBankingSessionException;
 use App\Exceptions\Banking\TransientBankingProviderException;
@@ -83,9 +84,20 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
         'X-RateLimit-Reset',
     ];
 
+    /**
+     * @param  BankingSyncTrigger  $trigger  Who asked for this sync. Third and
+     *                                       last because callers pass $fullSync
+     *                                       positionally; a constructor property
+     *                                       survives serialization, so failed()
+     *                                       can read it off its fresh instance
+     *                                       and an in-flight payload written
+     *                                       before this existed unserializes to
+     *                                       the default.
+     */
     public function __construct(
         public BankingConnection $bankingConnection,
         public bool $fullSync = false,
+        public BankingSyncTrigger $trigger = BankingSyncTrigger::Scheduled,
     ) {}
 
     public function uniqueId(): string
@@ -415,7 +427,9 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
             'duration_ms' => $startTime === null
                 ? null
                 : (int) round((microtime(true) - $startTime) * 1000),
-            'metadata' => $metadata,
+            // On every row, including the ones that carry nothing else, so the
+            // trigger can be counted without a join or a null branch.
+            'metadata' => ['trigger' => $this->trigger->value, ...($metadata ?? [])],
             'created_at' => now(),
         ]);
     }

--- a/app/Jobs/SyncBankingConnectionJob.php
+++ b/app/Jobs/SyncBankingConnectionJob.php
@@ -85,20 +85,33 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
     ];
 
     /**
-     * @param  BankingSyncTrigger  $trigger  Who asked for this sync. Third and
-     *                                       last because callers pass $fullSync
-     *                                       positionally; a constructor property
-     *                                       survives serialization, so failed()
-     *                                       can read it off its fresh instance
-     *                                       and an in-flight payload written
-     *                                       before this existed unserializes to
-     *                                       the default.
+     * Who asked for this sync. A property rather than something handle() works
+     * out, because it has to travel in the serialized payload: failed() is
+     * called on a fresh instance the queue unserializes, and that is the run
+     * with no other trace of what triggered it.
+     *
+     * Deliberately not promoted, unlike its siblings. A promoted property has no
+     * class-level default - the default lives on the constructor parameter - so
+     * the jobs already queued when this deploys, serialized without the key,
+     * would come back with it *uninitialized* rather than Scheduled, and the
+     * first read would throw. A declared default is what unserialize() leaves in
+     * place for a key the payload does not carry, which is also why it costs
+     * those in-flight jobs nothing: SerializesModels omits a property still
+     * equal to its default, so a scheduled sync does not carry the key either.
+     */
+    public BankingSyncTrigger $trigger = BankingSyncTrigger::Scheduled;
+
+    /**
+     * @param  BankingSyncTrigger  $trigger  Third and last: callers pass
+     *                                       $fullSync positionally.
      */
     public function __construct(
         public BankingConnection $bankingConnection,
         public bool $fullSync = false,
-        public BankingSyncTrigger $trigger = BankingSyncTrigger::Scheduled,
-    ) {}
+        BankingSyncTrigger $trigger = BankingSyncTrigger::Scheduled,
+    ) {
+        $this->trigger = $trigger;
+    }
 
     public function uniqueId(): string
     {

--- a/tests/Feature/OpenBanking/BankingSyncTelemetryTest.php
+++ b/tests/Feature/OpenBanking/BankingSyncTelemetryTest.php
@@ -2,6 +2,8 @@
 
 use App\Contracts\BankingProviderInterface;
 use App\Enums\BankingSyncLogStatus;
+use App\Enums\BankingSyncTrigger;
+use App\Jobs\SyncAllBankingConnectionsJob;
 use App\Jobs\SyncBankingConnectionJob;
 use App\Models\Account;
 use App\Models\BankingConnection;
@@ -11,6 +13,7 @@ use Illuminate\Contracts\Queue\Job;
 use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
 
 /**
  * The shape production keeps producing: one bank, one account, transactions the
@@ -45,7 +48,16 @@ function telemetryConnection(int $accounts = 1): BankingConnection
  */
 function telemetryJob(BankingConnection $connection): SyncBankingConnectionJob
 {
-    $job = new SyncBankingConnectionJob($connection);
+    return telemetryAttempt(new SyncBankingConnectionJob($connection));
+}
+
+/**
+ * Give an existing job the queue-job mock its attempts() reads, on its final
+ * attempt so the reporting gate is open. Used directly when the job under test
+ * has to be the instance a controller actually dispatched, trigger included.
+ */
+function telemetryAttempt(SyncBankingConnectionJob $job): SyncBankingConnectionJob
+{
     $job->job = Mockery::mock(Job::class);
     $job->job->shouldReceive('attempts')->andReturn(3);
     $job->job->shouldReceive('isReleased')->andReturn(false);
@@ -122,6 +134,17 @@ function fakeRateLimitedBalances(string $message = 'Too many requests', array $h
             'code' => 429,
             'message' => $message,
         ], 429, $headers),
+    ]);
+}
+
+/**
+ * Nothing goes wrong: the bank serves transactions and balances.
+ */
+function fakeSuccessfulSync(): void
+{
+    Http::fake([
+        'api.enablebanking.com/accounts/*/transactions*' => Http::response(telemetryTransactionsPayload()),
+        'api.enablebanking.com/accounts/*/balances*' => Http::response(['balances' => []]),
     ]);
 }
 
@@ -277,4 +300,55 @@ test('a successful payload never reaches the logs', function () {
 
     expect($serialized)->not->toContain('DE89370400440532013000')
         ->and($serialized)->not->toContain('response_body');
+});
+
+/**
+ * Which trigger dispatched a sync is the one thing the sync logs never recorded,
+ * so "how many manual syncs per user per day" - the number a rate limit on the
+ * Sync button has to be sized against - could only be approximated by the hour
+ * a row landed in. These two pin down the pair that matters: the button and the
+ * scheduled sweep it has to be told apart from.
+ */
+test('a sync started from the Sync button is recorded as manual', function () {
+    $connection = telemetryConnection();
+    fakeSuccessfulSync();
+    Queue::fake();
+
+    $this->actingAs($connection->user)
+        ->post("/settings/connections/{$connection->id}/sync")
+        ->assertSessionHas('success');
+
+    // The instance the controller actually dispatched, not a rebuilt one, so the
+    // trigger under test is the one that travelled through the queue payload.
+    /** @var SyncBankingConnectionJob $dispatched */
+    $dispatched = Queue::pushed(SyncBankingConnectionJob::class)->sole();
+
+    expect($dispatched->trigger)->toBe(BankingSyncTrigger::Manual);
+
+    runSync(telemetryAttempt($dispatched));
+
+    $log = BankingSyncLog::query()->where('banking_connection_id', $connection->id)->sole();
+
+    expect($log->status)->toBe(BankingSyncLogStatus::Success)
+        ->and($log->metadata['trigger'])->toBe('manual');
+});
+
+test('a sync from the scheduled sweep is recorded as scheduled', function () {
+    $connection = telemetryConnection();
+    fakeSuccessfulSync();
+    Queue::fake();
+
+    (new SyncAllBankingConnectionsJob)->handle();
+
+    /** @var SyncBankingConnectionJob $dispatched */
+    $dispatched = Queue::pushed(SyncBankingConnectionJob::class)->sole();
+
+    expect($dispatched->trigger)->toBe(BankingSyncTrigger::Scheduled);
+
+    runSync(telemetryAttempt($dispatched));
+
+    $log = BankingSyncLog::query()->where('banking_connection_id', $connection->id)->sole();
+
+    expect($log->status)->toBe(BankingSyncLogStatus::Success)
+        ->and($log->metadata['trigger'])->toBe('scheduled');
 });

--- a/tests/Feature/OpenBanking/BankingSyncTelemetryTest.php
+++ b/tests/Feature/OpenBanking/BankingSyncTelemetryTest.php
@@ -352,3 +352,28 @@ test('a sync from the scheduled sweep is recorded as scheduled', function () {
     expect($log->status)->toBe(BankingSyncLogStatus::Success)
         ->and($log->metadata['trigger'])->toBe('scheduled');
 });
+
+/**
+ * The deploy itself: jobs are already on the queue, serialized before $trigger
+ * existed. Promoting the property would bring them back with it uninitialized
+ * rather than Scheduled, and the first read - which is every branch of handle(),
+ * and failed() too - would throw instead of syncing.
+ */
+test('a job queued before the trigger existed still records, as scheduled', function () {
+    $connection = telemetryConnection();
+    fakeSuccessfulSync();
+
+    // Exactly what unserialize() does with an old payload: build the object
+    // without running the constructor, then restore only the keys it carries.
+    $job = (new ReflectionClass(SyncBankingConnectionJob::class))->newInstanceWithoutConstructor();
+    $job->__unserialize(['bankingConnection' => $connection, 'fullSync' => false]);
+
+    expect($job->trigger)->toBe(BankingSyncTrigger::Scheduled);
+
+    runSync(telemetryAttempt($job));
+
+    $log = BankingSyncLog::query()->where('banking_connection_id', $connection->id)->sole();
+
+    expect($log->status)->toBe(BankingSyncLogStatus::Success)
+        ->and($log->metadata['trigger'])->toBe('scheduled');
+});

--- a/tests/Feature/OpenBanking/SyncRetryAndLoggingTest.php
+++ b/tests/Feature/OpenBanking/SyncRetryAndLoggingTest.php
@@ -362,7 +362,7 @@ test('expired session marks the connection expired and emails the user instead o
 
     $log = BankingSyncLog::where('banking_connection_id', $connection->id)->first();
     expect($log->status)->toBe(BankingSyncLogStatus::Skipped);
-    expect($log->metadata)->toBe(['reason' => 'expired']);
+    expect($log->metadata)->toMatchArray(['trigger' => 'scheduled', 'reason' => 'expired']);
 
     Mail::assertQueued(BankingConnectionExpiredEmail::class, function (BankingConnectionExpiredEmail $mail) use ($user, $connection) {
         return $mail->user->is($user)
@@ -684,7 +684,7 @@ test('skipped sync creates a skipped log entry and emails user for newly expired
     expect($connection->status)->toBe(BankingConnectionStatus::Expired);
     expect($log)->not->toBeNull();
     expect($log->status)->toBe(BankingSyncLogStatus::Skipped);
-    expect($log->metadata)->toBe(['reason' => 'expired']);
+    expect($log->metadata)->toMatchArray(['trigger' => 'scheduled', 'reason' => 'expired']);
 
     Mail::assertQueued(BankingConnectionExpiredEmail::class, function (BankingConnectionExpiredEmail $mail) use ($user, $connection) {
         return $mail->user->is($user)


### PR DESCRIPTION
Instrumentation only. The owner is weighing a rate limit on the manual **Sync**
button and wanted numbers first — this makes the numbers gettable, and does not
add the limit.

## What changed

`banking_sync_logs` already gets one row per sync attempt, and its `metadata`
JSON column is already where this kind of dimension lives (`metadata['reason']`).
The one thing a row never said is *who asked for the sync*, and that cannot be
inferred: `SyncBankingConnectionJob` is dispatched from eleven places.

So every row now carries `metadata['trigger']`, and every dispatch site is
labelled:

| Trigger | Dispatched from |
| --- | --- |
| `scheduled` | `SyncAllBankingConnectionsJob` — the six-hourly sweep |
| `manual` | `ConnectionController::sync` — the Sync button |
| `connect` | first-time connection: `AuthorizationController`, `AccountMappingController::show` (onboarding auto-map), `OpenBankingConnectController`, `WiseController` |
| `reconnect` | `AuthorizationController` — re-authorizing an existing connection |
| `account_mapping` | `AccountMappingController::store` — user finished mapping |
| `account_linked` | `ConnectionAccountController` — one account linked to an existing connection |
| `credentials_updated` | `ConnectionController::updateCredentials` |
| `command` | `banking:sync` run by hand with `--user` / `--connection` |

No migration, no new table, no new column, no reporting command, no frontend
change. `scheduled` is also the class default, so a dispatch site added later
and left unlabelled lands in the sweep's bucket rather than inflating whichever
on-demand trigger someone is sizing a limit against.

## The query

Manual syncs per user per day:

```sql
SELECT DATE(l.created_at) AS day,
       c.user_id,
       COUNT(*) AS manual_syncs
FROM banking_sync_logs l
JOIN banking_connections c ON c.id = l.banking_connection_id
WHERE l.metadata->>'$.trigger' = 'manual'
  AND l.attempt = 1
  AND l.created_at >= NOW() - INTERVAL 30 DAY
GROUP BY day, c.user_id
ORDER BY manual_syncs DESC;
```

`attempt = 1` because a single dispatch can write more than one row — the job
retries once, and a death outside `handle()` writes its own. Over the last 30
days of off-cycle rows in production that is 209 rows at attempt 1 against 16 at
attempt 2 or 3, so counting rows instead of dispatches overstates by ~7%.

And the first thing worth running after this deploys, to see the mix:

```sql
SELECT COALESCE(metadata->>'$.trigger', '(before this shipped)') AS trigger_name,
       COUNT(*) AS rows_count,
       COUNT(DISTINCT banking_connection_id) AS connections
FROM banking_sync_logs
WHERE created_at >= NOW() - INTERVAL 7 DAY
GROUP BY trigger_name
ORDER BY rows_count DESC;
```

Rows written before this shipped have no `trigger` key, hence the `COALESCE`.

## What the retro numbers already say: manual syncs look rare

Worth stating up front, because it may mean the limit is not worth building.
`banking_sync_logs` holds 81,514 rows since 2026-03-31 across 571 connections,
and the scheduler is `Schedule::command('banking:sync')->everySixHours()` —
00/06/12/18 UTC. That makes the sweep separable from everything else by clock
time alone, which is the best approximation available without this PR.

Last 30 days:

| Bucket | Rows | Connections |
| --- | --- | --- |
| Sweep hour, first 15 minutes | 31,670 | 397 |
| Sweep hour, minutes 15–59 | 959 | 308 |
| Outside a sweep hour entirely | **225** | 146 |

The sweep's tail runs long, so an off-cycle sync that happens to land inside a
sweep hour cannot be told apart from it. That leaves **225 rows in 30 days** as
the honest upper bound for *every* off-cycle trigger combined — manual button,
reconnect, mapping, account linking, credentials, hand-run command.

Split per user per day (again all off-cycle triggers together, so the manual
share is smaller still):

| Off-cycle rows in one day | User-days |
| --- | --- |
| 10 | 3 |
| 8 | 2 |
| 6 | 1 |
| 5 | 2 |
| 4 | 6 |
| 3 | 10 |
| 2 | 26 |
| 1 | 57 |

107 user-days in a month, 83 of them at one or two rows, and the worst day
anyone had was 10. Nobody is hammering the button. My read is that a limit is
not the problem worth solving right now — but that is the owner's call, and this
PR is what turns the guess above into the real number in about a week.

## What this does not count, and why

- **Clicks the controller refuses.** The subscription gate, a connection that is
  not active, and a live bank-side backoff all return before dispatch. Those
  clicks spend no bank access, so they are not part of what a limit would be
  protecting.
- **Duplicate clicks swallowed by `ShouldBeUnique`.** Same reasoning: free.

The syncs that actually execute are the right denominator for sizing a limit, so
recording happens on the dispatch path only. If the question ever becomes "how
often do users click Sync", not "how many syncs do they cause", this data will
not answer it.

## Deploy safety — the one real bug in the first pass

Both reviews independently caught it, and it was worth catching: the trigger
started life as a *promoted* constructor property. A promoted property has no
class-level default — the default lives on the constructor parameter — and
`unserialize()` never runs the constructor. So the sync jobs already sitting on
the queue at deploy time, serialized without the key, would have come back with
the property **uninitialized** rather than `Scheduled`. Every branch of
`handle()` reads it, and so does `failed()`, so each of those jobs would have
thrown instead of syncing: no log row, and the connection never even marked
`Error`.

Fixed structurally rather than guarded at each read — the property is declared
with a real default. That also makes the deploy free in both directions, since
`SerializesModels` omits a property still equal to its default:

```
before:                O:33:"…SyncBankingConnectionJob":2:{…bankingConnection…fullSync…}
after, scheduled:      O:33:"…SyncBankingConnectionJob":2:{…bankingConnection…fullSync…}   ← identical
after, manual:         O:33:"…SyncBankingConnectionJob":3:{…trigger…bankingConnection…fullSync…}
```

There is a test for it that reproduces the queue's own path: build the instance
without the constructor, then `__unserialize()` only the keys the old payload
carried.

## Tests

`tests/Feature/OpenBanking/BankingSyncTelemetryTest.php`, on the existing
`telemetryConnection()` / `telemetryJob()` helpers:

- the Sync endpoint produces a row tagged `manual` — asserted on the job
  instance the controller actually dispatched, not a rebuilt one;
- the scheduled sweep produces a row tagged `scheduled`;
- a job queued before the trigger existed still records, as `scheduled`.

`telemetryJob()` was split into itself plus `telemetryAttempt()` so the queue-job
mock can be attached to a dispatched instance without duplicating it.

## QA

Verified against the local database through each real entry point, not just in
tests:

| Entry point | Row written |
| --- | --- |
| `php artisan banking:sync --connection=… --sync` | `{"trigger": "command", …}` |
| the sweep's own per-connection dispatch | `{"trigger": "scheduled", …}` |
| authenticated `POST /settings/connections/{id}/sync` over HTTP | `{"trigger": "manual", …}` |

Both queries above were then run for real: the per-user-per-day one against the
local rows those three produced, and against production to confirm the syntax
(it returns empty there, as it should until this ships).

## Notes

- `AccountMappingController::store` shows at cyclomatic complexity 11 in
  `php artisan crap`. Pre-existing — this diff adds an argument to one call and
  no branches. Left alone.
- `banking:health` does not read `banking_sync_logs` at all, so new metadata
  keys cannot disturb it.
