### PR TITLE
fix(dashboard): stop a rate-limiter deadlock 500ing a chart

### DIFF
--- a/app/Http/Middleware/FailOpenThrottleRequests.php
+++ b/app/Http/Middleware/FailOpenThrottleRequests.php
@@ -28,10 +28,27 @@ use Symfony\Component\HttpFoundation\Response;
  * through. A chart that fails to draw, on the other hand, is the user's whole
  * reason for being on the page.
  *
- * Narrow on purpose. Only a concurrency error counts, so a genuinely broken
- * cache table still fails loudly; and only before the request has run, so a
- * deadlock raised by the controller's own queries is never swallowed and never
- * replayed.
+ * Narrow on purpose. Only a concurrency error counts - `causedByConcurrencyError`
+ * is the framework's own test for busy rather than broken - so a missing cache
+ * table still fails loudly. And only before the request has run, so a deadlock
+ * raised by the controller's own queries is never swallowed and never replayed.
+ *
+ * "Before the request has run" is exactly that, and not "before the response is
+ * finished": the parent reads the counter once more on the way out, to attach the
+ * remaining-attempts headers. A concurrency error there would still surface. That
+ * read is a plain select rather than the insert-and-lock pair that deadlocks, so it
+ * is a boundary worth knowing rather than a hole worth plumbing.
+ *
+ * Deliberately not applied anywhere else. Login, two-factor, the password update and
+ * the MCP endpoints stay on the framework's `throttle`, where a limiter that cannot
+ * record a hit refuses the request: failing open on a chart is a trade, failing open
+ * on an auth endpoint is a hole.
+ *
+ * Where the signal goes when this fires: `Log::warning` reaches Sentry as a log
+ * entry rather than an issue, so PHP-LARAVEL-J itself will fall quiet while the
+ * contention it reported carries on. Watch
+ * `message:"Rate limiter could not record a hit"` instead - and if that line ever
+ * climbs, the answer is the cache store, not this class.
  *
  * The real fix is a cache store that is not a table. Until then, this.
  */

--- a/app/Http/Middleware/FailOpenThrottleRequests.php
+++ b/app/Http/Middleware/FailOpenThrottleRequests.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Database\DetectsConcurrencyErrors;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Throttles like the framework does, but never turns its own bookkeeping into a
+ * failed request.
+ *
+ * The cache store is the database, so recording a hit is two statements against
+ * the `cache` table: `insertOrIgnore` for the window's `:timer` row and a
+ * `select ... for update` to increment the counter. Two requests from the same
+ * user racing each other take those in an order MySQL can deadlock on, and the
+ * loser's request dies with a 500 - which is how PHP-LARAVEL-J has been
+ * breaking a dashboard chart every day or two, most recently on
+ * `/api/cashflow/sankey`. The dashboard fires several of these calls at once, so
+ * it is the page that races itself hardest.
+ *
+ * Letting the request through is the right way to be wrong here. The limit on
+ * this group is 300 requests a minute for an authenticated, same-origin API: it
+ * exists to stop a runaway client, and one unrecorded hit does not let one
+ * through. A chart that fails to draw, on the other hand, is the user's whole
+ * reason for being on the page.
+ *
+ * Narrow on purpose. Only a concurrency error counts, so a genuinely broken
+ * cache table still fails loudly; and only before the request has run, so a
+ * deadlock raised by the controller's own queries is never swallowed and never
+ * replayed.
+ *
+ * The real fix is a cache store that is not a table. Until then, this.
+ */
+class FailOpenThrottleRequests extends ThrottleRequests
+{
+    use DetectsConcurrencyErrors;
+
+    /**
+     * @param  array<int, object>  $limits
+     */
+    protected function handleRequest($request, Closure $next, array $limits): Response
+    {
+        $requestRan = false;
+
+        $run = function (Request $request) use ($next, &$requestRan) {
+            $requestRan = true;
+
+            return $next($request);
+        };
+
+        try {
+            return parent::handleRequest($request, $run, $limits);
+        } catch (\Throwable $e) {
+            // Deliberately every throwable, and not `QueryException`: the framework
+            // does not declare what its cache store throws, so narrowing here would
+            // only be narrowing what static analysis can see. What gets swallowed
+            // is decided below, and that condition is the narrow one.
+            if ($requestRan || ! $this->causedByConcurrencyError($e)) {
+                throw $e;
+            }
+
+            Log::warning('Rate limiter could not record a hit, letting the request through', [
+                'path' => $request->path(),
+                'error' => $e->getMessage(),
+            ]);
+
+            // Without the parent's remaining-attempts headers: it adds them on the
+            // way back out, and we are past that. Nothing reads them.
+            return $run($request);
+        }
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -4,6 +4,7 @@ use App\Http\Middleware\AssignPriceExperimentArm;
 use App\Http\Middleware\BlockDemoAccountActions;
 use App\Http\Middleware\EnsureOnboardingComplete;
 use App\Http\Middleware\EnsureUserIsSubscribed;
+use App\Http\Middleware\FailOpenThrottleRequests;
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
 use App\Http\Middleware\SetLocale;
@@ -58,6 +59,10 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
 
         $middleware->alias([
+            // The internal API's own throttle. Same behaviour as the framework's,
+            // except a deadlock in the limiter's own cache write lets the request
+            // through instead of 500ing it - see the class for why.
+            'throttle.fail-open' => FailOpenThrottleRequests::class,
             'subscribed' => EnsureUserIsSubscribed::class,
             'onboarded' => EnsureOnboardingComplete::class,
             'block-demo' => BlockDemoAccountActions::class,

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,7 +14,7 @@ use App\Http\Controllers\EncryptionController;
 use App\Http\Controllers\Sync\TransactionSyncController;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(['web', 'auth', 'throttle:300,1'])->group(function () {
+Route::middleware(['web', 'auth', 'throttle.fail-open:300,1'])->group(function () {
     // Encryption (legacy decrypt-migration support only)
     Route::get('encryption/message', [EncryptionController::class, 'getMessage']);
 

--- a/tests/Unit/Http/Middleware/FailOpenThrottleRequestsTest.php
+++ b/tests/Unit/Http/Middleware/FailOpenThrottleRequestsTest.php
@@ -61,6 +61,42 @@ it('serves the request when the limiter cannot record the hit', function () {
         ->once();
 });
 
+it('serves the request when the limiter cannot even read the counter', function () {
+    // The over-limit check is a read, not the two-statement write, and it is inside
+    // the same guard on purpose: a limit we cannot look up is not a limit the user
+    // should be refused by. Stated as a test because it is not what the deadlock in
+    // production does, so nothing else pins it.
+    $limiter = Mockery::mock(RateLimiter::class);
+    $limiter->shouldReceive('tooManyAttempts')->once()->andThrow(cacheDeadlock());
+
+    $response = failOpenThrottle($limiter)->handle(
+        throttledApiRequest(),
+        fn () => new Response('a chart', 200),
+        300,
+        1,
+    );
+
+    expect($response->getStatusCode())->toBe(200);
+});
+
+it('serves the fail-open response without the rate limit headers', function () {
+    $limiter = Mockery::mock(RateLimiter::class);
+    $limiter->shouldReceive('tooManyAttempts')->andReturn(false);
+    $limiter->shouldReceive('hit')->once()->andThrow(cacheDeadlock());
+
+    $response = failOpenThrottle($limiter)->handle(
+        throttledApiRequest(),
+        fn () => new Response('a chart', 200),
+        300,
+        1,
+    );
+
+    // The parent attaches them on the way back out, which this path never reaches.
+    // Nothing in the app reads them; asserting it keeps that true.
+    expect($response->headers->has('X-RateLimit-Limit'))->toBeFalse();
+    expect($response->headers->has('X-RateLimit-Remaining'))->toBeFalse();
+});
+
 it('lets a deadlock raised by the request itself through untouched', function () {
     $limiter = Mockery::mock(RateLimiter::class);
     $limiter->shouldReceive('tooManyAttempts')->andReturn(false);

--- a/tests/Unit/Http/Middleware/FailOpenThrottleRequestsTest.php
+++ b/tests/Unit/Http/Middleware/FailOpenThrottleRequestsTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use App\Http\Middleware\FailOpenThrottleRequests;
+use Illuminate\Cache\RateLimiter;
+use Illuminate\Database\QueryException;
+use Illuminate\Http\Exceptions\ThrottleRequestsException;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Log;
+
+function cacheDeadlock(): QueryException
+{
+    return new QueryException(
+        'mysql',
+        'insert ignore into `cache` (`key`, `value`, `expiration`) values (?, ?, ?)',
+        [],
+        new PDOException('SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction'),
+    );
+}
+
+function failOpenThrottle(RateLimiter $limiter): FailOpenThrottleRequests
+{
+    return new FailOpenThrottleRequests($limiter);
+}
+
+function throttledApiRequest(): Request
+{
+    $request = Request::create('/api/cashflow/sankey', 'GET');
+
+    // The framework's signature falls back to the route when there is no user, and
+    // throws without either.
+    $request->setRouteResolver(fn () => new Route('GET', 'api/cashflow/sankey', []));
+
+    return $request;
+}
+
+it('serves the request when the limiter cannot record the hit', function () {
+    Log::spy();
+
+    $limiter = Mockery::mock(RateLimiter::class);
+    $limiter->shouldReceive('tooManyAttempts')->andReturn(false);
+    $limiter->shouldReceive('hit')->once()->andThrow(cacheDeadlock());
+
+    $ran = 0;
+
+    $response = failOpenThrottle($limiter)->handle(throttledApiRequest(), function () use (&$ran) {
+        $ran++;
+
+        return new Response('a chart', 200);
+    }, 300, 1);
+
+    // The user gets their chart, exactly once: the deadlock happened before the
+    // request ran, so letting it through cannot replay anything.
+    expect($response->getStatusCode())->toBe(200);
+    expect($response->getContent())->toBe('a chart');
+    expect($ran)->toBe(1);
+
+    Log::shouldHaveReceived('warning')
+        ->with('Rate limiter could not record a hit, letting the request through', Mockery::any())
+        ->once();
+});
+
+it('lets a deadlock raised by the request itself through untouched', function () {
+    $limiter = Mockery::mock(RateLimiter::class);
+    $limiter->shouldReceive('tooManyAttempts')->andReturn(false);
+    $limiter->shouldReceive('hit')->once();
+
+    $ran = 0;
+
+    // A controller query that deadlocks is a different event: it must surface, and
+    // it must not be retried behind the user's back.
+    // A closure and not an arrow function: the latter would capture $ran by value,
+    // and the assertion below would read its own copy.
+    expect(function () use ($limiter, &$ran) {
+        failOpenThrottle($limiter)->handle(throttledApiRequest(), function () use (&$ran) {
+            $ran++;
+
+            throw cacheDeadlock();
+        }, 300, 1);
+    })->toThrow(QueryException::class);
+
+    expect($ran)->toBe(1);
+});
+
+it('still fails when the cache is broken rather than busy', function () {
+    $broken = new QueryException(
+        'mysql',
+        'insert ignore into `cache` (`key`, `value`, `expiration`) values (?, ?, ?)',
+        [],
+        new PDOException("SQLSTATE[42S02]: Base table or view not found: 1146 Table 'default.cache' doesn't exist"),
+    );
+
+    $limiter = Mockery::mock(RateLimiter::class);
+    $limiter->shouldReceive('tooManyAttempts')->andReturn(false);
+    $limiter->shouldReceive('hit')->once()->andThrow($broken);
+
+    expect(fn () => failOpenThrottle($limiter)->handle(throttledApiRequest(), fn () => new Response('never', 200), 300, 1))
+        ->toThrow(QueryException::class);
+});
+
+it('still refuses a request that is over the limit', function () {
+    $limiter = Mockery::mock(RateLimiter::class);
+    $limiter->shouldReceive('tooManyAttempts')->andReturn(true);
+    $limiter->shouldReceive('availableIn')->andReturn(30);
+
+    expect(fn () => failOpenThrottle($limiter)->handle(throttledApiRequest(), fn () => new Response('never', 200), 300, 1))
+        ->toThrow(ThrottleRequestsException::class);
+});


### PR DESCRIPTION
**Draft on purpose.** The diagnosis is solid and the code is tested, but this trades
a piece of the rate limiter's guarantee for a chart that draws, and there are two
alternatives you may prefer. Details at the bottom.

## The bug is not where Sentry says it is

`PHP-LARAVEL-J`: 312 events since April, and still going — two in the last three
days, on `/api/cashflow/trend` and `/api/cashflow/sankey`. Sentry's culprit points at
the cashflow endpoints, and the cashflow query has nothing to do with it:

```
ThrottleRequests::handleRequest -> RateLimiter::hit -> increment
  -> cache->add('<key>:timer') -> DatabaseStore::add
  -> insert ignore into `cache` -> 1213 deadlock
```

The cache store is the database, so recording one throttle hit is two statements
against the `cache` table: an `insertOrIgnore` for the window's `:timer` row and a
`select … for update` for the counter. The dashboard fires several `/api/cashflow/*`
calls at once, so it races itself, and the request that loses the deadlock dies with
a 500.

## What the user sees today

Nothing, which is the worst version. `use-cashflow-data.ts` catches a rejected fetch
with `console.error` and leaves `data` at its zeroed defaults — so a failed chart
does not read as "something went wrong", it reads as **"you had €0 this period"**. No
toast, no retry, no error state.

## The change

The internal API group throttles through a subclass that serves the request when the
limiter cannot record the hit. Narrow in both directions:

- only a concurrency error (`causedByConcurrencyError`, the framework's own
  busy-rather-than-broken test), so a missing cache table still fails loudly;
- only before the request has run, so a deadlock from the controller's own queries is
  neither swallowed nor replayed.

It logs a warning when it fires. The limit is 300/minute on an authenticated,
same-origin API — it exists to stop a runaway client, and one unrecorded hit does not
let one through.

## What the reviews changed, and what they flagged

Applied, one commit each: tests for the two edges (the over-limit *read* is inside the
guard too, on purpose; the fail-open response carries no `X-RateLimit-*` headers), and
a docblock that says where the guard stops, where it is deliberately absent, and where
the signal goes.

Flagged and deliberately left as they are — the decisions, not surprises:

1. **This does not close PHP-LARAVEL-J's whole surface.** A deadlock inside the
   cashflow controllers' own queries produces the same silent empty chart and is
   untouched by this.
2. **The group includes mutating endpoints** (`PATCH transactions/bulk`, the balance
   writes, `PUT accounts/{account}`), so during a bookkeeping deadlock those skip
   being throttled too. Safe from double execution — the guard is pre-`$next` — but it
   is a widening beyond the charts this was written for.
3. **Sentry will read as if this got fixed.** The swallowed deadlocks become a
   `Log::warning`, which lands as a Sentry *log* rather than an issue, so the issue
   falls quiet while the contention continues. The line to watch is named in the
   class doc.
4. **Login, two-factor, the password update and the MCP endpoints keep the
   framework's `throttle`.** Failing open on a chart is a trade; failing open on an
   auth endpoint is a hole.

## The alternatives, since you may prefer one

- **A cache store that is not a table.** The actual fix. `composer.json` has no Redis
  dependency and the queue, cache and unique-job locks all run on MySQL, so it is an
  infra addition rather than a config flip — which is why it is not this PR.
- **Retry these GETs in the frontend.** Fixes the user-visible symptom without
  touching the throttle at all, and would also cover the controller-side deadlocks in
  (1). Arguably the more complete answer to the *user's* problem; this middleware is
  the more direct answer to the *mechanism*.

## Testing

`tests/Unit` + `tests/Feature/Api` — 151 tests pass. Six new cases: fail-open on the
hit, fail-open on the counter read, no double execution when the request itself
deadlocks, a broken cache table still failing, over-limit still refused, and no
rate-limit headers on the fail-open path. Pint, PHPStan and `crap` clean.