### PR TITLE
docs(ai): support any OpenAI-compatible endpoint as an AI provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -155,8 +155,8 @@ DEMO_ENCRYPTION_KEY=demo
 # Provider is configurable independently of the model and defaults to Gemini.
 # Set AI_PROVIDER to switch every AI feature at once (e.g. "ollama" for fully
 # local, private processing); the per-feature vars below override it. Accepts
-# any laravel/ai provider ("gemini", "ollama", "openai", ...); an unknown value
-# fails fast.
+# any laravel/ai provider ("gemini", "ollama", "openai", "openai-compatible",
+# ...); an unknown value fails fast.
 # AI_PROVIDER=gemini
 # AI_SUGGESTIONS_PROVIDER=gemini
 # AI_CATEGORIZATION_PROVIDER=gemini
@@ -175,6 +175,15 @@ GEMINI_BASE_URL=
 # authenticating proxy.
 # OLLAMA_URL=http://localhost:11434
 # OLLAMA_API_KEY=
+
+# --- OpenAI-compatible endpoints (OrcaRouter, LM Studio, vLLM, a gateway...) ---
+# Set AI_PROVIDER=openai-compatible and point OPENAI_COMPATIBLE_URL at the
+# versioned root of an endpoint speaking the OpenAI Chat Completions API (e.g.
+# https://api.orcarouter.ai/v1). The URL is required; the key is optional and is
+# sent as a bearer token when set. The model vars below must name a model that
+# endpoint serves (e.g. orcarouter/auto). One endpoint at a time.
+# OPENAI_COMPATIBLE_URL=
+# OPENAI_COMPATIBLE_API_KEY=
 
 # Model is overridable without a deploy; defaults to a Flash-tier Gemini model.
 # When using Ollama, set these to a locally available model (e.g. gemma3:12b).

--- a/README.md
+++ b/README.md
@@ -176,9 +176,10 @@ Whisper Money's AI features (transaction categorization and automation-rule
 suggestions) run on [`laravel/ai`](https://github.com/laravel/ai) and default to
 Google **Gemini**. The provider is configurable independently of the model, so
 you can point the app at **any text provider `laravel/ai` supports** — `gemini`,
-`openai`, `anthropic`, `azure`, `groq`, `xai`, `deepseek`, `mistral`, or a
-self-hosted **[Ollama](https://ollama.com)** server. Ollama is the headline case
-because it keeps AI processing fully local and private — data never leaves your
+`openai`, `anthropic`, `azure`, `groq`, `xai`, `deepseek`, `mistral`, a
+self-hosted **[Ollama](https://ollama.com)** server, or `openai-compatible` for
+any endpoint speaking the OpenAI API. Ollama is the headline case because it
+keeps AI processing fully local and private — data never leaves your
 infrastructure — but the switch is generic.
 
 Each provider needs its own credentials configured for `laravel/ai` (e.g.
@@ -198,6 +199,8 @@ unknown or non-text provider fails fast when the AI feature runs.
 | `GEMINI_API_KEY`             | -                    | Required when the provider is `gemini`.                               |
 | `OLLAMA_URL`                 | `http://localhost:11434` | Ollama server URL (used when the provider is `ollama`).           |
 | `OLLAMA_API_KEY`             | -                    | Optional; only needed behind an authenticating proxy.                 |
+| `OPENAI_COMPATIBLE_URL`      | -                    | Base URL of an OpenAI-compatible endpoint (required when the provider is `openai-compatible`). |
+| `OPENAI_COMPATIBLE_API_KEY`  | -                    | Optional; sent as a bearer token when set.                            |
 
 ### Example: fully local AI with Ollama
 
@@ -212,6 +215,41 @@ Make sure the model is pulled on the Ollama server first (`ollama pull gemma3:12
 Any other provider follows the same pattern: set `AI_PROVIDER`, that provider's
 credentials, and the `*_MODEL` vars to one of its models. Gemini remains the
 default, so existing deployments are unaffected.
+
+### Any OpenAI-compatible endpoint
+
+Plenty of services and local servers speak the OpenAI Chat Completions API
+without being OpenAI: router/gateway services such as
+[OrcaRouter](https://www.orcarouter.ai/), local runtimes like LM Studio or
+vLLM, hosted inference like Together or Fireworks, a LiteLLM instance, or your
+own corporate proxy. Set `AI_PROVIDER=openai-compatible` and point the app at
+one of them.
+
+- `OPENAI_COMPATIBLE_URL` is **required** — it is the base URL the app appends
+  `chat/completions` to, so give it the versioned root (e.g. `.../v1`). Leaving
+  it empty fails when the AI feature runs.
+- `OPENAI_COMPATIBLE_API_KEY` is **optional** — when set it is sent as
+  `Authorization: Bearer <key>`. Leave it empty for a local server that does not
+  authenticate.
+- The `*_MODEL` vars must name a model **that endpoint serves**. There is no
+  default, and the Gemini defaults are meaningless to it.
+- There is a **single** `openai-compatible` slot, so only one such endpoint can
+  be configured at a time. To reach two of them, put a router in front.
+
+Example with OrcaRouter:
+
+```dotenv
+AI_PROVIDER=openai-compatible
+OPENAI_COMPATIBLE_URL=https://api.orcarouter.ai/v1
+OPENAI_COMPATIBLE_API_KEY=sk-orca-...
+AI_SUGGESTIONS_MODEL=orcarouter/auto
+AI_CATEGORIZATION_MODEL=orcarouter/auto
+AI_REPORTS_MODEL=orcarouter/auto
+```
+
+`orcarouter/auto` lets OrcaRouter pick the model; naming one directly
+(`provider/model-name`) works too. Any other OpenAI-compatible endpoint follows
+the same shape — only the URL and the model names change.
 
 ## License
 

--- a/tests/Feature/Ai/OpenAiCompatibleProviderTest.php
+++ b/tests/Feature/Ai/OpenAiCompatibleProviderTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Services\Ai\ReportSummarizer;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Pointing AI_PROVIDER at an OpenAI-compatible endpoint (OrcaRouter, LM Studio,
+ * vLLM, a gateway...) needs no application code: laravel/ai ships the driver and
+ * our config already accepts any Lab case. This guards that claim — the README
+ * documents it — by driving the real gateway against a faked HTTP layer.
+ *
+ * The report summariser is the vehicle because it is the cheapest of the three
+ * AI features to invoke; the provider switch it reads is shared by all of them.
+ */
+it('prompts an OpenAI-compatible endpoint with a bearer token when the provider is switched to one', function () {
+    config([
+        'ai_reports.provider' => 'openai-compatible',
+        'ai_reports.model' => 'orcarouter/auto',
+        'ai.providers.openai-compatible.url' => 'https://api.orcarouter.ai/v1',
+        'ai.providers.openai-compatible.key' => 'sk-orca-test',
+    ]);
+
+    Http::fake([
+        'api.orcarouter.ai/*' => Http::response([
+            'model' => 'orcarouter/auto',
+            'choices' => [['message' => ['content' => 'Los registros bajan.'], 'finish_reason' => 'stop']],
+        ]),
+    ]);
+
+    $summary = app(ReportSummarizer::class)->summarize('test-report', 'Test report.', ['weeks' => []]);
+
+    expect($summary)->toBe('Los registros bajan.');
+
+    Http::assertSent(fn (Request $request): bool => $request->url() === 'https://api.orcarouter.ai/v1/chat/completions'
+        && $request->hasHeader('Authorization', 'Bearer sk-orca-test')
+        && $request['model'] === 'orcarouter/auto');
+});
+
+it('fails fast when an OpenAI-compatible endpoint is selected without a URL', function () {
+    config([
+        'ai_reports.provider' => 'openai-compatible',
+        'ai.providers.openai-compatible.url' => null,
+    ]);
+
+    // The summariser swallows every failure so a report still posts, so the
+    // misconfiguration surfaces as a null summary rather than an exception.
+    expect(app(ReportSummarizer::class)->summarize('test-report', 'Test report.', []))->toBeNull();
+});


### PR DESCRIPTION
## What

Documents that Whisper Money already supports **any OpenAI-compatible endpoint** as its AI
provider, with [OrcaRouter](https://www.orcarouter.ai/) as the worked example, and adds a
regression test proving it.

**This required no application code.** The driver and the switch already existed:

- `laravel/ai` v0.10.3 ships the `openai-compatible` driver (`Lab::OpenAICompatible`) and a
  vendor config entry reading `OPENAI_COMPATIBLE_URL` / `OPENAI_COMPATIBLE_API_KEY`.
- Our three AI features already resolve their provider with
  `Lab::from(config('ai_*.provider'))`, fed by `AI_PROVIDER`, so `openai-compatible`
  resolves as-is.

So the whole integration is a `.env` change:

```dotenv
AI_PROVIDER=openai-compatible
OPENAI_COMPATIBLE_URL=https://api.orcarouter.ai/v1
OPENAI_COMPATIBLE_API_KEY=sk-orca-...
AI_SUGGESTIONS_MODEL=orcarouter/auto
AI_CATEGORIZATION_MODEL=orcarouter/auto
AI_REPORTS_MODEL=orcarouter/auto
```

## Changes

- **`tests/Feature/Ai/OpenAiCompatibleProviderTest.php`** (new) — drives the *real* gateway
  against a faked HTTP layer and asserts the request lands on
  `https://api.orcarouter.ai/v1/chat/completions` with `Authorization: Bearer <key>` and the
  configured model. A second test covers the misconfiguration case (no URL). No agent fake, so
  it proves the URL and auth scheme rather than just that config resolves.
- **`README.md`** — new "Any OpenAI-compatible endpoint" subsection under `## AI Provider`,
  written generically (routers/gateways, LM Studio, vLLM, Together, Fireworks, LiteLLM, a
  corporate proxy) with OrcaRouter as the concrete example. Adds `OPENAI_COMPATIBLE_URL` and
  `OPENAI_COMPATIBLE_API_KEY` to the variables table.
- **`.env.example`** — a commented `# --- OpenAI-compatible endpoints ---` block next to the
  Gemini/Ollama ones. Both vars stay commented out: `.env.example` is copied verbatim in CI and
  an uncommented empty var reads back as `''` rather than `null`.

## Verification

- New test passes; mutating the provider to `gemini` makes it fail, so it is not vacuous.
- Full `tests/Feature/Ai` suite green (141 tests).
- Manually exercised the documented dotenv block through real env parsing (`artisan tinker`
  with the vars exported, URL pointed at a dead local port): `AI_PROVIDER` resolves to
  `Lab::OpenAICompatible`, the URL and key are read, and the outbound request goes to the
  configured URL. No call was made to OrcaRouter — we have no key.

## Deliberately not done

- No named `orcarouter` provider. That would mean publishing the full vendor `config/ai.php`
  and relaxing the three `Lab::from()` calls to accept a plain string — too much surface to
  maintain for the DX gained. The generic `openai-compatible` slot covers it.
- Gemini remains the default; nothing about existing deployments changes.
