### PR TITLE
fix(onboarding): stop telling users the server is unreachable as their bank opens

### DIFF
--- a/resources/js/lib/failed-navigation-toast.test.ts
+++ b/resources/js/lib/failed-navigation-toast.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const toastError = vi.fn();
 
@@ -20,13 +20,16 @@ async function freshModules() {
     vi.doMock('sonner', () => ({ toast: { error: toastError } }));
 
     const tracker = await import('./prefetch-tracker');
+    // The departure flag lives at module scope and is one-way, so the pair has to
+    // be imported fresh alongside the listener it now guards.
+    const leavePageModule = await import('./leave-page');
     const { installFailedNavigationToast } =
         await import('./failed-navigation-toast');
 
     tracker.trackPrefetchedUrls();
     installFailedNavigationToast();
 
-    return { listeners };
+    return { listeners, leavePage: leavePageModule.leavePage };
 }
 
 function failure(url: string) {
@@ -38,6 +41,24 @@ function prefetching(url: string) {
 }
 
 describe('installFailedNavigationToast', () => {
+    const realLocation = window.location;
+
+    beforeEach(() => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            writable: true,
+            value: { href: 'https://whisper.money/onboarding' },
+        });
+    });
+
+    afterEach(() => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            writable: true,
+            value: realLocation,
+        });
+    });
+
     it('tells the user when a navigation they asked for died on the network', async () => {
         const { listeners } = await freshModules();
 
@@ -76,6 +97,32 @@ describe('installFailedNavigationToast', () => {
         const { listeners } = await freshModules();
 
         listeners.networkError?.({ detail: { error: {} } });
+
+        expect(toastError).toHaveBeenCalledOnce();
+    });
+
+    it('says nothing about a request our own departure aborted', async () => {
+        const { listeners, leavePage } = await freshModules();
+
+        // What tapping a bank on the onboarding create-account step does, while
+        // that step's 4s poll is in flight.
+        leavePage('https://bank.example/authorize');
+        listeners.networkError?.(
+            failure('https://whisper.money/onboarding?step=create-account'),
+        );
+
+        expect(toastError).not.toHaveBeenCalled();
+    });
+
+    it('speaks up again once it is clear we stayed', async () => {
+        const { listeners, leavePage } = await freshModules();
+
+        leavePage('https://bank.example/authorize');
+        // An iOS PWA hands the redirect to Safari and keeps its own page alive.
+        document.dispatchEvent(new Event('visibilitychange'));
+        listeners.networkError?.(
+            failure('https://whisper.money/onboarding?step=create-account'),
+        );
 
         expect(toastError).toHaveBeenCalledOnce();
     });

--- a/resources/js/lib/failed-navigation-toast.ts
+++ b/resources/js/lib/failed-navigation-toast.ts
@@ -1,6 +1,7 @@
 import { __ } from '@/utils/i18n';
 import { router } from '@inertiajs/react';
 import { toast } from 'sonner';
+import { isLeavingPage } from './leave-page';
 import { wasPrefetched } from './prefetch-tracker';
 
 /**
@@ -13,7 +14,8 @@ import { wasPrefetched } from './prefetch-tracker';
  * made.
  *
  * Stays quiet for requests nobody asked for. A hover prefetch that fails costs the
- * user nothing, and saying so would be noise about a page they may never open.
+ * user nothing, and saying so would be noise about a page they may never open. The
+ * same goes for whatever a full page navigation of our own aborts on the way out.
  *
  * Deliberately does not call `preventDefault()`: that would skip the cleanup Inertia
  * runs for a failed prefetch, leaving a dead entry that a later click waits on
@@ -21,6 +23,20 @@ import { wasPrefetched } from './prefetch-tracker';
  */
 export function installFailedNavigationToast(): void {
     router.on('networkError', (event) => {
+        // A request our own departure killed did not fail. `leavePage` aborts
+        // whatever is in flight - most visibly the 4s poll the onboarding
+        // create-account step runs - and the browser reports that abort as a
+        // transport failure, so tapping a bank ended in "check your connection"
+        // while the bank's own page was already opening. Sentry has ignored these
+        // since it grew `isPageLeaveAbortNoise`; the user had no such luck.
+        //
+        // If the departure does not take - an iOS PWA hands the bank redirect to
+        // Safari and carries on polling in a live page - `leave-page` clears the
+        // flag the next time the page becomes visible, and this speaks up again.
+        if (isLeavingPage()) {
+            return;
+        }
+
         const failedUrl = (event.detail.error as { url?: string }).url;
 
         if (failedUrl !== undefined && wasPrefetched(failedUrl)) {

--- a/resources/js/lib/leave-page.test.ts
+++ b/resources/js/lib/leave-page.test.ts
@@ -90,6 +90,26 @@ describe('leave-page', () => {
         expect(isLeavingPage()).toBe(true);
     });
 
+    it('stops leaving when the departure it started never happened', async () => {
+        vi.useFakeTimers();
+
+        try {
+            const { leavePage, isLeavingPage } = await freshModule();
+
+            // An empty redirect url, a blocked top-level load, a bank that never
+            // answers: the document stays put and visible, so neither the restore
+            // nor the visibility listener can ever clear this.
+            leavePage('https://bank.example/authorize');
+            expect(isLeavingPage()).toBe(true);
+
+            vi.advanceTimersByTime(10_000);
+
+            expect(isLeavingPage()).toBe(false);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
     it('stops leaving when the page becomes visible again, as an iOS PWA does', async () => {
         const { leavePage, isLeavingPage } = await freshModule();
 

--- a/resources/js/lib/leave-page.ts
+++ b/resources/js/lib/leave-page.ts
@@ -14,14 +14,39 @@
  */
 let leaving = false;
 
+/**
+ * How long a departure is allowed to be in progress.
+ *
+ * The recovery listeners below can only clear the flag once the page has actually
+ * gone away and come back. A navigation that never happens at all - an empty
+ * redirect url, a top-level load an extension blocks, a bank endpoint that never
+ * answers - leaves the document exactly where it was, so neither of them fires and
+ * the flag stays set for the rest of the session. That used to cost one missing
+ * Sentry report; now that the failed-navigation toast reads the same flag, it would
+ * cost the user every "we could not reach the server" they had coming.
+ *
+ * An abort caused by leaving is reported within milliseconds, so anything this far
+ * past the attempt belongs to a page that stayed. A departure that does take unloads
+ * the document and takes the timer with it.
+ */
+const DEPARTURE_TIMEOUT_MS = 10_000;
+
 export function leavePage(url: string): void {
     leaving = true;
     window.location.href = url;
+    forgetDepartureIfWeStayed();
 }
 
 export function reloadPage(): void {
     leaving = true;
     window.location.reload();
+    forgetDepartureIfWeStayed();
+}
+
+function forgetDepartureIfWeStayed(): void {
+    window.setTimeout(() => {
+        leaving = false;
+    }, DEPARTURE_TIMEOUT_MS);
 }
 
 export function isLeavingPage(): boolean {


### PR DESCRIPTION
## What the user sees

They reach the create-account step of onboarding, tap their bank, and the last
thing we show them before the bank's page loads is a red toast: **"We could not
reach the server. Check your connection."** Nothing had failed.

Sentry logged one of these an hour before this branch was written:
`HttpNetworkError: Network error (https://whisper.money/onboarding?step=create-account)`.

## Why

That step runs a 4s `usePoll` (for the iOS PWA case, where the bank redirect is
handed to Safari and completes in another browser). Tapping a bank goes through
`use-connect-flow`, which ends in `leavePage(redirect_url)` — and assigning
`window.location` aborts every request still in flight, including that poll.
Browsers report an abort to XHR as a transport failure, so Inertia raises
`networkError` and the global toast fires.

`leave-page.ts` already exists precisely to tell this apart, and `sentry.ts` has
used it since it grew `isPageLeaveAbortNoise` — so these events have been kept out
of Sentry for a while. The user had no such luck. Same flag, same reason.

PR #816 named this exact corner as deliberately out of its scope.

## The second commit, and why it is not optional

Both reviews independently found the same hole: `leaving` is one-way. `pageshow`
and `visibilitychange` can only clear it once the page has actually gone away and
come back, so a navigation that never happens at all — an empty redirect url, a
top-level load an extension blocks, a bank endpoint that never answers — leaves
the document exactly where it was with the flag stuck on.

That used to cost one missing Sentry report. Once the toast reads the same flag it
would cost the user **every** network warning for the rest of the session,
including the saves that silently did not save — which is the whole reason that
toast exists. So a departure now expires after ten seconds: an abort caused by
leaving is reported within milliseconds, and a real departure unloads the document
and takes the timer with it.

## Not changed

A failed bank authorization still tells the user: `use-connect-flow` renders its
own inline "Failed to connect. Please try again." from the `fetch` rejection, and
`leavePage` is only reached after a 2xx with a redirect url.

## Testing

- `failed-navigation-toast.test.ts`: silent while leaving; speaks again once the
  page proves it stayed. Mutation-verified — with the guard stubbed to `false`,
  the first case fails.
- `leave-page.test.ts`: a departure that never happened expires on its own.
- `resources/js/lib` (22 files, 195 tests) passes; prettier and eslint clean.