### PR TITLE
fix(banking): retry the year-wide window a bank connector refuses without saying why

### DIFF
--- a/app/Jobs/SyncBankingConnectionJob.php
+++ b/app/Jobs/SyncBankingConnectionJob.php
@@ -85,6 +85,15 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
     ];
 
     /**
+     * Request query parameters worth keeping on a failed call. Allow-listed for
+     * the same reason the headers above are: a query string is a place a token
+     * could ride along into a log this project keeps in public.
+     *
+     * @var list<string>
+     */
+    private const array LOGGED_QUERY_PARAMS = ['date_from', 'date_to', 'strategy'];
+
+    /**
      * Who asked for this sync. A property rather than something handle() works
      * out, because it has to travel in the serialized payload: failed() is
      * called on a fresh instance the queue unserializes, and that is the run
@@ -491,7 +500,35 @@ class SyncBankingConnectionJob implements ShouldBeUnique, ShouldQueue
             // with account data on an error status cannot empty it into the logs.
             'response_body' => Str::limit($failure->response->body(), 500),
             'rate_limit_headers' => $this->rateLimitHeaders($failure->response),
+            'request_window' => $this->requestWindow($failure->response),
         ];
+    }
+
+    /**
+     * The date range the failed call asked the bank for.
+     *
+     * The one fact this record was missing. A bank connector answers "Unknown
+     * error" and nothing else, so a run dying because the window was too wide
+     * looked exactly like a flaky bank - which is how one account went 75 days
+     * importing nothing before anyone could tell the two apart.
+     *
+     * @return array<string, string>
+     */
+    private function requestWindow(Response $response): array
+    {
+        parse_str($response->effectiveUri()?->getQuery() ?? '', $query);
+
+        $window = [];
+
+        foreach (self::LOGGED_QUERY_PARAMS as $name) {
+            $value = $query[$name] ?? null;
+
+            if (is_string($value) && $value !== '') {
+                $window[$name] = $value;
+            }
+        }
+
+        return $window;
     }
 
     /**

--- a/app/Services/Banking/EnableBankingProvider.php
+++ b/app/Services/Banking/EnableBankingProvider.php
@@ -12,6 +12,7 @@ use Firebase\JWT\JWT;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
@@ -19,6 +20,13 @@ use Illuminate\Support\Str;
 class EnableBankingProvider implements BankingProviderInterface
 {
     private const BASE_URL = 'https://api.enablebanking.com';
+
+    /**
+     * The widest transactions window a bank is assumed to serve unattended, and
+     * the first rung of `TransactionSyncService`'s narrowing ladder. Anything
+     * wider is what a bank connector's opaque refusal is read as being about.
+     */
+    private const int WIDE_WINDOW_DAYS = 90;
 
     public function __construct(
         private string $appId,
@@ -115,7 +123,7 @@ class EnableBankingProvider implements BankingProviderInterface
                 previous: $e,
             );
         } catch (RequestException $e) {
-            if ($this->isWrongPeriod($e)) {
+            if ($this->isWrongPeriod($e) || $this->isRefusedWideWindow($e, $dateFrom, $dateTo)) {
                 throw new WrongTransactionsPeriodException(
                     'EnableBanking rejected the requested transactions period as too wide.',
                     previous: $e,
@@ -353,6 +361,30 @@ class EnableBankingProvider implements BankingProviderInterface
         return $e->response->status() === 422
             && is_string($message)
             && str_contains(strtolower($message), 'period');
+    }
+
+    /**
+     * Whether a bank connector that failed opaquely was answering a window
+     * wider than banks behind Redsys will serve.
+     *
+     * Renta 4 sits behind Redsys, which refuses a 365-day range with
+     * `EXECUTION_DATE_INVALID` - but that code only ever appears in the ASPSP
+     * half of the provider's request log. What reaches us, verified against
+     * production on 2026-08-22, is `{"code":400,"message":"Error interacting
+     * with ASPSP","detail":"Unknown error","error":"ASPSP_ERROR"}`: nothing
+     * bank-specific to key on. So the width of the window we asked for is the
+     * signal, and narrowing to 90 days is the cheapest way to find out.
+     *
+     * Self-bounding, which is the point: 90 days is the ladder's first rung and
+     * a 90-day window is not wider than 90 days, so the retry can only classify
+     * as an ordinary connector failure. A bank that 400s for an unrelated
+     * reason therefore costs one extra request against its allowance, not three.
+     */
+    private function isRefusedWideWindow(RequestException $e, string $dateFrom, string $dateTo): bool
+    {
+        // Dates are 'Y-m-d', where string order is date order.
+        return $this->isAspspError($e)
+            && $dateFrom < Carbon::parse($dateTo)->subDays(self::WIDE_WINDOW_DAYS)->toDateString();
     }
 
     /**

--- a/app/Services/Banking/EnableBankingProvider.php
+++ b/app/Services/Banking/EnableBankingProvider.php
@@ -25,6 +25,11 @@ class EnableBankingProvider implements BankingProviderInterface
      * The widest transactions window a bank is assumed to serve unattended, and
      * the first rung of `TransactionSyncService`'s narrowing ladder. Anything
      * wider is what a bank connector's opaque refusal is read as being about.
+     *
+     * It has to stay equal to that first rung, or the retry lands on a window
+     * still counted as wide and the ladder walks all three steps at a bank's
+     * expense. TransactionSyncServiceTest pins the two together by counting the
+     * requests one opaque refusal costs, so drifting them apart fails there.
      */
     private const int WIDE_WINDOW_DAYS = 90;
 

--- a/tests/Feature/OpenBanking/BankingSyncTelemetryTest.php
+++ b/tests/Feature/OpenBanking/BankingSyncTelemetryTest.php
@@ -3,6 +3,7 @@
 use App\Contracts\BankingProviderInterface;
 use App\Enums\BankingSyncLogStatus;
 use App\Enums\BankingSyncTrigger;
+use App\Exceptions\Banking\TransientBankingProviderException;
 use App\Jobs\SyncAllBankingConnectionsJob;
 use App\Jobs\SyncBankingConnectionJob;
 use App\Models\Account;
@@ -28,6 +29,9 @@ function telemetryConnection(int $accounts = 1): BankingConnection
         'aspsp_name' => 'Trade Republic',
         'aspsp_country' => 'DE',
         'last_synced_at' => now()->subDay(),
+        // The column's own default, spelled out because the factory leaves the
+        // attribute unset in memory and the failure paths increment it.
+        'consecutive_sync_failures' => 0,
     ]);
 
     for ($i = 1; $i <= $accounts; $i++) {
@@ -227,6 +231,47 @@ test('a rate limit on transactions says so in the log the backoff writes', funct
         ->and($context['response_body'])->toContain('Too many requests')
         // Nothing told us how long to wait, so the hour is ours, not the bank's.
         ->and($context['rate_limit_headers'])->toBe([]);
+});
+
+test('a failed sync records the window it asked the bank for', function () {
+    // The Renta 4 shape: an account with no transactions asks for a year and the
+    // bank connector answers "Unknown error". Without the window on the record,
+    // that is indistinguishable from a flaky bank - which is how it hid for 75
+    // days. Both windows the run tries end up in the log.
+    $connection = telemetryConnection();
+
+    Http::fake([
+        'api.enablebanking.com/accounts/ext-1/transactions*' => Http::response([
+            'code' => 400,
+            'message' => 'Error interacting with ASPSP',
+            'detail' => 'Unknown error',
+            'error' => 'ASPSP_ERROR',
+        ], 400),
+        'api.enablebanking.com/accounts/ext-1/balances*' => Http::response(['balances' => []]),
+    ]);
+
+    try {
+        runSync(telemetryJob($connection));
+    } catch (TransientBankingProviderException) {
+        // Rethrown so the queue can retry. The record it wrote is the point.
+    }
+
+    $log = BankingSyncLog::query()
+        ->where('banking_connection_id', $connection->id)
+        ->latest('created_at')
+        ->firstOrFail();
+
+    expect($log->status)->toBe(BankingSyncLogStatus::Failed)
+        ->and($log->metadata['status_code'])->toBe(400)
+        ->and($log->metadata['provider_code'])->toBe('ASPSP_ERROR')
+        ->and($log->metadata['operation'])->toBe('transactions')
+        // The narrowed retry is the last call made, so its window is the one
+        // recorded: 90 days, with the 'longest' strategy dropped.
+        // MySQL normalises the key order of a JSON column, hence toMatchArray.
+        ->and($log->metadata['request_window'])->toMatchArray([
+            'date_from' => now()->subDays(90)->toDateString(),
+            'date_to' => now()->toDateString(),
+        ]);
 });
 
 test('a run killed by the rate limit reports what it had already imported', function () {

--- a/tests/Feature/OpenBanking/EnableBankingProviderTest.php
+++ b/tests/Feature/OpenBanking/EnableBankingProviderTest.php
@@ -26,7 +26,7 @@ test('getTransactions wraps EnableBanking ASPSP errors as non-reportable transie
     $provider = enableBankingProviderForTest();
 
     try {
-        $provider->getTransactions('ext-123', '2025-05-05', '2026-05-05', strategy: 'longest');
+        $provider->getTransactions('ext-123', '2026-04-08', '2026-07-07');
     } catch (TransientBankingProviderException $e) {
         expect($e)->toBeInstanceOf(ShouldntReport::class)
             ->and($e->provider)->toBe('enablebanking')
@@ -247,6 +247,62 @@ test('getTransactions keeps unrelated 422 validation errors reportable', functio
 
     expect(fn () => $provider->getTransactions('ext-123', '2026-04-06', '2026-07-07'))
         ->toThrow(RequestException::class);
+});
+
+test('getTransactions reads an opaque bank connector failure on a year-wide window as a period refusal', function () {
+    // Exactly what production answers for Renta 4, which sits behind Redsys:
+    // the EXECUTION_DATE_INVALID that Redsys actually raised never reaches us,
+    // so the width of the window we asked for is the only signal there is.
+    Http::fake([
+        'api.enablebanking.com/accounts/ext-123/transactions*' => Http::response([
+            'code' => 400,
+            'message' => 'Error interacting with ASPSP',
+            'detail' => 'Unknown error',
+            'error' => 'ASPSP_ERROR',
+        ], 400),
+    ]);
+
+    $provider = enableBankingProviderForTest();
+
+    expect(fn () => $provider->getTransactions('ext-123', '2025-07-07', '2026-07-07', strategy: 'longest'))
+        ->toThrow(WrongTransactionsPeriodException::class);
+});
+
+test('getTransactions keeps a bank connector failure on a 90-day window transient', function () {
+    // The first rung of the narrowing ladder, and the bound on the retry above:
+    // a 90-day window is not wider than 90 days, so the same body classifies as
+    // an ordinary connector failure and the ladder stops after one extra call.
+    Http::fake([
+        'api.enablebanking.com/accounts/ext-123/transactions*' => Http::response([
+            'code' => 400,
+            'message' => 'Error interacting with ASPSP',
+            'detail' => 'Unknown error',
+            'error' => 'ASPSP_ERROR',
+        ], 400),
+    ]);
+
+    $provider = enableBankingProviderForTest();
+
+    expect(fn () => $provider->getTransactions('ext-123', '2026-04-08', '2026-07-07'))
+        ->toThrow(TransientBankingProviderException::class);
+});
+
+test('getBalances is unaffected by the wide-window rule', function () {
+    // Only the transactions call carries a window, and Renta 4's balances have
+    // been the one thing that works all along. Keep it that way.
+    Http::fake([
+        'api.enablebanking.com/accounts/ext-123/balances' => Http::response([
+            'code' => 400,
+            'message' => 'Error interacting with ASPSP',
+            'detail' => 'Unknown error',
+            'error' => 'ASPSP_ERROR',
+        ], 400),
+    ]);
+
+    $provider = enableBankingProviderForTest();
+
+    expect(fn () => $provider->getBalances('ext-123'))
+        ->toThrow(TransientBankingProviderException::class);
 });
 
 test('getTransactions keeps non-ASPSP client errors reportable', function () {

--- a/tests/Feature/OpenBanking/TransactionSyncServiceTest.php
+++ b/tests/Feature/OpenBanking/TransactionSyncServiceTest.php
@@ -2,6 +2,7 @@
 
 use App\Contracts\BankingProviderInterface;
 use App\Enums\TransactionSource;
+use App\Exceptions\Banking\TransientBankingProviderException;
 use App\Exceptions\Banking\WrongTransactionsPeriodException;
 use App\Models\Account;
 use App\Models\Bank;
@@ -833,6 +834,39 @@ test('sync recovers the year-wide window a bank connector refuses with an opaque
     Http::assertSentCount(2);
     Http::assertSent(fn (Request $request) => str_contains($request->url(), 'date_from=2026-04-08')
         && ! str_contains($request->url(), 'strategy'));
+});
+
+test('sync stops after one narrowed retry when the connector keeps failing opaquely', function () {
+    // The bound on the rule above, pinned end to end: an opaque 400 that has
+    // nothing to do with the window buys the bank one extra request against its
+    // metered allowance, not the ladder's three. It holds because the retry is
+    // 90 days wide and 90 is not wider than 90 - so if that ever drifts apart
+    // from the ladder's first rung, this count is what says so.
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->create(['user_id' => $user->id]);
+    $account = Account::factory()->connected()->create([
+        'user_id' => $user->id,
+        'banking_connection_id' => $connection->id,
+        'external_account_id' => 'ext-123',
+    ]);
+
+    Http::fake([
+        'api.enablebanking.com/accounts/ext-123/transactions*' => Http::response([
+            'code' => 400,
+            'message' => 'Error interacting with ASPSP',
+            'detail' => 'Unknown error',
+            'error' => 'ASPSP_ERROR',
+        ], 400),
+    ]);
+
+    $service = new TransactionSyncService(enableBankingProviderForTest(), new TransactionDescriptionFormatter);
+
+    // Transient, not a period refusal: the syncer keeps the account rather than
+    // skipping it as one the bank refuses to serve any window for.
+    expect(fn () => $service->sync($account, '2025-07-07', '2026-07-07', 'longest', saveDailyBalances: false))
+        ->toThrow(TransientBankingProviderException::class);
+
+    Http::assertSentCount(2);
 });
 
 test('sync does not retry when the rejected window is already narrow', function () {

--- a/tests/Feature/OpenBanking/TransactionSyncServiceTest.php
+++ b/tests/Feature/OpenBanking/TransactionSyncServiceTest.php
@@ -10,7 +10,9 @@ use App\Models\Transaction;
 use App\Models\User;
 use App\Services\Banking\TransactionDescriptionFormatter;
 use App\Services\Banking\TransactionSyncService;
+use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
 
 test('sync creates transactions from provider data', function () {
     $user = User::factory()->onboarded()->create();
@@ -780,6 +782,57 @@ test('sync gives up on the account when even the narrowest window is rejected', 
 
     expect(fn () => $service->sync($account, '2026-04-06', '2026-07-07', saveDailyBalances: false))
         ->toThrow(WrongTransactionsPeriodException::class);
+});
+
+test('sync recovers the year-wide window a bank connector refuses with an opaque 400', function () {
+    // The Renta 4 regression, end to end through the real provider: an account
+    // with no transactions asks for a year, Redsys refuses it as
+    // EXECUTION_DATE_INVALID, and all EnableBanking passes on is an opaque
+    // ASPSP_ERROR. The narrowing ladder has to run off that alone.
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->create(['user_id' => $user->id]);
+    $account = Account::factory()->connected()->create([
+        'user_id' => $user->id,
+        'banking_connection_id' => $connection->id,
+        'external_account_id' => 'ext-123',
+    ]);
+
+    Http::fake(function (Request $request) {
+        parse_str((string) parse_url($request->url(), PHP_URL_QUERY), $query);
+
+        if (($query['date_from'] ?? null) === '2025-07-07') {
+            return Http::response([
+                'code' => 400,
+                'message' => 'Error interacting with ASPSP',
+                'detail' => 'Unknown error',
+                'error' => 'ASPSP_ERROR',
+            ], 400);
+        }
+
+        return Http::response([
+            'transactions' => [
+                [
+                    'transaction_id' => 'txn-001',
+                    'transaction_amount' => ['amount' => '50.00', 'currency' => 'EUR'],
+                    'credit_debit_indicator' => 'DBIT',
+                    'booking_date' => '2026-05-15',
+                    'remittance_information' => ['Renta 4 fee'],
+                ],
+            ],
+            'continuation_key' => null,
+        ]);
+    });
+
+    $service = new TransactionSyncService(enableBankingProviderForTest(), new TransactionDescriptionFormatter);
+    $created = $service->sync($account, '2025-07-07', '2026-07-07', 'longest', saveDailyBalances: false);
+
+    expect($created)->toBe(1);
+
+    // One refusal, one narrowed retry, and no further rungs: the 90-day window
+    // is not wide, so a connector that keeps failing is not worth three calls.
+    Http::assertSentCount(2);
+    Http::assertSent(fn (Request $request) => str_contains($request->url(), 'date_from=2026-04-08')
+        && ! str_contains($request->url(), 'strategy'));
 });
 
 test('sync does not retry when the rejected window is already narrow', function () {


### PR DESCRIPTION
## The bug

One Renta 4 Banco account has imported **zero transactions since it was connected 75 days ago**. Its balances have worked the whole time. Every `transactions` call comes back 400, every cycle, and it is our bug — a closed loop:

1. The account has no transactions, so `EnableBankingSyncer::resolveDateFrom()` finds no watermark and asks for **365 days** with `strategy=longest`.
2. Renta 4 sits behind **Redsys**, which refuses that range with `EXECUTION_DATE_INVALID`.
3. `isWrongPeriod()` requires **422 + "period" in the message**. What we get is a 400, so `WrongTransactionsPeriodException` is never thrown and **the narrowing ladder that already exists never runs**.
4. Nothing imported → no watermark next run → back to step 1. Forever.

## The question this had to settle first

`EXECUTION_DATE_INVALID` is only visible in the ASPSP half of the provider's control panel. The open question was whether it ever reaches us — a code-based match would be much tighter than one keyed on the window.

**It does not.** Read straight out of production `banking_sync_logs.metadata.response_body`, what Enable Banking returns to us is:

```json
{"code":400,"message":"Error interacting with ASPSP","detail":"Unknown error","error":"ASPSP_ERROR"}
```

`detail: "Unknown error"`. There is nothing bank-specific to key on, so the width of the window we asked for is the only signal there is.

## The fix

`EnableBankingProvider::isRefusedWideWindow()` — a **400/`ASPSP_ERROR` on a transactions window wider than 90 days** is read as the period refusal it is, which hands it to the ladder that was already there. The first rung is 90 days, the usual Redsys limit.

**It is self-bounding, and that is the point.** 90 is also the ladder's first rung, and a 90-day window is not *wider* than 90 — so the retry can only classify as an ordinary connector failure. A bank that 400s for an unrelated reason costs **one** extra request against its metered allowance, never three. `TransactionSyncServiceTest` pins that by counting requests, so the two `90`s cannot drift apart unnoticed.

### Blast radius, measured before shipping

The rule can only fire for an account with no `enablebanking` transaction in the last 90 days — anything syncing normally asks for a ~3-day window. Of every connection that saw a 400/`ASPSP_ERROR` on transactions in the last 14 days:

| Bank | Accounts | With recent transactions (rule cannot fire) |
|---|---|---|
| CaixaBank | 11 | 10 |
| Openbank | 8 | 8 |
| N26 | 38 | 13 |
| Trade Republic | 1 | 1 |
| imagin | 1 | 1 |
| **Renta 4 Banco** | **1** | **0** |

Renta 4 is the only persistent case (24 failures / 1 connection, every cycle); the rest are one-day blips on connections whose windows are narrow anyway.

## Making the reason visible

The premise that "the sync log never records why" turned out to be **half wrong, and worth correcting**: since 2026-08-20 `metadata` already carries `status_code`, `provider_code`, `operation`, `response_body` and `rate_limit_headers`. It is `error_message` alone that reads as a flaky bank — which is exactly what misled the first pass at this.

The one fact genuinely missing was **the window the failed call asked for**, so `SyncBankingConnectionJob::requestWindow()` adds it:

```json
"request_window": {"date_from": "2026-05-24", "date_to": "2026-08-22"}
```

Allow-listed to `date_from` / `date_to` / `strategy`, like the rate-limit headers next to it, because a query string is somewhere a token could ride along into a log. With it, "we asked for a range no bank will serve" and "the bank is flaky" are one query apart instead of 75 days.

## Verifying on the next scheduled cycle

Cycles run at 00:00 / 06:00 / 12:00 / 18:00 UTC. After the next one, connection `019ea3a9-32b6-72c8-800e-78911dbcd4b1`:

```sql
-- Should be non-zero for the first time ever.
SELECT COUNT(*) FROM transactions t
JOIN accounts a ON a.id = t.account_id
WHERE a.banking_connection_id = '019ea3a9-32b6-72c8-800e-78911dbcd4b1';

-- Should read `success`, not TransientBankingProviderException.
SELECT status, error_class, metadata FROM banking_sync_logs
WHERE banking_connection_id = '019ea3a9-32b6-72c8-800e-78911dbcd4b1'
ORDER BY created_at DESC LIMIT 4;
```

In the provider's request log, the account should show **two** transactions calls: the year-wide one still refused, then a 90-day one that returns 200.

**If it still fails**, the new `metadata.request_window` says immediately whether the retry went out at 90 days — which would mean Redsys's real ceiling is narrower and the rule should point at the ladder's second rung instead. That is the diagnosis this used to be missing.

## QA

Backend-only, so no browser. Ran the real `SyncBankingConnectionJob` against the local database with the HTTP layer returning production's exact body:

| Scenario | Calls | Result |
|---|---|---|
| Renta 4: year refused, 90 days served | `2025-08-22→2026-08-22 longest` → 400, `2026-05-24→2026-08-22` → 200 | **2 transactions imported**, connection `active`, sync log `success` |
| Connector broken at every window | same two calls | **stops at 2**, connection `error`, still `TransientBankingProviderException`, `request_window` recorded |
| Healthy account, narrow window, same 400 | `2026-08-17→2026-08-22` → 400 | **1 call, no retry** — unchanged from today |

## Deliberately not changed

- **429 classification.** `isRateLimitError()` is untouched; the new branch only picks which exception wraps the same 400.
- **Report level.** The 400 still matches `isAspspError()` in `isExpectedProviderOutcome()`, so it stays a warning and `WrongTransactionsPeriodException` is `ShouldntReport`. No new Sentry traffic.
- **Balances before transactions** (#837) and the page-budget resume markers.
- **`resolveDateFrom` still asks for a full year** on a first sync. Shrinking that globally would quietly cut the history every new connection gets, at every bank.

## Known limit

The user gets 90 days of history rather than 365 — the same trade the existing 422 ladder already makes, since the watermark then sits recent and the 90–365 day gap is never re-requested. Recovering it would mean setting the pagination resume marker after a narrowed retry so the next cycle walks further back; that is #837's machinery and a separate change. Ninety days of history beats the nothing this account has today.
