### PR TITLE
fix(banking): report the population that actually syncs, and the history that proves it

### DIFF
--- a/app/Console/Commands/BankHealthCommand.php
+++ b/app/Console/Commands/BankHealthCommand.php
@@ -4,8 +4,11 @@ namespace App\Console\Commands;
 
 use App\Console\Commands\Concerns\QueriesBankFailures;
 use App\Enums\BankingConnectionStatus;
+use App\Enums\BankingSyncLogStatus;
 use App\Mail\BankHealthAlertEmail;
 use App\Models\BankingConnection;
+use App\Models\BankingSyncLog;
+use Carbon\Carbon;
 use Carbon\CarbonInterface;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
@@ -23,6 +26,12 @@ use Illuminate\Support\Facades\Mail;
  * decided by those commands' own predicates, shared through
  * {@see QueriesBankFailures}, so the table cannot claim something different from
  * the notice it tells the operator to send.
+ *
+ * Every column but one is a snapshot of right now, which is how a six-day
+ * Openbank outage left no trace in this report the morning it recovered. The
+ * last column is the cure: the same banks measured against `banking_sync_logs`,
+ * the row the sync job writes on every run, so an outage is visible while it is
+ * happening and still legible once it is over.
  *
  * The metric is internal: nothing here is shown to a user, and the email goes to
  * REPORT_RECIPIENTS.
@@ -47,6 +56,24 @@ class BankHealthCommand extends Command
     ];
 
     /**
+     * A bank with no sync run to measure over the window, so the history half of
+     * the report has nothing to say about it either.
+     */
+    private const NO_SYNC_HISTORY = [
+        'runs' => 0,
+        'succeeded_runs' => 0,
+        'failed_runs' => 0,
+        'last_success_at' => null,
+    ];
+
+    /**
+     * How many runs must have failed before a drought counts as the bank's, rather
+     * than as a single bad cycle. The scheduler syncs every six hours, so four is
+     * a full day of them.
+     */
+    private const MIN_FAILED_RUNS = 4;
+
+    /**
      * The name and signature of the console command.
      *
      * @var string
@@ -54,7 +81,8 @@ class BankHealthCommand extends Command
     protected $signature = 'banking:health
                             {--email : Also email the owners about the banks that are broken for everyone}
                             {--repeat-after=7 : Days before the same bank can be alerted about again}
-                            {--stale-hours=48 : Hours without a successful sync before a live connection counts as failing}';
+                            {--stale-hours=48 : Hours without a successful sync before a live connection counts as failing}
+                            {--history-days=7 : Days of sync history to measure each bank\'s success rate over}';
 
     /**
      * The console command description.
@@ -94,12 +122,14 @@ class BankHealthCommand extends Command
     {
         $failures = $this->authorizationFailures();
         $sync = $this->syncHealth();
+        $history = $this->syncHistory();
 
         return $this->attempts()
             ->map(fn (array $bank, string $key) => $this->summarise([
                 ...$bank,
                 ...($failures->get($key) ?? ['failed_authorizations' => 0, 'affected_users' => 0]),
                 ...($sync[$key] ?? self::NO_LIVE_CONNECTIONS),
+                ...($history[$key] ?? self::NO_SYNC_HISTORY),
             ]))
             ->sortBy([['severity', 'desc'], ['failing', 'desc'], ['users', 'desc'], ['name', 'asc']])
             ->values();
@@ -152,6 +182,53 @@ class BankHealthCommand extends Command
                 'failed_authorizations' => (int) $row->failed_authorizations,
                 'affected_users' => (int) $row->affected_users,
             ]);
+    }
+
+    /**
+     * How every bank's syncs have actually gone, from the row the job writes on
+     * every run.
+     *
+     * This is the half of the report that outlives the outage. Everything else
+     * here is measured from the connections as they stand right now, so the six
+     * days Openbank spent answering nothing but 400s read as a healthy bank the
+     * morning it recovered, and read as a healthy bank all the way through too:
+     * only 4 of its 13 connections had gone stale enough for the snapshot to
+     * notice.
+     *
+     * `skipped` rows are left out. A run nobody attempted - a deleted owner, a
+     * lapsed consent, a backoff still in force - is evidence in neither
+     * direction, and rate limits alone account for most of them.
+     *
+     * The join is deliberately raw rather than a relation: it must see the logs
+     * of soft-deleted connections too, because a week of a bank's history should
+     * not disappear the moment one of its users disconnects.
+     *
+     * @return array<array-key, array{runs: int, succeeded_runs: int, failed_runs: int, last_success_at: CarbonInterface|null}>
+     */
+    private function syncHistory(): array
+    {
+        return BankingSyncLog::query()
+            ->join('banking_connections', 'banking_connections.id', '=', 'banking_sync_logs.banking_connection_id')
+            ->tap($this->matchesEnableBanking())
+            ->whereIn('banking_sync_logs.status', [BankingSyncLogStatus::Success, BankingSyncLogStatus::Failed])
+            ->where('banking_sync_logs.created_at', '>=', now()->subDays($this->historyDays()))
+            ->groupBy('banking_connections.aspsp_name', 'banking_connections.aspsp_country')
+            ->selectRaw(
+                'banking_connections.aspsp_name, banking_connections.aspsp_country, COUNT(*) as runs,'
+                .' SUM(CASE WHEN banking_sync_logs.status = ? THEN 1 ELSE 0 END) as succeeded_runs,'
+                .' MAX(CASE WHEN banking_sync_logs.status = ? THEN banking_sync_logs.created_at END) as last_success_at',
+                [BankingSyncLogStatus::Success->value, BankingSyncLogStatus::Success->value],
+            )
+            ->toBase()
+            ->get()
+            ->keyBy(fn (object $row): string => $this->bankIdentifier($row->aspsp_name, $row->aspsp_country))
+            ->map(fn (object $row): array => [
+                'runs' => (int) $row->runs,
+                'succeeded_runs' => (int) $row->succeeded_runs,
+                'failed_runs' => (int) $row->runs - (int) $row->succeeded_runs,
+                'last_success_at' => $row->last_success_at === null ? null : Carbon::parse($row->last_success_at),
+            ])
+            ->all();
     }
 
     /**
@@ -327,7 +404,48 @@ class BankHealthCommand extends Command
             return "unproven: never connects, {$bank['affected_users']} user(s)";
         }
 
+        // Ahead of the snapshot below because it is the better evidence when both
+        // fire: days of runs, rather than how the connections happen to look this
+        // minute.
+        if ($this->isDownInHistory($bank)) {
+            return $bank['last_success_at'] instanceof CarbonInterface
+                ? 'BROKEN: last good sync '.$bank['last_success_at']->diffForHumans()
+                : "BROKEN: no good sync in {$this->historyDays()}d";
+        }
+
         return $this->syncState($bank);
+    }
+
+    /**
+     * Whether the bank has gone this long without a single sync working, while
+     * still failing runs.
+     *
+     * This is the one verdict that does not need MIN_AFFECTED_USERS, and it is why
+     * the floor can stay where it is for the other two. That floor guards a
+     * judgement about single events - one rejected authorization is
+     * indistinguishable from one person cancelling at their bank - and a day of
+     * consecutive failed runs with nothing to show for it is not a single event.
+     * Renta 4 Banco is the bank this exists for: one user, so under the floor
+     * forever, and a transactions endpoint that has 400ed on every call for
+     * months.
+     *
+     * `syncing` rather than `live` is what makes it safe. A throttled connection
+     * fails its 429 run and then skips every run until the backoff elapses, so a
+     * bank that is merely rate limited looks exactly like this in the log -
+     * Trade Republic FR has 24 failed runs, no successes, and is working fine.
+     * isBackingOff() already holds those apart, so requiring one connection the
+     * provider is not throttling keeps them out.
+     *
+     * @param  array<string, mixed>  $bank
+     */
+    private function isDownInHistory(array $bank): bool
+    {
+        if ($bank['syncing'] === 0 || $bank['failed_runs'] < self::MIN_FAILED_RUNS) {
+            return false;
+        }
+
+        return ! $bank['last_success_at'] instanceof CarbonInterface
+            || $bank['last_success_at']->lessThan(now()->subHours($this->staleHours()));
     }
 
     /**
@@ -354,7 +472,7 @@ class BankHealthCommand extends Command
     private function severity(array $bank): int
     {
         return match (true) {
-            $this->neverAuthorizes($bank), $this->isFullyDown($bank) => 3,
+            $this->neverAuthorizes($bank), $this->isFullyDown($bank), $this->isDownInHistory($bank) => 3,
             $this->neverConnected($bank), $bank['failing'] > 0 => 2,
             $bank['rate_limited'] > 0 => 1,
             default => 0,
@@ -371,7 +489,7 @@ class BankHealthCommand extends Command
     {
         $command = match (true) {
             $this->neverAuthorizes($bank) => 'banking:notify-connect-failure',
-            $this->isFullyDown($bank) => 'banking:notify-outage',
+            $this->isFullyDown($bank), $this->isDownInHistory($bank) => 'banking:notify-outage',
             default => null,
         };
 
@@ -399,6 +517,16 @@ class BankHealthCommand extends Command
                 ."from {$bank['affected_users']} user(s), and not a single session in {$bank['attempts']} attempt(s).";
         }
 
+        if ($this->isDownInHistory($bank)) {
+            $lastGoodSync = $bank['last_success_at'] instanceof CarbonInterface
+                ? 'the last one that worked was '.$bank['last_success_at']->diffForHumans()
+                : 'not one has worked in that whole window';
+
+            return "Not a single sync to it has worked lately: {$bank['failed_runs']} failed run(s) out of {$bank['runs']} in the last "
+                ."{$this->historyDays()} day(s), across {$bank['syncing']} connection(s) the scheduler is still retrying, from "
+                ."{$bank['live_users']} user(s); {$lastGoodSync}.";
+        }
+
         if ($this->isFullyDown($bank)) {
             $lastSync = $bank['newest_failing_sync'] instanceof CarbonInterface
                 ? 'the most recent of them synced '.$bank['newest_failing_sync']->diffForHumans()
@@ -418,7 +546,7 @@ class BankHealthCommand extends Command
     private function renderReport(Collection $banks): void
     {
         $this->table(
-            ['Bank', 'Country', 'Attempts', 'Failed auth', 'Users', 'Connected', 'Live', 'Not syncing', 'Throttled', 'Newest sync', 'State'],
+            ['Bank', 'Country', 'Attempts', 'Failed auth', 'Users', 'Connected', 'Live', 'Not syncing', 'Throttled', 'Newest sync', "Runs ok ({$this->historyDays()}d)", 'State'],
             $banks->map(fn (array $bank): array => [
                 $bank['name'],
                 $bank['country'],
@@ -430,6 +558,7 @@ class BankHealthCommand extends Command
                 $bank['syncing'] > 0 ? "{$bank['failing']}/{$bank['syncing']}" : '-',
                 $bank['rate_limited'] ?: '-',
                 $bank['newest_sync'] instanceof CarbonInterface ? $bank['newest_sync']->diffForHumans() : 'never',
+                $this->successRate($bank),
                 $bank['state'],
             ])->all(),
         );
@@ -542,8 +671,32 @@ class BankHealthCommand extends Command
         return max(1, (int) $this->option('repeat-after'));
     }
 
+    /**
+     * What share of the window's runs worked, with the run count beside it so a
+     * bank with three runs is not read as one with three hundred.
+     *
+     * This is the column that keeps an outage legible after it ends: Openbank
+     * recovered on its own and every other column called it healthy the same day,
+     * while this one still read 5% of 405.
+     *
+     * @param  array<string, mixed>  $bank
+     */
+    private function successRate(array $bank): string
+    {
+        if ($bank['runs'] === 0) {
+            return '-';
+        }
+
+        return round($bank['succeeded_runs'] / $bank['runs'] * 100).'% of '.$bank['runs'];
+    }
+
     private function staleHours(): int
     {
         return max(1, (int) $this->option('stale-hours'));
+    }
+
+    private function historyDays(): int
+    {
+        return max(1, (int) $this->option('history-days'));
     }
 }

--- a/app/Console/Commands/BankHealthCommand.php
+++ b/app/Console/Commands/BankHealthCommand.php
@@ -201,7 +201,13 @@ class BankHealthCommand extends Command
      *
      * The join is deliberately raw rather than a relation: it must see the logs
      * of soft-deleted connections too, because a week of a bank's history should
-     * not disappear the moment one of its users disconnects.
+     * not disappear the moment one of its users disconnects one of them.
+     *
+     * A soft-deleted *owner* is the opposite case, and the reason `users` is
+     * joined at all. Nothing dispatches those connections, so their runs stopped
+     * when their owner left - and counting them would pad the evidence for this
+     * verdict with attempts nobody is making, which is precisely the defect
+     * matchesOutage() was missing its own whereHas('user') for.
      *
      * @return array<array-key, array{runs: int, succeeded_runs: int, failed_runs: int, last_success_at: CarbonInterface|null}>
      */
@@ -209,6 +215,8 @@ class BankHealthCommand extends Command
     {
         return BankingSyncLog::query()
             ->join('banking_connections', 'banking_connections.id', '=', 'banking_sync_logs.banking_connection_id')
+            ->join('users', 'users.id', '=', 'banking_connections.user_id')
+            ->whereNull('users.deleted_at')
             ->tap($this->matchesEnableBanking())
             ->whereIn('banking_sync_logs.status', [BankingSyncLogStatus::Success, BankingSyncLogStatus::Failed])
             ->where('banking_sync_logs.created_at', '>=', now()->subDays($this->historyDays()))
@@ -520,11 +528,14 @@ class BankHealthCommand extends Command
         if ($this->isDownInHistory($bank)) {
             $lastGoodSync = $bank['last_success_at'] instanceof CarbonInterface
                 ? 'the last one that worked was '.$bank['last_success_at']->diffForHumans()
-                : 'not one has worked in that whole window';
+                : 'not one of them has ever worked';
 
-            return "Not a single sync to it has worked lately: {$bank['failed_runs']} failed run(s) out of {$bank['runs']} in the last "
-                ."{$this->historyDays()} day(s), across {$bank['syncing']} connection(s) the scheduler is still retrying, from "
-                ."{$bank['live_users']} user(s); {$lastGoodSync}.";
+            // Two measurements, kept in separate sentences on purpose: the runs are
+            // every attempt in the window, the connections are the ones live right
+            // now, and they do not share a denominator.
+            return "Not a single sync to it has worked lately: {$bank['failed_runs']} of its {$bank['runs']} run(s) in the last "
+                ."{$this->historyDays()} day(s) failed, and {$lastGoodSync}. It still has {$bank['syncing']} connection(s) being "
+                ."retried against it, from {$bank['live_users']} user(s), and they are getting nothing.";
         }
 
         if ($this->isFullyDown($bank)) {

--- a/app/Console/Commands/Concerns/QueriesBankFailures.php
+++ b/app/Console/Commands/Concerns/QueriesBankFailures.php
@@ -83,11 +83,18 @@ trait QueriesBankFailures
      * This is what keeps a claim about the bank honest. An expired, revoked or
      * retry-capped connection is stuck for its own reason and its owner does have
      * to reconnect, which is the opposite of a bank-side outage.
+     *
+     * `whereHas('user')` is the half this mirror was missing, and it was the
+     * whole report: every failing connection in it - 43 of them, at ten banks -
+     * belonged to a soft-deleted account. Nothing syncs those, so their clocks
+     * are frozen at whenever their owner left and they read as permanently down.
+     * With them out, not one bank was degraded.
      */
     protected function matchesOutage(Closure $matchesBank): Closure
     {
         return fn (Builder $query) => $query
             ->tap($matchesBank)
+            ->whereHas('user')
             ->where(fn (Builder $query) => $query
                 ->where('status', BankingConnectionStatus::Active)
                 ->orWhere(fn (Builder $query) => $query

--- a/app/Console/Commands/NotifyBankOutageCommand.php
+++ b/app/Console/Commands/NotifyBankOutageCommand.php
@@ -110,7 +110,7 @@ class NotifyBankOutageCommand extends Command implements Isolatable
             - BankingConnection::query()->tap($matchesOutage)->count();
 
         if ($excluded > 0) {
-            $this->warn("Skipping {$excluded} other connection(s) to {$displayName}: expired, revoked or past the retry cap. Those need a reconnect, not this notice.");
+            $this->warn("Skipping {$excluded} other connection(s) to {$displayName}: expired, revoked, past the retry cap, or left behind by a deleted account. Those need a reconnect, not this notice.");
         }
     }
 
@@ -124,7 +124,7 @@ class NotifyBankOutageCommand extends Command implements Isolatable
         $existing = BankingConnection::query()->tap($this->matchesBank($aspsp, $country))->count();
 
         if ($existing > 0) {
-            $this->warn("{$existing} connection(s) to {$displayName} exist, but none is waiting on the bank: expired, revoked or past the retry cap. Those need a reconnect, not this notice.");
+            $this->warn("{$existing} connection(s) to {$displayName} exist, but none is waiting on the bank: expired, revoked, past the retry cap, or left behind by a deleted account. Those need a reconnect, not this notice.");
 
             return self::SUCCESS;
         }

--- a/resources/views/mail/bank-health-alert.blade.php
+++ b/resources/views/mail/bank-health-alert.blade.php
@@ -1,10 +1,11 @@
 <x-mail::message>
 # {{ count($banks) }} bank(s) broken for everyone
 
-Every connection to the bank(s) below is failing, so nobody using them is getting
-data. Each one has a command that tells its users, ready to paste — it runs as a
-dry run, so it only lists who would be emailed. Drop `--dry-run` from the end to
-actually send it, and it will ask for confirmation first.
+Nothing is getting through to the bank(s) below, so nobody using them is getting
+data — the line under each one says how we know. Each has a command that tells its
+users, ready to paste; it runs as a dry run, so it only lists who would be
+emailed. Drop `--dry-run` from the end to actually send it, and it will ask for
+confirmation first.
 
 @if ($looksLikeProviderOutage)
 **Check Enable Banking first.** This is most of the banks we have a live

--- a/tests/Feature/Console/BankHealthCommandTest.php
+++ b/tests/Feature/Console/BankHealthCommandTest.php
@@ -359,6 +359,24 @@ test('does not blame a bank for the connections of users who deleted their accou
     Mail::assertNothingOutgoing();
 });
 
+test('does not pad a bank\'s failure history with runs from a deleted account', function () {
+    // The same contamination as the snapshot columns, one table over: nothing has
+    // dispatched the departed user's connection since they left, so counting its
+    // runs would let a bank be called broken on evidence nobody is producing.
+    $left = healthConnection('Half Abandoned Bank', ['last_synced_at' => now()->subDays(9)]);
+    failedRuns($left, 8);
+    $left->user->delete();
+
+    // One live connection, failing, but nowhere near a day's worth of cycles.
+    failedRuns(healthConnection('Half Abandoned Bank'), 2);
+
+    artisan('banking:health', ['--email' => true])
+        ->expectsOutputToContain('No bank is broken for everyone. Nothing to alert about.')
+        ->assertSuccessful();
+
+    Mail::assertNothingOutgoing();
+});
+
 test('reports a bank whose every run failed, on one user\'s evidence', function () {
     // Renta 4 Banco's shape: its balances answer, so the connection's clock keeps
     // being written and every snapshot column reads it as healthy, while its
@@ -373,8 +391,8 @@ test('reports a bank whose every run failed, on one user\'s evidence', function 
         ->and(alertedBanks()[0]['notify_command'])
         ->toBe('php artisan banking:notify-outage "Renta 4 Banco" --country=ES')
         ->and(alertedBanks()[0]['reason'])
-        ->toContain('4 failed run(s) out of 4 in the last 7 day(s)')
-        ->toContain('not one has worked in that whole window');
+        ->toContain('4 of its 4 run(s) in the last 7 day(s) failed')
+        ->toContain('not one of them has ever worked');
 });
 
 test('reports a bank still failing every run while some of its connections look fresh', function () {
@@ -391,7 +409,7 @@ test('reports a bank still failing every run while some of its connections look 
     artisan('banking:health', ['--email' => true])->assertSuccessful();
 
     expect(alertedBanks()[0]['reason'])
-        ->toContain('16 failed run(s) out of 17 in the last 7 day(s)')
+        ->toContain('16 of its 17 run(s) in the last 7 day(s) failed')
         ->toContain('the last one that worked was 4 days ago');
 });
 

--- a/tests/Feature/Console/BankHealthCommandTest.php
+++ b/tests/Feature/Console/BankHealthCommandTest.php
@@ -460,6 +460,22 @@ test('a run nobody attempted is evidence in neither direction', function () {
     Mail::assertNothingOutgoing();
 });
 
+test('leaves a bank alone once its connections are past the retry cap', function () {
+    // Nothing dispatches these any more, so the history stops at whenever they
+    // were given up on. Their owners have to reconnect, which is the opposite of
+    // what banking:notify-outage would tell them - and it refuses them too.
+    failedRuns(healthConnection('Stranded Bank', [
+        'status' => BankingConnectionStatus::Error,
+        'consecutive_sync_failures' => SyncBankingConnectionJob::MAX_SCHEDULED_RETRIES,
+    ]), 8);
+
+    artisan('banking:health', ['--email' => true])
+        ->expectsOutputToContain('No bank is broken for everyone. Nothing to alert about.')
+        ->assertSuccessful();
+
+    Mail::assertNothingOutgoing();
+});
+
 test('the history window decides how far back the runs are read', function () {
     $connection = healthConnection('Old News Bank');
 

--- a/tests/Feature/Console/BankHealthCommandTest.php
+++ b/tests/Feature/Console/BankHealthCommandTest.php
@@ -1,10 +1,13 @@
 <?php
 
 use App\Enums\BankingConnectionStatus;
+use App\Enums\BankingSyncLogStatus;
 use App\Jobs\SyncBankingConnectionJob;
 use App\Mail\BankHealthAlertEmail;
 use App\Models\BankingConnection;
+use App\Models\BankingSyncLog;
 use App\Models\User;
+use Carbon\CarbonInterface;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Mail;
 
@@ -52,6 +55,28 @@ function rejectedAuthorization(string $bank): BankingConnection
 function stalledConnection(string $bank): BankingConnection
 {
     return healthConnection($bank, ['last_synced_at' => now()->subDays(5)]);
+}
+
+/**
+ * A run the sync job recorded against a connection.
+ */
+function syncRun(BankingConnection $connection, BankingSyncLogStatus $status, CarbonInterface $at): void
+{
+    BankingSyncLog::create([
+        'banking_connection_id' => $connection->id,
+        'status' => $status,
+        'created_at' => $at,
+    ]);
+}
+
+/**
+ * One failed run per scheduled cycle, counting back from now.
+ */
+function failedRuns(BankingConnection $connection, int $cycles): void
+{
+    foreach (range(1, $cycles) as $cycle) {
+        syncRun($connection, BankingSyncLogStatus::Failed, now()->subHours($cycle * 6));
+    }
 }
 
 /**
@@ -318,4 +343,137 @@ test('blames the bank when it is the only one failing', function () {
     artisan('banking:health', ['--email' => true])->assertSuccessful();
 
     Mail::assertSent(BankHealthAlertEmail::class, fn (BankHealthAlertEmail $mail) => ! $mail->looksLikeProviderOutage);
+});
+
+test('does not blame a bank for the connections of users who deleted their accounts', function () {
+    // Every failing connection in the production report was one of these: nothing
+    // syncs them, so their clocks are frozen at whenever their owner left and they
+    // read as permanently down. Ten banks were being reported as degraded on them.
+    stalledConnection('Abandoned Bank')->user->delete();
+    stalledConnection('Abandoned Bank')->user->delete();
+
+    artisan('banking:health', ['--email' => true])
+        ->expectsOutputToContain('No bank is broken for everyone. Nothing to alert about.')
+        ->assertSuccessful();
+
+    Mail::assertNothingOutgoing();
+});
+
+test('reports a bank whose every run failed, on one user\'s evidence', function () {
+    // Renta 4 Banco's shape: its balances answer, so the connection's clock keeps
+    // being written and every snapshot column reads it as healthy, while its
+    // transactions call has 400ed on every attempt for months. One user, so the
+    // two-user floor would hide it forever.
+    failedRuns(healthConnection('Renta 4 Banco'), 4);
+
+    artisan('banking:health', ['--email' => true])->assertSuccessful();
+
+    expect(alertedBanks())->toHaveCount(1)
+        ->and(alertedBanks()[0]['display_name'])->toBe('Renta 4 Banco (ES)')
+        ->and(alertedBanks()[0]['notify_command'])
+        ->toBe('php artisan banking:notify-outage "Renta 4 Banco" --country=ES')
+        ->and(alertedBanks()[0]['reason'])
+        ->toContain('4 failed run(s) out of 4 in the last 7 day(s)')
+        ->toContain('not one has worked in that whole window');
+});
+
+test('reports a bank still failing every run while some of its connections look fresh', function () {
+    // Openbank during its six-day outage: only 4 of its 13 connections had been
+    // quiet long enough for the snapshot to call them failing, so the report saw a
+    // bank that was merely degraded and never alerted.
+    $stopped = healthConnection('Openbank', ['last_synced_at' => now()->subDays(5)]);
+    $stillFresh = healthConnection('Openbank');
+
+    failedRuns($stopped, 8);
+    failedRuns($stillFresh, 8);
+    syncRun($stillFresh, BankingSyncLogStatus::Success, now()->subDays(4));
+
+    artisan('banking:health', ['--email' => true])->assertSuccessful();
+
+    expect(alertedBanks()[0]['reason'])
+        ->toContain('16 failed run(s) out of 17 in the last 7 day(s)')
+        ->toContain('the last one that worked was 4 days ago');
+});
+
+test('keeps a recovered outage legible in the report', function () {
+    // The bank is answering again, so every snapshot column calls it healthy on
+    // the morning it recovers. The window is the only place the six days it spent
+    // down are still visible.
+    $connection = healthConnection('Recovered Bank');
+    failedRuns($connection, 8);
+    syncRun($connection, BankingSyncLogStatus::Success, now()->subHour());
+
+    artisan('banking:health', ['--email' => true])
+        ->expectsOutputToContain('11% of 9')
+        ->expectsOutputToContain('No bank is broken for everyone. Nothing to alert about.')
+        ->assertSuccessful();
+
+    Mail::assertNothingOutgoing();
+});
+
+test('does not read a throttled bank as an outage from its history', function () {
+    // Trade Republic FR: 24 failed runs, not one success, and working fine. The
+    // 429 fails the run that hits it, and every run after it is skipped until the
+    // backoff elapses, so a rate limit reads exactly like a dead connector.
+    failedRuns(healthConnection('Trade Republic', ['rate_limited_until' => now()->addHour()]), 8);
+
+    artisan('banking:health', ['--email' => true])
+        ->expectsOutputToContain('No bank is broken for everyone. Nothing to alert about.')
+        ->assertSuccessful();
+
+    Mail::assertNothingOutgoing();
+});
+
+test('does not call a single bad cycle a drought', function () {
+    failedRuns(healthConnection('Blip Bank'), 3);
+
+    artisan('banking:health', ['--email' => true])
+        ->expectsOutputToContain('No bank is broken for everyone. Nothing to alert about.')
+        ->assertSuccessful();
+
+    Mail::assertNothingOutgoing();
+});
+
+test('a bank that synced inside the staleness window is not down', function () {
+    $connection = healthConnection('Flaky But Alive Bank');
+    failedRuns($connection, 8);
+    syncRun($connection, BankingSyncLogStatus::Success, now()->subHours(12));
+
+    artisan('banking:health', ['--email' => true])
+        ->expectsOutputToContain('No bank is broken for everyone. Nothing to alert about.')
+        ->assertSuccessful();
+
+    Mail::assertNothingOutgoing();
+});
+
+test('a run nobody attempted is evidence in neither direction', function () {
+    $connection = healthConnection('Skipped Bank');
+
+    foreach (range(1, 8) as $cycle) {
+        syncRun($connection, BankingSyncLogStatus::Skipped, now()->subHours($cycle * 6));
+    }
+
+    artisan('banking:health', ['--email' => true])
+        ->expectsOutputToContain('No bank is broken for everyone. Nothing to alert about.')
+        ->assertSuccessful();
+
+    Mail::assertNothingOutgoing();
+});
+
+test('the history window decides how far back the runs are read', function () {
+    $connection = healthConnection('Old News Bank');
+
+    foreach (range(1, 8) as $cycle) {
+        syncRun($connection, BankingSyncLogStatus::Failed, now()->subDays(10)->subHours($cycle));
+    }
+
+    artisan('banking:health', ['--email' => true])
+        ->expectsOutputToContain('No bank is broken for everyone. Nothing to alert about.')
+        ->assertSuccessful();
+
+    Mail::assertNothingOutgoing();
+
+    artisan('banking:health', ['--email' => true, '--history-days' => 14])->assertSuccessful();
+
+    expect(alertedBanks()[0]['display_name'])->toBe('Old News Bank (ES)');
 });

--- a/tests/Feature/Console/NotifyBankOutageCommandTest.php
+++ b/tests/Feature/Console/NotifyBankOutageCommandTest.php
@@ -144,6 +144,9 @@ test('skips soft-deleted users', function () {
     outageUser('deleted@example.com')->delete();
 
     artisan('banking:notify-outage', ['aspsp' => 'QA Outage Bank', '--force' => true])
+        // Nothing syncs a connection whose owner is gone, so it is not waiting on
+        // the bank either - which is what `banking:health` was counting it as.
+        ->expectsOutputToContain('none is waiting on the bank')
         ->assertSuccessful();
 
     Mail::assertNothingOutgoing();


### PR DESCRIPTION
`banking:health` was reporting a population that does not exist, and forgetting an
outage the moment it ended. Three fixes, all in the report and the two
`banking:notify-*` commands that share its definitions.

## The report blamed banks for users who had left

`QueriesBankFailures::matchesOutage()` mirrors `SyncAllBankingConnectionsJob`'s
dispatch filter, which is what keeps a claim about a bank honest — except the job
also has `->whereHas('user')` and the mirror did not.

Measured against production: **43 connections counted as "not syncing" were 100%
owned by soft-deleted users** — every single failing connection in the report.
They made it blame Revolut ES (10), ING ES (8), BBVA (4), CaixaBank (4), Bankinter
(2) and imagin (2) for outages that do not exist. With them excluded, **not one
bank is degraded.** Their `updated_at` is frozen at their last successful sync,
and Enable Banking's own call log shows these sessions stop receiving API calls on
the day of deletion, so they waste no quota — the defect was purely in the
reporting.

One `->whereHas('user')`, in the trait, so the report and both notify commands
agree. `banking:notify-outage` now also names a deleted account among the reasons
a connection is not waiting on the bank, since that is the answer an operator now
gets for one.

## A six-day total outage left no trace

Openbank was completely broken from 12 to 20 Aug — 1,149 provider errors
(`ASPSP_ERROR`, 400) split evenly between `balances` and `transactions`, one user
accumulating 553 of them. It recovered on its own on the 21st, and by that morning
every column of this report called it healthy, because every column was a snapshot
of current state. It never alerted while it *was* broken either: `isFullyDown()`
wants every connection of the bank to look stale, and only 4 of its 13 did.

`banking_sync_logs` had the whole thing on record — 64 to 88 `failed` rows a day
with zero successes — and the report simply never read it. It does now:

- a **`Runs ok (Nd)` column** (`--history-days`, default 7) beside today's state,
  so an outage is visible while it happens and still legible after it ends;
- a **verdict** for a bank that has not had one sync work in longer than
  `--stale-hours` while still failing runs.

`skipped` rows are left out — a run nobody attempted is evidence in neither
direction — and so is any run belonging to a connection whose owner has left,
which is the same fix as above one table over.

## The 2-user floor hid a bank broken for 75 days

`Renta 4 Banco` has one user, so `MIN_AFFECTED_USERS = 2` meant it could never be
reported. Its shape is the nasty one: `balances` returns 200 while `transactions`
returns 400 `ASPSP_ERROR` on every single call, so the connection's clock keeps
being written and every snapshot column reads it as perfectly healthy while it has
zero transactions and always will.

The floor stays where it is — one person cancelling twice at their bank is
genuinely indistinguishable from a broken connector — but the new verdict does not
use it. That floor guards a judgement about single events, and a day of
consecutive failed runs with nothing to show for it is not a single event, whether
one user is behind it or twenty.

What keeps that safe is `syncing > 0`: a rate limit fails the run that hits it and
skips every run after until the backoff elapses, so a merely throttled bank looks
identical in the log. Trade Republic FR is the whole argument — 24 failed runs, not
one success, working fine — and `isBackingOff()` already holds those apart, so
requiring one connection the provider is not throttling keeps them out.

## Backtested against production

Replaying the verdict over the real sync log:

| As of | Fires on |
| --- | --- |
| 13 Aug | nothing (only throttled Trade Republic, which `syncing > 0` excludes) |
| **14 Aug** | **Openbank ES** — two days into the outage |
| 17 Aug | Openbank ES |
| today | nothing at all |

`consecutive_sync_failures` is deliberately still not a signal anywhere: it is 0 on
every live connection in production, because it is only written on the path that
also caps the retries, and passing the cap removes the connection from this
population altogether.

## Notes

- A bank whose connections have all crossed the retry cap stays silent however
  total its failure history, because it leaves `syncing` at zero. That is the
  existing doctrine — past the cap the user has to reconnect, and
  `banking:notify-outage` refuses to write to them — and there is now a test
  saying so, since nothing did.
- No index was added to `banking_sync_logs`: 81k rows total, 8.5k in a 7-day
  window, read once a day.
- A beta-connector flag would sharpen this report further (Enable Banking marks
  the connectors it does not stand behind, and they predict which banks break),
  but it is out of scope here and belongs with whoever owns the provider catalogue.

## Testing

- 30 tests on `banking:health`, covering each shape above from real production
  data: the departed-account population, the outage that is still failing while
  some connections look fresh, the recovered outage still legible in the column,
  the throttled bank that must not be alerted on, the single bad cycle, the
  history window, and the retry cap.
- Ran end to end locally against seeded replicas of all four shapes: the report,
  the alert email, and the `banking:notify-outage` command it recommends, which
  resolves the right single user and refuses the departed-account bank.
- `pest`, `pint --test`, `phpstan`, `crap`, `dry` green.
