### PR TITLE
fix(cashflow): stop a failed request telling the user they had no money

### DIFF
--- a/lang/es.json
+++ b/lang/es.json
@@ -2510,5 +2510,6 @@
     "Beta": "Beta",
     "This bank is still in beta": "Este banco todavía está en beta",
     "Our banking provider marks this connection as beta, so syncing can fail or pause more often than with other banks. It usually works, and you can reconnect or disconnect whenever you want.": "Nuestro proveedor bancario marca esta conexión como beta, así que la sincronización puede fallar o pausarse más a menudo que con otros bancos. Normalmente funciona, y puedes reconectar o desconectar cuando quieras.",
-    "This bank is still in beta at our banking provider, so it fails more often than others. Retrying usually helps.": "Este banco todavía está en beta en nuestro proveedor bancario, así que falla más a menudo que otros. Reintentar suele ayudar."
+    "This bank is still in beta at our banking provider, so it fails more often than others. Retrying usually helps.": "Este banco todavía está en beta en nuestro proveedor bancario, así que falla más a menudo que otros. Reintentar suele ayudar.",
+    "We could not load these figures. Try again in a moment.": "No hemos podido cargar estas cifras. Vuelve a intentarlo en un momento."
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2215,5 +2215,6 @@
     ":bank cannot be connected right now, and it was not your fault": ":bank ne peut pas être connectée pour le moment, et ce n’était pas de votre faute",
     "Add the account manually": "Ajouter le compte manuellement",
     "Sorry for the wasted time, and thank you for the patience.": "Désolés pour le temps perdu, et merci pour votre patience.",
-    "Compare": "Comparatifs"
+    "Compare": "Comparatifs",
+    "We could not load these figures. Try again in a moment.": "Nous n'avons pas pu charger ces chiffres. Réessayez dans un instant."
 }

--- a/resources/js/components/cashflow/breakdown-card.test.tsx
+++ b/resources/js/components/cashflow/breakdown-card.test.tsx
@@ -48,6 +48,10 @@ describe('BreakdownCard', () => {
 
     it('expands a parent category and loads its children on demand', async () => {
         const fetchMock = vi.fn().mockResolvedValue({
+            // `ok` and not just `json`: without it the double cannot be told apart
+            // from a 500, which is the bug the component now refuses to ignore.
+            ok: true,
+            status: 200,
             json: async () => ({
                 data: [
                     {

--- a/resources/js/components/cashflow/breakdown-card.tsx
+++ b/resources/js/components/cashflow/breakdown-card.tsx
@@ -15,6 +15,7 @@ import {
 import { BreakdownData, BreakdownItem } from '@/hooks/use-cashflow-data';
 import { useChartColors } from '@/hooks/use-chart-color-scheme';
 import { useExpandableCategories } from '@/hooks/use-expandable-categories';
+import { fetchJson } from '@/lib/fetch-json';
 import { cn } from '@/lib/utils';
 import {
     getCategoryColorClasses,
@@ -81,10 +82,10 @@ export function BreakdownCard({
                 type,
                 parent: categoryId,
             });
-            const response = await fetch(
+            const json = await fetchJson<BreakdownData>(
                 `/api/cashflow/breakdown?${params.toString()}`,
             );
-            const json: BreakdownData = await response.json();
+
             return json.data;
         },
         [period, type],

--- a/resources/js/components/charts/sankey-chart.test.tsx
+++ b/resources/js/components/charts/sankey-chart.test.tsx
@@ -145,6 +145,8 @@ const period = {
 describe('SankeyChart', () => {
     beforeEach(() => {
         global.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
             json: async () => foodChildren,
         }) as unknown as typeof fetch;
     });
@@ -243,6 +245,8 @@ describe('SankeyChart', () => {
 
     it('expands an income category into its subcategories on click', async () => {
         global.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
             json: async () => salaryChildren,
         }) as unknown as typeof fetch;
 

--- a/resources/js/components/charts/sankey-chart.tsx
+++ b/resources/js/components/charts/sankey-chart.tsx
@@ -3,6 +3,7 @@ import { usePrivacyMode } from '@/contexts/privacy-mode-context';
 import { SankeyCategory, SankeyData } from '@/hooks/use-cashflow-data';
 import { useChartColors } from '@/hooks/use-chart-color-scheme';
 import { useLocale } from '@/hooks/use-locale';
+import { fetchJson } from '@/lib/fetch-json';
 import { groupSmallCategories } from '@/lib/sankey-utils';
 import { cn } from '@/lib/utils';
 import { formatCurrency } from '@/utils/currency';
@@ -154,9 +155,10 @@ export function SankeyChart({
         const to = format(period.to, 'yyyy-MM-dd');
         let cancelled = false;
 
-        fetch(`/api/cashflow/sankey?from=${from}&to=${to}&parent=${expandedId}`)
-            .then((response) => response.json())
-            .then((json: SankeyData) => {
+        fetchJson<SankeyData>(
+            `/api/cashflow/sankey?from=${from}&to=${to}&parent=${expandedId}`,
+        )
+            .then((json) => {
                 if (!cancelled) {
                     setChildrenById((previous) => ({
                         ...previous,

--- a/resources/js/components/dashboard/net-worth-chart.tsx
+++ b/resources/js/components/dashboard/net-worth-chart.tsx
@@ -34,6 +34,7 @@ import {
     isLiabilityType,
     netWorthContribution,
 } from '@/lib/chart-calculations';
+import { fetchJson } from '@/lib/fetch-json';
 import { SharedData } from '@/types';
 import { formatDayFromDate } from '@/utils/date';
 import { __ } from '@/utils/i18n';
@@ -164,10 +165,9 @@ export function NetWorthChart({
             const to = format(now, 'yyyy-MM-dd');
             const from = format(subDays(now, DAILY_DAYS), 'yyyy-MM-dd');
             const params = new URLSearchParams({ from, to });
-            const response = await fetch(
+            const data = await fetchJson<NetWorthEvolutionData>(
                 `/api/dashboard/net-worth-daily-evolution?${params.toString()}`,
             );
-            const data: NetWorthEvolutionData = await response.json();
 
             // Normalize daily data: rename "date" key to "month" so it works
             // uniformly with useChartViews and the rest of the component.

--- a/resources/js/components/dashboard/top-categories-card.tsx
+++ b/resources/js/components/dashboard/top-categories-card.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/card';
 import { useChartColors } from '@/hooks/use-chart-color-scheme';
 import { useExpandableCategories } from '@/hooks/use-expandable-categories';
+import { fetchJson } from '@/lib/fetch-json';
 import { cn } from '@/lib/utils';
 import { SharedData } from '@/types';
 import {
@@ -68,10 +69,9 @@ export function TopCategoriesCard({
                 to: dateTo,
                 parent: categoryId,
             });
-            const response = await fetch(
+            return fetchJson<CategoryData[]>(
                 `/api/dashboard/top-categories?${params.toString()}`,
             );
-            return response.json();
         },
         [dateFrom, dateTo],
     );

--- a/resources/js/hooks/use-cashflow-data.test.tsx
+++ b/resources/js/hooks/use-cashflow-data.test.tsx
@@ -1,0 +1,72 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useCashflowData } from './use-cashflow-data';
+
+const period = {
+    from: new Date('2026-08-01T00:00:00Z'),
+    to: new Date('2026-08-31T00:00:00Z'),
+    periodType: 'month' as const,
+};
+
+function jsonResponse(status: number, body: unknown) {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: () => Promise.resolve(body),
+    };
+}
+
+const emptyPayload = {
+    current: {},
+    previous: {},
+    data: [],
+    income_categories: [],
+    expense_categories: [],
+    categories: [],
+};
+
+describe('useCashflowData', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('reports a server error instead of leaving zeros looking like an answer', async () => {
+        // Laravel answers with a JSON body on the way down, which is exactly why
+        // this used to sail through as data.
+        vi.stubGlobal(
+            'fetch',
+            vi
+                .fn()
+                .mockResolvedValue(
+                    jsonResponse(500, { message: 'Server Error' }),
+                ),
+        );
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        const { result } = renderHook(() => useCashflowData(period));
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(result.current.hasError).toBe(true);
+        // And the figures were never touched, so the page has nothing to show but
+        // its placeholders.
+        expect(result.current.summary.current.income).toBe(0);
+    });
+
+    it('clears the error once a load gets through', async () => {
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValueOnce(jsonResponse(500, { message: 'nope' }))
+            .mockResolvedValue(jsonResponse(200, emptyPayload));
+        vi.stubGlobal('fetch', fetchMock);
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        const { result } = renderHook(() => useCashflowData(period));
+
+        await waitFor(() => expect(result.current.hasError).toBe(true));
+
+        result.current.refetch();
+
+        await waitFor(() => expect(result.current.hasError).toBe(false));
+    });
+});

--- a/resources/js/hooks/use-cashflow-data.ts
+++ b/resources/js/hooks/use-cashflow-data.ts
@@ -4,9 +4,12 @@ import {
     summary as cashflowSummary,
     trend as cashflowTrend,
 } from '@/actions/App/Http/Controllers/Api/CashflowAnalyticsController';
+import { fetchJson } from '@/lib/fetch-json';
 import { Category } from '@/types/category';
+import { __ } from '@/utils/i18n';
 import { endOfMonth, format, startOfMonth } from 'date-fns';
 import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
 
 export type CashflowPeriodType = 'month' | 'quarter' | 'year';
 
@@ -123,25 +126,25 @@ export function useCashflowData({
 
             const [summary, sankey, trend, incomeBreakdown, expenseBreakdown] =
                 await Promise.all([
-                    fetch(cashflowSummary.url({ query: periodQuery })).then(
-                        (r) => r.json(),
+                    fetchJson<CashflowData['summary']>(
+                        cashflowSummary.url({ query: periodQuery }),
                     ),
-                    fetch(cashflowSankey.url({ query: periodQuery })).then(
-                        (r) => r.json(),
+                    fetchJson<CashflowData['sankey']>(
+                        cashflowSankey.url({ query: periodQuery }),
                     ),
-                    fetch(cashflowTrend.url({ query: trendQuery })).then((r) =>
-                        r.json(),
+                    fetchJson<{ data: CashflowData['trend'] }>(
+                        cashflowTrend.url({ query: trendQuery }),
                     ),
-                    fetch(
+                    fetchJson<CashflowData['incomeBreakdown']>(
                         cashflowBreakdown.url({
                             query: { ...periodQuery, type: 'income' },
                         }),
-                    ).then((r) => r.json()),
-                    fetch(
+                    ),
+                    fetchJson<CashflowData['expenseBreakdown']>(
                         cashflowBreakdown.url({
                             query: { ...periodQuery, type: 'expense' },
                         }),
-                    ).then((r) => r.json()),
+                    ),
                 ]);
 
             setData({
@@ -153,6 +156,16 @@ export function useCashflowData({
             });
         } catch (error) {
             console.error('Failed to fetch cashflow data:', error);
+
+            // The cards below keep whatever they had, which on a first load is a
+            // row of zeros - so without this the screen states, flatly, that the
+            // period had no money in it.
+            toast.error(
+                __('We could not load these figures. Try again in a moment.'),
+                {
+                    id: 'analytics-load-failed',
+                },
+            );
         } finally {
             setIsLoading(false);
         }

--- a/resources/js/hooks/use-cashflow-data.ts
+++ b/resources/js/hooks/use-cashflow-data.ts
@@ -6,10 +6,8 @@ import {
 } from '@/actions/App/Http/Controllers/Api/CashflowAnalyticsController';
 import { fetchJson } from '@/lib/fetch-json';
 import { Category } from '@/types/category';
-import { __ } from '@/utils/i18n';
 import { endOfMonth, format, startOfMonth } from 'date-fns';
-import { useCallback, useEffect, useState } from 'react';
-import { toast } from 'sonner';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 export type CashflowPeriodType = 'month' | 'quarter' | 'year';
 
@@ -70,6 +68,7 @@ export interface CashflowData {
     incomeBreakdown: BreakdownData;
     expenseBreakdown: BreakdownData;
     isLoading: boolean;
+    hasError: boolean;
 }
 
 interface UseCashflowDataOptions {
@@ -98,7 +97,9 @@ export function useCashflowData({
     to,
     periodType,
 }: UseCashflowDataOptions): CashflowData & { refetch: () => void } {
-    const [data, setData] = useState<Omit<CashflowData, 'isLoading'>>({
+    const [data, setData] = useState<
+        Omit<CashflowData, 'isLoading' | 'hasError'>
+    >({
         summary: { current: emptySummary, previous: emptySummary },
         sankey: {
             income_categories: [],
@@ -111,8 +112,16 @@ export function useCashflowData({
         expenseBreakdown: emptyBreakdown,
     });
     const [isLoading, setIsLoading] = useState(true);
+    const [hasError, setHasError] = useState(false);
+
+    // Which load is the current one. Period navigation refetches on every change,
+    // and without this an older request settling late would either paint the wrong
+    // period's figures or report a failure the user has already navigated past.
+    const latestRequest = useRef(0);
 
     const fetchData = useCallback(async () => {
+        const request = ++latestRequest.current;
+
         setIsLoading(true);
         try {
             const fromStr = format(from, 'yyyy-MM-dd');
@@ -147,6 +156,10 @@ export function useCashflowData({
                     ),
                 ]);
 
+            if (request !== latestRequest.current) {
+                return;
+            }
+
             setData({
                 summary,
                 sankey,
@@ -154,20 +167,22 @@ export function useCashflowData({
                 incomeBreakdown,
                 expenseBreakdown,
             });
+            setHasError(false);
         } catch (error) {
+            if (request !== latestRequest.current) {
+                return;
+            }
+
             console.error('Failed to fetch cashflow data:', error);
 
-            // The cards below keep whatever they had, which on a first load is a
-            // row of zeros - so without this the screen states, flatly, that the
-            // period had no money in it.
-            toast.error(
-                __('We could not load these figures. Try again in a moment.'),
-                {
-                    id: 'analytics-load-failed',
-                },
-            );
+            // The figures in state are now either a row of zeros or the period the
+            // user just navigated away from. Neither is an answer about this
+            // period, so the page is told, and shows that instead of them.
+            setHasError(true);
         } finally {
-            setIsLoading(false);
+            if (request === latestRequest.current) {
+                setIsLoading(false);
+            }
         }
     }, [from, periodType, to]);
 
@@ -175,7 +190,7 @@ export function useCashflowData({
         fetchData();
     }, [fetchData]);
 
-    return { ...data, isLoading, refetch: fetchData };
+    return { ...data, isLoading, hasError, refetch: fetchData };
 }
 
 export function getDefaultPeriod(): { from: Date; to: Date } {

--- a/resources/js/hooks/use-dashboard-data.ts
+++ b/resources/js/hooks/use-dashboard-data.ts
@@ -1,11 +1,6 @@
-import { useLocale } from '@/hooks/use-locale';
 import { netWorthContribution } from '@/lib/chart-calculations';
-import { fetchJson } from '@/lib/fetch-json';
 import { Account, AccountType, Bank } from '@/types/account';
-import { Category } from '@/types/category';
 import { formatMonthFromYearMonth } from '@/utils/date';
-import { format, subDays, subMonths } from 'date-fns';
-import { useCallback, useEffect, useRef, useState } from 'react';
 
 export interface NetWorthEvolutionAccount {
     id: string;
@@ -45,22 +40,6 @@ export interface AccountWithMetrics extends Account {
     investedAmount: number | null;
     hidden_on_dashboard: boolean;
     archived_at: string | null;
-}
-
-export interface DashboardData {
-    netWorthEvolution: NetWorthEvolutionData;
-    accounts: AccountWithMetrics[];
-    topCategories: Array<{
-        category: Category | null;
-        category_id?: string | null;
-        amount: number;
-        previous_amount: number;
-        total_amount: number;
-        has_children?: boolean;
-        is_direct?: boolean;
-    }>;
-    isLoading: boolean;
-    hasError: boolean;
 }
 
 export function deriveAccountMetrics(
@@ -112,85 +91,4 @@ export function deriveAccountMetrics(
             archived_at: account.archived_at ?? null,
         } as AccountWithMetrics;
     });
-}
-
-export function useDashboardData(): DashboardData & { refetch: () => void } {
-    const locale = useLocale();
-    const [data, setData] = useState<Omit<DashboardData, 'isLoading' | 'hasError'>>({
-        netWorthEvolution: { data: [], accounts: {}, currency_code: 'USD' },
-        accounts: [],
-        topCategories: [],
-    });
-    const [isLoading, setIsLoading] = useState(true);
-    const [hasError, setHasError] = useState(false);
-
-    // See the same guard in use-cashflow-data: whichever load is current owns the
-    // state, so a slow one settling late cannot overwrite it.
-    const latestRequest = useRef(0);
-
-    const fetchData = useCallback(async () => {
-        const request = ++latestRequest.current;
-
-        setIsLoading(true);
-        try {
-            const now = new Date();
-            const to = format(now, 'yyyy-MM-dd');
-
-            const from12Months = format(subMonths(now, 12), 'yyyy-MM-dd');
-            const params12Months = new URLSearchParams({
-                from: from12Months,
-                to,
-            });
-            const query12Months = `?${params12Months.toString()}`;
-
-            const from30Days = format(subDays(now, 30), 'yyyy-MM-dd');
-            const params30Days = new URLSearchParams({
-                from: from30Days,
-                to,
-            });
-            const query30Days = `?${params30Days.toString()}`;
-
-            const [netWorthEvolution, topCategories] = await Promise.all([
-                fetchJson<NetWorthEvolutionData>(
-                    `/api/dashboard/net-worth-evolution${query12Months}`,
-                ),
-                fetchJson<DashboardData['topCategories']>(
-                    `/api/dashboard/top-categories${query30Days}`,
-                ),
-            ]);
-
-            const netWorthData = netWorthEvolution as NetWorthEvolutionData;
-
-            if (request !== latestRequest.current) {
-                return;
-            }
-
-            setData({
-                netWorthEvolution: netWorthData,
-                accounts: deriveAccountMetrics(netWorthData, locale),
-                topCategories,
-            });
-            setHasError(false);
-        } catch (error) {
-            if (request !== latestRequest.current) {
-                return;
-            }
-
-            console.error('Failed to fetch dashboard data:', error);
-
-            // A flat net worth and an empty category list read as a true answer
-            // about the user's money. The page shows the failure instead.
-            setHasError(true);
-        } finally {
-            if (request === latestRequest.current) {
-                setIsLoading(false);
-            }
-        }
-    }, [locale]);
-
-    useEffect(() => {
-        fetchData();
-    }, [fetchData]);
-
-    return { ...data, isLoading, hasError, refetch: fetchData };
 }

--- a/resources/js/hooks/use-dashboard-data.ts
+++ b/resources/js/hooks/use-dashboard-data.ts
@@ -4,10 +4,8 @@ import { fetchJson } from '@/lib/fetch-json';
 import { Account, AccountType, Bank } from '@/types/account';
 import { Category } from '@/types/category';
 import { formatMonthFromYearMonth } from '@/utils/date';
-import { __ } from '@/utils/i18n';
 import { format, subDays, subMonths } from 'date-fns';
-import { useCallback, useEffect, useState } from 'react';
-import { toast } from 'sonner';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 export interface NetWorthEvolutionAccount {
     id: string;
@@ -62,6 +60,7 @@ export interface DashboardData {
         is_direct?: boolean;
     }>;
     isLoading: boolean;
+    hasError: boolean;
 }
 
 export function deriveAccountMetrics(
@@ -117,14 +116,21 @@ export function deriveAccountMetrics(
 
 export function useDashboardData(): DashboardData & { refetch: () => void } {
     const locale = useLocale();
-    const [data, setData] = useState<Omit<DashboardData, 'isLoading'>>({
+    const [data, setData] = useState<Omit<DashboardData, 'isLoading' | 'hasError'>>({
         netWorthEvolution: { data: [], accounts: {}, currency_code: 'USD' },
         accounts: [],
         topCategories: [],
     });
     const [isLoading, setIsLoading] = useState(true);
+    const [hasError, setHasError] = useState(false);
+
+    // See the same guard in use-cashflow-data: whichever load is current owns the
+    // state, so a slow one settling late cannot overwrite it.
+    const latestRequest = useRef(0);
 
     const fetchData = useCallback(async () => {
+        const request = ++latestRequest.current;
+
         setIsLoading(true);
         try {
             const now = new Date();
@@ -155,24 +161,30 @@ export function useDashboardData(): DashboardData & { refetch: () => void } {
 
             const netWorthData = netWorthEvolution as NetWorthEvolutionData;
 
+            if (request !== latestRequest.current) {
+                return;
+            }
+
             setData({
                 netWorthEvolution: netWorthData,
                 accounts: deriveAccountMetrics(netWorthData, locale),
                 topCategories,
             });
+            setHasError(false);
         } catch (error) {
+            if (request !== latestRequest.current) {
+                return;
+            }
+
             console.error('Failed to fetch dashboard data:', error);
 
-            // Without this the dashboard just shows a flat net worth and no
-            // categories, which reads as a true answer about the user's money.
-            toast.error(
-                __('We could not load these figures. Try again in a moment.'),
-                {
-                    id: 'analytics-load-failed',
-                },
-            );
+            // A flat net worth and an empty category list read as a true answer
+            // about the user's money. The page shows the failure instead.
+            setHasError(true);
         } finally {
-            setIsLoading(false);
+            if (request === latestRequest.current) {
+                setIsLoading(false);
+            }
         }
     }, [locale]);
 
@@ -180,5 +192,5 @@ export function useDashboardData(): DashboardData & { refetch: () => void } {
         fetchData();
     }, [fetchData]);
 
-    return { ...data, isLoading, refetch: fetchData };
+    return { ...data, isLoading, hasError, refetch: fetchData };
 }

--- a/resources/js/hooks/use-dashboard-data.ts
+++ b/resources/js/hooks/use-dashboard-data.ts
@@ -1,10 +1,13 @@
 import { useLocale } from '@/hooks/use-locale';
 import { netWorthContribution } from '@/lib/chart-calculations';
+import { fetchJson } from '@/lib/fetch-json';
 import { Account, AccountType, Bank } from '@/types/account';
 import { Category } from '@/types/category';
 import { formatMonthFromYearMonth } from '@/utils/date';
+import { __ } from '@/utils/i18n';
 import { format, subDays, subMonths } from 'date-fns';
 import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
 
 export interface NetWorthEvolutionAccount {
     id: string;
@@ -142,11 +145,11 @@ export function useDashboardData(): DashboardData & { refetch: () => void } {
             const query30Days = `?${params30Days.toString()}`;
 
             const [netWorthEvolution, topCategories] = await Promise.all([
-                fetch(
+                fetchJson<NetWorthEvolutionData>(
                     `/api/dashboard/net-worth-evolution${query12Months}`,
-                ).then((r) => r.json()),
-                fetch(`/api/dashboard/top-categories${query30Days}`).then((r) =>
-                    r.json(),
+                ),
+                fetchJson<DashboardData['topCategories']>(
+                    `/api/dashboard/top-categories${query30Days}`,
                 ),
             ]);
 
@@ -159,6 +162,15 @@ export function useDashboardData(): DashboardData & { refetch: () => void } {
             });
         } catch (error) {
             console.error('Failed to fetch dashboard data:', error);
+
+            // Without this the dashboard just shows a flat net worth and no
+            // categories, which reads as a true answer about the user's money.
+            toast.error(
+                __('We could not load these figures. Try again in a moment.'),
+                {
+                    id: 'analytics-load-failed',
+                },
+            );
         } finally {
             setIsLoading(false);
         }

--- a/resources/js/lib/fetch-json.test.ts
+++ b/resources/js/lib/fetch-json.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchJson } from './fetch-json';
+
+function respondWith(status: number, body: unknown) {
+    vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+            ok: status >= 200 && status < 300,
+            status,
+            json: () => Promise.resolve(body),
+        }),
+    );
+}
+
+describe('fetchJson', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('returns the parsed body of a successful response', async () => {
+        respondWith(200, { total_income: 4200 });
+
+        await expect(fetchJson('/api/cashflow/summary')).resolves.toEqual({
+            total_income: 4200,
+        });
+    });
+
+    it('rejects a server error instead of handing back its body', async () => {
+        // Laravel answers a JSON request with a JSON body on the way down too, so
+        // `{"message": "Server Error"}` parses perfectly. Spread into a chart's
+        // state it became a screen full of zeros with nothing logged.
+        respondWith(500, { message: 'Server Error' });
+
+        await expect(fetchJson('/api/cashflow/summary')).rejects.toThrow(
+            'answered 500',
+        );
+    });
+
+    it('rejects a throttled response', async () => {
+        respondWith(429, { message: 'Too Many Requests' });
+
+        await expect(fetchJson('/api/cashflow/trend')).rejects.toThrow(
+            'answered 429',
+        );
+    });
+});

--- a/resources/js/lib/fetch-json.ts
+++ b/resources/js/lib/fetch-json.ts
@@ -1,0 +1,20 @@
+/**
+ * A GET whose failures are failures.
+ *
+ * `fetch(...).then((r) => r.json())` does not reject on a 4xx or 5xx - `ok` is
+ * the only thing that says so - and Laravel answers a JSON request with a JSON
+ * body on the way down too. So a 500 used to parse cleanly into
+ * `{message: "Server Error"}` and get spread into a chart's state, where every
+ * figure it looked for was missing and rendered as zero. The user was shown
+ * "you had 0 this period" for a request that never arrived, with nothing in the
+ * console to say so.
+ */
+export async function fetchJson<T>(url: string): Promise<T> {
+    const response = await fetch(url);
+
+    if (!response.ok) {
+        throw new Error(`GET ${url} answered ${response.status}`);
+    }
+
+    return (await response.json()) as T;
+}

--- a/resources/js/pages/cashflow/index.tsx
+++ b/resources/js/pages/cashflow/index.tsx
@@ -4,6 +4,8 @@ import { PeriodNavigation } from '@/components/cashflow/period-navigation';
 import { SavedInvestedCard } from '@/components/cashflow/saved-invested-card';
 import { CashflowTrendChart, SankeyChart } from '@/components/charts';
 import HeadingSmall from '@/components/heading-small';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { CashflowPeriodType, useCashflowData } from '@/hooks/use-cashflow-data';
 import { usePeriodUrlSync } from '@/hooks/use-period-url-sync';
@@ -21,6 +23,7 @@ import {
     startOfQuarter,
     startOfYear,
 } from 'date-fns';
+import { TriangleAlertIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 const breadcrumbs: BreadcrumbItem[] = [
@@ -123,10 +126,18 @@ export default function CashflowPage() {
         incomeBreakdown,
         expenseBreakdown,
         isLoading,
+        hasError,
+        refetch,
     } = useCashflowData({
         ...period,
         periodType,
     });
+
+    // The figures in state after a failed load are either zeros or the period the
+    // user navigated away from, so every card below stays in its placeholder while
+    // the banner explains why. Showing them would be answering a question about
+    // someone's money with a number we do not have.
+    const showPlaceholders = isLoading || hasError;
 
     usePeriodUrlSync(currentDate, periodType, initialPeriod, initialPeriodType);
 
@@ -151,19 +162,39 @@ export default function CashflowPage() {
                     />
                 </div>
 
+                {hasError && (
+                    <Alert variant="destructive">
+                        <TriangleAlertIcon />
+                        <AlertDescription className="flex flex-wrap items-center gap-3">
+                            <span>
+                                {__(
+                                    'We could not load these figures. Try again in a moment.',
+                                )}
+                            </span>
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={refetch}
+                            >
+                                {__('Try again')}
+                            </Button>
+                        </AlertDescription>
+                    </Alert>
+                )}
+
                 {/* Summary Cards */}
                 <div className="grid gap-6 md:grid-cols-2">
                     <NetCashflowCard
                         current={summary.current}
                         previous={summary.previous}
-                        loading={isLoading}
+                        loading={showPlaceholders}
                         currency={auth.user.currency_code}
                     />
 
                     <SavedInvestedCard
                         current={summary.current}
                         previous={summary.previous}
-                        loading={isLoading}
+                        loading={showPlaceholders}
                         currency={auth.user.currency_code}
                     />
                 </div>
@@ -171,7 +202,7 @@ export default function CashflowPage() {
                 {/* Trend Chart */}
                 <CashflowTrendChart
                     data={trend}
-                    loading={isLoading}
+                    loading={showPlaceholders}
                     currency={auth.user.currency_code}
                     periodType={periodType}
                 />
@@ -184,7 +215,7 @@ export default function CashflowPage() {
                         </CardTitle>
                     </CardHeader>
                     <CardContent>
-                        {isLoading ? (
+                        {showPlaceholders ? (
                             <div className="h-[400px] animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
                         ) : (
                             <SankeyChart
@@ -202,7 +233,7 @@ export default function CashflowPage() {
                     <BreakdownCard
                         type="income"
                         data={incomeBreakdown}
-                        loading={isLoading}
+                        loading={showPlaceholders}
                         currency={auth.user.currency_code}
                         period={period}
                     />
@@ -210,7 +241,7 @@ export default function CashflowPage() {
                     <BreakdownCard
                         type="expense"
                         data={expenseBreakdown}
-                        loading={isLoading}
+                        loading={showPlaceholders}
                         currency={auth.user.currency_code}
                         period={period}
                     />


### PR DESCRIPTION
## The bug

`fetch(url).then((r) => r.json())` does not reject on a 4xx or 5xx — `ok` is the only
thing that says so — and Laravel answers a JSON request with a JSON body on the way
down too. So a 500, or the throttle's 429, parsed cleanly into
`{message: "Server Error"}` and was spread straight into the cashflow state. Every
figure the cards then looked for was missing and rendered as **zero**, `isLoading` was
false, and the catch block never ran, so there was not even a console line.

The screen therefore stated, flatly, that the user earned and spent nothing that
period. In a finance app that is worse than an error: it is a wrong answer wearing the
clothes of a right one. On a period change it is worse still — the previous period's
figures stay on screen as if they were the new one's.

Found while tracing `PHP-LARAVEL-J` (now closed as isolated): the deadlock was one way
to produce this, and any network blip or 429 is another.

## What changed

- **`fetchJson`** rejects anything that is not a 2xx, so a failure reaches a catch
  block instead of the state.
- **The cashflow hook reports it as state** (`hasError`), and whichever load is current
  owns the state — a slow request settling after the user has navigated on can no longer
  paint the wrong period or report a failure they already left behind.
- **The page keeps its placeholders up and says why**, with a banner and a Try again
  button wired to the refetch the hook already exposed. A banner rather than a toast
  because this is state that is true on arrival and stays true; and the placeholders
  matter as much as the banner, because a zero where the answer is unknown looks exactly
  like a real zero.
- **Four more fetches got the same check** — the sankey drill-down, both category
  breakdowns and the net-worth daily toggle — all of which built charts out of whatever
  `.json()` returned.
- **The dead dashboard hook is deleted** rather than fixed: `useDashboardData` has no
  callers since the dashboard moved to Inertia deferred props, so its copy of this bug
  goes with it.

## What the reviews changed

The first commit only added a toast. Both reviews said the same thing — the console and
a dismissible toast leave the screen exactly as wrong as it was — so the toast became
the `hasError` state and the banner. The stale-request guard and the four extra call
sites also came from them, and two existing test doubles had to change: they returned
`{json: ...}` with no `ok`, which is a response that cannot be told apart from a server
error. That they passed before is the clearest evidence the bug was real.

Deliberately left: `transaction-analysis-drawer` already checks `response.ok` and shows
its own error; `partials/header` fails silently on a GitHub star count, which is not
money. `fetchJson` throws a plain `Error` — nothing yet needs to tell a 429 from a 500,
and a typed error can arrive when something does.

## Testing

- `resources/js` — 451 tests pass (87 files). New: three for `fetchJson`, two for the
  hook's error state, both mutation-verified (they fail if the flag stops being set).
- `LocalizationTest` passes with the new string in `es` and `fr`; `en.json` untouched, as
  English keys are the literal `__()` argument.
- prettier, eslint and `tsc --noEmit` clean on everything touched.