### PR TITLE
fix(banking): call the balances endpoint before the pagination that starves it

### DIFF
--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 /**
  * @property AccountType $type
  * @property ?Carbon $archived_at
+ * @property ?Carbon $transactions_paginate_before
  */
 class Account extends Model
 {
@@ -37,6 +38,7 @@ class Account extends Model
         'encrypted',
         'banking_connection_id',
         'external_account_id',
+        'transactions_paginate_before',
         'iban',
         'linked_at',
         'position',
@@ -51,6 +53,7 @@ class Account extends Model
         'user_id',
         'space_id',
         'bank_id',
+        'transactions_paginate_before',
         'iban',
         'position',
         'hidden_on_dashboard',
@@ -85,6 +88,7 @@ class Account extends Model
             'type' => AccountType::class,
             'encrypted' => 'boolean',
             'linked_at' => 'datetime',
+            'transactions_paginate_before' => 'date',
             'position' => 'integer',
             'hidden_on_dashboard' => 'boolean',
             'archived_at' => 'datetime',

--- a/app/Services/Banking/Sync/EnableBankingSyncer.php
+++ b/app/Services/Banking/Sync/EnableBankingSyncer.php
@@ -188,15 +188,37 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
         // window is built on has already moved past it.
         $resumeBefore = $account->transactions_paginate_before?->toDateString();
 
+        if ($resumeBefore !== null) {
+            $dateFrom = $this->resolveDateFrom($account, $resumeBefore, forceFullWindow: true);
+
+            // Unless the full window has since closed over the marker: it moves
+            // forward a day at a time, so a marker left alone for long enough
+            // ends up before the start of the history we ask for and there is
+            // nothing left to walk back to. Falling through to the routine
+            // window is what keeps that from inverting into date_from > date_to;
+            // the run that ends without being cut short clears the marker.
+            if ($dateFrom < $resumeBefore) {
+                return [$dateFrom, $resumeBefore, $this->strategyFor($dateFrom)];
+            }
+        }
+
         // A first sync on a connection that has synced before can only come from
         // the --full flag, an explicit request to re-pull the whole history.
-        $forceFullWindow = $resumeBefore !== null || ($isFirstSync && $connection->last_synced_at !== null);
+        $forceFullWindow = $isFirstSync && $connection->last_synced_at !== null;
 
-        $dateTo = $resumeBefore ?? now()->toDateString();
+        $dateTo = now()->toDateString();
         $dateFrom = $this->resolveDateFrom($account, $dateTo, $forceFullWindow);
-        $shortWindowStart = now()->subDays(self::SHORT_WINDOW_DAYS)->toDateString();
 
-        return [$dateFrom, $dateTo, $dateFrom < $shortWindowStart ? 'longest' : null];
+        return [$dateFrom, $dateTo, $this->strategyFor($dateFrom)];
+    }
+
+    /**
+     * The strategy a window starting this far back needs, or null when it is
+     * narrow enough to ask for plainly.
+     */
+    private function strategyFor(string $dateFrom): ?string
+    {
+        return $dateFrom < now()->subDays(self::SHORT_WINDOW_DAYS)->toDateString() ? 'longest' : null;
     }
 
     /**

--- a/app/Services/Banking/Sync/EnableBankingSyncer.php
+++ b/app/Services/Banking/Sync/EnableBankingSyncer.php
@@ -50,8 +50,6 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
 
     public function sync(BankingConnection $connection, bool $isFirstSync): array
     {
-        $dateTo = now()->toDateString();
-
         $transactionsPerBank = [];
         $balanceFailed = 0;
         $balanceRateLimitFailure = null;
@@ -60,15 +58,33 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
         $accountsAttempted = 0;
 
         $connection->load('accounts.bank');
+        $pageBudget = $this->pageBudget($connection);
 
         try {
             foreach ($connection->accounts as $account) {
                 $created = 0;
                 $accountsAttempted++;
-                [$dateFrom, $strategy] = $this->resolveWindow($connection, $account, $dateTo, $isFirstSync);
+                [$dateFrom, $dateTo, $strategy] = $this->resolveWindow($connection, $account, $isFirstSync);
+
+                // Read before the balance sync below writes today's row.
+                $owedBackfill = $this->owesHistoricalBalances($account, $isFirstSync);
+
+                // Balances first, and deliberately so. The transactions call is
+                // the paginated one: it is what spends the consent's metered
+                // daily allowance, and it is what throws. A balance call queued
+                // behind it is the call that never happens - Trade Republic made
+                // 5,740 transaction requests in the week to 2026-08-21 and not
+                // one balance request, because every run died paginating before
+                // it got here. One request per account, taken while there is
+                // still allowance left to take it with.
+                $balanceSynced = $this->syncBalances($connection, $account, $balanceRateLimitFailure);
+
+                if (! $balanceSynced) {
+                    $balanceFailed++;
+                }
 
                 try {
-                    $created = $this->transactionSync->sync($account, $dateFrom, $dateTo, $strategy, saveDailyBalances: ! $account->isLinked());
+                    $created = $this->transactionSync->sync($account, $dateFrom, $dateTo, $strategy, saveDailyBalances: ! $account->isLinked(), pageBudget: $pageBudget);
                 } catch (InaccessibleBankAccountException|WrongTransactionsPeriodException $e) {
                     // A single account the bank no longer exposes, or whose history
                     // window it refuses even after narrowing, must not break the
@@ -87,9 +103,9 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
 
                 $transactionsPerBank = $this->tally($transactionsPerBank, $account, $created);
 
-                if (! $this->syncBalances($connection, $account, $isFirstSync, $balanceRateLimitFailure)) {
-                    $balanceFailed++;
-                }
+                // Local arithmetic over the rows just imported, so unlike the
+                // balance request itself this half has to follow them.
+                $this->backfillHistoricalBalances($connection, $account, $owedBackfill && $balanceSynced);
             }
         } catch (\Throwable $e) {
             $this->logAbortedSync($connection, $e, [
@@ -121,11 +137,7 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
             throw $transactionFailure;
         }
 
-        if ($isFirstSync) {
-            $connection->update(['bank_transactions_email_cutoff_at' => now()]);
-        } elseif ($connection->user->canReceiveEmails()) {
-            SendDailyBankTransactionsSyncedEmailJob::dispatch($connection->user, now()->toDateString());
-        }
+        $this->notifyRunCompleted($connection, $isFirstSync);
 
         return [
             'transactions_synced' => array_sum($transactionsPerBank),
@@ -165,18 +177,44 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
     /**
      * The window to ask the bank for, and the strategy a window that wide needs.
      *
-     * @return array{0: string, 1: string|null}
+     * @return array{0: string, 1: string, 2: string|null}
      */
-    private function resolveWindow(BankingConnection $connection, Account $account, string $dateTo, bool $isFirstSync): array
+    private function resolveWindow(BankingConnection $connection, Account $account, bool $isFirstSync): array
     {
+        // A previous run ran out of page budget partway down this account's
+        // history. The provider serves pages newest-first, so picking up where
+        // it stopped means ending the window there instead of at today - and
+        // asking for the full history again, because the watermark the routine
+        // window is built on has already moved past it.
+        $resumeBefore = $account->transactions_paginate_before?->toDateString();
+
         // A first sync on a connection that has synced before can only come from
         // the --full flag, an explicit request to re-pull the whole history.
-        $forceFullWindow = $isFirstSync && $connection->last_synced_at !== null;
+        $forceFullWindow = $resumeBefore !== null || ($isFirstSync && $connection->last_synced_at !== null);
 
+        $dateTo = $resumeBefore ?? now()->toDateString();
         $dateFrom = $this->resolveDateFrom($account, $dateTo, $forceFullWindow);
         $shortWindowStart = now()->subDays(self::SHORT_WINDOW_DAYS)->toDateString();
 
-        return [$dateFrom, $dateFrom < $shortWindowStart ? 'longest' : null];
+        return [$dateFrom, $dateTo, $dateFrom < $shortWindowStart ? 'longest' : null];
+    }
+
+    /**
+     * How many transaction pages one account may cost this connection's bank,
+     * from `config('banking.transaction_page_budget')`. PHP_INT_MAX is
+     * unbudgeted, which is every bank that has not needed an entry.
+     */
+    private function pageBudget(BankingConnection $connection): int
+    {
+        $budgets = config('banking.transaction_page_budget');
+
+        if (! is_array($budgets)) {
+            return PHP_INT_MAX;
+        }
+
+        $budget = $budgets[$connection->aspsp_name ?? ''] ?? $budgets['default'] ?? null;
+
+        return is_int($budget) && $budget > 0 ? $budget : PHP_INT_MAX;
     }
 
     /**
@@ -208,7 +246,7 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
     }
 
     /**
-     * Sync one account's balances, tolerating a provider that will not serve them.
+     * Fetch one account's balances, tolerating a provider that will not serve them.
      *
      * `$rateLimitFailure` is filled in with the 429 when the provider rate limited
      * the call, so the caller can hand the job what its backoff policy needs.
@@ -219,25 +257,14 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
      *
      * @return bool Whether the balances were synced
      */
-    private function syncBalances(BankingConnection $connection, Account $account, bool $isFirstSync, ?RequestException &$rateLimitFailure): bool
+    private function syncBalances(BankingConnection $connection, Account $account, ?RequestException &$rateLimitFailure): bool
     {
         if ($rateLimitFailure !== null) {
             return false;
         }
 
-        // Read before the sync below writes today's row. The backfill used to be
-        // spent on the first sync alone, which was safe while a refused balance
-        // call discarded the whole run and left the next one a first sync too.
-        // Now that the run is kept, an account that has never had a balance is
-        // still owed it; the backfill only ever writes dates it has not written.
-        $backfillPending = $isFirstSync || $account->balances()->doesntExist();
-
         try {
             $this->balanceSync->sync($account);
-
-            if ($backfillPending && ! $account->isLinked()) {
-                $this->balanceSync->calculateHistoricalBalances($account);
-            }
 
             return true;
         } catch (\Throwable $e) {
@@ -274,11 +301,73 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
     }
 
     /**
-     * Tally what one account imported, under the bank it came from.
+     * What a completed run leaves behind: the cutoff that keeps the daily email
+     * from reporting a whole imported history as today's news, or the email
+     * itself on every run after that.
+     */
+    private function notifyRunCompleted(BankingConnection $connection, bool $isFirstSync): void
+    {
+        if ($isFirstSync) {
+            $connection->update(['bank_transactions_email_cutoff_at' => now()]);
+
+            return;
+        }
+
+        if ($connection->user->canReceiveEmails()) {
+            SendDailyBankTransactionsSyncedEmailJob::dispatch($connection->user, now()->toDateString());
+        }
+    }
+
+    /**
+     * Whether this account is still owed the daily balances derived from its
+     * transactions.
      *
-     * Counted before the balances call, which is the one that throws most often:
-     * a tally taken after it would report zero imported for a run that had in
-     * fact just imported them.
+     * Read before the balance sync writes today's row. The backfill used to be
+     * spent on the first sync alone, which was safe while a refused balance call
+     * discarded the whole run and left the next one a first sync too. Now that
+     * the run is kept, an account that has never had a balance is still owed it;
+     * the backfill only ever writes dates it has not written.
+     *
+     * A linked account's balances are its counterpart's, not its own.
+     */
+    private function owesHistoricalBalances(Account $account, bool $isFirstSync): bool
+    {
+        if ($account->isLinked()) {
+            return false;
+        }
+
+        return $isFirstSync || $account->balances()->doesntExist();
+    }
+
+    /**
+     * Fill in the days between the balance the bank reported and the
+     * transactions just imported.
+     *
+     * Local arithmetic, so unlike the balance request itself this half has to
+     * follow the transactions - and it is tolerated the same way, because it is
+     * derived data. Letting it end the run would leave `last_synced_at` unset
+     * over already-persisted transactions and charge the connection a strike
+     * towards being dropped from the schedule for good.
+     */
+    private function backfillHistoricalBalances(BankingConnection $connection, Account $account, bool $owed): void
+    {
+        if (! $owed) {
+            return;
+        }
+
+        try {
+            $this->balanceSync->calculateHistoricalBalances($account);
+        } catch (\Throwable $e) {
+            Log::warning('EnableBanking historical balance backfill failed, continuing', [
+                ...$connection->logContext(),
+                'account_id' => $account->id,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Tally what one account imported, under the bank it came from.
      *
      * @param  array<string, int>  $transactionsPerBank
      * @return array<string, int>

--- a/app/Services/Banking/Sync/EnableBankingSyncer.php
+++ b/app/Services/Banking/Sync/EnableBankingSyncer.php
@@ -186,7 +186,13 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
         // it stopped means ending the window there instead of at today - and
         // asking for the full history again, because the watermark the routine
         // window is built on has already moved past it.
-        $resumeBefore = $account->transactions_paginate_before?->toDateString();
+        //
+        // Until it drains, the account's window ends in the past, so its newest
+        // transactions wait for the backfill to finish. That is the accepted
+        // cost: the balance, which is what reads as zero today, is fetched on
+        // every one of those runs regardless. A --full resync is an explicit
+        // request to re-pull everything, so it starts over rather than resuming.
+        $resumeBefore = $isFirstSync ? null : $account->transactions_paginate_before?->toDateString();
 
         if ($resumeBefore !== null) {
             $dateFrom = $this->resolveDateFrom($account, $resumeBefore, forceFullWindow: true);
@@ -329,7 +335,12 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
      */
     private function notifyRunCompleted(BankingConnection $connection, bool $isFirstSync): void
     {
-        if ($isFirstSync) {
+        // A run still walking an account's history back is importing rows dated
+        // months ago, and the daily email keys on when a row was written rather
+        // than when it happened. Announcing those as today's news is the very
+        // thing the cutoff exists to prevent, so it moves with the backfill and
+        // the email waits until there is no history left owed.
+        if ($isFirstSync || $this->isBackfillingHistory($connection)) {
             $connection->update(['bank_transactions_email_cutoff_at' => now()]);
 
             return;
@@ -338,6 +349,17 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
         if ($connection->user->canReceiveEmails()) {
             SendDailyBankTransactionsSyncedEmailJob::dispatch($connection->user, now()->toDateString());
         }
+    }
+
+    /**
+     * Whether any of this connection's accounts still owes history to a run the
+     * page budget cut short.
+     */
+    private function isBackfillingHistory(BankingConnection $connection): bool
+    {
+        return $connection->accounts->contains(
+            fn (Account $account) => $account->transactions_paginate_before !== null
+        );
     }
 
     /**

--- a/app/Services/Banking/TransactionSyncService.php
+++ b/app/Services/Banking/TransactionSyncService.php
@@ -30,15 +30,23 @@ class TransactionSyncService
     /**
      * Sync transactions for a connected account.
      *
+     * `$pageBudget` caps how many pages this run will fetch, for banks that
+     * meter a consent so tightly that unbounded pagination spends the whole
+     * allowance before the sync reaches anything else. The default is as many
+     * as it takes, which is what every bank without an entry in
+     * `config('banking.transaction_page_budget')` gets.
+     *
      * @return int Number of new transactions created
      */
-    public function sync(Account $account, string $dateFrom, string $dateTo, ?string $strategy = null, bool $saveDailyBalances = true): int
+    public function sync(Account $account, string $dateFrom, string $dateTo, ?string $strategy = null, bool $saveDailyBalances = true, int $pageBudget = PHP_INT_MAX): int
     {
         if (! $account->external_account_id) {
             return 0;
         }
 
         $created = 0;
+        $pages = 0;
+        $oldestSeen = null;
         $continuationKey = null;
         $dailyBalances = [];
         $bankName = $account->bank?->name;
@@ -73,6 +81,8 @@ class TransactionSyncService
                         $strategy,
                     );
 
+                    $pages++;
+
                     foreach ($result['transactions'] as $transaction) {
                         if ($this->importTransaction($account, $transaction, $bankName, $knownFingerprints, $knownExternalIds)) {
                             $created++;
@@ -83,8 +93,9 @@ class TransactionSyncService
                         }
                     }
 
+                    $oldestSeen = $this->oldestDate($oldestSeen, $result['transactions']);
                     $continuationKey = $result['continuation_key'];
-                } while ($continuationKey);
+                } while ($continuationKey && $pages < $pageBudget);
 
                 break;
             } catch (WrongTransactionsPeriodException $e) {
@@ -110,14 +121,72 @@ class TransactionSyncService
             $this->saveDailyBalances($account, $dailyBalances);
         }
 
+        $this->recordPaginationFrontier($account, $continuationKey !== null, $oldestSeen, $dateTo);
+
         Log::info('Synced transactions', [
             'account_id' => $account->id,
             'new_transactions' => $created,
             'date_from' => $dateFrom,
             'date_to' => $dateTo,
+            'pages' => $pages,
         ]);
 
         return $created;
+    }
+
+    /**
+     * The earliest booking date across a page and everything seen before it.
+     *
+     * Dates are 'Y-m-d', where string order is date order.
+     *
+     * @param  array<int, array<string, mixed>>  $transactions
+     */
+    private function oldestDate(?string $oldestSeen, array $transactions): ?string
+    {
+        foreach ($transactions as $transaction) {
+            $date = $this->parseDate($transaction);
+            $oldestSeen = $oldestSeen === null || $date < $oldestSeen ? $date : $oldestSeen;
+        }
+
+        return $oldestSeen;
+    }
+
+    /**
+     * Remember where a run the page budget cut short stopped, so the next one
+     * resumes there instead of re-reading the pages this one already has.
+     *
+     * The marker has to exist because the window start is derived from the
+     * *newest* transaction we hold, while the provider paginates
+     * **newest-first** - verified 2026-08-21 against production insert order,
+     * which runs newest to oldest on every bank we sync, Trade Republic
+     * included. A truncated run therefore holds the recent end of the window
+     * and moves that watermark to today, so without a marker the next run would
+     * ask for the same recent days again and the older history would never be
+     * reached.
+     *
+     * Cleared by a run that paginated to the end, and by one that was cut short
+     * without reaching anything older than it was already asked for: there is
+     * nothing further back to walk to, and keeping the marker would re-request
+     * the same window every cycle.
+     */
+    private function recordPaginationFrontier(Account $account, bool $truncated, ?string $oldestSeen, string $dateTo): void
+    {
+        $frontier = $truncated && $oldestSeen !== null && $oldestSeen < $dateTo ? $oldestSeen : null;
+        $current = $account->transactions_paginate_before?->toDateString();
+
+        if ($truncated) {
+            Log::warning('Transaction page budget stopped the sync early', [
+                'account_id' => $account->id,
+                'date_to' => $dateTo,
+                'resume_before' => $frontier,
+            ]);
+        }
+
+        if ($frontier === $current) {
+            return;
+        }
+
+        $account->update(['transactions_paginate_before' => $frontier]);
     }
 
     /**

--- a/app/Services/Banking/TransactionSyncService.php
+++ b/app/Services/Banking/TransactionSyncService.php
@@ -68,6 +68,10 @@ class TransactionSyncService
         // rows; daily balances are keyed by date), and strategy is dropped on
         // the narrowed retry so the explicit date_from is honoured rather than
         // overridden by "longest".
+        // `$pages` deliberately survives a narrowed retry: the budget counts the
+        // requests this run has made, not the ones this attempt has made, so a
+        // bank that refuses two windows before serving one cannot spend three
+        // budgets on a single account.
         while (true) {
             try {
                 $continuationKey = null;
@@ -171,14 +175,19 @@ class TransactionSyncService
      */
     private function recordPaginationFrontier(Account $account, bool $truncated, ?string $oldestSeen, string $dateTo): void
     {
-        $frontier = $truncated && $oldestSeen !== null && $oldestSeen < $dateTo ? $oldestSeen : null;
+        $frontier = $this->nextFrontier($truncated, $oldestSeen, $dateTo);
         $current = $account->transactions_paginate_before?->toDateString();
 
         if ($truncated) {
             Log::warning('Transaction page budget stopped the sync early', [
                 'account_id' => $account->id,
                 'date_to' => $dateTo,
+                'oldest_reached' => $oldestSeen,
                 'resume_before' => $frontier,
+                // The run spent its whole budget without getting past the date
+                // it was already asked for, so the day it stopped on is stepped
+                // over rather than re-read. Worth seeing in the logs.
+                'skipped_remainder_of' => $oldestSeen !== null && $oldestSeen >= $dateTo ? $dateTo : null,
             ]);
         }
 
@@ -187,6 +196,39 @@ class TransactionSyncService
         }
 
         $account->update(['transactions_paginate_before' => $frontier]);
+    }
+
+    /**
+     * Where the next run picks this account's history up, or null when there is
+     * nothing left to pick up.
+     *
+     * Every branch returns either null or a date strictly earlier than the one
+     * this run was asked for, which is what makes the walk terminate: a run
+     * either finishes the history, finds none, or moves the frontier back by at
+     * least a day.
+     */
+    private function nextFrontier(bool $truncated, ?string $oldestSeen, string $dateTo): ?string
+    {
+        // Paginated to the end, or the window held nothing at all: nothing owed.
+        if (! $truncated || $oldestSeen === null) {
+            return null;
+        }
+
+        // The run walked back past the end of the window it was given, which is
+        // the ordinary case: resume from the oldest date it reached.
+        if ($oldestSeen < $dateTo) {
+            return $oldestSeen;
+        }
+
+        // The budget ran out without the run getting past that date at all -
+        // pages carrying nothing older, or a single day with more pages than the
+        // budget. Resuming at the same date would re-read the same pages every
+        // cycle and never reach the history behind them, so step over the day.
+        //
+        // ponytail: costs the tail of that one day. Persisting the provider's
+        // own continuation key would resume exactly instead, if a bank ever
+        // turns out to page a single day more finely than its budget allows.
+        return Carbon::parse($dateTo)->subDay()->toDateString();
     }
 
     /**

--- a/config/banking.php
+++ b/config/banking.php
@@ -1,0 +1,34 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Transaction page budget
+    |--------------------------------------------------------------------------
+    |
+    | The most transaction pages one sync run will fetch for a single account,
+    | keyed by the bank's `aspsp_name`, with `default` covering every bank not
+    | listed and `null` meaning no budget at all.
+    |
+    | Banks meter a consent at a few accesses a day, and the transactions
+    | endpoint is paginated, so a bank that pages finely can spend the whole
+    | allowance before the sync ever reaches its balances call. Trade Republic
+    | did exactly that: 5,740 transaction requests in the week to 2026-08-21 and
+    | not one balance request, ~19 pages per run against an allowance that runs
+    | out around there, so every run died on a 429 and their users' net worth
+    | read zero.
+    |
+    | Stopping early costs no history. The provider paginates newest-first, so a
+    | run cut short holds the recent end of the window, and the date it stopped
+    | at is kept in `accounts.transactions_paginate_before` for the next run to
+    | resume from.
+    |
+    */
+
+    'transaction_page_budget' => [
+        'default' => null,
+        'Trade Republic' => 10,
+    ],
+
+];

--- a/database/migrations/2026_08_21_090000_add_transactions_paginate_before_to_accounts_table.php
+++ b/database/migrations/2026_08_21_090000_add_transactions_paginate_before_to_accounts_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('accounts', function (Blueprint $table) {
+            // Where a sync run stopped paginating the bank's history because it
+            // ran out of its page budget, so the next run can pick the history
+            // up from there. Null means nothing is owed - which is what every
+            // existing account is, since none of them has ever been cut short.
+            $table->date('transactions_paginate_before')->nullable()->after('external_account_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('accounts', function (Blueprint $table) {
+            $table->dropColumn('transactions_paginate_before');
+        });
+    }
+};

--- a/tests/Feature/OpenBanking/EnableBankingPageBudgetTest.php
+++ b/tests/Feature/OpenBanking/EnableBankingPageBudgetTest.php
@@ -280,3 +280,30 @@ test('a budgeted bank walks its history across runs instead of re-reading the sa
         ->map(fn ($date) => $date->toDateString())->sort()->values()->all())
         ->toBe(['2026-06-07', '2026-06-08', '2026-06-09', '2026-06-10']);
 });
+
+test('a marker the full window has closed over is ignored instead of inverting the window', function () {
+    Carbon::setTestNow('2026-08-21 09:00:00');
+
+    $connection = enableBankingConnectionWithAccounts(1);
+
+    // Written when a year back still reached past it; a year back is now later.
+    $connection->accounts[0]->update(['transactions_paginate_before' => '2025-08-01']);
+
+    $window = null;
+    $transactionSync = Mockery::mock(TransactionSyncService::class);
+    $transactionSync->shouldReceive('sync')->andReturnUsing(
+        function ($account, $dateFrom, $dateTo) use (&$window) {
+            $window = [$dateFrom, $dateTo];
+
+            return 0;
+        }
+    );
+
+    $balanceSync = Mockery::mock(BalanceSyncService::class);
+    $balanceSync->shouldReceive('sync')->andReturnNull();
+    $balanceSync->shouldReceive('calculateHistoricalBalances')->andReturnNull();
+
+    runSync(new SyncBankingConnectionJob($connection), $transactionSync, $balanceSync);
+
+    expect($window)->toBe(['2025-08-21', '2026-08-21']);
+});

--- a/tests/Feature/OpenBanking/EnableBankingPageBudgetTest.php
+++ b/tests/Feature/OpenBanking/EnableBankingPageBudgetTest.php
@@ -1,0 +1,250 @@
+<?php
+
+use App\Contracts\BankingProviderInterface;
+use App\Enums\TransactionSource;
+use App\Jobs\SyncBankingConnectionJob;
+use App\Models\Account;
+use App\Services\Banking\BalanceSyncService;
+use App\Services\Banking\TransactionDescriptionFormatter;
+use App\Services\Banking\TransactionSyncService;
+use Carbon\Carbon;
+use GuzzleHttp\Psr7\Response as PsrResponse;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response as ClientResponse;
+
+/**
+ * A provider serving one transaction per page, newest first, a day older each
+ * page - the pagination Enable Banking really does, and the shape that let
+ * Trade Republic spend ~19 requests a run on an allowance that runs out around
+ * there. `$newestDate` dates page one; `$lastPage` is the page the continuation
+ * key stops at, so a test can pick between a run the budget cuts short and one
+ * that ends by itself.
+ */
+function pagingProvider(array &$requests, string $newestDate, int $lastPage = 1_000): BankingProviderInterface
+{
+    $provider = Mockery::mock(BankingProviderInterface::class);
+    $provider->shouldReceive('getTransactions')->andReturnUsing(
+        function (string $accountId, string $dateFrom, string $dateTo) use (&$requests, $newestDate, $lastPage) {
+            $requests[] = ['date_from' => $dateFrom, 'date_to' => $dateTo];
+            $page = count($requests);
+
+            return [
+                'transactions' => [[
+                    'transaction_id' => "txn-{$page}",
+                    'transaction_amount' => ['amount' => '10.00', 'currency' => 'EUR'],
+                    'credit_debit_indicator' => 'DBIT',
+                    'booking_date' => Carbon::parse($newestDate)->subDays($page - 1)->toDateString(),
+                    'remittance_information' => ["Page {$page}"],
+                ]],
+                'continuation_key' => $page < $lastPage ? "key-{$page}" : null,
+            ];
+        }
+    );
+
+    return $provider;
+}
+
+function budgetedAccount(): Account
+{
+    $connection = enableBankingConnectionWithAccounts(1);
+
+    return $connection->accounts[0];
+}
+
+function rateLimitedTransactions(): RequestException
+{
+    return new RequestException(new ClientResponse(
+        new PsrResponse(429, [], json_encode(['code' => 429, 'message' => 'Too many requests']))
+    ));
+}
+
+test('a run the page budget cuts short records the date the next run resumes from', function () {
+    $account = budgetedAccount();
+    $requests = [];
+
+    // Pages dated 2026-06-08, -07, -06: newest first, as the provider serves them.
+    $service = new TransactionSyncService(
+        pagingProvider($requests, '2026-06-08'),
+        new TransactionDescriptionFormatter,
+    );
+
+    $created = $service->sync($account, '2025-08-21', '2026-08-21', pageBudget: 3);
+
+    expect($requests)->toHaveCount(3)
+        ->and($created)->toBe(3);
+
+    $account->refresh();
+    expect($account->transactions_paginate_before->toDateString())->toBe('2026-06-06');
+});
+
+test('a run that paginates to the end owes nothing and leaves no marker', function () {
+    $account = budgetedAccount();
+    $account->update(['transactions_paginate_before' => '2026-06-03']);
+    $requests = [];
+
+    $service = new TransactionSyncService(
+        pagingProvider($requests, '2026-06-01', lastPage: 2),
+        new TransactionDescriptionFormatter,
+    );
+
+    $service->sync($account, '2025-08-21', '2026-06-03', pageBudget: 5);
+
+    expect($requests)->toHaveCount(2);
+
+    $account->refresh();
+    expect($account->transactions_paginate_before)->toBeNull();
+});
+
+test('a cut-short run that reached nothing older than it was asked for gives up instead of looping', function () {
+    $account = budgetedAccount();
+    $account->update(['transactions_paginate_before' => '2026-06-03']);
+    $requests = [];
+
+    // The one page the budget allows is dated on the window's own end date, so
+    // the frontier cannot move and keeping the marker would re-request this
+    // same window every cycle.
+    $service = new TransactionSyncService(
+        pagingProvider($requests, '2026-06-03'),
+        new TransactionDescriptionFormatter,
+    );
+
+    $service->sync($account, '2025-08-21', '2026-06-03', pageBudget: 1);
+
+    $account->refresh();
+    expect($account->transactions_paginate_before)->toBeNull();
+});
+
+test('a bank with no budget configured paginates to the end as before', function () {
+    $account = budgetedAccount();
+    $requests = [];
+
+    $service = new TransactionSyncService(
+        pagingProvider($requests, '2026-06-01', lastPage: 4),
+        new TransactionDescriptionFormatter,
+    );
+
+    $service->sync($account, '2025-08-21', '2026-08-21');
+
+    expect($requests)->toHaveCount(4);
+
+    $account->refresh();
+    expect($account->transactions_paginate_before)->toBeNull();
+});
+
+test('the budget is read per bank from config, and an unlisted bank stays unbudgeted', function () {
+    config(['banking.transaction_page_budget' => ['default' => null, 'Metered Bank' => 2]]);
+
+    $connection = enableBankingConnectionWithAccounts(1);
+    $connection->update(['aspsp_name' => 'Metered Bank']);
+
+    $budgets = [];
+    $transactionSync = Mockery::mock(TransactionSyncService::class);
+    $transactionSync->shouldReceive('sync')->andReturnUsing(
+        function ($account, $dateFrom, $dateTo, $strategy, $saveDailyBalances, $pageBudget) use (&$budgets) {
+            $budgets[] = $pageBudget;
+
+            return 0;
+        }
+    );
+
+    $balanceSync = Mockery::mock(BalanceSyncService::class);
+    $balanceSync->shouldReceive('sync')->andReturnNull();
+    $balanceSync->shouldReceive('calculateHistoricalBalances')->andReturnNull();
+
+    runSync(new SyncBankingConnectionJob($connection->refresh()), $transactionSync, $balanceSync);
+
+    expect($budgets)->toBe([2]);
+
+    config(['banking.transaction_page_budget' => ['default' => null]]);
+    $budgets = [];
+
+    runSync(new SyncBankingConnectionJob($connection->refresh()), $transactionSync, $balanceSync);
+
+    expect($budgets)->toBe([PHP_INT_MAX]);
+});
+
+test('the balance request is made before the pagination that used to starve it', function () {
+    $connection = enableBankingConnectionWithAccounts(2);
+
+    $calls = [];
+
+    $transactionSync = Mockery::mock(TransactionSyncService::class);
+    $transactionSync->shouldReceive('sync')->andReturnUsing(function () use (&$calls) {
+        $calls[] = 'transactions';
+
+        return 0;
+    });
+
+    $balanceSync = Mockery::mock(BalanceSyncService::class);
+    $balanceSync->shouldReceive('sync')->andReturnUsing(function () use (&$calls) {
+        $calls[] = 'balances';
+    });
+    $balanceSync->shouldReceive('calculateHistoricalBalances')->andReturnNull();
+
+    runSync(new SyncBankingConnectionJob($connection), $transactionSync, $balanceSync);
+
+    expect($calls)->toBe(['balances', 'transactions', 'balances', 'transactions']);
+});
+
+test('a rate limit on the transactions call no longer costs the account its balance', function () {
+    $connection = enableBankingConnectionWithAccounts(1);
+
+    $transactionSync = Mockery::mock(TransactionSyncService::class);
+    $transactionSync->shouldReceive('sync')->andThrow(rateLimitedTransactions());
+
+    $balanced = 0;
+    $balanceSync = Mockery::mock(BalanceSyncService::class);
+    $balanceSync->shouldReceive('sync')->andReturnUsing(function () use (&$balanced) {
+        $balanced++;
+    });
+    $balanceSync->shouldReceive('calculateHistoricalBalances')->andReturnNull();
+
+    try {
+        runSync(finalAttemptJobFor($connection), $transactionSync, $balanceSync);
+    } catch (RequestException) {
+        // Expected: the run still fails, which is what applies the backoff.
+    }
+
+    // The whole point. In production this request was never made once in a week
+    // of Trade Republic syncs, because the 429 landed before the sync got here.
+    expect($balanced)->toBe(1);
+
+    // And the backoff the 429 exists to trigger is untouched: no reclassifying
+    // the exception, no reporting it as a success.
+    $connection->refresh();
+    expect($connection->rate_limited_until)->not->toBeNull();
+});
+
+test('the next run resumes the history at the marker instead of the watermark', function () {
+    $connection = enableBankingConnectionWithAccounts(1);
+    $connection->accounts[0]->update(['transactions_paginate_before' => '2026-05-01']);
+
+    // A transaction dated today: the watermark a routine window would be built
+    // on, and the reason a naive page cap would never reach the old history.
+    $connection->accounts[0]->transactions()->create([
+        'user_id' => $connection->user_id,
+        'description' => 'Recent',
+        'transaction_date' => now()->toDateString(),
+        'amount' => -100,
+        'currency_code' => 'EUR',
+        'source' => TransactionSource::EnableBanking,
+    ]);
+
+    $window = null;
+    $transactionSync = Mockery::mock(TransactionSyncService::class);
+    $transactionSync->shouldReceive('sync')->andReturnUsing(
+        function ($account, $dateFrom, $dateTo) use (&$window) {
+            $window = [$dateFrom, $dateTo];
+
+            return 0;
+        }
+    );
+
+    $balanceSync = Mockery::mock(BalanceSyncService::class);
+    $balanceSync->shouldReceive('sync')->andReturnNull();
+    $balanceSync->shouldReceive('calculateHistoricalBalances')->andReturnNull();
+
+    runSync(new SyncBankingConnectionJob($connection), $transactionSync, $balanceSync);
+
+    expect($window)->toBe([now()->subYear()->toDateString(), '2026-05-01']);
+});

--- a/tests/Feature/OpenBanking/EnableBankingPageBudgetTest.php
+++ b/tests/Feature/OpenBanking/EnableBankingPageBudgetTest.php
@@ -2,6 +2,7 @@
 
 use App\Contracts\BankingProviderInterface;
 use App\Enums\TransactionSource;
+use App\Jobs\SendDailyBankTransactionsSyncedEmailJob;
 use App\Jobs\SyncBankingConnectionJob;
 use App\Models\Account;
 use App\Services\Banking\BalanceSyncService;
@@ -11,6 +12,7 @@ use Carbon\Carbon;
 use GuzzleHttp\Psr7\Response as PsrResponse;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response as ClientResponse;
+use Illuminate\Support\Facades\Queue;
 
 /**
  * A provider serving one transaction per page, newest first, a day older each
@@ -95,20 +97,41 @@ test('a run that paginates to the end owes nothing and leaves no marker', functi
     expect($account->transactions_paginate_before)->toBeNull();
 });
 
-test('a cut-short run that reached nothing older than it was asked for gives up instead of looping', function () {
+test('a cut-short run that reached nothing older steps over the day instead of looping on it', function () {
     $account = budgetedAccount();
     $account->update(['transactions_paginate_before' => '2026-06-03']);
     $requests = [];
 
     // The one page the budget allows is dated on the window's own end date, so
-    // the frontier cannot move and keeping the marker would re-request this
-    // same window every cycle.
+    // resuming there would re-request the same page every cycle and never reach
+    // the history behind it - which is how a day paginated more finely than the
+    // budget, or a run of pages carrying nothing older, would silently swallow
+    // the rest of the account's history.
     $service = new TransactionSyncService(
         pagingProvider($requests, '2026-06-03'),
         new TransactionDescriptionFormatter,
     );
 
     $service->sync($account, '2025-08-21', '2026-06-03', pageBudget: 1);
+
+    $account->refresh();
+    expect($account->transactions_paginate_before->toDateString())->toBe('2026-06-02');
+});
+
+test('a cut-short run over a window holding nothing at all owes no more history', function () {
+    $account = budgetedAccount();
+    $account->update(['transactions_paginate_before' => '2026-06-03']);
+
+    // Pages, and a continuation key, but no transactions in any of them: there
+    // is nothing behind this window to come back for.
+    $provider = Mockery::mock(BankingProviderInterface::class);
+    $provider->shouldReceive('getTransactions')->andReturn([
+        'transactions' => [],
+        'continuation_key' => 'more',
+    ]);
+
+    $service = new TransactionSyncService($provider, new TransactionDescriptionFormatter);
+    $service->sync($account, '2025-08-21', '2026-06-03', pageBudget: 2);
 
     $account->refresh();
     expect($account->transactions_paginate_before)->toBeNull();
@@ -305,5 +328,55 @@ test('a marker the full window has closed over is ignored instead of inverting t
 
     runSync(new SyncBankingConnectionJob($connection), $transactionSync, $balanceSync);
 
+    expect($window)->toBe(['2025-08-21', '2026-08-21']);
+});
+
+test('a run still owing history moves the email cutoff instead of announcing it as new', function () {
+    Queue::fake();
+    Carbon::setTestNow('2026-08-21 09:00:00');
+    config(['banking.transaction_page_budget' => ['default' => null, 'Metered Bank' => 2]]);
+
+    $connection = enableBankingConnectionWithAccounts(1);
+    $connection->update(['aspsp_name' => 'Metered Bank']);
+
+    $requests = [];
+    $provider = pagingProvider($requests, '2026-06-10');
+    $provider->shouldReceive('getBalances')->andReturn(['balances' => []]);
+    app()->instance(BankingProviderInterface::class, $provider);
+
+    runSync(new SyncBankingConnectionJob($connection->refresh()));
+
+    // The rows this run imported are dated June; the daily email keys on when a
+    // row was written, so sending it would report a backfill as today's news.
+    Queue::assertNotPushed(SendDailyBankTransactionsSyncedEmailJob::class);
+
+    $connection->refresh();
+    expect($connection->bank_transactions_email_cutoff_at->toDateTimeString())->toBe('2026-08-21 09:00:00');
+});
+
+test('a full resync re-pulls the whole history instead of resuming a leftover marker', function () {
+    Carbon::setTestNow('2026-08-21 09:00:00');
+
+    $connection = enableBankingConnectionWithAccounts(1);
+    $connection->accounts[0]->update(['transactions_paginate_before' => '2026-05-01']);
+
+    $window = null;
+    $transactionSync = Mockery::mock(TransactionSyncService::class);
+    $transactionSync->shouldReceive('sync')->andReturnUsing(
+        function ($account, $dateFrom, $dateTo) use (&$window) {
+            $window = [$dateFrom, $dateTo];
+
+            return 0;
+        }
+    );
+
+    $balanceSync = Mockery::mock(BalanceSyncService::class);
+    $balanceSync->shouldReceive('sync')->andReturnNull();
+    $balanceSync->shouldReceive('calculateHistoricalBalances')->andReturnNull();
+
+    runSync(new SyncBankingConnectionJob($connection, fullSync: true), $transactionSync, $balanceSync);
+
+    // --full is an explicit request for everything; a marker left by a run the
+    // budget cut short must not quietly narrow it back down.
     expect($window)->toBe(['2025-08-21', '2026-08-21']);
 });

--- a/tests/Feature/OpenBanking/EnableBankingPageBudgetTest.php
+++ b/tests/Feature/OpenBanking/EnableBankingPageBudgetTest.php
@@ -248,3 +248,35 @@ test('the next run resumes the history at the marker instead of the watermark', 
 
     expect($window)->toBe([now()->subYear()->toDateString(), '2026-05-01']);
 });
+
+test('a budgeted bank walks its history across runs instead of re-reading the same pages', function () {
+    Carbon::setTestNow('2026-08-21 09:00:00');
+    config(['banking.transaction_page_budget' => ['default' => null, 'Metered Bank' => 2]]);
+
+    $connection = enableBankingConnectionWithAccounts(1);
+    $connection->update(['aspsp_name' => 'Metered Bank']);
+
+    $requests = [];
+    $provider = pagingProvider($requests, '2026-06-10');
+    $provider->shouldReceive('getBalances')->twice()->andReturn(['balances' => []]);
+    app()->instance(BankingProviderInterface::class, $provider);
+
+    // Two runs of the real syncer over the real transaction service, so the
+    // marker written by one is the window read by the next.
+    runSync(new SyncBankingConnectionJob($connection->refresh()));
+    runSync(new SyncBankingConnectionJob($connection->refresh()));
+
+    // Both runs reached the balances endpoint, which is the request Trade
+    // Republic never once made in a week of syncs (Mockery asserts the count).
+    // Run one took pages 1-2 of a window ending today; run two picked the
+    // history up at the date it stopped rather than at today's watermark, which
+    // is what a page cap without a marker would have done for ever.
+    expect($requests)->toHaveCount(4)
+        ->and($requests[0]['date_to'])->toBe('2026-08-21')
+        ->and($requests[2]['date_to'])->toBe('2026-06-09');
+
+    // And the older history the second run reached is actually in the database.
+    expect($connection->accounts[0]->transactions()->pluck('transaction_date')
+        ->map(fn ($date) => $date->toDateString())->sort()->values()->all())
+        ->toBe(['2026-06-07', '2026-06-08', '2026-06-09', '2026-06-10']);
+});

--- a/tests/Feature/OpenBanking/EnableBankingPartialAccountFailureTest.php
+++ b/tests/Feature/OpenBanking/EnableBankingPartialAccountFailureTest.php
@@ -3,42 +3,13 @@
 use App\Enums\BankingConnectionStatus;
 use App\Enums\BankingSyncLogStatus;
 use App\Exceptions\Banking\TransientBankingProviderException;
-use App\Jobs\SyncBankingConnectionJob;
 use App\Models\Account;
-use App\Models\BankingConnection;
 use App\Models\BankingSyncLog;
-use App\Models\User;
 use App\Services\Banking\BalanceSyncService;
 use App\Services\Banking\TransactionSyncService;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Http\Client\RequestException;
-
-/**
- * A connection whose accounts the bank serves unevenly. Production had a CaixaBank
- * one in this shape for five weeks: account 1 importing transactions while accounts
- * 2 and 3 sat frozen at the date of the last complete run.
- */
-function enableBankingConnectionWithAccounts(int $count): BankingConnection
-{
-    $user = User::factory()->onboarded()->create();
-    $connection = BankingConnection::factory()->create([
-        'user_id' => $user->id,
-        'status' => BankingConnectionStatus::Active,
-        'last_synced_at' => now()->subDay(),
-        'consecutive_sync_failures' => 0,
-    ]);
-
-    for ($i = 1; $i <= $count; $i++) {
-        Account::factory()->connected()->create([
-            'user_id' => $user->id,
-            'banking_connection_id' => $connection->id,
-            'external_account_id' => "ext-{$i}",
-        ]);
-    }
-
-    return $connection;
-}
 
 function aspspError(): TransientBankingProviderException
 {
@@ -48,18 +19,6 @@ function aspspError(): TransientBankingProviderException
         statusCode: 400,
         providerCode: 'ASPSP_ERROR',
     );
-}
-
-function finalAttemptJobFor(BankingConnection $connection): SyncBankingConnectionJob
-{
-    $job = new SyncBankingConnectionJob($connection);
-    $job->job = Mockery::mock(Job::class);
-    $job->job->shouldReceive('attempts')->andReturn(3);
-    $job->job->shouldReceive('isReleased')->andReturn(false);
-    $job->job->shouldReceive('isDeletedOrReleased')->andReturn(false);
-    $job->job->shouldReceive('hasFailed')->andReturn(false);
-
-    return $job;
 }
 
 test('an account the bank cannot serve no longer starves the accounts behind it', function () {
@@ -85,6 +44,7 @@ test('an account the bank cannot serve no longer starves the accounts behind it'
     $balanceSync->shouldReceive('sync')->andReturnUsing(function ($account) use (&$balancedAccounts) {
         $balancedAccounts[] = $account->id;
     });
+    $balanceSync->shouldReceive('calculateHistoricalBalances')->andReturnNull();
 
     try {
         runSync(finalAttemptJobFor($connection), $transactionSync, $balanceSync);
@@ -113,6 +73,7 @@ test('a partially failing run is still recorded as failed', function () {
 
     $balanceSync = Mockery::mock(BalanceSyncService::class);
     $balanceSync->shouldReceive('sync')->andReturnNull();
+    $balanceSync->shouldReceive('calculateHistoricalBalances')->andReturnNull();
 
     try {
         runSync(finalAttemptJobFor($connection), $transactionSync, $balanceSync);
@@ -145,6 +106,7 @@ test('a provider that never answered stops the run instead of retrying every acc
 
     $balanceSync = Mockery::mock(BalanceSyncService::class);
     $balanceSync->shouldReceive('sync')->andReturnNull();
+    $balanceSync->shouldReceive('calculateHistoricalBalances')->andReturnNull();
 
     try {
         runSync(finalAttemptJobFor($connection), $transactionSync, $balanceSync);
@@ -172,6 +134,7 @@ test('a rate limit still reaches the job instead of being swallowed per account'
 
     $balanceSync = Mockery::mock(BalanceSyncService::class);
     $balanceSync->shouldReceive('sync')->andReturnNull();
+    $balanceSync->shouldReceive('calculateHistoricalBalances')->andReturnNull();
 
     try {
         runSync(finalAttemptJobFor($connection), $transactionSync, $balanceSync);

--- a/tests/Feature/OpenBanking/SyncBankingConnectionJobTest.php
+++ b/tests/Feature/OpenBanking/SyncBankingConnectionJobTest.php
@@ -413,8 +413,10 @@ test('an expired session during the balance call is not swallowed', function () 
         'external_account_id' => 'ext-123',
     ]);
 
+    // Balances are fetched before the transactions pagination, so a consent
+    // that has lapsed is known before a single page is requested.
     $transactionSync = Mockery::mock(TransactionSyncService::class);
-    $transactionSync->shouldReceive('sync')->once()->andReturn(0);
+    $transactionSync->shouldReceive('sync')->never();
 
     $balanceSync = Mockery::mock(BalanceSyncService::class);
     $balanceSync->shouldReceive('sync')->once()->andThrow(

--- a/tests/Feature/OpenBanking/SyncRetryAndLoggingTest.php
+++ b/tests/Feature/OpenBanking/SyncRetryAndLoggingTest.php
@@ -396,8 +396,11 @@ test('an inaccessible account is skipped and the rest of the connection still sy
         return 2;
     });
 
+    // Both accounts, including the dead one: balances come from a different
+    // endpoint and are fetched before the transactions call that refuses it.
     $balanceSync = Mockery::mock(BalanceSyncService::class);
-    $balanceSync->shouldReceive('sync')->once();
+    $balanceSync->shouldReceive('sync')->twice();
+    $balanceSync->shouldReceive('calculateHistoricalBalances');
 
     $job = new SyncBankingConnectionJob($connection);
 
@@ -440,7 +443,8 @@ test('an account whose period the bank refuses is skipped, not crashed, and the 
     });
 
     $balanceSync = Mockery::mock(BalanceSyncService::class);
-    $balanceSync->shouldReceive('sync')->once();
+    $balanceSync->shouldReceive('sync')->twice();
+    $balanceSync->shouldReceive('calculateHistoricalBalances');
 
     $job = new SyncBankingConnectionJob($connection);
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,8 +1,10 @@
 <?php
 
+use App\Enums\BankingConnectionStatus;
 use App\Jobs\SyncBankingConnectionJob;
 use App\Models\Account;
 use App\Models\AccountBalance;
+use App\Models\BankingConnection;
 use App\Models\Budget;
 use App\Models\BudgetPeriod;
 use App\Models\Category;
@@ -13,6 +15,7 @@ use App\Services\Banking\BalanceSyncService;
 use App\Services\Banking\EnableBankingProvider;
 use App\Services\Banking\Sync\BankingConnectionSyncerFactory;
 use App\Services\Banking\TransactionSyncService;
+use Illuminate\Contracts\Queue\Job;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\DB;
@@ -328,6 +331,44 @@ function runSync(
     }
 
     $job->handle(app(BankingConnectionSyncerFactory::class));
+}
+
+/**
+ * A connection whose accounts the bank serves unevenly. Production had a CaixaBank
+ * one in this shape for five weeks: account 1 importing transactions while accounts
+ * 2 and 3 sat frozen at the date of the last complete run.
+ */
+function enableBankingConnectionWithAccounts(int $count): BankingConnection
+{
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->create([
+        'user_id' => $user->id,
+        'status' => BankingConnectionStatus::Active,
+        'last_synced_at' => now()->subDay(),
+        'consecutive_sync_failures' => 0,
+    ]);
+
+    for ($i = 1; $i <= $count; $i++) {
+        Account::factory()->connected()->create([
+            'user_id' => $user->id,
+            'banking_connection_id' => $connection->id,
+            'external_account_id' => "ext-{$i}",
+        ]);
+    }
+
+    return $connection;
+}
+
+function finalAttemptJobFor(BankingConnection $connection): SyncBankingConnectionJob
+{
+    $job = new SyncBankingConnectionJob($connection);
+    $job->job = Mockery::mock(Job::class);
+    $job->job->shouldReceive('attempts')->andReturn(3);
+    $job->job->shouldReceive('isReleased')->andReturn(false);
+    $job->job->shouldReceive('isDeletedOrReleased')->andReturn(false);
+    $job->job->shouldReceive('hasFailed')->andReturn(false);
+
+    return $job;
 }
 
 /**


### PR DESCRIPTION
## The bug

Enable Banking's `/balances` endpoint is never reached for Trade Republic. Measured in
the provider's own control panel over the 7 days to 21 Aug: **5,740 calls to
`GET /account/{}/transactions` and exactly 0 to `/balances`**, across 21 sessions. Not
"the balance call sometimes fails" — it is never made.

In production today that leaves **15 accounts with imported transactions and zero
`account_balances` rows** (13 Trade Republic, 2 Openbank), 14 of them on connections
whose `last_synced_at` is still NULL. Those users see their transactions while their
balance and net worth read €0, behind the indefinite `Syncing transactions and
balances…` spinner that polls every 5s.

**Mechanism.** In `EnableBankingSyncer::sync`'s per-account loop, `syncBalances()` sat
*after* `transactionSync->sync()`. The transactions call is both the paginated one — the
one that spends the consent's metered daily allowance — and the one that throws: a raw
429 `RequestException` matches none of the inner catches, so it escapes the `foreach`
into the outer `catch (\Throwable)` and is rethrown. The balance call in that iteration,
and every account behind it, never happens. 96 of 96 recent Trade Republic sync-log
failures are `operation: transactions`, status 429, which is why #817's balance-429
swallow has never once fired for them: it guards the wrong endpoint.

## The fix

**1. The balance request runs before the transactions pagination.** One request per
account, taken while there is still allowance to take it with. Only the historical-balance
backfill stays behind the transactions, because it is local arithmetic over the rows just
imported — no provider call.

Nothing about failure handling moves. A transactions 429 is still a raw `RequestException`,
still fails the run, and still reaches `SyncBankingConnectionJob::isRateLimitError` →
`applyRateLimitBackoff` byte for byte. No exception is reclassified, and no run that failed
to fetch an account's transactions reports success.

**2. A per-bank transaction page budget** (`config/banking.php`, keyed on `aspsp_name`).
Trade Republic gets 10, against the ~19 pages its runs were spending before dying on a
429 — for accounts holding 2 to 13 transactions each. Every other bank stays unbudgeted,
so their behaviour is unchanged.

## Stopping early costs no history

The provider paginates **newest-first**. Verified against production insert order: for
every large single-burst import, rows land newest `transaction_date` first, on every bank
we sync (Trade Republic 9 bursts of 9). The window start comes from the *newest*
transaction we hold, so a naive page cap would move that watermark to today and re-read
the same recent pages for ever, never reaching the older history.

So a run the budget cuts short records the oldest date it reached in a new
`accounts.transactions_paginate_before`, and the next run resumes with that as `date_to`
and the full-history window as `date_from`. The marker clears three ways, each of which
guarantees the walk terminates:

- the run paginated to the end — nothing is owed;
- the run was cut short and its window held no transactions at all — there is nothing
  behind it to come back for;
- the full window has since moved forward past the marker — otherwise `date_from` would
  overtake `date_to`.

A run that is cut short without getting past the date it was asked for — a day paginated
more finely than the budget, or pages carrying nothing older — steps over that day rather
than clearing the marker. Clearing would read as "no history left" and silently drop the
rest of the account's history, which is the one thing this must not do; the cost is the
tail of that single day, marked in the code with the exact upgrade path (persisting the
provider's continuation key) if a bank ever needs it. Every branch either finishes,
clears, or moves the frontier back at least a day, so the walk always terminates.

Existing accounts migrate to NULL, which means "nothing owed": the window they get is the
one they get today.

## Two consequences of resuming, both handled

A run still owing history imports rows dated months ago, and the daily "bank
transactions synced" email keys on when a row was **written**, not when it happened. So
while an account is backfilling, the cutoff moves with it and the email waits until
nothing is owed — otherwise a Trade Republic user would get a year of history announced
to them one dayful at a time. And a `--full` resync ignores any marker left behind, since
it is an explicit request for everything.

The other accepted cost is written down in the code: while an account is draining its
backlog its window ends in the past, so its newest transactions wait for the walk to
finish. The balance — the thing that reads €0 today — is fetched on every one of those
runs regardless, which is the point.

## QA

Ran the real `banking:sync --sync` command against the dev database with only the HTTP
layer faked, as a Trade Republic connection with a 3-page budget against a provider
serving 10 newest-first pages:

```
RUN 1 | calls=balances,transactions,transactions,transactions | marker=2026-08-18 | txns= 3 | emails_queued=0
RUN 2 | calls=balances,transactions,transactions,transactions | marker=2026-08-15 | txns= 6 | emails_queued=0
RUN 3 | calls=balances,transactions,transactions,transactions | marker=none       | txns= 9 | emails_queued=1
RUN 4 | calls=balances,transactions                           | marker=none       | txns=10 | emails_queued=1

Oldest transaction reached: 2026-08-11   Newest: 2026-08-20
Balance rows: 2026-08-18, -19, -20, -21
Sync logs: success(127ms), success(62ms), success(90ms), success(26ms)
```

`balances` is the first call of every run; the walk reaches all ten pages across four runs
and then settles into the routine window; the digest stays quiet until the backfill is
done; and `last_synced_at` is set from run 1, which is what ends the indefinite spinner.

Migration applied to the dev database in 72ms — one nullable column on a 6,120-row table
in production.

## Tests

`tests/Feature/OpenBanking/EnableBankingPageBudgetTest.php` covers the budget stopping
pagination, each of the three ways the marker clears, an unbudgeted bank paginating to the
end as before, the per-bank config lookup, the balances-before-transactions ordering, a
transactions 429 no longer costing the account its balance while still applying the
backoff, a `--full` resync ignoring a leftover marker, a backfilling run moving the email
cutoff instead of dispatching the digest, and — end to end through the real syncer and the
real transaction service — a budgeted bank walking its history across two runs instead of
re-reading the same pages.

Three existing tests changed with the ordering: an expired session is now known before a
single page is requested, and an account whose *transactions* the bank refuses now gets
its balance anyway, since balances come from a different endpoint.
