### PR TITLE
fix(dashboard): stop a dropped deferred load leaving the page on skeletons forever

### DIFF
--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -26,6 +26,7 @@ import { SyncProvider } from './contexts/sync-context';
 import { initializeTheme } from './hooks/use-appearance';
 import { initializeChartColorScheme } from './hooks/use-chart-color-scheme';
 import { installChunkLoadRecovery } from './lib/chunk-load-recovery';
+import { installDeferredPropsRecovery } from './lib/deferred-props-recovery';
 import { installFailedNavigationToast } from './lib/failed-navigation-toast';
 import { leavePage } from './lib/leave-page';
 import { initializePostHog } from './lib/posthog';
@@ -43,6 +44,7 @@ import type { ExpiredBankingConnectionNotification, SharedData } from './types';
 import { __, setTranslations } from './utils/i18n';
 
 installChunkLoadRecovery();
+installDeferredPropsRecovery();
 trackUnattendedRequests();
 installFailedNavigationToast();
 

--- a/resources/js/lib/deferred-props-recovery.test.ts
+++ b/resources/js/lib/deferred-props-recovery.test.ts
@@ -39,6 +39,8 @@ function deferredVisit(only: string[]) {
     };
 }
 
+const networkError = { detail: { error: {} } };
+
 describe('installDeferredPropsRecovery', () => {
     afterEach(() => {
         vi.useRealTimers();
@@ -49,54 +51,80 @@ describe('installDeferredPropsRecovery', () => {
         vi.useFakeTimers();
         const { listeners } = await freshModule();
 
-        listeners.before?.(deferredVisit(['netWorthEvolution']));
-        listeners.networkError?.({ detail: { error: {} } });
+        // The real order, which is what the first version of this got wrong:
+        // Inertia fires `before` for the deferred request and `navigate` for its
+        // page in the same tick, and only then can the request fail.
+        listeners.before?.(deferredVisit(['dashboard']));
+        listeners.navigate?.({});
+        listeners.networkError?.(networkError);
 
         // Not immediately: the connection that just dropped is given a moment.
         expect(reload).not.toHaveBeenCalled();
 
         vi.advanceTimersByTime(2_000);
 
-        expect(reload).toHaveBeenCalledWith({ only: ['netWorthEvolution'] });
+        expect(reload).toHaveBeenCalledWith({ only: ['dashboard'] });
     });
 
-    it('retries once and then leaves the page alone', async () => {
+    it('leaves a load that got through alone', async () => {
         vi.useFakeTimers();
         const { listeners } = await freshModule();
 
-        listeners.before?.(deferredVisit(['netWorthEvolution']));
-        listeners.networkError?.({ detail: { error: {} } });
+        listeners.before?.(deferredVisit(['dashboard']));
+        listeners.navigate?.({});
+        listeners.finish?.(deferredVisit(['dashboard']));
+
+        // A save blipping later on the same page is not the deferred load's
+        // problem, and must not pull those queries again.
+        listeners.networkError?.(networkError);
         vi.advanceTimersByTime(2_000);
 
-        listeners.before?.(deferredVisit(['netWorthEvolution']));
-        listeners.networkError?.({ detail: { error: {} } });
+        expect(reload).not.toHaveBeenCalled();
+    });
+
+    it('retries once, whatever the retry does', async () => {
+        vi.useFakeTimers();
+        const { listeners } = await freshModule();
+
+        listeners.before?.(deferredVisit(['dashboard']));
+        listeners.networkError?.(networkError);
+        vi.advanceTimersByTime(2_000);
+
+        // The retry is a plain reload, so Inertia does not mark it deferred and
+        // nothing here is armed again by its own failure.
+        listeners.before?.({
+            detail: {
+                visit: {
+                    url: new URL('https://whisper.money/dashboard'),
+                    only: ['dashboard'],
+                },
+            },
+        });
+        listeners.networkError?.(networkError);
         vi.advanceTimersByTime(2_000);
 
         expect(reload).toHaveBeenCalledOnce();
     });
 
-    it('starts over on the next page', async () => {
+    it('does not ask a page the user has left for its props', async () => {
         vi.useFakeTimers();
         const { listeners } = await freshModule();
 
-        listeners.before?.(deferredVisit(['netWorthEvolution']));
-        listeners.networkError?.({ detail: { error: {} } });
-        vi.advanceTimersByTime(2_000);
+        listeners.before?.(deferredVisit(['dashboard']));
+        listeners.networkError?.(networkError);
 
+        // Off to another page inside the two seconds: the reload would target
+        // wherever they are now, asking for props that page does not have.
         listeners.navigate?.({});
-        listeners.before?.(deferredVisit(['transactions']));
-        listeners.networkError?.({ detail: { error: {} } });
         vi.advanceTimersByTime(2_000);
 
-        expect(reload).toHaveBeenCalledTimes(2);
-        expect(reload).toHaveBeenLastCalledWith({ only: ['transactions'] });
+        expect(reload).not.toHaveBeenCalled();
     });
 
     it('stays out of the way of a request nobody deferred', async () => {
         vi.useFakeTimers();
         const { listeners } = await freshModule();
 
-        // A save, a navigation, a poll: not our business.
         listeners.before?.({
             detail: {
                 visit: {
@@ -105,7 +133,7 @@ describe('installDeferredPropsRecovery', () => {
                 },
             },
         });
-        listeners.networkError?.({ detail: { error: {} } });
+        listeners.networkError?.(networkError);
         vi.advanceTimersByTime(2_000);
 
         expect(reload).not.toHaveBeenCalled();

--- a/resources/js/lib/deferred-props-recovery.test.ts
+++ b/resources/js/lib/deferred-props-recovery.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const reload = vi.fn();
+
+async function freshModule() {
+    vi.resetModules();
+    reload.mockClear();
+
+    const listeners: Record<string, (e: unknown) => void> = {};
+
+    vi.doMock('@inertiajs/react', () => ({
+        router: {
+            on: (name: string, cb: (e: unknown) => void) => {
+                listeners[name] = cb;
+
+                return () => delete listeners[name];
+            },
+            reload,
+        },
+    }));
+
+    const { installDeferredPropsRecovery } =
+        await import('./deferred-props-recovery');
+
+    installDeferredPropsRecovery();
+
+    return { listeners };
+}
+
+function deferredVisit(only: string[]) {
+    return {
+        detail: {
+            visit: {
+                url: new URL('https://whisper.money/dashboard'),
+                only,
+                deferredProps: true,
+            },
+        },
+    };
+}
+
+describe('installDeferredPropsRecovery', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.doUnmock('@inertiajs/react');
+    });
+
+    it('asks again for the props whose request died', async () => {
+        vi.useFakeTimers();
+        const { listeners } = await freshModule();
+
+        listeners.before?.(deferredVisit(['netWorthEvolution']));
+        listeners.networkError?.({ detail: { error: {} } });
+
+        // Not immediately: the connection that just dropped is given a moment.
+        expect(reload).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(2_000);
+
+        expect(reload).toHaveBeenCalledWith({ only: ['netWorthEvolution'] });
+    });
+
+    it('retries once and then leaves the page alone', async () => {
+        vi.useFakeTimers();
+        const { listeners } = await freshModule();
+
+        listeners.before?.(deferredVisit(['netWorthEvolution']));
+        listeners.networkError?.({ detail: { error: {} } });
+        vi.advanceTimersByTime(2_000);
+
+        listeners.before?.(deferredVisit(['netWorthEvolution']));
+        listeners.networkError?.({ detail: { error: {} } });
+        vi.advanceTimersByTime(2_000);
+
+        expect(reload).toHaveBeenCalledOnce();
+    });
+
+    it('starts over on the next page', async () => {
+        vi.useFakeTimers();
+        const { listeners } = await freshModule();
+
+        listeners.before?.(deferredVisit(['netWorthEvolution']));
+        listeners.networkError?.({ detail: { error: {} } });
+        vi.advanceTimersByTime(2_000);
+
+        listeners.navigate?.({});
+        listeners.before?.(deferredVisit(['transactions']));
+        listeners.networkError?.({ detail: { error: {} } });
+        vi.advanceTimersByTime(2_000);
+
+        expect(reload).toHaveBeenCalledTimes(2);
+        expect(reload).toHaveBeenLastCalledWith({ only: ['transactions'] });
+    });
+
+    it('stays out of the way of a request nobody deferred', async () => {
+        vi.useFakeTimers();
+        const { listeners } = await freshModule();
+
+        // A save, a navigation, a poll: not our business.
+        listeners.before?.({
+            detail: {
+                visit: {
+                    url: new URL('https://whisper.money/settings/accounts'),
+                    only: [],
+                },
+            },
+        });
+        listeners.networkError?.({ detail: { error: {} } });
+        vi.advanceTimersByTime(2_000);
+
+        expect(reload).not.toHaveBeenCalled();
+    });
+});

--- a/resources/js/lib/deferred-props-recovery.ts
+++ b/resources/js/lib/deferred-props-recovery.ts
@@ -23,6 +23,20 @@ import { router } from '@inertiajs/react';
  * - The retry is a plain `router.reload`, which Inertia does not mark as a
  *   deferred-props request. So a retry that fails arms nothing, and one is the
  *   most this can ever do - no counter needed to say so.
+ *
+ * Assumes one deferred group in flight at a time, which is what the two pages
+ * using `<Deferred>` do today - the dashboard defers all three of its props under
+ * a single group, so `loadDeferredProps` makes one request. A second group would
+ * share this slot and only the later one would be retried, leaving the earlier
+ * skeleton exactly as stuck as it is today. Key this by group if that ever
+ * happens.
+ *
+ * What it does not do is give the user a way out once the retry has failed too.
+ * The skeleton is stuck again, and all they have is the failed-navigation toast
+ * telling them the server could not be reached. That is the ceiling on purpose:
+ * the blip is the common case and this fixes it, while a real error state inside
+ * `<Deferred>`'s fallback is a per-page change on top of a framework component
+ * that has no error path at all.
  */
 const RETRY_DELAY_MS = 2_000;
 

--- a/resources/js/lib/deferred-props-recovery.ts
+++ b/resources/js/lib/deferred-props-recovery.ts
@@ -1,0 +1,58 @@
+import { router } from '@inertiajs/react';
+
+/**
+ * Asks again for the deferred props that died on the network.
+ *
+ * `<Deferred>` renders its fallback until the props are defined, and it has no
+ * error path: Inertia's `rescue` covers props the *server* chose to rescue, not a
+ * request that never arrived. So when the transport fails, the skeleton stays up
+ * for as long as the page lives - and the dashboard, the first page after logging
+ * in, is three of them. Nothing on screen says why, which reads as an app that is
+ * simply broken. It is the same failure the connections page had before #822, one
+ * layer down.
+ *
+ * One retry, a couple of seconds later, once per page. A blip is the common case
+ * and asking again is the whole fix; a connection that is really gone is already
+ * being reported by the failed-navigation toast, and retrying past that would
+ * trade one silence for a loop.
+ */
+const RETRY_DELAY_MS = 2_000;
+
+let pendingProps: string[] | null = null;
+let retriedThisPage = false;
+
+export function installDeferredPropsRecovery(): void {
+    router.on('before', (event) => {
+        const { visit } = event.detail;
+
+        // Inertia marks the request it makes for deferred props on the internal
+        // shape of the visit, which the `before` event is not typed as - hence the
+        // cast, the same one the unattended-request tracker needs for a poll. If a
+        // future version stops setting it, nothing is retried and the skeleton
+        // behaves as it does today.
+        if ((visit as { deferredProps?: boolean }).deferredProps === true) {
+            pendingProps = visit.only;
+        }
+    });
+
+    router.on('navigate', () => {
+        pendingProps = null;
+        retriedThisPage = false;
+    });
+
+    router.on('networkError', () => {
+        if (pendingProps === null || retriedThisPage) {
+            return;
+        }
+
+        // Deliberately not matched against the failed request's url. The window
+        // this state is open for is one in-flight deferred load, and the worst a
+        // mismatch can do is ask for props we already have.
+        const only = pendingProps;
+
+        pendingProps = null;
+        retriedThisPage = true;
+
+        window.setTimeout(() => router.reload({ only }), RETRY_DELAY_MS);
+    });
+}

--- a/resources/js/lib/deferred-props-recovery.ts
+++ b/resources/js/lib/deferred-props-recovery.ts
@@ -3,56 +3,79 @@ import { router } from '@inertiajs/react';
 /**
  * Asks again for the deferred props that died on the network.
  *
- * `<Deferred>` renders its fallback until the props are defined, and it has no
- * error path: Inertia's `rescue` covers props the *server* chose to rescue, not a
+ * `<Deferred>` renders its fallback until the props are defined and has no error
+ * path: Inertia's `rescue` covers props the *server* chose to rescue, not a
  * request that never arrived. So when the transport fails, the skeleton stays up
  * for as long as the page lives - and the dashboard, the first page after logging
  * in, is three of them. Nothing on screen says why, which reads as an app that is
- * simply broken. It is the same failure the connections page had before #822, one
- * layer down.
+ * simply broken.
  *
- * One retry, a couple of seconds later, once per page. A blip is the common case
- * and asking again is the whole fix; a connection that is really gone is already
- * being reported by the failed-navigation toast, and retrying past that would
- * trade one silence for a loop.
+ * The event order this hangs off, all of it verified in `@inertiajs/core` rather
+ * than assumed, because the first version of this file got it wrong and did
+ * nothing at all:
+ *
+ * - `before` for the deferred request and `navigate` for the page it belongs to
+ *   fire in the same tick (`Page.set` calls `loadDeferredProps` and then
+ *   `fireNavigateEvent`), so `navigate` cannot be used to bound this - it arrives
+ *   long before the request it would be bounding has a chance to fail.
+ * - `networkError` fires from the request's `.catch`, `finish` from the `.finally`
+ *   after it, so a failure is always seen while the request is still pending here.
+ * - The retry is a plain `router.reload`, which Inertia does not mark as a
+ *   deferred-props request. So a retry that fails arms nothing, and one is the
+ *   most this can ever do - no counter needed to say so.
  */
 const RETRY_DELAY_MS = 2_000;
 
 let pendingProps: string[] | null = null;
-let retriedThisPage = false;
+let retryTimer: number | null = null;
+
+function isDeferredPropsVisit(visit: object): boolean {
+    // Inertia marks it on the internal shape of the visit, which these events are
+    // not typed as. If a future version stops setting it, nothing is retried and
+    // the skeleton behaves as it does today.
+    return (visit as { deferredProps?: boolean }).deferredProps === true;
+}
 
 export function installDeferredPropsRecovery(): void {
     router.on('before', (event) => {
         const { visit } = event.detail;
 
-        // Inertia marks the request it makes for deferred props on the internal
-        // shape of the visit, which the `before` event is not typed as - hence the
-        // cast, the same one the unattended-request tracker needs for a poll. If a
-        // future version stops setting it, nothing is retried and the skeleton
-        // behaves as it does today.
-        if ((visit as { deferredProps?: boolean }).deferredProps === true) {
+        if (isDeferredPropsVisit(visit)) {
             pendingProps = visit.only;
         }
     });
 
-    router.on('navigate', () => {
-        pendingProps = null;
-        retriedThisPage = false;
+    // However it ended. A success needs no retry, and a failure has already
+    // scheduled one below - either way the request is no longer pending, and
+    // leaving it armed would let an unrelated failure later on the same page pull
+    // the dashboard's heaviest queries for no reason.
+    router.on('finish', (event) => {
+        if (isDeferredPropsVisit(event.detail.visit)) {
+            pendingProps = null;
+        }
     });
 
     router.on('networkError', () => {
-        if (pendingProps === null || retriedThisPage) {
+        if (pendingProps === null) {
             return;
         }
 
-        // Deliberately not matched against the failed request's url. The window
-        // this state is open for is one in-flight deferred load, and the worst a
-        // mismatch can do is ask for props we already have.
         const only = pendingProps;
 
         pendingProps = null;
-        retriedThisPage = true;
+        retryTimer = window.setTimeout(() => {
+            retryTimer = null;
+            router.reload({ only });
+        }, RETRY_DELAY_MS);
+    });
 
-        window.setTimeout(() => router.reload({ only }), RETRY_DELAY_MS);
+    // A page the user has left must not be asked for its props: `router.reload`
+    // targets wherever they are now, and `only` would name props that page does
+    // not have.
+    router.on('navigate', () => {
+        if (retryTimer !== null) {
+            window.clearTimeout(retryTimer);
+            retryTimer = null;
+        }
     });
 }


### PR DESCRIPTION
## What the user sees

They open the dashboard on a phone, the network blips for a second, and the page
stays on its skeletons — three of them — for as long as they leave it open. Nothing
says why. It reads as an app that is simply broken, on the first page after logging
in.

`PHP-LARAVEL-5E`'s latest event is exactly this: Chrome Mobile in Munich, with the
page url and the failed request both `/dashboard`, so it was the deferred load and
not a navigation. Seven users on that issue since 17 Aug.

## Why it happens

`<Deferred>` renders its `fallback` whenever the props are undefined and has no
error path — Inertia's `rescue` prop covers props the *server* chose to rescue, not
a request that never arrived. So a transport failure means the skeleton is
permanent. `dashboard.tsx` has three of these blocks; `Accounts/Show.tsx` has one.

## The fix

Ask for the props again, once, two seconds later. A blip is the common case and
asking again is the whole fix.

## The first attempt did nothing, and that is worth reading

The architecture review caught that my first commit was inert, and the framework
source agrees: `Page.set` calls `loadDeferredProps` and then `fireNavigateEvent`
**in the same tick**, so the `navigate` handler I used to bound the state wiped it a
full round trip before the request it was guarding could fail. My tests passed
because they fired `before` and `networkError` back to back — an order Inertia never
produces. Same shape of mistake as the job flag in #833: a mechanism that cannot
survive the real lifecycle, with a test that agreed with it.

Rebuilt on what the source actually does, each fact checked:

- `networkError` comes from the request's `.catch` and `finish` from the `.finally`
  after it, so **`finish`** closes the window. It also clears the pending state on
  success — the other bug both reviews found: left armed, an unrelated save blipping
  later on the same page would have pulled the dashboard's heaviest queries for
  nothing.
- The retry is a plain `router.reload`, which Inertia does not mark as deferred, so
  a failing retry arms nothing. One retry is the ceiling by construction; the
  counter is gone.
- `navigate` now only cancels a scheduled retry — the product review's first
  finding: the timer was never cleared, so leaving the dashboard inside those two
  seconds fired a reload at whatever page the user had moved to, asking for props it
  does not have.

## Deliberate limits, both written into the file

- **One deferred group in flight.** Both pages defer under a single group today, so
  there is one request. A second group would share the slot and only the later one
  would be retried, leaving the earlier skeleton as stuck as it is now.
- **No way out once the retry fails too.** The skeleton is stuck again and the user
  has only the failed-navigation toast. An error state inside a framework component
  that has no error path is a per-page change and a product decision, not this PR.

## Testing

- `resources/js` — 456 tests pass (88 files). Five new ones drive the **real** event
  order, and two of them fail against the inert first commit.
- prettier, eslint, `tsc --noEmit` clean.