### PR TITLE
feat: add OrcaRouter as a named AI provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -154,9 +154,9 @@ DEMO_ENCRYPTION_KEY=demo
 #
 # Provider is configurable independently of the model and defaults to Gemini.
 # Set AI_PROVIDER to switch every AI feature at once (e.g. "ollama" for fully
-# local, private processing); the per-feature vars below override it. Accepts
-# any laravel/ai provider ("gemini", "ollama", "openai", ...); an unknown value
-# fails fast.
+# local, private processing, or "orcarouter" for the OrcaRouter gateway); the
+# per-feature vars below override it. Accepts any laravel/ai provider ("gemini",
+# "ollama", "openai", ...) or a named provider such as "orcarouter".
 # AI_PROVIDER=gemini
 # AI_SUGGESTIONS_PROVIDER=gemini
 # AI_CATEGORIZATION_PROVIDER=gemini
@@ -168,6 +168,15 @@ GEMINI_BASE_URL=
 # GEMINI_BASE_URL is optional — leave empty to use Google AI Studio
 # (https://generativelanguage.googleapis.com/v1beta). Only set it for a
 # proxy or Vertex AI gateway.
+
+# --- OrcaRouter (gateway, OpenAI-compatible) ---
+# Set AI_PROVIDER=orcarouter (or a per-feature *_PROVIDER) to route the AI
+# features through the OrcaRouter gateway. ORCAROUTER_API_KEY is required;
+# ORCAROUTER_URL defaults to the OrcaRouter API base. The default model is the
+# gateway's auto-routed "orcarouter/auto"; per-feature *_MODEL vars still apply.
+# ORCAROUTER_API_KEY=
+# ORCAROUTER_URL=https://api.orcarouter.ai/v1
+# ORCAROUTER_MODEL=orcarouter/auto
 
 # --- Ollama (local, self-hosted models — no API key needed) ---
 # Point OLLAMA_URL at your Ollama server and set the model vars below to a

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The template includes:
 | `STRIPE_KEY`            | -       | Stripe publishable key                             |
 | `STRIPE_SECRET`         | -       | Stripe secret key                                  |
 | `STRIPE_WEBHOOK_SECRET` | -       | Stripe webhook signing secret                      |
-| `AI_PROVIDER`           | `gemini`| AI provider for every AI feature (`gemini`, `ollama`, `openai`, ...) |
+| `AI_PROVIDER`           | `gemini`| AI provider for every AI feature (`gemini`, `ollama`, `openai`, `orcarouter`, ...) |
 
 ## AI Provider
 
@@ -176,8 +176,9 @@ Whisper Money's AI features (transaction categorization and automation-rule
 suggestions) run on [`laravel/ai`](https://github.com/laravel/ai) and default to
 Google **Gemini**. The provider is configurable independently of the model, so
 you can point the app at **any text provider `laravel/ai` supports** — `gemini`,
-`openai`, `anthropic`, `azure`, `groq`, `xai`, `deepseek`, `mistral`, or a
-self-hosted **[Ollama](https://ollama.com)** server. Ollama is the headline case
+`openai`, `anthropic`, `azure`, `groq`, `xai`, `deepseek`, `mistral`, a
+self-hosted **[Ollama](https://ollama.com)** server, or the
+**[OrcaRouter](https://www.orcarouter.ai)** gateway. Ollama is the headline case
 because it keeps AI processing fully local and private — data never leaves your
 infrastructure — but the switch is generic.
 
@@ -198,6 +199,9 @@ unknown or non-text provider fails fast when the AI feature runs.
 | `GEMINI_API_KEY`             | -                    | Required when the provider is `gemini`.                               |
 | `OLLAMA_URL`                 | `http://localhost:11434` | Ollama server URL (used when the provider is `ollama`).           |
 | `OLLAMA_API_KEY`             | -                    | Optional; only needed behind an authenticating proxy.                 |
+| `ORCAROUTER_API_KEY`         | -                    | Required when the provider is `orcarouter`.                           |
+| `ORCAROUTER_URL`             | `https://api.orcarouter.ai/v1` | OrcaRouter API base URL.                                     |
+| `ORCAROUTER_MODEL`           | `orcarouter/auto`    | OrcaRouter model (defaults to the gateway's auto-routed model).       |
 
 ### Example: fully local AI with Ollama
 
@@ -209,6 +213,20 @@ AI_CATEGORIZATION_MODEL=gemma3:12b
 ```
 
 Make sure the model is pulled on the Ollama server first (`ollama pull gemma3:12b`).
+
+### Example: AI through the OrcaRouter gateway
+
+```dotenv
+AI_PROVIDER=orcarouter
+ORCAROUTER_API_KEY=your-orcarouter-key
+```
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible gateway that
+routes the AI features to frontier models over a single endpoint. It also runs
+gateway-level, zero-trust security for AI agents on the same endpoint —
+screening every prompt/response and governing every tool call on a default-deny
+basis, with no application code changes.
+
 Any other provider follows the same pattern: set `AI_PROVIDER`, that provider's
 credentials, and the `*_MODEL` vars to one of its models. Gemini remains the
 default, so existing deployments are unaffected.

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -11,8 +11,12 @@ use App\Services\Ai\UncategorizedTransactionMatcher;
 use App\Services\Banking\EnableBankingProvider;
 use App\Services\Discord\DiscordWebhook;
 use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Ai\Ai;
+use Laravel\Ai\Providers\OpenAiCompatibleProvider;
 use Laravel\Cashier\Cashier;
 use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
 use Laravel\Passport\Passport;
@@ -60,5 +64,22 @@ class AppServiceProvider extends ServiceProvider
         // Render the OAuth consent screen (Claude Desktop / ChatGPT connecting
         // to the MCP server) with our own on-brand Blade view.
         Passport::authorizationView(fn (array $parameters) => response()->view('mcp.authorize', $parameters));
+
+        // Register the named OrcaRouter provider as an openai-compatible instance.
+        // Referencing it is as easy as AI_PROVIDER=orcarouter — laravel/ai routes
+        // the three AI features through this gateway. See config/orcarouter.php.
+        // Runs here (not register()) so laravel/ai's AiManager binding exists.
+        Ai::extend('orcarouter', function (Application $app, array $config): OpenAiCompatibleProvider {
+            return new OpenAiCompatibleProvider(
+                array_merge($config, [
+                    'url' => config('orcarouter.url'),
+                    'key' => config('orcarouter.key'),
+                    'models' => [
+                        'text' => ['default' => config('orcarouter.model')],
+                    ],
+                ]),
+                $app->make(Dispatcher::class),
+            );
+        });
     }
 }

--- a/app/Services/Ai/AiProviderResolver.php
+++ b/app/Services/Ai/AiProviderResolver.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Services\Ai;
+
+use Laravel\Ai\Enums\Lab;
+
+/**
+ * Resolves the configured AI provider string into a value laravel/ai accepts
+ * as a `provider:` argument (a `Lab` enum case or a named provider string).
+ *
+ * laravel/ai lets you reference a named openai-compatible instance by its
+ * config key (e.g. `provider: 'orcarouter'`), but the app historically passes
+ * every provider value through `Lab::from()`, which throws for values that are
+ * not enum cases. This helper is the single tolerant place that maps a config
+ * string to a `Lab` case when it has one and otherwise falls back to the raw
+ * string so named providers (OrcaRouter) keep working.
+ */
+class AiProviderResolver
+{
+    /**
+     * Resolve a provider config string to a `Lab` case or a named provider string.
+     */
+    public static function resolve(string $provider): Lab|string
+    {
+        return Lab::tryFrom($provider) ?? $provider;
+    }
+}

--- a/app/Services/Ai/CategorizeTransactions.php
+++ b/app/Services/Ai/CategorizeTransactions.php
@@ -9,7 +9,6 @@ use App\Models\Transaction;
 use App\Models\User;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
-use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Exceptions\FailoverableException;
 use Throwable;
 
@@ -170,7 +169,7 @@ class CategorizeTransactions
 
         $response = (new TransactionCategorizationAgent)->prompt(
             $payload,
-            provider: Lab::from((string) config('ai_categorization.provider')),
+            provider: AiProviderResolver::resolve((string) config('ai_categorization.provider')),
             model: (string) config('ai_categorization.model'),
         );
 

--- a/app/Services/Ai/LaravelAiRuleSuggestionGenerator.php
+++ b/app/Services/Ai/LaravelAiRuleSuggestionGenerator.php
@@ -5,7 +5,6 @@ namespace App\Services\Ai;
 use App\Ai\Agents\RuleSuggestionAgent;
 use App\Services\Ai\Contracts\RuleSuggestionGenerator;
 use Illuminate\Support\Facades\Log;
-use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Exceptions\FailoverableException;
 use Throwable;
 
@@ -91,7 +90,7 @@ class LaravelAiRuleSuggestionGenerator implements RuleSuggestionGenerator
 
         $response = (new RuleSuggestionAgent)->prompt(
             $payload,
-            provider: Lab::from((string) config('ai_suggestions.provider')),
+            provider: AiProviderResolver::resolve((string) config('ai_suggestions.provider')),
             model: (string) config('ai_suggestions.model'),
         );
 

--- a/app/Services/Ai/ReportSummarizer.php
+++ b/app/Services/Ai/ReportSummarizer.php
@@ -6,7 +6,6 @@ use App\Ai\Agents\ReportSummaryAgent;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
-use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Exceptions\FailoverableException;
 use Throwable;
 
@@ -52,7 +51,7 @@ class ReportSummarizer
                     'previous' => $previous['payload'] ?? null,
                     'previous_captured_at' => $previous['captured_at'] ?? null,
                 ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
-                provider: Lab::from((string) config('ai_reports.provider')),
+                provider: AiProviderResolver::resolve((string) config('ai_reports.provider')),
                 model: (string) config('ai_reports.model'),
                 timeout: (int) config('ai_reports.timeout'),
             );

--- a/config/ai_categorization.php
+++ b/config/ai_categorization.php
@@ -9,15 +9,18 @@ return [
     |
     | Provider and model for transaction categorization, both env-overridable.
     | The provider defaults to Gemini but accepts any laravel/ai provider (a
-    | valid Laravel\Ai\Enums\Lab case — an unknown value fails fast). Cost is
-    | negligible at any tier, so the model is chosen for accuracy. See the
-    | README "AI Provider" section for the shared options (e.g. local Ollama).
+    | valid Laravel\Ai\Enums\Lab case or a named provider like "orcarouter").
+    | Cost is negligible at any tier, so the model is chosen for accuracy. See
+    | the README "AI Provider" section for the shared options (e.g. local Ollama
+    | or the OrcaRouter gateway).
     |
     */
 
     'provider' => env('AI_CATEGORIZATION_PROVIDER', env('AI_PROVIDER', 'gemini')),
 
-    'model' => env('AI_CATEGORIZATION_MODEL', 'gemini-flash-latest'),
+    'model' => env('AI_CATEGORIZATION_MODEL', env('AI_CATEGORIZATION_PROVIDER', env('AI_PROVIDER', 'gemini')) === 'orcarouter'
+        ? env('ORCAROUTER_MODEL', 'orcarouter/auto')
+        : 'gemini-flash-latest'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/ai_reports.php
+++ b/config/ai_reports.php
@@ -10,15 +10,18 @@ return [
     | Provider and model for the AI summary that opens the scheduled stats
     | reports (`stats:subscription-funnel`, `stats:ai-cohort-report`). The
     | provider defaults to Gemini but accepts any laravel/ai provider (a valid
-    | Laravel\Ai\Enums\Lab case); a Flash-tier model is plenty for summarising
-    | a handful of pre-computed figures. See the README "AI Provider" section
-    | for the shared AI_PROVIDER switch.
+    | Laravel\Ai\Enums\Lab case or a named provider like "orcarouter"); a
+    | Flash-tier model is plenty for summarising a handful of pre-computed
+    | figures. See the README "AI Provider" section for the shared AI_PROVIDER
+    | switch and the OrcaRouter gateway.
     |
     */
 
     'provider' => env('AI_REPORTS_PROVIDER', env('AI_PROVIDER', 'gemini')),
 
-    'model' => env('AI_REPORTS_MODEL', 'gemini-flash-latest'),
+    'model' => env('AI_REPORTS_MODEL', env('AI_REPORTS_PROVIDER', env('AI_PROVIDER', 'gemini')) === 'orcarouter'
+        ? env('ORCAROUTER_MODEL', 'orcarouter/auto')
+        : 'gemini-flash-latest'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/ai_suggestions.php
+++ b/config/ai_suggestions.php
@@ -9,15 +9,18 @@ return [
     |
     | Provider and model for automation-rule suggestions, both env-overridable.
     | The provider defaults to Gemini but accepts any laravel/ai provider (a
-    | valid Laravel\Ai\Enums\Lab case — an unknown value fails fast). Any
-    | Flash-tier model suits this constrained task. See the README "AI Provider"
-    | section for the shared options (e.g. local Ollama, the AI_PROVIDER switch).
+    | valid Laravel\Ai\Enums\Lab case or a named provider like "orcarouter").
+    | Any Flash-tier model suits this constrained task. See the README "AI
+    | Provider" section for the shared options (e.g. local Ollama, the
+    | AI_PROVIDER switch, or the OrcaRouter gateway).
     |
     */
 
     'provider' => env('AI_SUGGESTIONS_PROVIDER', env('AI_PROVIDER', 'gemini')),
 
-    'model' => env('AI_SUGGESTIONS_MODEL', 'gemini-flash-latest'),
+    'model' => env('AI_SUGGESTIONS_MODEL', env('AI_SUGGESTIONS_PROVIDER', env('AI_PROVIDER', 'gemini')) === 'orcarouter'
+        ? env('ORCAROUTER_MODEL', 'orcarouter/auto')
+        : 'gemini-flash-latest'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/orcarouter.php
+++ b/config/orcarouter.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | OrcaRouter provider
+    |--------------------------------------------------------------------------
+    |
+    | Named openai-compatible provider instance used when AI_PROVIDER (or a
+    | per-feature *_PROVIDER) is set to "orcarouter". OrcaRouter is a gateway
+    | that serves frontier models over an OpenAI-compatible endpoint, so it is
+    | wired through laravel/ai's openai-compatible driver with its own base URL
+    | and key. The default model is the gateway's auto-routed "orcarouter/auto";
+    | the per-feature *_MODEL vars still override it.
+    |
+    */
+
+    'url' => env('ORCAROUTER_URL', 'https://api.orcarouter.ai/v1'),
+
+    'key' => env('ORCAROUTER_API_KEY'),
+
+    'model' => env('ORCAROUTER_MODEL', 'orcarouter/auto'),
+
+];

--- a/tests/Feature/Ai/CategorizeTransactionsTest.php
+++ b/tests/Feature/Ai/CategorizeTransactionsTest.php
@@ -249,3 +249,30 @@ it('skips results whose category index does not resolve', function () {
     expect($outcomes)->toBe([])
         ->and($transaction->category_id)->toBeNull();
 });
+
+it('routes prompts through the named OrcaRouter provider', function () {
+    config()->set('ai_categorization.provider', 'orcarouter');
+    config()->set('ai_categorization.model', 'orcarouter/auto');
+
+    $user = User::factory()->create();
+    $category = groceries($user);
+    $transaction = uncategorized($user);
+
+    $index = leafIndex(CategoryCatalog::forUser($user), $category->id);
+
+    TransactionCategorizationAgent::fake([
+        ['results' => [[
+            'ref' => $transaction->id,
+            'category_index' => $index,
+            'confidence' => 0.95,
+            'merchant_unambiguous' => true,
+        ]]],
+    ]);
+
+    app(CategorizeTransactions::class)->forTransactions($user, collect([$transaction]));
+
+    TransactionCategorizationAgent::assertPrompted(
+        fn ($prompt): bool => (string) $prompt->provider === 'orcarouter'
+            && $prompt->model === 'orcarouter/auto',
+    );
+});

--- a/tests/Feature/Ai/RuleSuggestionGeneratorTest.php
+++ b/tests/Feature/Ai/RuleSuggestionGeneratorTest.php
@@ -75,10 +75,13 @@ it('fails fast with a clear error when the configured provider is unknown', func
 
     RuleSuggestionAgent::fake([['suggestions' => []]]);
 
+    // The provider string is passed through laravel/ai's manager, which throws
+    // InvalidArgumentException for an unknown driver (instead of the old
+    // Lab::from ValueError), so the misconfiguration still fails fast.
     expect(fn () => (new LaravelAiRuleSuggestionGenerator)->generate(
         groups: [benchGroup('alpha')],
         categoryOptions: [['id' => 'cat-1', 'name' => 'X', 'path' => 'X', 'type' => 'expense', 'direction' => 'outflow', 'is_leaf' => true]],
-    ))->toThrow(ValueError::class);
+    ))->toThrow(InvalidArgumentException::class);
 });
 
 function genSuggestion(string $key): array

--- a/tests/Unit/Ai/AiProviderResolverTest.php
+++ b/tests/Unit/Ai/AiProviderResolverTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use App\Services\Ai\AiProviderResolver;
+use Laravel\Ai\Enums\Lab;
+
+it('resolves known lab provider names to their enum case', function () {
+    expect(AiProviderResolver::resolve('gemini'))->toBe(Lab::Gemini);
+    expect(AiProviderResolver::resolve('openai'))->toBe(Lab::OpenAI);
+    expect(AiProviderResolver::resolve('openai-compatible'))->toBe(Lab::OpenAiCompatible);
+    expect(AiProviderResolver::resolve('ollama'))->toBe(Lab::Ollama);
+});
+
+it('keeps named custom providers as strings so laravel/ai can look them up by config key', function () {
+    expect(AiProviderResolver::resolve('orcarouter'))->toBe('orcarouter');
+});

--- a/tests/Unit/Ai/AiProviderResolverTest.php
+++ b/tests/Unit/Ai/AiProviderResolverTest.php
@@ -6,7 +6,7 @@ use Laravel\Ai\Enums\Lab;
 it('resolves known lab provider names to their enum case', function () {
     expect(AiProviderResolver::resolve('gemini'))->toBe(Lab::Gemini);
     expect(AiProviderResolver::resolve('openai'))->toBe(Lab::OpenAI);
-    expect(AiProviderResolver::resolve('openai-compatible'))->toBe(Lab::OpenAiCompatible);
+    expect(AiProviderResolver::resolve('openai-compatible'))->toBe(Lab::OpenAICompatible);
     expect(AiProviderResolver::resolve('ollama'))->toBe(Lab::Ollama);
 });
 


### PR DESCRIPTION
## Add [OrcaRouter](https://www.orcarouter.ai) as a named AI provider

This PR adds **OrcaRouter** as a named provider for the AI features (transaction categorization, automation-rule suggestions, and report summaries), alongside the existing Gemini, Ollama, and other laravel/ai providers.

### What changed

- **`config/orcarouter.php`** — new config for the OrcaRouter gateway: `ORCAROUTER_URL` (defaults to `https://api.orcarouter.ai/v1`), `ORCAROUTER_API_KEY`, and the default model `orcarouter/auto`.
- **`app/Providers/AppServiceProvider.php`** — registers the named `orcarouter` provider via `Ai::extend()` using laravel/ai's `openai-compatible` driver (Bearer auth + custom base URL).
- **`app/Services/Ai/AiProviderResolver.php`** — small helper that maps a provider config string to a `Lab` enum case when one exists, and otherwise passes the named provider string through to laravel/ai (so named providers like `orcarouter` resolve by config key).
- **`config/ai_categorization.php`, `config/ai_suggestions.php`, `config/ai_reports.php`** — default the model to `orcarouter/auto` when the provider is `orcarouter`; per-feature `*_MODEL` vars still override.
- **`.env.example` / `README.md`** — document `ORCAROUTER_API_KEY` / `ORCAROUTER_URL` / `ORCAROUTER_MODEL` and the `AI_PROVIDER=orcarouter` switch.
- **Tests** — unit test for `AiProviderResolver`, a feature test proving `AI_CATEGORIZATION_PROVIDER=orcarouter` routes prompts through the named provider, and an updated fail-fast test (unknown providers now surface `InvalidArgumentException` from laravel/ai's manager instead of `ValueError` from `Lab::from`).

### How it works

Set `AI_PROVIDER=orcarouter` (or a per-feature `*_PROVIDER`) and `ORCAROUTER_API_KEY`:

```dotenv
AI_PROVIDER=orcarouter
ORCAROUTER_API_KEY=your-orcarouter-key
```

laravel/ai then routes all three AI features to `https://api.orcarouter.ai/v1/chat/completions` with the configured key. Gemini stays the default, so existing deployments are unaffected.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible gateway that routes to frontier models over a single endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### Verification

- `php -l` passes on all changed files.
- Pint (`laravel` preset) passes on all changed files.
- `git diff --check` is clean.
- **L3 live test**: `POST https://api.orcarouter.ai/v1/chat/completions` with `model=orcarouter/auto` and a real key returns **HTTP 200** with a valid `chat.completion` — the exact request shape the `openai-compatible` driver sends.

Disclosure: I'm an engineer on the OrcaRouter team.
