### PR TITLE
fix(banking): drop a pagination marker that cannot contribute anything

### DIFF
--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\AccountType;
+use App\Enums\TransactionSource;
 use App\Models\Concerns\BelongsToSpace;
 use App\Services\BudgetTransactionService;
 use Carbon\Carbon;
@@ -192,6 +193,27 @@ class Account extends Model
     public function loanDetail(): HasOne
     {
         return $this->hasOne(LoanDetail::class);
+    }
+
+    /**
+     * Whether the bank sync already holds transactions dated before $date for
+     * this account, which is what makes a pagination resume marker there pure
+     * cost: the span behind it has been walked, and re-requesting it only feeds
+     * dedup while the window's end - and every recent transaction with it -
+     * stays in the past.
+     *
+     * Only bank-sourced rows count, the same way the sync window's watermark
+     * only counts them: a manual row or a CSV import dated years back says
+     * nothing about how far the provider has actually been paginated. Trashed
+     * rows do count, because dedup sees them too.
+     */
+    public function hasSyncedTransactionsBefore(string $date): bool
+    {
+        return $this->transactions()
+            ->withTrashed()
+            ->where('source', TransactionSource::EnableBanking)
+            ->where('transaction_date', '<', $date)
+            ->exists();
     }
 
     public function isConnected(): bool

--- a/app/Services/Banking/Sync/EnableBankingSyncer.php
+++ b/app/Services/Banking/Sync/EnableBankingSyncer.php
@@ -187,12 +187,12 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
         // asking for the full history again, because the watermark the routine
         // window is built on has already moved past it.
         //
-        // Until it drains, the account's window ends in the past, so its newest
-        // transactions wait for the backfill to finish. That is the accepted
-        // cost: the balance, which is what reads as zero today, is fetched on
-        // every one of those runs regardless. A --full resync is an explicit
-        // request to re-pull everything, so it starts over rather than resuming.
-        $resumeBefore = $isFirstSync ? null : $account->transactions_paginate_before?->toDateString();
+        // While it drains, the account's window ends in the past, so its newest
+        // transactions wait for the backfill to finish - which is why a marker
+        // that cannot contribute anything is dropped rather than resumed.
+        // A --full resync is an explicit request to re-pull everything, so it
+        // starts over rather than resuming.
+        $resumeBefore = $this->resumePoint($account, $isFirstSync);
 
         if ($resumeBefore !== null) {
             $dateFrom = $this->resolveDateFrom($account, $resumeBefore, forceFullWindow: true);
@@ -216,6 +216,35 @@ class EnableBankingSyncer extends AbstractBankingConnectionSyncer
         $dateFrom = $this->resolveDateFrom($account, $dateTo, $forceFullWindow);
 
         return [$dateFrom, $dateTo, $this->strategyFor($dateFrom)];
+    }
+
+    /**
+     * Where a run the page budget cut short left this account's history, or
+     * null when picking it up is not worth a run.
+     *
+     * A marker whose span the account already holds is pure cost: the run
+     * spends its whole budget on history dedup will throw away, and pays for it
+     * with the recent transactions the resume window's end shuts out. Measured
+     * over the 2026-08-22 cycles, this was every Trade Republic account that
+     * had one - one of them re-requesting 282 days it held in full, at 10
+     * requests a cycle, four cycles a day, moving the marker a single day each
+     * time. Falling through to the routine window imports the recent
+     * transactions again; the run that follows clears the marker itself, either
+     * by finishing or by being cut short over ground it already covers.
+     */
+    private function resumePoint(Account $account, bool $isFirstSync): ?string
+    {
+        if ($isFirstSync) {
+            return null;
+        }
+
+        $marker = $account->transactions_paginate_before?->toDateString();
+
+        if ($marker === null || $account->hasSyncedTransactionsBefore($marker)) {
+            return null;
+        }
+
+        return $marker;
     }
 
     /**

--- a/app/Services/Banking/TransactionSyncService.php
+++ b/app/Services/Banking/TransactionSyncService.php
@@ -180,7 +180,7 @@ class TransactionSyncService
         $current = $account->transactions_paginate_before?->toDateString();
         $frontier = $this->nextFrontier($truncated, $oldestSeen, $dateTo);
 
-        if ($frontier !== null && $this->backfillIsSpent($account, $frontier, $current !== null, $created)) {
+        if ($frontier !== null && $this->backfillIsSpent($account, $frontier, resumed: $current !== null, created: $created)) {
             $frontier = null;
         }
 

--- a/app/Services/Banking/TransactionSyncService.php
+++ b/app/Services/Banking/TransactionSyncService.php
@@ -125,7 +125,7 @@ class TransactionSyncService
             $this->saveDailyBalances($account, $dailyBalances);
         }
 
-        $this->recordPaginationFrontier($account, $continuationKey !== null, $oldestSeen, $dateTo);
+        $this->recordPaginationFrontier($account, $continuationKey !== null, $oldestSeen, $dateTo, $created);
 
         Log::info('Synced transactions', [
             'account_id' => $account->id,
@@ -168,15 +168,21 @@ class TransactionSyncService
      * ask for the same recent days again and the older history would never be
      * reached.
      *
-     * Cleared by a run that paginated to the end, and by one that was cut short
-     * without reaching anything older than it was already asked for: there is
-     * nothing further back to walk to, and keeping the marker would re-request
-     * the same window every cycle.
+     * Cleared by a run that paginated to the end, by one that was cut short
+     * without reaching anything older than it was already asked for, and by one
+     * whose next frontier would be spent on history the account already holds:
+     * there is nothing further back to walk to, and keeping the marker would
+     * re-request the same window every cycle while shutting out everything
+     * recent.
      */
-    private function recordPaginationFrontier(Account $account, bool $truncated, ?string $oldestSeen, string $dateTo): void
+    private function recordPaginationFrontier(Account $account, bool $truncated, ?string $oldestSeen, string $dateTo, int $created): void
     {
-        $frontier = $this->nextFrontier($truncated, $oldestSeen, $dateTo);
         $current = $account->transactions_paginate_before?->toDateString();
+        $frontier = $this->nextFrontier($truncated, $oldestSeen, $dateTo);
+
+        if ($frontier !== null && $this->backfillIsSpent($account, $frontier, $current !== null, $created)) {
+            $frontier = null;
+        }
 
         if ($truncated) {
             Log::warning('Transaction page budget stopped the sync early', [
@@ -184,6 +190,10 @@ class TransactionSyncService
                 'date_to' => $dateTo,
                 'oldest_reached' => $oldestSeen,
                 'resume_before' => $frontier,
+                // The marker this run arrived with and is not handing on, so a
+                // backfill that gave up is greppable rather than inferred from
+                // a resume_before that silently turned null.
+                'dropped_marker' => $frontier === null ? $current : null,
                 // The run spent its whole budget without getting past the date
                 // it was already asked for, so the day it stopped on is stepped
                 // over rather than re-read. Worth seeing in the logs.
@@ -196,6 +206,29 @@ class TransactionSyncService
         }
 
         $account->update(['transactions_paginate_before' => $frontier]);
+    }
+
+    /**
+     * Whether walking further back has stopped being worth a run, so the marker
+     * is dropped and the account goes back to the routine window that ends
+     * today. Two ways to know, both measured on Trade Republic on 2026-08-22:
+     *
+     *  - The span behind the frontier is already synced. The provider was being
+     *    asked for months it had already served, at 10 requests a cycle, for
+     *    dedup to throw all of it away.
+     *  - A run that resumed a marker imported nothing at all. 111 transaction
+     *    requests bought 2 transactions across one cycle, because the pages come
+     *    back nearly empty; a budget spent on that while the window's end keeps
+     *    every recent transaction out is a run better not repeated.
+     *
+     * The cost is a history the bank does hold but pages too thinly to reach:
+     * that account keeps whatever it has and stops walking. Recent transactions
+     * are worth more than a backfill that moves a day per cycle, and a --full
+     * resync still asks for everything.
+     */
+    private function backfillIsSpent(Account $account, string $frontier, bool $resumed, int $created): bool
+    {
+        return ($resumed && $created === 0) || $account->hasSyncedTransactionsBefore($frontier);
     }
 
     /**

--- a/tests/Feature/OpenBanking/EnableBankingPageBudgetTest.php
+++ b/tests/Feature/OpenBanking/EnableBankingPageBudgetTest.php
@@ -380,3 +380,79 @@ test('a full resync re-pulls the whole history instead of resuming a leftover ma
     // budget cut short must not quietly narrow it back down.
     expect($window)->toBe(['2025-08-21', '2026-08-21']);
 });
+
+test('a marker over history the account already holds is dropped and the recent window comes back', function () {
+    Carbon::setTestNow('2026-08-21 09:00:00');
+    config(['banking.transaction_page_budget' => ['default' => null, 'Metered Bank' => 2]]);
+
+    $connection = enableBankingConnectionWithAccounts(1);
+    $connection->update(['aspsp_name' => 'Metered Bank']);
+    $account = $connection->accounts[0];
+
+    // The shape production stalled in: a marker in May over an account whose
+    // own synced history already reaches further back than it. Resuming there
+    // re-requests months of rows dedup throws away, and the window's end keeps
+    // every recent transaction out while it does.
+    $account->update(['transactions_paginate_before' => '2026-05-31']);
+    $account->transactions()->create([
+        'user_id' => $connection->user_id,
+        'description' => 'Already synced, older than the marker',
+        'transaction_date' => '2026-05-01',
+        'amount' => -100,
+        'currency_code' => 'EUR',
+        'source' => TransactionSource::EnableBanking,
+    ]);
+
+    $requests = [];
+    $provider = pagingProvider($requests, '2026-08-21');
+    $provider->shouldReceive('getBalances')->andReturn(['balances' => []]);
+    app()->instance(BankingProviderInterface::class, $provider);
+
+    runSync(new SyncBankingConnectionJob($connection->refresh()));
+
+    // The routine window, ending today, so today's transactions arrive.
+    expect($requests[0]['date_to'])->toBe('2026-08-21')
+        ->and($account->transactions()->whereDate('transaction_date', '>=', '2026-08-20')->count())->toBe(2);
+
+    // And the run cut short over ground it already covers does not hand the
+    // marker on, so the next cycle asks for the recent window too.
+    expect($account->refresh()->transactions_paginate_before)->toBeNull();
+});
+
+test('a run that resumes a marker and imports nothing gives up on it', function () {
+    $account = budgetedAccount();
+    $account->update(['transactions_paginate_before' => '2026-06-03']);
+
+    // Held already, so every page this run walks is a dedup miss - while the
+    // account holds nothing older than the marker, which is what keeps the
+    // frontier looking like progress worth another run.
+    $account->transactions()->create([
+        'user_id' => $account->user_id,
+        'description' => 'Known',
+        'transaction_date' => '2026-06-03',
+        'amount' => -1000,
+        'currency_code' => 'EUR',
+        'source' => TransactionSource::EnableBanking,
+        'external_transaction_id' => 'known',
+    ]);
+
+    $provider = Mockery::mock(BankingProviderInterface::class);
+    $provider->shouldReceive('getTransactions')->andReturn([
+        'transactions' => [[
+            'transaction_id' => 'known',
+            'transaction_amount' => ['amount' => '10.00', 'currency' => 'EUR'],
+            'credit_debit_indicator' => 'DBIT',
+            'booking_date' => '2026-06-02',
+            'remittance_information' => ['Known'],
+        ]],
+        'continuation_key' => 'more',
+    ]);
+
+    $service = new TransactionSyncService($provider, new TransactionDescriptionFormatter);
+
+    expect($service->sync($account, '2025-08-21', '2026-06-03', pageBudget: 2))->toBe(0);
+
+    // 111 requests bought 2 transactions across one production cycle. A budget
+    // spent on nothing is not worth blocking the recent window for another one.
+    expect($account->refresh()->transactions_paginate_before)->toBeNull();
+});


### PR DESCRIPTION
## Why

#837 capped Trade Republic's transaction pagination at 10 pages per run and left
`accounts.transactions_paginate_before` so the next run resumes the older history. It
accepted a known cost in its own words: *"until it drains, the account's window ends in the
past, so its newest transactions wait for the backfill to finish."*

Measured across the 12:00 and 18:00 UTC cycles on 2026-08-22, over the 12 Trade Republic
accounts holding a marker, that drain is months rather than days:

| marker moved back in one cycle | accounts |
| --- | --- |
| 1 day | 6 |
| 0 days | 5 |
| new marker appeared | 1 |

Four cycles a day, so ~4 days of history recovered per calendar day — and meanwhile those
accounts import nothing recent, because the resume window *ends* at the marker. Only one of
the twelve imported anything at 18:00 (3 transactions, internal gap-filling; its oldest
transaction date did not move). At 12:00 Trade Republic spent 111 transaction requests to
import 2 transactions.

It crawls because `recordPaginationFrontier()` derives the next marker from the oldest date
the run actually *saw*, and Trade Republic's pages come back nearly empty, so that date
rarely beats the one the run was already asked for — the marker steps over a single day
(the existing `skipped_remainder_of` log field is exactly this case).

Most of that work was provably redundant. In resume mode the window start comes from
`resolveDateFrom(..., forceFullWindow: true)`, which without a watermark is
`now()->subYear()`. Account `019f9470`: marker `2026-05-31`, own oldest transaction
`2025-12-16` — ~282 days re-requested every cycle for dedup to throw away.

## What changed

A marker is only worth a run while walking back is still productive. Two conditions now
drop it instead of handing it on:

1. **The span behind it is already synced** (`Account::hasSyncedTransactionsBefore()`).
   Checked before resuming, so the run goes straight back to the routine window that ends
   today, and again before a new frontier is stored, so a truncated routine run cannot
   re-create a marker over ground it already covers. Only bank-sourced rows count, the same
   way the window's watermark only counts them — a CSV import dated years back says nothing
   about how far the provider has been paginated.
2. **A run that resumed a marker imported nothing at all.** Cheap, and it covers the
   accounts rule 1 misses: the ones whose own history starts *at* the marker.

Together those give the mechanism a coherent stopping rule: the backfill walks while it is
productive and stops the moment it isn't. A genuine backfill — every resume run importing
new older rows — still walks its history across runs exactly as #837 built it.

Applied to the 12 production markers as they stand: **7 clear on the next cycle** (rule 1),
**5 on the cycle after** (rule 2 fires at the end of their next resume run).

Deliberate trade-off: an account whose bank does hold older history but pages it too thinly
to reach will keep what it has and stop walking. That is the point — recent transactions are
worth more than a backfill moving a day per cycle — and `--full` still asks for everything.

### Not changed, on purpose

- **Balances before transactions** in `EnableBankingSyncer::sync`. Untouched ordering.
- **The page budget** (`config/banking.php`, `'Trade Republic' => 10`). Untouched.
- **The marker itself.** The provider paginates newest-first while the window start derives
  from the newest row we hold, so deleting it would make a truncated run re-read the same
  recent days for ever. This stops it running when it is useless, not existing.
- The `isWrongPeriod` narrowing ladder from #842 (Renta 4) is not in this path.
- **Left out:** counting only pages that carry transactions, instead of all pages. With
  these two rules an empty-page storm now costs one run per account before the marker is
  dropped, so the budget's page-vs-transaction semantics stopped being what blocks users.
  Worth doing on its own merits, not needed for this fix.

The new query runs only when a marker exists, or when a run was cut short — the common path
does no extra work.

## Tests

`tests/Feature/OpenBanking/EnableBankingPageBudgetTest.php`, both through the real syncer /
real transaction service:

- a marker over history the account already holds is dropped, the window ends today again,
  and today's transactions are imported;
- a run that resumes a marker and imports nothing gives up on it.

The #837 tests are unchanged and still green, including the one that pins a budgeted bank
walking its history across runs.

## How to verify in production

Sync cycles run at 00:00 / 06:00 / 12:00 / 18:00 UTC, so this is one data point every six
hours. After the first cycle post-deploy:

```sql
SELECT SUBSTRING(a.id,1,8) AS acct,
       a.transactions_paginate_before AS marker,
       MAX(t.transaction_date) AS newest_synced
FROM accounts a
LEFT JOIN transactions t ON t.account_id = a.id AND t.source = 'enablebanking'
WHERE a.banking_connection_id IN (SELECT id FROM banking_connections WHERE aspsp_name = 'Trade Republic')
GROUP BY a.id, a.transactions_paginate_before;
```

Expected: markers going null (7 accounts in the first cycle, the remaining 5 in the second),
and `newest_synced` moving to within a day or two of today for accounts that have activity.
Balances must not regress — every eligible connection should still have today's row in
`account_balances`, which is what #837 bought and what this must not undo. In the logs,
`Transaction page budget stopped the sync early` now carries `dropped_marker`, naming the
marker a run arrived with and chose not to hand on.

## What the two reviews raised

Both reviews landed on the same objection from opposite directions: *is the marker still
doing real work when we drop it?* One argued rule 1 fires too rarely to help ("an account
still backfilling has nothing before its marker by definition"), the other that it fires too
eagerly (one lone old row is not proof of coverage). The production rows answer both, so
here they are — history at or behind each marker:

| acct | marker | rows ≤ marker | days with rows | oldest ≤ marker |
| --- | --- | --- | --- | --- |
| 019f9470 | 2026-05-31 | 3 | 2 | 2026-05-01 |
| 019fc385 | 2026-05-31 | 2 | 2 | 2026-05-04 |
| 019fa2c3 | 2026-05-24 | 9 | 7 | 2026-05-01 |
| 019fa7f0 | 2026-07-19 | 74 | 20 | 2026-06-29 |
| 019ffaa8 | 2026-06-01 | 3 | 2 | 2026-05-18 |
| 01a023ce | 2026-06-20 | 5 | 3 | 2026-06-18 |
| 01a02534 | 2026-05-25 | 5 | 2 | 2026-05-23 |
| 019fe6b2 | 2026-07-21 | 1 | 1 | *= marker* |
| 01a01f17 | 2026-06-01 | 1 | 1 | *= marker* |

Seven accounts hold synced rows **strictly before** their own marker, which is what rule 1
keys on — the marker sits above history we already have, because the provider serves its
pages newest-first largely regardless of the window it was given. That is also why a marker
can crawl back a day while importing nothing: the day it steps onto is a day we already
hold. Eleven of the twelve accounts imported *nothing at all* in the 18:00 cycle, so rule
2's trigger is the normal outcome for the remaining five, not a rare one.

The residual case a review is right about: an account importing genuinely new old rows every
cycle keeps its marker and keeps waiting. None of the twelve measured accounts is in that
state, and that is the marker doing its job — the run is productive.

And the accepted hole, stated plainly: rule 1 asks whether older synced history exists, not
whether the span behind the marker is complete. `019f9470` holds rows on two days in May
under a marker at 2026-05-31, so dropping it may leave a gap in the middle. The first new
test is built on exactly that fixture — one old row with empty space behind it — so the
behaviour is pinned rather than incidental. The alternative was months of no recent
transactions for a gap the provider pages too thinly to close anyway, and `--full` still
asks for everything.
