### PR TITLE
fix(onboarding): stop a background poll telling the user their connection is down

### DIFF
--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -29,21 +29,21 @@ import { installChunkLoadRecovery } from './lib/chunk-load-recovery';
 import { installFailedNavigationToast } from './lib/failed-navigation-toast';
 import { leavePage } from './lib/leave-page';
 import { initializePostHog } from './lib/posthog';
-import { trackPrefetchedUrls } from './lib/prefetch-tracker';
 import {
     isBrowserExtensionNoise,
     isChunkLoadErrorEvent,
     isFacebookInAppBrowserJavaBridgeNoise,
-    isFailedPrefetchNoise,
     isPageLeaveAbortNoise,
     isPostMessageDataCloneNoise,
     isSafariCashbackExtensionNoise,
+    isUnattendedRequestNoise,
 } from './lib/sentry';
+import { trackUnattendedRequests } from './lib/unattended-requests';
 import type { ExpiredBankingConnectionNotification, SharedData } from './types';
 import { __, setTranslations } from './utils/i18n';
 
 installChunkLoadRecovery();
-trackPrefetchedUrls();
+trackUnattendedRequests();
 installFailedNavigationToast();
 
 Sentry.init({
@@ -56,7 +56,7 @@ Sentry.init({
         if (
             isChunkLoadErrorEvent(event) ||
             isPageLeaveAbortNoise(event) ||
-            isFailedPrefetchNoise(event) ||
+            isUnattendedRequestNoise(event) ||
             isBrowserExtensionNoise(event) ||
             isPostMessageDataCloneNoise(event) ||
             isFacebookInAppBrowserJavaBridgeNoise(event) ||

--- a/resources/js/lib/failed-navigation-toast.test.ts
+++ b/resources/js/lib/failed-navigation-toast.test.ts
@@ -127,6 +127,49 @@ describe('installFailedNavigationToast', () => {
         expect(toastError).toHaveBeenCalledOnce();
     });
 
+    it('speaks up for a real reload that a poll tick overlapped', async () => {
+        const { listeners } = await freshModules();
+
+        // Inertia does not cancel an in-flight visit to the page you are already
+        // on, so the poll keeps ticking underneath a reload the user asked for.
+        listeners.before?.({
+            detail: {
+                visit: {
+                    url: new URL('https://whisper.money/settings/connections'),
+                    prefetch: false,
+                },
+            },
+        });
+        listeners.before?.(
+            polling('https://whisper.money/settings/connections'),
+        );
+        listeners.networkError?.(
+            failure('https://whisper.money/settings/connections'),
+        );
+
+        expect(toastError).toHaveBeenCalledOnce();
+    });
+
+    it('stops attributing a poll once its window has passed', async () => {
+        vi.useFakeTimers();
+
+        try {
+            const { listeners } = await freshModules();
+
+            // The poll stopped - the step moved on, the page unmounted - so the
+            // next failure at that url belongs to whoever asked for it next.
+            listeners.before?.(polling('https://whisper.money/onboarding'));
+            vi.setSystemTime(Date.now() + 31_000);
+            listeners.networkError?.(
+                failure('https://whisper.money/onboarding'),
+            );
+
+            expect(toastError).toHaveBeenCalledOnce();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
     it('still speaks up when the error carries no url', async () => {
         const { listeners } = await freshModules();
 

--- a/resources/js/lib/failed-navigation-toast.test.ts
+++ b/resources/js/lib/failed-navigation-toast.test.ts
@@ -110,6 +110,43 @@ describe('installFailedNavigationToast', () => {
         expect(toastError).not.toHaveBeenCalled();
     });
 
+    it('speaks up when the lost beats keep coming', async () => {
+        const { listeners } = await freshModules();
+
+        // A connection that is actually gone, on a page where the poll is the only
+        // thing happening: nothing else would ever tell the user.
+        for (let beat = 0; beat < 3; beat++) {
+            listeners.before?.(polling('https://whisper.money/onboarding'));
+            listeners.networkError?.(
+                failure('https://whisper.money/onboarding'),
+            );
+        }
+
+        expect(toastError).toHaveBeenCalledOnce();
+    });
+
+    it('forgets the lost beats as soon as something gets through', async () => {
+        const { listeners } = await freshModules();
+
+        for (let beat = 0; beat < 2; beat++) {
+            listeners.before?.(polling('https://whisper.money/onboarding'));
+            listeners.networkError?.(
+                failure('https://whisper.money/onboarding'),
+            );
+        }
+
+        listeners.success?.({ detail: {} });
+
+        for (let beat = 0; beat < 2; beat++) {
+            listeners.before?.(polling('https://whisper.money/onboarding'));
+            listeners.networkError?.(
+                failure('https://whisper.money/onboarding'),
+            );
+        }
+
+        expect(toastError).not.toHaveBeenCalled();
+    });
+
     it('speaks up once the user asks for the page a poll was refreshing', async () => {
         const { listeners } = await freshModules();
 

--- a/resources/js/lib/failed-navigation-toast.test.ts
+++ b/resources/js/lib/failed-navigation-toast.test.ts
@@ -19,14 +19,14 @@ async function freshModules() {
     }));
     vi.doMock('sonner', () => ({ toast: { error: toastError } }));
 
-    const tracker = await import('./prefetch-tracker');
+    const tracker = await import('./unattended-requests');
     // The departure flag lives at module scope and is one-way, so the pair has to
     // be imported fresh alongside the listener it now guards.
     const leavePageModule = await import('./leave-page');
     const { installFailedNavigationToast } =
         await import('./failed-navigation-toast');
 
-    tracker.trackPrefetchedUrls();
+    tracker.trackUnattendedRequests();
     installFailedNavigationToast();
 
     return { listeners, leavePage: leavePageModule.leavePage };
@@ -34,6 +34,14 @@ async function freshModules() {
 
 function failure(url: string) {
     return { detail: { error: { url } } };
+}
+
+function polling(url: string) {
+    return {
+        detail: {
+            visit: { url: new URL(url), prefetch: false, poll: true },
+        },
+    };
 }
 
 function prefetching(url: string) {
@@ -89,6 +97,32 @@ describe('installFailedNavigationToast', () => {
             },
         });
         listeners.networkError?.(failure('https://whisper.money/cashflow'));
+
+        expect(toastError).toHaveBeenCalledOnce();
+    });
+
+    it('says nothing about a poll the user never asked for', async () => {
+        const { listeners } = await freshModules();
+
+        listeners.before?.(polling('https://whisper.money/onboarding'));
+        listeners.networkError?.(failure('https://whisper.money/onboarding'));
+
+        expect(toastError).not.toHaveBeenCalled();
+    });
+
+    it('speaks up once the user asks for the page a poll was refreshing', async () => {
+        const { listeners } = await freshModules();
+
+        listeners.before?.(polling('https://whisper.money/onboarding'));
+        listeners.before?.({
+            detail: {
+                visit: {
+                    url: new URL('https://whisper.money/onboarding'),
+                    prefetch: false,
+                },
+            },
+        });
+        listeners.networkError?.(failure('https://whisper.money/onboarding'));
 
         expect(toastError).toHaveBeenCalledOnce();
     });

--- a/resources/js/lib/failed-navigation-toast.ts
+++ b/resources/js/lib/failed-navigation-toast.ts
@@ -19,11 +19,32 @@ import { wasUnattended } from './unattended-requests';
  * later. The same goes for whatever a full page navigation of our own aborts on the
  * way out.
  *
+ * Quiet is not the same as mute, though: see {@link LOST_BEATS_BEFORE_SPEAKING}.
+ *
  * Deliberately does not call `preventDefault()`: that would skip the cleanup Inertia
  * runs for a failed prefetch, leaving a dead entry that a later click waits on
  * forever.
  */
+/**
+ * How many unattended failures in a row it takes to speak up anyway.
+ *
+ * One lost beat is a blip and the next tick answers it. A run of them is the
+ * user's connection being gone - and on the two pages that poll, the onboarding
+ * create-account step and the connections page, the poll is the only thing
+ * happening, so nothing else would ever mention it. Three ticks is twelve seconds
+ * of silence there, which is about as long as staring at a page that has stopped
+ * updating stays comfortable.
+ */
+const LOST_BEATS_BEFORE_SPEAKING = 3;
+
+let lostBeats = 0;
+
 export function installFailedNavigationToast(): void {
+    // Anything getting through means the connection is not the problem.
+    router.on('success', () => {
+        lostBeats = 0;
+    });
+
     router.on('networkError', (event) => {
         // A request our own departure killed did not fail. `leavePage` aborts
         // whatever is in flight - most visibly the 4s poll the onboarding
@@ -42,7 +63,11 @@ export function installFailedNavigationToast(): void {
         const failedUrl = (event.detail.error as { url?: string }).url;
 
         if (failedUrl !== undefined && wasUnattended(failedUrl)) {
-            return;
+            lostBeats++;
+
+            if (lostBeats < LOST_BEATS_BEFORE_SPEAKING) {
+                return;
+            }
         }
 
         toast.error(

--- a/resources/js/lib/failed-navigation-toast.ts
+++ b/resources/js/lib/failed-navigation-toast.ts
@@ -2,7 +2,7 @@ import { __ } from '@/utils/i18n';
 import { router } from '@inertiajs/react';
 import { toast } from 'sonner';
 import { isLeavingPage } from './leave-page';
-import { wasPrefetched } from './prefetch-tracker';
+import { wasUnattended } from './unattended-requests';
 
 /**
  * Tells the user when a navigation or a save died on the network.
@@ -13,9 +13,11 @@ import { wasPrefetched } from './prefetch-tracker';
  * `PATCH /settings/accounts/{uuid}`, which is a change the user believed they had
  * made.
  *
- * Stays quiet for requests nobody asked for. A hover prefetch that fails costs the
- * user nothing, and saying so would be noise about a page they may never open. The
- * same goes for whatever a full page navigation of our own aborts on the way out.
+ * Stays quiet for requests nobody asked for: a hover prefetch that fails costs the
+ * user nothing and saying so would be noise about a page they may never open, and a
+ * background poll that misses one beat is answered by the next one four seconds
+ * later. The same goes for whatever a full page navigation of our own aborts on the
+ * way out.
  *
  * Deliberately does not call `preventDefault()`: that would skip the cleanup Inertia
  * runs for a failed prefetch, leaving a dead entry that a later click waits on
@@ -39,7 +41,7 @@ export function installFailedNavigationToast(): void {
 
         const failedUrl = (event.detail.error as { url?: string }).url;
 
-        if (failedUrl !== undefined && wasPrefetched(failedUrl)) {
+        if (failedUrl !== undefined && wasUnattended(failedUrl)) {
             return;
         }
 

--- a/resources/js/lib/sentry.test.ts
+++ b/resources/js/lib/sentry.test.ts
@@ -400,7 +400,7 @@ describe('isBrowserExtensionNoise', () => {
     });
 });
 
-describe('isFailedPrefetchNoise', () => {
+describe('isUnattendedRequestNoise', () => {
     async function freshModulesWithFakedRouter() {
         vi.resetModules();
         const listeners: Record<string, (e: unknown) => void> = {};
@@ -414,9 +414,9 @@ describe('isFailedPrefetchNoise', () => {
             },
         }));
 
-        const tracker = await import('./prefetch-tracker');
+        const tracker = await import('./unattended-requests');
         const sentry = await import('./sentry');
-        tracker.trackPrefetchedUrls();
+        tracker.trackUnattendedRequests();
 
         return { ...tracker, ...sentry, listeners };
     }
@@ -440,7 +440,7 @@ describe('isFailedPrefetchNoise', () => {
     }
 
     it('drops the failure of a page we only guessed at', async () => {
-        const { isFailedPrefetchNoise, listeners } =
+        const { isUnattendedRequestNoise, listeners } =
             await freshModulesWithFakedRouter();
 
         // Hovering the sidebar prefetches Cashflow from whatever page you are on.
@@ -451,26 +451,50 @@ describe('isFailedPrefetchNoise', () => {
         });
 
         expect(
-            isFailedPrefetchNoise(
+            isUnattendedRequestNoise(
                 networkError('https://whisper.money/cashflow'),
             ),
         ).toBe(true);
     });
 
+    it('drops the failure of a poll running in the background', async () => {
+        const { isUnattendedRequestNoise, listeners } =
+            await freshModulesWithFakedRouter();
+
+        // The onboarding create-account step reloads every 4s to notice a bank
+        // that finished connecting somewhere else.
+        listeners.before?.({
+            detail: {
+                visit: {
+                    url: new URL('https://whisper.money/onboarding'),
+                    prefetch: false,
+                    poll: true,
+                },
+            },
+        });
+
+        expect(
+            isUnattendedRequestNoise(
+                networkError('https://whisper.money/onboarding'),
+            ),
+        ).toBe(true);
+    });
+
     it('keeps the failure of a navigation someone was waiting for', async () => {
-        const { isFailedPrefetchNoise } = await freshModulesWithFakedRouter();
+        const { isUnattendedRequestNoise } =
+            await freshModulesWithFakedRouter();
 
         // Never prefetched, so this is a click that went nowhere - the case the
         // suppression must not swallow.
         expect(
-            isFailedPrefetchNoise(
+            isUnattendedRequestNoise(
                 networkError('https://whisper.money/budgets'),
             ),
         ).toBe(false);
     });
 
     it('stops attributing a prefetch once its window has passed', async () => {
-        const { isFailedPrefetchNoise, listeners } =
+        const { isUnattendedRequestNoise, listeners } =
             await freshModulesWithFakedRouter();
 
         listeners.prefetching?.({
@@ -482,17 +506,18 @@ describe('isFailedPrefetchNoise', () => {
         vi.setSystemTime(Date.now() + 61_000);
 
         expect(
-            isFailedPrefetchNoise(
+            isUnattendedRequestNoise(
                 networkError('https://whisper.money/cashflow'),
             ),
         ).toBe(false);
     });
 
     it('keeps a network error that is not Inertia-shaped', async () => {
-        const { isFailedPrefetchNoise } = await freshModulesWithFakedRouter();
+        const { isUnattendedRequestNoise } =
+            await freshModulesWithFakedRouter();
 
         expect(
-            isFailedPrefetchNoise({
+            isUnattendedRequestNoise({
                 exception: {
                     values: [{ type: 'AxiosError', value: 'Network Error' }],
                 },
@@ -501,7 +526,7 @@ describe('isFailedPrefetchNoise', () => {
     });
 
     it('keeps the failure of a click that landed on our in-flight prefetch', async () => {
-        const { isFailedPrefetchNoise, listeners } =
+        const { isUnattendedRequestNoise, listeners } =
             await freshModulesWithFakedRouter();
 
         listeners.prefetching?.({
@@ -522,14 +547,14 @@ describe('isFailedPrefetchNoise', () => {
         });
 
         expect(
-            isFailedPrefetchNoise(
+            isUnattendedRequestNoise(
                 networkError('https://whisper.money/cashflow'),
             ),
         ).toBe(false);
     });
 
     it('still ignores a prefetch that starts while another page is loading', async () => {
-        const { isFailedPrefetchNoise, listeners } =
+        const { isUnattendedRequestNoise, listeners } =
             await freshModulesWithFakedRouter();
 
         listeners.before?.({
@@ -547,7 +572,7 @@ describe('isFailedPrefetchNoise', () => {
         });
 
         expect(
-            isFailedPrefetchNoise(
+            isUnattendedRequestNoise(
                 networkError('https://whisper.money/cashflow'),
             ),
         ).toBe(true);

--- a/resources/js/lib/sentry.ts
+++ b/resources/js/lib/sentry.ts
@@ -1,7 +1,7 @@
 import type { Event } from '@sentry/react';
 import { isChunkLoadError } from './chunk-load-recovery';
 import { isLeavingPage } from './leave-page';
-import { wasPrefetched } from './prefetch-tracker';
+import { wasUnattended } from './unattended-requests';
 
 const CLONE_ERROR_MESSAGE_PATTERN =
     /object (can not|could not|couldn't|can't) be cloned/i;
@@ -120,22 +120,27 @@ export function isPageLeaveAbortNoise(event: Event): boolean {
 }
 
 /**
- * A speculative request that failed.
+ * A request nobody asked for that failed.
  *
  * Every sidebar item is a `<Link prefetch>`, so hovering the nav fetches a page the
  * user has not committed to. When one fails there is nothing to fix and nothing the
  * user notices - the next real click just makes a real request, and Inertia has
  * already dropped the dead entry so the click is not wedged. Reporting it buries the
  * navigations that genuinely failed on someone who was waiting for one.
+ *
+ * A background poll is the same story on a timer: the onboarding create-account step
+ * asks every 4s whether a bank finished connecting elsewhere, so a single beat lost
+ * to a flaky connection says nothing an issue could act on. The poll four seconds
+ * later is the retry.
  */
-export function isFailedPrefetchNoise(event: Event): boolean {
+export function isUnattendedRequestNoise(event: Event): boolean {
     return (
         event.exception?.values?.some((exception) => {
             const failedUrl = INERTIA_NETWORK_ERROR_PATTERN.exec(
                 exception.value ?? '',
             )?.[1];
 
-            return failedUrl !== undefined && wasPrefetched(failedUrl);
+            return failedUrl !== undefined && wasUnattended(failedUrl);
         }) ?? false
     );
 }

--- a/resources/js/lib/unattended-requests.ts
+++ b/resources/js/lib/unattended-requests.ts
@@ -1,8 +1,14 @@
 import { router } from '@inertiajs/react';
 
 /**
- * Remembers which URLs we only speculatively fetched, so a failed one can be told
- * apart from a request someone was actually waiting for.
+ * Remembers which URLs nobody asked for, so a failed one can be told apart from a
+ * request someone was actually waiting for.
+ *
+ * Two kinds qualify. A hover prefetch, and a background poll: the onboarding
+ * create-account step reloads every 4s and the connections page every 5s, both to
+ * notice work that finished somewhere else. A user sitting on either page has not
+ * asked for anything, so a connection that blips for one beat owes them neither a
+ * toast nor a Sentry issue - the next tick, four seconds later, is the answer.
  *
  * Every sidebar item is a `<Link prefetch>`, so hovering the nav fetches a page
  * nobody has committed to visiting. When one of those fails at the transport level
@@ -17,10 +23,10 @@ import { router } from '@inertiajs/react';
  * rejecting chain before the unhandled rejection is captured — anything cleared
  * there would already be gone by the time beforeSend asks.
  */
-const prefetchedAt = new Map<string, number>();
+const unattendedAt = new Map<string, number>();
 
 /**
- * Backstop for a prefetch nobody ever asked for afterwards. Matched to Inertia's own
+ * Backstop for a request nobody ever asked for afterwards. Matched to Inertia's own
  * `cacheFor` default: past that a successful prefetch has been evicted, so a click
  * issues a fresh request and its failure is the user's, not ours to explain away.
  * Inertia sets no XHR timeout, so a hung request can still fail after this and be
@@ -28,9 +34,9 @@ const prefetchedAt = new Map<string, number>();
  */
 const ATTRIBUTION_WINDOW_MS = 30_000;
 
-export function trackPrefetchedUrls(): void {
+export function trackUnattendedRequests(): void {
     router.on('prefetching', (event) => {
-        prefetchedAt.set(requestKey(event.detail.visit.url), Date.now());
+        unattendedAt.set(requestKey(event.detail.visit.url), Date.now());
     });
 
     // The moment someone asks for the page themselves, its failure is theirs and not
@@ -38,9 +44,24 @@ export function trackPrefetchedUrls(): void {
     // which is the common case: Inertia hands them that same request and shows the
     // progress bar, so they are visibly waiting on it. This also keeps the map
     // bounded, rather than relying on the window above.
+    //
+    // A poll is recognised here rather than on its own event because Inertia has
+    // none for it. It marks the visit it creates for a poll with `poll: true`, on
+    // the internal shape of the visit rather than the `PendingVisit` this event is
+    // typed as - hence the cast. If a future version stops setting it, the polls
+    // simply stop being recognised and their noise comes back, which is the safe
+    // direction to be wrong in.
     router.on('before', (event) => {
-        if (!event.detail.visit.prefetch) {
-            prefetchedAt.delete(requestKey(event.detail.visit.url));
+        const { visit } = event.detail;
+
+        if ((visit as { poll?: boolean }).poll === true) {
+            unattendedAt.set(requestKey(visit.url), Date.now());
+
+            return;
+        }
+
+        if (!visit.prefetch) {
+            unattendedAt.delete(requestKey(visit.url));
         }
     });
 }
@@ -56,15 +77,15 @@ function requestKey(url: URL): string {
     return withoutHash.href;
 }
 
-export function wasPrefetched(url: string): boolean {
-    const at = prefetchedAt.get(url);
+export function wasUnattended(url: string): boolean {
+    const at = unattendedAt.get(url);
 
     if (at === undefined) {
         return false;
     }
 
     if (Date.now() - at > ATTRIBUTION_WINDOW_MS) {
-        prefetchedAt.delete(url);
+        unattendedAt.delete(url);
 
         return false;
     }

--- a/resources/js/lib/unattended-requests.ts
+++ b/resources/js/lib/unattended-requests.ts
@@ -26,6 +26,12 @@ import { router } from '@inertiajs/react';
 const unattendedAt = new Map<string, number>();
 
 /**
+ * URLs a real request is in flight for right now, which a poll to the same URL
+ * must not overwrite.
+ */
+const awaitedUrls = new Set<string>();
+
+/**
  * Backstop for a request nobody ever asked for afterwards. Matched to Inertia's own
  * `cacheFor` default: past that a successful prefetch has been evicted, so a click
  * issues a fresh request and its failure is the user's, not ours to explain away.
@@ -46,24 +52,49 @@ export function trackUnattendedRequests(): void {
     // bounded, rather than relying on the window above.
     //
     // A poll is recognised here rather than on its own event because Inertia has
-    // none for it. It marks the visit it creates for a poll with `poll: true`, on
-    // the internal shape of the visit rather than the `PendingVisit` this event is
-    // typed as - hence the cast. If a future version stops setting it, the polls
-    // simply stop being recognised and their noise comes back, which is the safe
-    // direction to be wrong in.
+    // none for it.
     router.on('before', (event) => {
         const { visit } = event.detail;
+        const key = requestKey(visit.url);
 
-        if ((visit as { poll?: boolean }).poll === true) {
-            unattendedAt.set(requestKey(visit.url), Date.now());
+        if (isPoll(visit)) {
+            // Never claim a URL somebody is already waiting on. Inertia does not
+            // cancel an in-flight visit to the page you are already on, and a poll
+            // reloads exactly that page - so a tick can land between a real reload
+            // and its failure, and re-arm the very entry that decides whether that
+            // failure is worth telling anyone about.
+            if (!awaitedUrls.has(key)) {
+                unattendedAt.set(key, Date.now());
+            }
 
             return;
         }
 
         if (!visit.prefetch) {
-            unattendedAt.delete(requestKey(visit.url));
+            unattendedAt.delete(key);
+            awaitedUrls.add(key);
         }
     });
+
+    // However it ended. The entry above only has to outlive the request it belongs
+    // to, and `finish` is the one event that fires on every outcome.
+    router.on('finish', (event) => {
+        const { visit } = event.detail;
+
+        if (!isPoll(visit) && !visit.prefetch) {
+            awaitedUrls.delete(requestKey(visit.url));
+        }
+    });
+}
+
+/**
+ * Inertia marks the visit its own poller creates with `poll: true`, on the internal
+ * shape of the visit rather than the `PendingVisit` these events are typed as -
+ * hence the cast. If a future version stops setting it, polls simply stop being
+ * recognised and their noise comes back, which is the safe direction to be wrong in.
+ */
+function isPoll(visit: { poll?: boolean }): boolean {
+    return visit.poll === true;
 }
 
 /**


### PR DESCRIPTION
## What the user sees

They are on the onboarding create-account step, about to hand us their bank. Their
connection drops one beat. Up comes a red toast: **"We could not reach the server.
Check your connection."** — for a request they never made.

`PHP-LARAVEL-5E` regressed after #838 with exactly this: a Chrome/Windows user in
Peru, on a build carrying that fix, whose create-account poll died mid-beat.

## Why

That step reloads every 4s to notice a bank that finished connecting in another
browser (the iOS PWA case), and the connections page does the same every 5s while a
first sync runs. Nobody asked for either. Inertia raises `networkError` for them all
the same, so the toast fires and Sentry takes an unhandled rejection nothing can act
on. The poll four seconds later is the retry.

The codebase already had this shape for hover prefetches (#800), so this grows the
second case rather than a second mechanism. Renamed to match what it now covers:
`prefetch-tracker` → `unattended-requests`, `wasPrefetched` → `wasUnattended`,
`isFailedPrefetchNoise` → `isUnattendedRequestNoise`.

## What the two reviews changed

They disagreed with each other on one point and were each right about their own, so
both are in, one commit apiece.

**The architecture review found the bug arriving from the other direction.** Inertia
does not cancel an in-flight visit to the page you are already on, and a poll reloads
exactly that page. So "user reloads the connections page → poll ticks 5s later → the
reload then dies" left the poll's fresh entry in the map and swallowed the failure
the user *was* waiting on. A poll now declines to claim a url while a real request
for it is in flight; `finish` clears the marker. Its missing window-expiry case is
tested too.

**The product review found what silence costs.** On those two pages the poll is the
only thing happening, so a genuinely offline user would have got nothing at all: no
toast, no Sentry event, no change on screen. Worse than the false alarm this branch
set out to remove. So the quiet now lasts three lost beats — twelve seconds on the 4s
poll — and then it speaks, with the sentence the app already has in every language.
Anything getting through resets the count. The review's own suggestion was a passive
"still trying to reach the server" indicator on both pages; this seemed the smaller
answer to the same problem.

## Known and deliberate

A poll that fails and a Sentry issue that never arrives is a signal we are choosing
to lose — the same trade #800 accepted for prefetches, at a higher frequency. What
survives it: `networkError` only fires for genuine transport failures, so a 4xx/5xx
from a poll still reports, and a connection that stays down still reaches the user
through the toast after three beats.

## Testing

- `resources/js/lib` — 202 tests, all passing (22 files).
- Mutation-verified: with the poll branch stubbed to `false`, the two new
  suppression tests fail; the rest still pass.
- prettier, eslint and `tsc --noEmit` clean on the changed files.