### PR TITLE
feat(mcp): list automation rules and apply one to existing transactions

### DIFF
--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -5,3 +5,4 @@ Before planning or editing, find the row whose globs match the file's path and r
 | Applies to | Rule file |
 | --- | --- |
 | app/Jobs/** | .ai/rules/jobs.md |
+| app/Mcp/** | .ai/rules/mcp.md |

--- a/.ai/rules/mcp.md
+++ b/.ai/rules/mcp.md
@@ -1,0 +1,22 @@
+---
+paths:
+  - 'app/Mcp/**'
+---
+
+# MCP server
+
+## Adding or removing a tool touches four other files, all enforced
+Registering a class in `WhisperMoneyServer::$tools` is the easy half. Four surfaces go red in CI if they are not updated with it:
+
+1. `tests/Unit/Mcp/ToolAnnotationsTest.php` — hardcodes the read-only tool list, the destructive list, and the total as `count($readOnly) + <write count>`.
+2. `tests/Unit/Mcp/LandingToolCountTest.php` — asserts `MCP_READ_TOOL_COUNT` and `MCP_WRITE_TOOL_COUNT` in `resources/js/pages/welcome.tsx` match the served split. The landing page states those two numbers in prose; the tool-chip animation next to them is unrelated marketing and needs no edit.
+3. `chatgpt-app-submission.json` — every served tool needs a `tools.<name>` entry with `annotations` plus all three justifications. `app_info.description` also enumerates what the app can do.
+4. The `#[Instructions]` block on `WhisperMoneyServer` — the server-level doc the agent actually reads.
+
+`ToolAnnotationsTest` also caps every tool `#[Description]` at 200 characters (the ChatGPT submission form's limit). Detail that does not fit belongs in a schema field description or the instructions.
+
+## MCP strings stay English, including in comments
+Never add `__()` anywhere under `app/Mcp`. The localization extractor scans docblocks and comments too, so even an example `__('…')` inside a comment becomes a required `lang/es.json` key and reddens CI.
+
+## Presenters are shared through a Concerns trait, never copied
+A row shape returned by more than one tool lives in `app/Mcp/Tools/Concerns/Presents*.php` (see `PresentsBudgets`, `PresentsAutomationRules`). Read tools extend `McpTool` and write tools extend `WriteTool`, so a presenter parked on `WriteTool` is unreachable from a list tool — and copying it trips `bun run dry`, a required check.

--- a/app/Http/Controllers/Settings/AutomationRuleApplicationController.php
+++ b/app/Http/Controllers/Settings/AutomationRuleApplicationController.php
@@ -7,20 +7,15 @@ use App\Http\Requests\Settings\ApplyAutomationRuleRequest;
 use App\Jobs\ApplySingleAutomationRuleJob;
 use App\Models\AutomationRule;
 use App\Models\Transaction;
-use App\Services\AutomationRuleService;
+use App\Services\AutomationRuleApplier;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Str;
 
 class AutomationRuleApplicationController extends Controller
 {
     use AuthorizesRequests;
-
-    private const SYNC_THRESHOLD = 100;
-
-    private const MATCHES_CACHE_TTL_MINUTES = 15;
 
     private const PER_PAGE_DEFAULT = 50;
 
@@ -32,7 +27,7 @@ class AutomationRuleApplicationController extends Controller
     public function matches(
         Request $request,
         AutomationRule $automationRule,
-        AutomationRuleService $service,
+        AutomationRuleApplier $applier,
     ): JsonResponse {
         $this->authorize('update', $automationRule);
 
@@ -40,7 +35,7 @@ class AutomationRuleApplicationController extends Controller
         $offset = max(0, (int) $request->integer('offset', 0));
         $perPage = min(self::PER_PAGE_MAX, max(1, (int) $request->integer('per_page', self::PER_PAGE_DEFAULT)));
 
-        $matchingIds = $this->resolveMatchingIds($automationRule, $service, $onlyUncategorized);
+        $matchingIds = $applier->matchingIds($automationRule, $onlyUncategorized);
         $total = count($matchingIds);
         $pageIds = array_slice($matchingIds, $offset, $perPage);
 
@@ -75,14 +70,12 @@ class AutomationRuleApplicationController extends Controller
     public function apply(
         ApplyAutomationRuleRequest $request,
         AutomationRule $automationRule,
-        AutomationRuleService $service,
+        AutomationRuleApplier $applier,
     ): JsonResponse {
         $this->authorize('update', $automationRule);
 
-        $automationRule->loadMissing('labels');
-
         $onlyUncategorized = (bool) $request->boolean('only_uncategorized', true);
-        $matchingIds = $this->resolveMatchingIds($automationRule, $service, $onlyUncategorized);
+        $matchingIds = $applier->matchingIds($automationRule, $onlyUncategorized);
         $total = count($matchingIds);
 
         if ($total === 0) {
@@ -95,43 +88,20 @@ class AutomationRuleApplicationController extends Controller
             ]);
         }
 
-        if ($total <= self::SYNC_THRESHOLD) {
-            $transactions = Transaction::query()
-                ->where('user_id', $automationRule->user_id)
-                ->whereIn('id', $matchingIds)
-                ->whereNull('description_iv')
-                ->with(['account.bank', 'category', 'labels'])
-                ->get();
-
-            $changed = $service->applyRuleActionsToTransactions($transactions, $automationRule, $onlyUncategorized);
-
-            $applied = $transactions->count();
-
-            $this->forgetMatchesCache($automationRule, $onlyUncategorized);
+        if ($total <= AutomationRuleApplier::SYNC_THRESHOLD) {
+            $result = $applier->applyNow($automationRule, $matchingIds, $onlyUncategorized);
 
             return response()->json([
                 'status' => 'done',
-                'processed' => $applied,
+                'processed' => $result['applied'],
                 'total' => $total,
-                'applied' => $applied,
-                'updated' => $changed,
+                'applied' => $result['applied'],
+                'updated' => $result['updated'],
             ]);
         }
 
-        $jobId = (string) Str::uuid();
-
-        Cache::put(
-            ApplySingleAutomationRuleJob::cacheKeyForJobId($automationRule->user_id, $jobId),
-            ['status' => 'pending', 'processed' => 0, 'total' => $total, 'applied' => 0, 'updated' => 0],
-            now()->addHour(),
-        );
-
-        ApplySingleAutomationRuleJob::dispatch($automationRule, $jobId, $matchingIds, $onlyUncategorized);
-
-        $this->forgetMatchesCache($automationRule, $onlyUncategorized);
-
         return response()->json([
-            'job_id' => $jobId,
+            'job_id' => $applier->queue($automationRule, $matchingIds, $onlyUncategorized),
             'total' => $total,
         ], 202);
     }
@@ -148,69 +118,5 @@ class AutomationRuleApplicationController extends Controller
         }
 
         return response()->json($progress);
-    }
-
-    /**
-     * Resolve and cache the list of transaction IDs matching this rule.
-     *
-     * @return array<int, string>
-     */
-    private function resolveMatchingIds(
-        AutomationRule $rule,
-        AutomationRuleService $service,
-        bool $onlyUncategorized,
-    ): array {
-        $cacheKey = $this->matchesCacheKey($rule, $onlyUncategorized);
-
-        $cached = Cache::get($cacheKey);
-        if (is_array($cached)) {
-            return array_values(array_unique($cached));
-        }
-
-        $rule->loadMissing('labels');
-
-        $ids = [];
-
-        $eagerLoads = $service->eagerLoadsForRuleEvaluation($rule);
-        if ($onlyUncategorized && $rule->action_category_id === null) {
-            $eagerLoads[] = 'labels';
-        }
-
-        Transaction::query()
-            ->where('user_id', $rule->user_id)
-            ->whereNull('description_iv')
-            ->with(array_values(array_unique($eagerLoads)))
-            ->orderByDesc('transaction_date')
-            ->orderByDesc('created_at')
-            ->chunk(500, function ($transactions) use ($rule, $service, $onlyUncategorized, &$ids) {
-                foreach ($transactions as $transaction) {
-                    if ($onlyUncategorized && $service->shouldSkipForOnlyUncategorized($rule, $transaction)) {
-                        continue;
-                    }
-
-                    if ($service->ruleMatches($rule, $transaction)) {
-                        $ids[] = $transaction->id;
-                    }
-                }
-            });
-
-        $ids = array_values(array_unique($ids));
-
-        Cache::put($cacheKey, $ids, now()->addMinutes(self::MATCHES_CACHE_TTL_MINUTES));
-
-        return $ids;
-    }
-
-    private function matchesCacheKey(AutomationRule $rule, bool $onlyUncategorized): string
-    {
-        $flag = $onlyUncategorized ? '1' : '0';
-        $stamp = $rule->updated_at?->getTimestamp() ?? 0;
-
-        return "automation_rule_matches:{$rule->user_id}:{$rule->id}:{$flag}:{$stamp}";
-    }
-
-    private function forgetMatchesCache(AutomationRule $rule, bool $onlyUncategorized): void
-    {
-        Cache::forget($this->matchesCacheKey($rule, $onlyUncategorized));
     }
 }

--- a/app/Mcp/Servers/WhisperMoneyServer.php
+++ b/app/Mcp/Servers/WhisperMoneyServer.php
@@ -2,6 +2,7 @@
 
 namespace App\Mcp\Servers;
 
+use App\Mcp\Tools\ApplyAutomationRule;
 use App\Mcp\Tools\CategorizeTransaction;
 use App\Mcp\Tools\CreateAutomationRule;
 use App\Mcp\Tools\CreateBalance;
@@ -18,6 +19,7 @@ use App\Mcp\Tools\GetCashflow;
 use App\Mcp\Tools\GetNetWorth;
 use App\Mcp\Tools\LabelTransaction;
 use App\Mcp\Tools\ListAccounts;
+use App\Mcp\Tools\ListAutomationRules;
 use App\Mcp\Tools\ListBudgets;
 use App\Mcp\Tools\ListCategories;
 use App\Mcp\Tools\ListLabels;
@@ -55,14 +57,21 @@ data.
   so treat `spent_amount` as provisional while `processing_historical` is true.
   A budget's period length, start day, rollover and tracked categories are fixed
   once created: to change those, delete the budget and create it again.
+- An automation rule categorizes and labels transactions automatically. It only
+  runs on transactions created after it, so applying one to the history already
+  in the account is a separate, preview-first step: `list_automation_rules` for
+  the ids, then `apply_automation_rule`, which reports the matches and changes
+  nothing until it is called again with `dry_run: false`. Amounts inside a
+  rule's `rules_json` are in MAJOR units, unlike every other amount here.
 - To find recurring charges (subscriptions), use `search_transactions` and group
   the results by merchant and cadence yourself.
 
 Write tools (create_transaction, update_transaction, delete_transaction,
-categorize_transaction, label_transaction, create_balance and full CRUD for
-budgets, categories, labels and automation rules) require a read & write token;
-a read-only token can analyse data but never change it. Manual transactions can be
-created on any account, bank-connected ones included — a sync never removes them.
+categorize_transaction, label_transaction, create_balance, apply_automation_rule
+and full CRUD for budgets, categories, labels and automation rules) require a
+read & write token; a read-only token can analyse data but never change it.
+Manual transactions can be created on any account, bank-connected ones included
+— a sync never removes them.
 Bank/imported transactions themselves are protected: only manually-created ones
 can be edited or deleted, though you can categorize and label any transaction.
 Balances can only be recorded on non-connected accounts, since a connected
@@ -81,6 +90,7 @@ class WhisperMoneyServer extends Server
         ListCategories::class,
         ListLabels::class,
         ListBudgets::class,
+        ListAutomationRules::class,
         ListSpaces::class,
 
         // Write
@@ -99,6 +109,7 @@ class WhisperMoneyServer extends Server
         CreateAutomationRule::class,
         UpdateAutomationRule::class,
         DeleteAutomationRule::class,
+        ApplyAutomationRule::class,
         CreateBudget::class,
         UpdateBudget::class,
         DeleteBudget::class,

--- a/app/Mcp/Tools/ApplyAutomationRule.php
+++ b/app/Mcp/Tools/ApplyAutomationRule.php
@@ -29,7 +29,7 @@ class ApplyAutomationRule extends WriteTool
         return [
             'automation_rule_id' => $schema->string()->description('Id of the automation rule to apply. Call list_automation_rules to see valid ids.')->required(),
             'dry_run' => $schema->boolean()->description('Default true: report how many transactions the rule matches, with a sample of them, and change nothing. Pass false to actually apply the rule\'s category, labels and note.'),
-            'only_uncategorized' => $schema->boolean()->description('Default true: skip transactions that already have a category (or, for a label-only rule, already carry every label it would add), so an existing categorization is never overwritten.'),
+            'only_uncategorized' => $schema->boolean()->description('Default true: skip transactions that already have a category (or, for a label-only rule, already carry every label it would add). Passing false makes the rule overwrite categories the user or another rule already set, so preview that combination before applying it.'),
             'space' => $schema->string()->description('Space id. Defaults to the personal space.'),
         ];
     }

--- a/app/Mcp/Tools/ApplyAutomationRule.php
+++ b/app/Mcp/Tools/ApplyAutomationRule.php
@@ -2,6 +2,7 @@
 
 namespace App\Mcp\Tools;
 
+use App\Models\Space;
 use App\Models\Transaction;
 use App\Models\User;
 use App\Services\AutomationRuleApplier;
@@ -50,8 +51,10 @@ class ApplyAutomationRule extends WriteTool
                 'dry_run' => true,
                 'automation_rule_id' => $rule->id,
                 'total_matches' => $total,
-                'sample' => $this->sample($matchingIds),
-                'next_step' => "Nothing was changed. Call apply_automation_rule again with dry_run false to apply the rule to all {$total} matching transactions.",
+                'sample' => $this->sample($matchingIds, $space),
+                'next_step' => $total === 0
+                    ? 'Nothing matched, so there is nothing to apply. Widen the rule with update_automation_rule, or set only_uncategorized false to include transactions that already have a category.'
+                    : "Nothing was changed. Call apply_automation_rule again with dry_run false to apply the rule to all {$total} matching transactions.",
             ]);
         }
 
@@ -62,7 +65,7 @@ class ApplyAutomationRule extends WriteTool
                 'status' => 'queued',
                 'automation_rule_id' => $rule->id,
                 'total' => $total,
-                'message' => 'Too many transactions to apply inline, so this finishes in the background over the next few minutes. Call apply_automation_rule with dry_run true again to see what is still unmatched.',
+                'message' => 'Too many transactions to apply inline, so this finishes in the background over the next few minutes. There is no progress tool: call apply_automation_rule with dry_run true again to see what the rule still matches.',
             ]);
         }
 
@@ -84,7 +87,7 @@ class ApplyAutomationRule extends WriteTool
      * @param  array<int, string>  $matchingIds
      * @return array<int, array<string, mixed>>
      */
-    private function sample(array $matchingIds): array
+    private function sample(array $matchingIds, Space $space): array
     {
         $ids = array_slice($matchingIds, 0, self::SAMPLE_SIZE);
 
@@ -92,7 +95,10 @@ class ApplyAutomationRule extends WriteTool
             return [];
         }
 
+        // Re-scoped to the space even though the ids already come from a
+        // space-scoped match, so this stays safe to read on its own.
         return Transaction::query()
+            ->forSpace($space)
             ->whereIn('id', $ids)
             ->with(['account:id,name', 'category:id,name', 'labels:id,name'])
             ->orderByDesc('transaction_date')

--- a/app/Mcp/Tools/ApplyAutomationRule.php
+++ b/app/Mcp/Tools/ApplyAutomationRule.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Models\Transaction;
+use App\Models\User;
+use App\Services\AutomationRuleApplier;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+
+#[Description('Apply an automation rule to transactions that already exist — rules otherwise only run on new ones. Previews the matches by default; pass dry_run false to actually apply them.')]
+class ApplyAutomationRule extends WriteTool
+{
+    /**
+     * How many matching transactions a preview lists. The full count is reported
+     * separately: the sample is only there to let the agent sanity check what
+     * the rule caught before committing to it.
+     */
+    private const SAMPLE_SIZE = 20;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'automation_rule_id' => $schema->string()->description('Id of the automation rule to apply. Call list_automation_rules to see valid ids.')->required(),
+            'dry_run' => $schema->boolean()->description('Default true: report how many transactions the rule matches, with a sample of them, and change nothing. Pass false to actually apply the rule\'s category, labels and note.'),
+            'only_uncategorized' => $schema->boolean()->description('Default true: skip transactions that already have a category (or, for a label-only rule, already carry every label it would add), so an existing categorization is never overwritten.'),
+            'space' => $schema->string()->description('Space id. Defaults to the personal space.'),
+        ];
+    }
+
+    protected function write(Request $request, User $user): Response
+    {
+        $space = $this->resolveSpace($request, $user);
+        $rule = $this->ruleInSpace($request, $space);
+
+        $dryRun = ! $request->has('dry_run') || $request->boolean('dry_run');
+        $onlyUncategorized = ! $request->has('only_uncategorized') || $request->boolean('only_uncategorized');
+
+        $applier = app(AutomationRuleApplier::class);
+        $matchingIds = $applier->matchingIds($rule, $onlyUncategorized, $space);
+        $total = count($matchingIds);
+
+        if ($dryRun) {
+            return $this->json([
+                'dry_run' => true,
+                'automation_rule_id' => $rule->id,
+                'total_matches' => $total,
+                'sample' => $this->sample($matchingIds),
+                'next_step' => "Nothing was changed. Call apply_automation_rule again with dry_run false to apply the rule to all {$total} matching transactions.",
+            ]);
+        }
+
+        if ($total > AutomationRuleApplier::SYNC_THRESHOLD) {
+            $applier->queue($rule, $matchingIds, $onlyUncategorized, $space);
+
+            return $this->json([
+                'status' => 'queued',
+                'automation_rule_id' => $rule->id,
+                'total' => $total,
+                'message' => 'Too many transactions to apply inline, so this finishes in the background over the next few minutes. Call apply_automation_rule with dry_run true again to see what is still unmatched.',
+            ]);
+        }
+
+        $result = $applier->applyNow($rule, $matchingIds, $onlyUncategorized, $space);
+
+        return $this->json([
+            'status' => 'done',
+            'automation_rule_id' => $rule->id,
+            'total' => $total,
+            // `applied` counts the transactions the rule ran over, `updated` the
+            // ones it actually changed — a row that already carried the rule's
+            // category and labels is applied but not updated.
+            'applied' => $result['applied'],
+            'updated' => $result['updated'],
+        ]);
+    }
+
+    /**
+     * @param  array<int, string>  $matchingIds
+     * @return array<int, array<string, mixed>>
+     */
+    private function sample(array $matchingIds): array
+    {
+        $ids = array_slice($matchingIds, 0, self::SAMPLE_SIZE);
+
+        if ($ids === []) {
+            return [];
+        }
+
+        return Transaction::query()
+            ->whereIn('id', $ids)
+            ->with(['account:id,name', 'category:id,name', 'labels:id,name'])
+            ->orderByDesc('transaction_date')
+            ->orderByDesc('created_at')
+            ->get()
+            ->map(fn (Transaction $transaction): array => $this->presentTransaction($transaction))
+            ->all();
+    }
+}

--- a/app/Mcp/Tools/Concerns/PresentsAutomationRules.php
+++ b/app/Mcp/Tools/Concerns/PresentsAutomationRules.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Mcp\Tools\Concerns;
+
+use App\Models\AutomationRule;
+use App\Models\Label;
+
+/**
+ * The automation-rule shape every rule tool returns, so list_automation_rules,
+ * create_automation_rule and update_automation_rule all hand the agent the same
+ * row. Note that amounts inside `rules_json` are in MAJOR units, unlike every
+ * other amount the MCP exposes.
+ */
+trait PresentsAutomationRules
+{
+    /**
+     * @return array<string, mixed>
+     */
+    protected function presentAutomationRule(AutomationRule $rule): array
+    {
+        $rule->loadMissing('labels:id,name');
+
+        return [
+            'id' => $rule->id,
+            'title' => $rule->title,
+            'priority' => $rule->priority,
+            'rules_json' => $rule->rules_json,
+            'action_category_id' => $rule->action_category_id,
+            'action_note' => $rule->action_note,
+            'origin' => $rule->origin->value,
+            'labels' => $rule->labels
+                ->map(fn (Label $label): array => ['id' => $label->id, 'name' => $label->name])
+                ->values()
+                ->all(),
+        ];
+    }
+}

--- a/app/Mcp/Tools/CreateAutomationRule.php
+++ b/app/Mcp/Tools/CreateAutomationRule.php
@@ -4,6 +4,7 @@ namespace App\Mcp\Tools;
 
 use App\Enums\RuleOrigin;
 use App\Mcp\Tools\Concerns\DecodesRulesJson;
+use App\Mcp\Tools\Concerns\PresentsAutomationRules;
 use App\Models\AutomationRule;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
@@ -15,7 +16,7 @@ use Laravel\Mcp\Server\Attributes\Description;
 #[Description('Create an automation rule that auto-applies a category and/or labels to matching transactions. At least one action (action_category_id or action_label_ids) is required; see rules_json for its format.')]
 class CreateAutomationRule extends WriteTool
 {
-    use DecodesRulesJson;
+    use DecodesRulesJson, PresentsAutomationRules;
 
     /**
      * @return array<string, mixed>

--- a/app/Mcp/Tools/ListAutomationRules.php
+++ b/app/Mcp/Tools/ListAutomationRules.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Mcp\Tools\Concerns\PresentsAutomationRules;
+use App\Models\AutomationRule;
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[Description('List the user\'s automation rules in a space, lowest priority number first. Use the ids with update_automation_rule, delete_automation_rule and apply_automation_rule.')]
+class ListAutomationRules extends McpTool
+{
+    use PresentsAutomationRules;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'space' => $schema->string()->description('Space id to query. Defaults to the personal space.'),
+        ];
+    }
+
+    protected function respond(Request $request, User $user): Response
+    {
+        $space = $this->resolveSpace($request, $user);
+
+        $rules = AutomationRule::query()
+            ->forSpace($space)
+            ->with('labels:id,name')
+            ->orderBy('priority')
+            ->orderBy('title')
+            ->get()
+            ->map(fn (AutomationRule $rule): array => $this->presentAutomationRule($rule))
+            ->all();
+
+        return $this->json([
+            'space_id' => $space->id,
+            'automation_rules' => $rules,
+        ]);
+    }
+}

--- a/app/Mcp/Tools/UpdateAutomationRule.php
+++ b/app/Mcp/Tools/UpdateAutomationRule.php
@@ -3,6 +3,7 @@
 namespace App\Mcp\Tools;
 
 use App\Mcp\Tools\Concerns\DecodesRulesJson;
+use App\Mcp\Tools\Concerns\PresentsAutomationRules;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Validation\ValidationException;
@@ -13,7 +14,7 @@ use Laravel\Mcp\Server\Attributes\Description;
 #[Description('Edit an automation rule. Only the fields you pass are changed. The rule must always keep at least one action (a category or labels). See create_automation_rule for the rules_json format.')]
 class UpdateAutomationRule extends WriteTool
 {
-    use DecodesRulesJson;
+    use DecodesRulesJson, PresentsAutomationRules;
 
     /**
      * @return array<string, mixed>

--- a/app/Mcp/Tools/WriteTool.php
+++ b/app/Mcp/Tools/WriteTool.php
@@ -144,7 +144,7 @@ abstract class WriteTool extends McpTool
 
     protected function ruleInSpace(Request $request, Space $space, string $key = 'automation_rule_id'): AutomationRule
     {
-        return $this->modelInSpace($request, $space, AutomationRule::query()->forSpace($space), $key, 'automation rule');
+        return $this->modelInSpace($request, $space, AutomationRule::query()->forSpace($space), $key, 'automation rule', 'Call list_automation_rules to see valid ids.');
     }
 
     /**
@@ -222,28 +222,6 @@ abstract class WriteTool extends McpTool
             'id' => $label->id,
             'name' => $label->name,
             'color' => $label->color,
-        ];
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    protected function presentAutomationRule(AutomationRule $rule): array
-    {
-        $rule->loadMissing('labels:id,name');
-
-        return [
-            'id' => $rule->id,
-            'title' => $rule->title,
-            'priority' => $rule->priority,
-            'rules_json' => $rule->rules_json,
-            'action_category_id' => $rule->action_category_id,
-            'action_note' => $rule->action_note,
-            'origin' => $rule->origin->value,
-            'labels' => $rule->labels
-                ->map(fn (Label $label): array => ['id' => $label->id, 'name' => $label->name])
-                ->values()
-                ->all(),
         ];
     }
 }

--- a/app/Services/AutomationRuleApplier.php
+++ b/app/Services/AutomationRuleApplier.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Services;
+
+use App\Jobs\ApplySingleAutomationRuleJob;
+use App\Models\AutomationRule;
+use App\Models\Space;
+use App\Models\Transaction;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+
+/**
+ * Applies an existing automation rule to transactions already in the database.
+ * Rules otherwise only run on newly created transactions (see
+ * App\Listeners\ApplyAutomationRules), so both the settings screen and the MCP
+ * apply_automation_rule tool come through here to backfill history.
+ *
+ * Resolving the matches means evaluating the rule row by row in PHP, so the id
+ * list is cached and re-used by the preview and the apply that follows it.
+ */
+class AutomationRuleApplier
+{
+    /**
+     * Match counts at or below this are applied inline; anything larger goes to
+     * the queue so the request does not hang on it.
+     */
+    public const SYNC_THRESHOLD = 100;
+
+    private const MATCHES_CACHE_TTL_MINUTES = 15;
+
+    public function __construct(private AutomationRuleService $service) {}
+
+    /**
+     * Ids of the transactions this rule matches, newest first.
+     *
+     * $space is a deliberate divergence for MCP callers: the web matches every
+     * transaction the rule's owner has, while an MCP call is scoped to one space
+     * so a personal-space rule can never recategorize a shared space's history.
+     *
+     * @return array<int, string>
+     */
+    public function matchingIds(AutomationRule $rule, bool $onlyUncategorized, ?Space $space = null): array
+    {
+        $cacheKey = $this->matchesCacheKey($rule, $onlyUncategorized, $space);
+
+        $cached = Cache::get($cacheKey);
+        if (is_array($cached)) {
+            return array_values(array_unique($cached));
+        }
+
+        $rule->loadMissing('labels');
+
+        $ids = [];
+
+        $eagerLoads = $this->service->eagerLoadsForRuleEvaluation($rule);
+        if ($onlyUncategorized && $rule->action_category_id === null) {
+            $eagerLoads[] = 'labels';
+        }
+
+        $this->transactions($rule, $space)
+            ->with(array_values(array_unique($eagerLoads)))
+            ->orderByDesc('transaction_date')
+            ->orderByDesc('created_at')
+            ->chunk(500, function ($transactions) use ($rule, $onlyUncategorized, &$ids) {
+                foreach ($transactions as $transaction) {
+                    if ($onlyUncategorized && $this->service->shouldSkipForOnlyUncategorized($rule, $transaction)) {
+                        continue;
+                    }
+
+                    if ($this->service->ruleMatches($rule, $transaction)) {
+                        $ids[] = $transaction->id;
+                    }
+                }
+            });
+
+        $ids = array_values(array_unique($ids));
+
+        Cache::put($cacheKey, $ids, now()->addMinutes(self::MATCHES_CACHE_TTL_MINUTES));
+
+        return $ids;
+    }
+
+    /**
+     * Apply the rule's actions to the matched transactions right now.
+     *
+     * @param  array<int, string>  $transactionIds
+     * @return array{applied: int, updated: int}
+     */
+    public function applyNow(AutomationRule $rule, array $transactionIds, bool $onlyUncategorized, ?Space $space = null): array
+    {
+        $rule->loadMissing('labels');
+
+        $transactions = $this->transactions($rule, $space)
+            ->whereIn('id', $transactionIds)
+            ->with(['account.bank', 'category', 'labels'])
+            ->get();
+
+        $updated = $this->service->applyRuleActionsToTransactions($transactions, $rule, $onlyUncategorized);
+
+        $this->forgetMatches($rule, $onlyUncategorized, $space);
+
+        return ['applied' => $transactions->count(), 'updated' => $updated];
+    }
+
+    /**
+     * Hand the matched transactions to the queue, returning the job id the web
+     * client polls for progress.
+     *
+     * @param  array<int, string>  $transactionIds
+     */
+    public function queue(AutomationRule $rule, array $transactionIds, bool $onlyUncategorized, ?Space $space = null): string
+    {
+        $jobId = (string) Str::uuid();
+
+        Cache::put(
+            ApplySingleAutomationRuleJob::cacheKeyForJobId($rule->user_id, $jobId),
+            ['status' => 'pending', 'processed' => 0, 'total' => count($transactionIds), 'applied' => 0, 'updated' => 0],
+            now()->addHour(),
+        );
+
+        ApplySingleAutomationRuleJob::dispatch($rule, $jobId, $transactionIds, $onlyUncategorized);
+
+        $this->forgetMatches($rule, $onlyUncategorized, $space);
+
+        return $jobId;
+    }
+
+    public function forgetMatches(AutomationRule $rule, bool $onlyUncategorized, ?Space $space = null): void
+    {
+        Cache::forget($this->matchesCacheKey($rule, $onlyUncategorized, $space));
+    }
+
+    /**
+     * The candidate transactions a rule may touch. Encrypted rows are excluded
+     * because rule evaluation reads the plaintext description.
+     *
+     * @return Builder<Transaction>
+     */
+    private function transactions(AutomationRule $rule, ?Space $space): Builder
+    {
+        $query = Transaction::query()
+            ->where('user_id', $rule->user_id)
+            ->whereNull('description_iv');
+
+        if ($space !== null) {
+            $query->forSpace($space);
+        }
+
+        return $query;
+    }
+
+    private function matchesCacheKey(AutomationRule $rule, bool $onlyUncategorized, ?Space $space): string
+    {
+        $flag = $onlyUncategorized ? '1' : '0';
+        $stamp = $rule->updated_at?->getTimestamp() ?? 0;
+        $scope = $space === null ? '' : ":space:{$space->id}";
+
+        return "automation_rule_matches:{$rule->user_id}:{$rule->id}:{$flag}:{$stamp}{$scope}";
+    }
+}

--- a/chatgpt-app-submission.json
+++ b/chatgpt-app-submission.json
@@ -4,7 +4,7 @@
   "app_info": {
     "display_name": "Whisper Money",
     "subtitle": "Chat with your own finances",
-    "description": "Whisper Money is a privacy-first personal finance app: your financial data is yours, and it is never shared with third parties. This app connects ChatGPT to your own Whisper Money account so you can analyse your money in plain language instead of clicking through dashboards.\n\nAsk questions like \"how much did I spend on groceries last month\", \"what's my net worth trend this year\", \"which subscriptions are draining me\" or \"break down Q2 by category\" — the app reads your transactions, accounts, categories, labels, budgets, cashflow and net worth and answers with your real numbers. You can also keep your books tidy from the conversation: log manual transactions, recategorize and label existing ones, record balances for manual accounts, and manage budgets, categories, labels and automation rules.\n\nYour synced bank data is protected: transactions imported from a bank connection can be categorized and labelled, but never edited or deleted, and balances can only be recorded on manual accounts. You can still add your own manual transactions to a bank-connected account — a sync never removes them. Data is scoped to the account you sign in with, including any shared spaces you belong to. The app reads and writes bookkeeping records only — it can never move money, make payments or reach any account outside Whisper Money.\n\nRequires a Whisper Money account on a paid (Pro) plan. Sign in happens through Whisper Money's own OAuth flow — ChatGPT never sees your password, and access can be revoked at any time from your account settings.",
+    "description": "Whisper Money is a privacy-first personal finance app: your financial data is yours, and it is never shared with third parties. This app connects ChatGPT to your own Whisper Money account so you can analyse your money in plain language instead of clicking through dashboards.\n\nAsk questions like \"how much did I spend on groceries last month\", \"what's my net worth trend this year\", \"which subscriptions are draining me\" or \"break down Q2 by category\" — the app reads your transactions, accounts, categories, labels, budgets, cashflow and net worth and answers with your real numbers. You can also keep your books tidy from the conversation: log manual transactions, recategorize and label existing ones, record balances for manual accounts, and manage budgets, categories, labels and automation rules — including running an automation rule over the transactions you already have, after previewing what it would match.\n\nYour synced bank data is protected: transactions imported from a bank connection can be categorized and labelled, but never edited or deleted, and balances can only be recorded on manual accounts. You can still add your own manual transactions to a bank-connected account — a sync never removes them. Data is scoped to the account you sign in with, including any shared spaces you belong to. The app reads and writes bookkeeping records only — it can never move money, make payments or reach any account outside Whisper Money.\n\nRequires a Whisper Money account on a paid (Pro) plan. Sign in happens through Whisper Money's own OAuth flow — ChatGPT never sees your password, and access can be revoked at any time from your account settings.",
     "category": "FINANCE"
   },
   "tools": {
@@ -61,6 +61,14 @@
       "justifications": {
         "read_only_justification": "Lists the user's own labels so later calls can reference label ids. It writes nothing.",
         "open_world_justification": "Lists only labels inside the authenticated user's own Whisper Money workspace, a closed system.",
+        "destructive_justification": "Read-only, so nothing can be changed or lost."
+      }
+    },
+    "list_automation_rules": {
+      "annotations": { "readOnlyHint": true, "openWorldHint": false, "destructiveHint": false },
+      "justifications": {
+        "read_only_justification": "Lists the user's own automation rules with their conditions and the category, labels and note each one applies. It writes nothing.",
+        "open_world_justification": "Lists only automation rules inside the authenticated user's own Whisper Money workspace, a closed system.",
         "destructive_justification": "Read-only, so nothing can be changed or lost."
       }
     },
@@ -198,6 +206,14 @@
         "read_only_justification": "Writes: it removes an automation rule from the user's own workspace.",
         "open_world_justification": "Deletes a rule inside the user's own Whisper Money workspace, a closed system.",
         "destructive_justification": "Irreversible: the rule definition is deleted and cannot be restored, so the model must confirm with the user first. Transactions it already categorized are left untouched."
+      }
+    },
+    "apply_automation_rule": {
+      "annotations": { "readOnlyHint": false, "openWorldHint": false, "destructiveHint": false },
+      "justifications": {
+        "read_only_justification": "Writes: it runs an existing automation rule over the transactions already in the user's own account, categorizing and labelling the ones it matches. It only reads while dry_run is left at its default.",
+        "open_world_justification": "Reads and updates rows inside the user's own Whisper Money workspace, a closed system.",
+        "destructive_justification": "Reversible: it assigns a category, labels and a note, all of which can be reassigned or removed afterwards, and no transaction is deleted. It also previews the matches unless dry_run is explicitly set to false."
       }
     },
     "create_budget": {

--- a/resources/js/pages/welcome.tsx
+++ b/resources/js/pages/welcome.tsx
@@ -930,8 +930,8 @@ function CashflowChartPreview() {
  * step with App\Mcp\Servers\WhisperMoneyServer, so the landing cannot claim a
  * number the server stopped serving.
  */
-const MCP_READ_TOOL_COUNT = 9;
-const MCP_WRITE_TOOL_COUNT = 18;
+const MCP_READ_TOOL_COUNT = 10;
+const MCP_WRITE_TOOL_COUNT = 19;
 
 /**
  * The figures the assistant reports on in the preview conversation. The budgets

--- a/tests/Feature/Mcp/McpToolsTest.php
+++ b/tests/Feature/Mcp/McpToolsTest.php
@@ -2,11 +2,13 @@
 
 use App\Mcp\Servers\WhisperMoneyServer;
 use App\Mcp\Tools\ListAccounts;
+use App\Mcp\Tools\ListAutomationRules;
 use App\Mcp\Tools\ListBudgets;
 use App\Mcp\Tools\ListCategories;
 use App\Mcp\Tools\ListSpaces;
 use App\Mcp\Tools\SearchTransactions;
 use App\Models\Account;
+use App\Models\AutomationRule;
 use App\Models\Budget;
 use App\Models\Category;
 use App\Models\Label;
@@ -218,4 +220,36 @@ it('never exposes another user\'s budgets', function () {
         ->tool(ListBudgets::class)
         ->assertOk()
         ->assertDontSee('Secret Budget');
+});
+
+it('lists the user\'s automation rules with their actions', function () {
+    $user = User::factory()->create();
+    $category = Category::factory()->create(['user_id' => $user->id, 'name' => 'Groceries']);
+    $label = Label::factory()->create(['user_id' => $user->id, 'name' => 'Essentials']);
+
+    $rule = AutomationRule::factory()->create([
+        'user_id' => $user->id,
+        'title' => 'Supermarket rule',
+        'priority' => 3,
+        'action_category_id' => $category->id,
+    ]);
+    $rule->labels()->attach($label->id);
+
+    WhisperMoneyServer::actingAs($user)
+        ->tool(ListAutomationRules::class)
+        ->assertOk()
+        ->assertSee(['Supermarket rule', '"priority":3', $category->id, 'Essentials']);
+});
+
+it('never exposes another user\'s automation rules', function () {
+    $user = User::factory()->create();
+    AutomationRule::factory()->create([
+        'user_id' => User::factory()->create()->id,
+        'title' => 'Secret Rule',
+    ]);
+
+    WhisperMoneyServer::actingAs($user)
+        ->tool(ListAutomationRules::class)
+        ->assertOk()
+        ->assertDontSee('Secret Rule');
 });

--- a/tests/Feature/Mcp/McpWriteToolsTest.php
+++ b/tests/Feature/Mcp/McpWriteToolsTest.php
@@ -1,7 +1,11 @@
 <?php
 
+use App\Enums\CategoryCashflowDirection;
 use App\Enums\CategorySource;
+use App\Enums\CategoryType;
+use App\Jobs\ApplySingleAutomationRuleJob;
 use App\Mcp\Servers\WhisperMoneyServer;
+use App\Mcp\Tools\ApplyAutomationRule;
 use App\Mcp\Tools\CategorizeTransaction;
 use App\Mcp\Tools\CreateAutomationRule;
 use App\Mcp\Tools\CreateBalance;
@@ -15,6 +19,7 @@ use App\Mcp\Tools\DeleteCategory;
 use App\Mcp\Tools\DeleteLabel;
 use App\Mcp\Tools\DeleteTransaction;
 use App\Mcp\Tools\LabelTransaction;
+use App\Mcp\Tools\ListAutomationRules;
 use App\Mcp\Tools\UpdateAutomationRule;
 use App\Mcp\Tools\UpdateBudget;
 use App\Mcp\Tools\UpdateCategory;
@@ -27,6 +32,8 @@ use App\Models\Category;
 use App\Models\Label;
 use App\Models\Transaction;
 use App\Models\User;
+use App\Services\AutomationRuleApplier;
+use Illuminate\Support\Facades\Queue;
 use Laravel\Mcp\Server\Testing\TestResponse;
 
 /**
@@ -612,7 +619,6 @@ it('never lets a write tool touch another user\'s data', function () {
 it('tells the agent which id was missing and where to find valid ones', function () {
     $user = User::factory()->create();
 
-    // Records that have a listing tool point the agent at it.
     callWriteTool($user, UpdateTransaction::class, [
         'transaction_id' => 'no-such-transaction',
         'description' => 'Nope',
@@ -620,10 +626,165 @@ it('tells the agent which id was missing and where to find valid ones', function
         'No transaction with id no-such-transaction in space '.$user->personalSpace->id.'. Call search_transactions to find ids.',
     ]);
 
-    // Those without one end at the sentence, with no dangling hint.
     callWriteTool($user, DeleteAutomationRule::class, [
         'automation_rule_id' => 'no-such-rule',
     ])->assertHasErrors([
-        'No automation rule with id no-such-rule in space '.$user->personalSpace->id.'.',
+        'No automation rule with id no-such-rule in space '.$user->personalSpace->id.'. Call list_automation_rules to see valid ids.',
     ]);
+});
+
+/**
+ * A rule that catches history it never ran on: the matching transactions are
+ * created first on purpose, because the TransactionCreated listener only
+ * applies rules that already exist — which is exactly the gap
+ * apply_automation_rule fills.
+ *
+ * @return array{0: AutomationRule, 1: Category, 2: Label}
+ */
+function groceryRuleOverHistory(User $user, int $matchingCount = 2): array
+{
+    $account = Account::factory()->create(['user_id' => $user->id, 'encrypted' => false]);
+    $category = Category::factory()->create(['user_id' => $user->id, 'name' => 'Groceries']);
+    $label = Label::factory()->create(['user_id' => $user->id, 'name' => 'Essentials']);
+
+    // plaintext(), because rule evaluation reads the description and skips
+    // every row the legacy encryption columns still mark as encrypted.
+    Transaction::factory()->plaintext()->count($matchingCount)->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'category_id' => null,
+        'description' => 'Grocery Store',
+        'amount' => -1_000,
+    ]);
+
+    Transaction::factory()->plaintext()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'category_id' => null,
+        'description' => 'Coffee Shop',
+        'amount' => -500,
+    ]);
+
+    $rule = AutomationRule::factory()->create([
+        'user_id' => $user->id,
+        'priority' => 1,
+        'rules_json' => ['in' => ['grocery', ['var' => 'description']]],
+        'action_category_id' => $category->id,
+    ]);
+    $rule->labels()->attach($label->id);
+
+    return [$rule, $category, $label];
+}
+
+it('previews an automation rule against existing transactions and changes nothing', function () {
+    $user = User::factory()->create();
+    [$rule] = groceryRuleOverHistory($user);
+
+    callWriteTool($user, ApplyAutomationRule::class, [
+        'automation_rule_id' => $rule->id,
+    ])->assertOk()
+        ->assertSee(['"dry_run":true', '"total_matches":2', 'Grocery Store'])
+        ->assertDontSee('Coffee Shop');
+
+    expect(Transaction::query()->where('user_id', $user->id)->whereNotNull('category_id')->count())->toBe(0)
+        ->and(Transaction::query()->where('user_id', $user->id)->has('labels')->count())->toBe(0);
+});
+
+it('applies an automation rule to existing transactions once the dry run is turned off', function () {
+    $user = User::factory()->create();
+    [$rule, $category, $label] = groceryRuleOverHistory($user);
+
+    callWriteTool($user, ApplyAutomationRule::class, [
+        'automation_rule_id' => $rule->id,
+        'dry_run' => false,
+    ])->assertOk()->assertSee(['"status":"done"', '"applied":2', '"updated":2']);
+
+    $matched = Transaction::query()->where('description', 'Grocery Store')->with('labels')->get();
+
+    expect($matched)->toHaveCount(2)
+        ->and($matched->pluck('category_id')->unique()->all())->toBe([$category->id])
+        ->and($matched->filter(fn (Transaction $t): bool => $t->labels->contains($label)))->toHaveCount(2);
+
+    // The transaction the rule does not match is left exactly as it was.
+    expect(Transaction::query()->where('description', 'Coffee Shop')->value('category_id'))->toBeNull();
+});
+
+it('hands a large apply to the queue instead of running it inline', function () {
+    Queue::fake();
+
+    $user = User::factory()->create();
+    [$rule] = groceryRuleOverHistory($user, AutomationRuleApplier::SYNC_THRESHOLD + 1);
+
+    callWriteTool($user, ApplyAutomationRule::class, [
+        'automation_rule_id' => $rule->id,
+        'dry_run' => false,
+    ])->assertOk()->assertSee(['"status":"queued"', '"total":101']);
+
+    Queue::assertPushed(ApplySingleAutomationRuleJob::class);
+
+    expect(Transaction::query()->where('user_id', $user->id)->whereNotNull('category_id')->count())->toBe(0);
+});
+
+it('lets a read-only token list automation rules but never apply one', function () {
+    $user = User::factory()->create();
+    [$rule] = groceryRuleOverHistory($user);
+
+    callWriteTool($user, ApplyAutomationRule::class, [
+        'automation_rule_id' => $rule->id,
+        'dry_run' => false,
+    ], ['mcp:read'])->assertHasErrors(['read-only']);
+
+    // The same read-only token still reaches the listing tool.
+    WhisperMoneyServer::actingAs($user)
+        ->tool(ListAutomationRules::class)
+        ->assertOk()
+        ->assertSee($rule->title);
+
+    expect(Transaction::query()->where('user_id', $user->id)->whereNotNull('category_id')->count())->toBe(0);
+});
+
+it('still enforces the Pro-plan gate on apply_automation_rule', function () {
+    config(['subscriptions.enabled' => true]);
+
+    $user = User::factory()->create();
+    [$rule] = groceryRuleOverHistory($user);
+
+    callWriteTool($user, ApplyAutomationRule::class, [
+        'automation_rule_id' => $rule->id,
+        'dry_run' => false,
+    ])->assertHasErrors(['Pro']);
+
+    expect(Transaction::query()->where('user_id', $user->id)->whereNotNull('category_id')->count())->toBe(0);
+});
+
+it('moves a subcategory under a different parent and cascades the type down its subtree', function () {
+    $user = User::factory()->create();
+
+    $expenses = Category::factory()->create([
+        'user_id' => $user->id,
+        'name' => 'Home',
+        'type' => CategoryType::Expense,
+        'cashflow_direction' => CategoryCashflowDirection::Hidden,
+    ]);
+    $savings = Category::factory()->create([
+        'user_id' => $user->id,
+        'name' => 'Savings',
+        'type' => CategoryType::Savings,
+        'cashflow_direction' => CategoryCashflowDirection::Outflow,
+    ]);
+
+    $child = Category::factory()->childOf($expenses)->create(['user_id' => $user->id, 'name' => 'Rainy day']);
+    $grandchild = Category::factory()->childOf($child)->create(['user_id' => $user->id, 'name' => 'Emergency fund']);
+
+    callWriteTool($user, UpdateCategory::class, [
+        'category_id' => $child->id,
+        'parent_id' => $savings->id,
+    ])->assertOk()->assertSee('"type":"savings"');
+
+    expect($child->fresh()->parent_id)->toBe($savings->id)
+        ->and($child->fresh()->type)->toBe(CategoryType::Savings)
+        ->and($child->fresh()->cashflow_direction)->toBe(CategoryCashflowDirection::Outflow)
+        // The whole subtree follows the new parent, not just the moved category.
+        ->and($grandchild->fresh()->type)->toBe(CategoryType::Savings)
+        ->and($grandchild->fresh()->cashflow_direction)->toBe(CategoryCashflowDirection::Outflow);
 });

--- a/tests/Unit/Mcp/ToolAnnotationsTest.php
+++ b/tests/Unit/Mcp/ToolAnnotationsTest.php
@@ -16,6 +16,7 @@ $readOnly = [
     'list_categories',
     'list_labels',
     'list_budgets',
+    'list_automation_rules',
     'list_spaces',
 ];
 
@@ -48,7 +49,7 @@ it('declares all three MCP hints on every tool', function () use ($readOnly, $de
     /** @var array<int, class-string<Tool>> $tools */
     $tools = (new ReflectionClass(WhisperMoneyServer::class))->getDefaultProperties()['tools'];
 
-    expect($tools)->toHaveCount(count($readOnly) + 18);
+    expect($tools)->toHaveCount(count($readOnly) + 19);
 
     foreach ($tools as $class) {
         $tool = new $class;


### PR DESCRIPTION
## Why

Two gaps in the MCP server, both around automation rules.

**Rules were write-only.** The server registered `create_automation_rule`,
`update_automation_rule` and `delete_automation_rule`, but nothing to read them. An
agent could never discover an `automation_rule_id`, so editing or deleting an existing
rule was unreachable in practice.

**A rule created over MCP only ever affected future transactions.** Rules fire from
`ApplyAutomationRules` on `TransactionCreated`. The settings screen can preview a rule's
matches and apply it to the history already in the account; MCP had no equivalent, so an
agent could write a rule and then watch it do nothing to the transactions the user was
actually asking about.

## What

Two new tools.

**`list_automation_rules`** — read-only, space-scoped, ordered by priority then title.
Returns each rule through the shared presenter (id, title, priority, `rules_json`,
`action_category_id`, `action_note`, origin, labels).

**`apply_automation_rule`** — applies a rule to transactions that already exist.
`dry_run` defaults to **true**: a preview reports the match count plus a bounded sample
(20) of matching transactions and changes nothing. `dry_run: false` actually applies.
One tool rather than a separate preview tool — same schema, same matcher, one entry to
keep in sync, and a true-by-default `dry_run` structurally enforces preview-first.
`only_uncategorized` keeps the web's semantics and default (`true`).

Sync vs queue reuses the web's threshold: at or below 100 matches it applies inline and
returns the counts; above it dispatches `ApplySingleAutomationRuleJob` and returns
`{status: "queued", total: N}`. There is deliberately **no** MCP status/polling tool —
re-running with `dry_run: true` is the status check, and the tool says so.

## Refactors this needed

- `presentAutomationRule()` moved out of `WriteTool` into
  `App\Mcp\Tools\Concerns\PresentsAutomationRules`, shared by the read tool and the two
  rule write tools — matching the existing `PresentsBudgets` convention. Copying it would
  have tripped `bun run dry`.
- The matcher and both apply paths moved out of `AutomationRuleApplicationController`
  into `App\Services\AutomationRuleApplier`, now shared by the web controller and the MCP
  tool. The controller's observable behaviour is unchanged — same cache key, same TTL,
  same threshold, same response shapes.
- `ruleInSpace()` was the only `modelInSpace()` caller without a "call list_… to see valid
  ids" hint, precisely because no list tool existed. It has one now.

### Space scoping is a deliberate divergence from the web

`AutomationRuleApplier` takes an optional `?Space`. The controller passes `null`, keeping
the web matcher exactly as it was (filtered by `user_id`). The MCP tool passes the
resolved space, so a personal-space rule can never recategorize a shared space's
transactions — consistent with every other MCP tool.

`ApplySingleAutomationRuleJob`'s constructor is untouched on purpose: adding a promoted
property to a queued job leaves every in-flight payload uninitialized at deploy.

## Surfaces kept in sync

- `tests/Unit/Mcp/ToolAnnotationsTest.php` — read-only list and the write-tool count.
- `chatgpt-app-submission.json` — annotations plus all three justifications for both new
  tools, and the automation-rule sentence in `app_info.description`.
- `WhisperMoneyServer` `#[Instructions]` — rules can be listed, and applying one to
  history is a separate, preview-first step.
- `resources/js/pages/welcome.tsx` — **not** in the original scope, but the landing page
  states the tool counts and `tests/Unit/Mcp/LandingToolCountTest.php` enforces them, so
  the two constants had to go 9→10 and 18→19. The tool-chip animation is untouched.

## Also in here

One test for the category-move path, which had no MCP coverage at all (`grep parent_id
tests/Feature/Mcp/` was empty). It moves a subcategory under a different parent and
asserts the type/cashflow cascade down the subtree — the only non-trivial branch in
`UpdateCategory`. Unrelated to automation rules; called out here so it does not read as
an accident.

## Testing

Pest coverage in the existing MCP test files: listing returns the user's rules and never
another user's; a dry run reports matches and mutates nothing; a real run categorizes and
labels the matching transactions and leaves the rest alone; the >threshold path dispatches
the job under `Queue::fake()`; a read-only token is refused on apply but still reaches the
list tool; the Pro-plan gate still bites.

QA'd the way it is actually used — real JSON-RPC calls to `/mcp` with real Sanctum tokens
against a local server:

- `list_automation_rules` with a read-only token returned the rule with its labels.
- `apply_automation_rule` with a read-only token was refused.
- Dry run reported 3 matches with the sample, and left every row uncategorized.
- `dry_run: false` reported `applied: 3, updated: 3`; the DB showed all three grocery rows
  categorized and labelled, and the unrelated cinema transaction untouched.
- Re-running the dry run returned 0 matches, which is the documented status check.
- A bad rule id returned the new "Call list_automation_rules to see valid ids" hint.

The refactored web endpoints were exercised the same way with a session cookie:
`GET .../matches` returned 2, `POST .../apply` returned
`processed/total/applied/updated = 2`, and the rows came back categorized and labelled.

`vendor/bin/pint`, PHPStan, `bun run dry`, `bun run format`, `bun run lint` and
`php artisan crap --base=origin/main --no-coverage` are all clean locally.
