### PR TITLE
chore: refresh Laravel Boost guidelines for Inertia v3

### DIFF
--- a/.agents/skills/inertia-react-development/SKILL.md
+++ b/.agents/skills/inertia-react-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inertia-react-development
-description: "Develops Inertia.js v2 React client-side applications. Activates when creating React pages, forms, or navigation; using <Link>, <Form>, useForm, or router; working with deferred props, prefetching, or polling; or when user mentions React with Inertia, React pages, React forms, or React navigation."
+description: "Develops Inertia.js v3 React client-side applications. Activates when creating React pages, forms, or navigation; using <Link>, <Form>, useForm, useHttp, setLayoutProps, or router; working with deferred props, prefetching, optimistic updates, instant visits, or polling; or when user mentions React with Inertia, React pages, React forms, or React navigation."
 license: MIT
 metadata:
   author: laravel
@@ -13,14 +13,14 @@ metadata:
 Activate this skill when:
 
 - Creating or modifying React page components for Inertia
-- Working with forms in React (using `<Form>` or `useForm`)
+- Working with forms in React (using `<Form>`, `useForm`, or `useHttp`)
 - Implementing client-side navigation with `<Link>` or `router`
-- Using v2 features: deferred props, prefetching, WhenVisible, InfiniteScroll, once props, flash data, or polling
+- Using v3 features: deferred props, prefetching, optimistic updates, instant visits, layout props, HTTP requests, WhenVisible, InfiniteScroll, once props, flash data, or polling
 - Building React-specific features with the Inertia protocol
 
 ## Documentation
 
-Use `search-docs` for detailed Inertia v2 React patterns and documentation.
+Use `search-docs` for detailed Inertia v3 React patterns and documentation.
 
 ## Basic Usage
 
@@ -263,7 +263,124 @@ export default function CreateUser() {
 }
 ```
 
-## Inertia v2 Features
+## Inertia v3 Features
+
+### HTTP Requests
+
+Use the `useHttp` hook for standalone HTTP requests that do not trigger Inertia page visits. It provides the same developer experience as `useForm`, but for plain JSON endpoints.
+
+<!-- useHttp Example -->
+```react
+import { useHttp } from '@inertiajs/react'
+
+export default function Search() {
+    const { data, setData, get, processing } = useHttp({
+        query: '',
+    })
+
+    function search(e) {
+        setData('query', e.target.value)
+        get('/api/search', {
+            onSuccess: (response) => {
+                console.log(response)
+            },
+        })
+    }
+
+    return (
+        <>
+            <input value={data.query} onChange={search} />
+            {processing && <div>Searching...</div>}
+        </>
+    )
+}
+```
+
+### Optimistic Updates
+
+Apply data changes instantly before the server responds, with automatic rollback on failure:
+
+<!-- Optimistic Update with Router -->
+```react
+import { router } from '@inertiajs/react'
+
+function like(post) {
+    router.optimistic((props) => ({
+        post: {
+            ...props.post,
+            likes: props.post.likes + 1,
+        },
+    })).post(`/posts/${post.id}/like`)
+}
+```
+
+Optimistic updates also work with `useForm` and the `<Form>` component:
+
+<!-- Optimistic Update with Form Component -->
+```react
+import { Form } from '@inertiajs/react'
+
+<Form
+    action="/todos"
+    method="post"
+    optimistic={(props, data) => ({
+        todos: [...props.todos, { id: Date.now(), name: data.name, done: false }],
+    })}
+>
+    <input type="text" name="name" />
+    <button type="submit">Add Todo</button>
+</Form>
+```
+
+### Instant Visits
+
+Navigate to a new page immediately without waiting for the server response. The target component renders right away with shared props, while page-specific props load in the background.
+
+<!-- Instant Visit with Link -->
+```react
+import { Link } from '@inertiajs/react'
+
+<Link href="/dashboard" component="Dashboard">Dashboard</Link>
+
+<Link
+    href="/posts/1"
+    component="Posts/Show"
+    pageProps={{ post: { id: 1, title: 'My Post' } }}
+>
+    View Post
+</Link>
+```
+
+### Layout Props
+
+Share dynamic data between pages and persistent layouts:
+
+<!-- Layout Props in Layout -->
+```react
+export default function Layout({ title = 'My App', showSidebar = true, children }) {
+    return (
+        <>
+            <header>{title}</header>
+            {showSidebar && <aside>Sidebar</aside>}
+            <main>{children}</main>
+        </>
+    )
+}
+```
+
+<!-- Setting Layout Props from Page -->
+```react
+import { setLayoutProps } from '@inertiajs/react'
+
+export default function Dashboard() {
+    setLayoutProps({
+        title: 'Dashboard',
+        showSidebar: false,
+    })
+
+    return <h1>Dashboard</h1>
+}
+```
 
 ### Deferred Props
 
@@ -272,7 +389,6 @@ Use deferred props to load data after initial page render:
 <!-- Deferred Props with Empty State -->
 ```react
 export default function UsersIndex({ users }) {
-    // users will be undefined initially, then populated
     return (
         <div>
             <h1>Users</h1>
@@ -295,21 +411,14 @@ export default function UsersIndex({ users }) {
 
 ### Polling
 
-Automatically refresh data at intervals:
+Use the `usePoll` hook to automatically refresh data at intervals. It handles cleanup on unmount and throttles polling when the tab is inactive.
 
-<!-- Polling Example -->
+<!-- Basic Polling -->
 ```react
-import { router } from '@inertiajs/react'
-import { useEffect } from 'react'
+import { usePoll } from '@inertiajs/react'
 
 export default function Dashboard({ stats }) {
-    useEffect(() => {
-        const interval = setInterval(() => {
-            router.reload({ only: ['stats'] })
-        }, 5000) // Poll every 5 seconds
-
-        return () => clearInterval(interval)
-    }, [])
+    usePoll(5000)
 
     return (
         <div>
@@ -319,6 +428,38 @@ export default function Dashboard({ stats }) {
     )
 }
 ```
+
+<!-- Polling With Request Options and Manual Control -->
+```react
+import { usePoll } from '@inertiajs/react'
+
+export default function Dashboard({ stats }) {
+    const { start, stop } = usePoll(5000, {
+        only: ['stats'],
+        onStart() {
+            console.log('Polling request started')
+        },
+        onFinish() {
+            console.log('Polling request finished')
+        },
+    }, {
+        autoStart: false,
+        keepAlive: true,
+    })
+
+    return (
+        <div>
+            <h1>Dashboard</h1>
+            <div>Active Users: {stats.activeUsers}</div>
+            <button onClick={start}>Start Polling</button>
+            <button onClick={stop}>Stop Polling</button>
+        </div>
+    )
+}
+```
+
+- `autoStart` (default `true`) - set to `false` to start polling manually via the returned `start()` function
+- `keepAlive` (default `false`) - set to `true` to prevent throttling when the browser tab is inactive
 
 ### WhenVisible
 
@@ -333,7 +474,6 @@ export default function Dashboard({ stats }) {
         <div>
             <h1>Dashboard</h1>
 
-            {/* stats prop is loaded only when this section scrolls into view */}
             <WhenVisible data="stats" buffer={200} fallback={<div className="animate-pulse">Loading stats...</div>}>
                 {({ fetching }) => (
                     <div>
@@ -348,6 +488,27 @@ export default function Dashboard({ stats }) {
 }
 ```
 
+### InfiniteScroll
+
+Automatically load additional pages of paginated data as users scroll:
+
+<!-- InfiniteScroll Example -->
+```react
+import { InfiniteScroll } from '@inertiajs/react'
+
+export default function Users({ users }) {
+    return (
+        <InfiniteScroll data="users">
+            {users.data.map(user => (
+                <div key={user.id}>{user.name}</div>
+            ))}
+        </InfiniteScroll>
+    )
+}
+```
+
+The server must use `Inertia::scroll()` to configure the paginated data. Use the `search-docs` tool with a query of `infinite scroll` for detailed guidance on buffers, manual loading, reverse mode, and custom trigger elements.
+
 ## Server-Side Patterns
 
 Server-side patterns (Inertia::render, props, middleware) are covered in inertia-laravel guidelines.
@@ -359,3 +520,5 @@ Server-side patterns (Inertia::render, props, middleware) are covered in inertia
 - Not handling the `undefined` state of deferred props before data loads
 - Using `<form>` without preventing default submission (use `<Form>` component or `e.preventDefault()`)
 - Forgetting to check if `<Form>` component is available in your Inertia version
+- Using `router.cancel()` instead of `router.cancelAll()` (v3 breaking change)
+- Using `router.on('invalid', ...)` or `router.on('exception', ...)` instead of the renamed `httpException` and `networkError` events

--- a/.agents/skills/pest-testing/SKILL.md
+++ b/.agents/skills/pest-testing/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: pest-testing
-description: "Use this skill for Pest PHP testing in Laravel projects only. Trigger whenever any test is being written, edited, fixed, or refactored — including fixing tests that broke after a code change, adding assertions, converting PHPUnit to Pest, adding datasets, and TDD workflows. Always activate when the user asks how to write something in Pest, mentions test files or directories (tests/Feature, tests/Unit, tests/Browser), or needs browser testing, smoke testing multiple pages for JS errors, or architecture tests. Covers: test()/it()/expect() syntax, datasets, mocking, browser testing (visit/click/fill), smoke testing, arch(), Livewire component tests, RefreshDatabase, and all Pest 4 features. Do not use for factories, seeders, migrations, controllers, models, or non-test PHP code."
+description: "Use this skill for Pest PHP testing in Laravel projects only. Trigger whenever any test is being written, edited, fixed, or refactored — including fixing tests that broke after a code change, adding assertions, converting PHPUnit to Pest, adding datasets, and TDD workflows. Always activate when the user asks how to write something in Pest, mentions test files or directories (tests/Feature, tests/Unit, tests/Browser), or needs browser testing, smoke testing multiple pages for JS errors, architecture tests, or faster test runs with Test Impact Analysis. Covers: test()/it()/expect() syntax, datasets, mocking, browser testing (visit/click/fill), smoke testing, arch(), Livewire component tests, RefreshDatabase, Tia (--tia), sharding, and all Pest 5 features. Do not use for factories, seeders, migrations, controllers, models, or non-test PHP code."
 license: MIT
 metadata:
   author: laravel
 ---
 
-# Pest Testing 4
+# Pest Testing 5
 
 ## Documentation
 
-Use `search-docs` for detailed Pest 4 patterns and documentation.
+Use `search-docs` for detailed Pest 5 patterns and documentation.
 
 ## Basic Usage
 
@@ -46,6 +46,7 @@ it('is true', function () {
 - Run minimal tests with filter before finalizing: `php artisan test --compact --filter=testName`.
 - Run all tests: `php artisan test --compact`.
 - Run file: `php artisan test --compact tests/Feature/ExampleTest.php`.
+- Run only tests affected by recent changes (Tia): `./vendor/bin/pest --parallel --tia`.
 
 ## Assertions
 
@@ -82,15 +83,57 @@ it('has emails', function (string $email) {
 ]);
 ```
 
-## Pest 4 Features
+## Pest 5 Features
 
 | Feature | Purpose |
 |---------|---------|
+| Tia (Test Impact Analysis) | Rerun only tests affected by recent changes |
+| Time-Balanced Sharding | Split tests across CI shards by execution time |
+| New Validation Expectations | `toBeEmail()`, `toBeUlid()`, `toBeIpAddress()`, and more |
 | Browser Testing | Full integration tests in real browsers |
 | Smoke Testing | Validate multiple pages quickly |
 | Visual Regression | Compare screenshots for visual changes |
-| Test Sharding | Parallel CI runs |
 | Architecture Testing | Enforce code conventions |
+
+### Tia (Test Impact Analysis)
+
+Tia reruns only tests affected by recent changes and replays cached results for the rest, dramatically reducing suite duration:
+
+<!-- Tia Example -->
+```shell
+./vendor/bin/pest --parallel --tia
+```
+
+- Replayed tests are not skipped — cached tests store everything they produced, including covered lines and branches.
+- Detects Laravel, Symfony, Livewire, and Inertia automatically.
+
+### New Validation Expectations
+
+Pest 5 ships eight new validation matchers, all supporting `.not` negation:
+
+<!-- Pest 5 Validation Expectations -->
+```php
+expect('nuno@pestphp.com')->toBeEmail();
+expect('01ARZ3NDEKTSV4RRFFQ69G5FAV')->toBeUlid();
+expect('192.168.1.1')->toBeIpAddress();
+expect('00:1a:2b:3c:4d:5e')->toBeMacAddress();
+expect('example.com')->toBeHostname();
+expect('example.co.uk')->toBeDomain();
+expect('Zm9vYmFy')->toBeBase64();
+expect('deadbeef')->toBeHexadecimal();
+```
+
+### Time-Balanced Sharding
+
+Distribute tests across CI shards by execution time rather than count:
+
+<!-- Pest Sharding Example -->
+```shell
+./vendor/bin/pest --update-shards
+./vendor/bin/pest --shard=1/4
+```
+
+Commit `tests/.pest/shards.json` to the repository so CI shards stay consistent.
 
 ### Browser Test Example
 
@@ -140,13 +183,7 @@ $pages->assertNoJavaScriptErrors()->assertNoConsoleLogs();
 
 Capture and compare screenshots to detect visual changes.
 
-### Test Sharding
-
-Split tests across parallel processes for faster CI runs.
-
 ### Architecture Testing
-
-Pest 4 includes architecture testing (from Pest 3):
 
 <!-- Architecture Test Example -->
 ```php

--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -1,0 +1,7 @@
+# Project Rules Index
+
+Before planning or editing, find the row whose globs match the file's path and read that rule file.
+
+| Applies to | Rule file |
+| --- | --- |
+| app/Jobs/** | .ai/rules/jobs.md |

--- a/.ai/rules/jobs.md
+++ b/.ai/rules/jobs.md
@@ -1,0 +1,13 @@
+---
+paths:
+  - 'app/Jobs/**'
+---
+
+# Jobs
+
+## failed() runs on a fresh instance, not the one that ran handle()
+The queue calls a job's `failed()` on a brand-new object: `CallQueuedHandler::failed()` does `unserialize($data['command'])` and only attaches the `Job` to it. So no property set during `handle()` is visible in `failed()` — a "did I already do X this run?" flag there is always its default, and a test that calls `$job->handle()` then `$job->failed()` on the same object will pass while doing nothing in production.
+
+Coordinate the two halves through something durable instead (a row, a cache key) and write the test with a fresh `new TheJob(...)` before calling `failed()`. `$this->attempts()` does work in `failed()` — the Job instance is attached.
+
+Bitten in #833, where a private bool flag was meant to stop `SyncBankingConnectionJob::failed()` re-logging a failure `handle()` had already recorded.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,11 +267,19 @@ This project has domain-specific skills available in `**/skills/**`. You MUST ac
 - ALWAYS use `search-docs` tool for version-specific Inertia documentation and updated code examples.
 - IMPORTANT: Activate `inertia-react-development` when working with Inertia client-side patterns.
 
-# Inertia v2
+# Inertia v3
 
-- Use all Inertia features from v1 and v2. Check the documentation before making changes to ensure the correct approach.
-- New features: deferred props, infinite scrolling (merging props + `WhenVisible`), lazy loading on scroll, polling, prefetching.
+- Use all Inertia features from v1, v2, and v3. Check the documentation before making changes to ensure the correct approach.
+- New v3 features: standalone HTTP requests (`useHttp` hook), optimistic updates with automatic rollback, layout props (`useLayoutProps` hook), instant visits, simplified SSR via `@inertiajs/vite` plugin, custom exception handling for error pages.
+- Carried over from v2: deferred props, infinite scroll, merging props, polling, prefetching, once props, flash data.
 - When using deferred props, add an empty state with a pulsing or animated skeleton.
+- Axios has been removed. Use the built-in XHR client with interceptors, or install Axios separately if needed.
+- `Inertia::lazy()` / `LazyProp` has been removed. Use `Inertia::optional()` instead.
+- Prop types (`Inertia::optional()`, `Inertia::defer()`, `Inertia::merge()`) work inside nested arrays with dot-notation paths.
+- SSR works automatically in Vite dev mode with `@inertiajs/vite` - no separate Node.js server needed during development.
+- Event renames: `invalid` is now `httpException`, `exception` is now `networkError`.
+- `router.cancel()` replaced by `router.cancelAll()`.
+- The `future` configuration namespace has been removed - all v2 future options are now always enabled.
 
 === laravel/core rules ===
 


### PR DESCRIPTION
## What

Regenerated the Laravel Boost guidelines in `CLAUDE.md` and refreshed the bundled agent skills.

- `CLAUDE.md`: the Inertia section moves from v2 to v3 — new features (`useHttp`, optimistic updates, layout props, instant visits, Vite-native SSR) plus the removals that used to silently mislead agents (`Inertia::lazy()`, Axios, `router.cancel()`, the `future` namespace).
- `.agents/skills/inertia-react-development` and `.agents/skills/pest-testing`: updated to the versions shipped with the current Boost release.
- `.ai/rules/`: adds the index and the first rule file (`jobs.md`), recorded from the `failed()`-on-a-fresh-instance trap hit in #833.

## Why

The guidelines still described Inertia v2 while the app runs v3, so agents were being pointed at APIs that no longer exist.

## Testing

Documentation and agent rules only — no application code touched.