### PR TITLE
feat(banking): email a bank's users a notice written as a markdown file

### DIFF
--- a/app/Console/Commands/NotifyBankUsersCommand.php
+++ b/app/Console/Commands/NotifyBankUsersCommand.php
@@ -27,8 +27,12 @@ use Illuminate\Support\Str;
  * with an `# H1`, which is used as the subject, and may use `:name` where the
  * recipient's name belongs.
  *
- * Unlike the outage notice, a bank present in several countries is notified in
- * all of them by default: an operator-written notice is usually about the bank
+ * Everyone with a live connection to the bank is notified, whatever state that
+ * connection is in. Unlike the outage notice, this one makes no claim about the
+ * bank answering or not, so there is nothing to narrow the recipients to.
+ *
+ * Also unlike the outage notice, a bank present in several countries is notified
+ * in all of them by default: an operator-written notice is usually about the bank
  * rather than about one country's connector, and `--country` is there when it
  * is not. Nothing double-sends either way, because the ledger is per user.
  */

--- a/app/Console/Commands/NotifyBankUsersCommand.php
+++ b/app/Console/Commands/NotifyBankUsersCommand.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Console\Commands\Concerns\NotifiesBankUsers;
+use App\Enums\DripEmailType;
+use App\Mail\BankNoticeEmail;
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\Isolatable;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+/**
+ * Emails everyone connected to one Enable Banking bank a notice written by hand
+ * as a Markdown file, for the one-off situations that do not deserve a command
+ * and a committed view of their own.
+ *
+ * Its `banking:notify-*` siblings each carry the copy for one recurring
+ * situation. Here the copy is a file the operator writes and uploads, so it is
+ * read and passed to the mailable as text: the queue worker that sends it is
+ * not guaranteed to have the file, and the file can change in between.
+ *
+ * One file per locale, `<base>.<locale>.md`. `<base>.en.md` must exist and is
+ * what anyone whose language has no file of its own receives. Each file opens
+ * with an `# H1`, which is used as the subject, and may use `:name` where the
+ * recipient's name belongs.
+ *
+ * Unlike the outage notice, a bank present in several countries is notified in
+ * all of them by default: an operator-written notice is usually about the bank
+ * rather than about one country's connector, and `--country` is there when it
+ * is not. Nothing double-sends either way, because the ledger is per user.
+ */
+class NotifyBankUsersCommand extends Command implements Isolatable
+{
+    use NotifiesBankUsers;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'banking:notify-users
+                            {aspsp : The bank name as stored on the connection, e.g. "Trade Republic"}
+                            {notice : Path to the notice, with or without its locale suffix, e.g. resources/notices/my-notice}
+                            {--country= : ISO country code, to notify one country of a bank present in several (e.g. ES)}
+                            {--dry-run : List the recipients without sending anything}
+                            {--force : Skip the confirmation prompt}
+                            {--resend : Notify users who already got this notice}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Email the users connected to one Enable Banking bank a notice written as a Markdown file';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $base = $this->noticeBase((string) $this->argument('notice'));
+        $notices = $this->readNotices($base);
+
+        if ($notices === null) {
+            return self::FAILURE;
+        }
+
+        $aspsp = (string) $this->argument('aspsp');
+        $country = $this->countryOption();
+        $banks = $this->affectedBanks($this->matchesBank($aspsp, $country));
+
+        if ($banks->isEmpty()) {
+            $this->reportUnknownBank($aspsp, $country);
+
+            return self::SUCCESS;
+        }
+
+        // The bank name comes from the data, so the console output and the
+        // ledger key agree however the operator typed it.
+        $bankName = (string) $banks->first()->aspsp_name;
+        $displayName = $bankName.' ('.$banks->pluck('aspsp_country')->sort()->implode(', ').')';
+        // The ledger key carries the notice as well as the bank, because the
+        // second notice ever sent to a bank must not be suppressed by the first.
+        // The country is left out on purpose: the ledger is per user, so a
+        // whole-bank run and a --country run cannot overlap.
+        $identifier = Str::slug($bankName.'-'.basename($base));
+
+        $users = $this->recipients($this->matchesBank($bankName, $country), DripEmailType::BankNotice, $identifier);
+
+        if ($users->isEmpty()) {
+            $this->info("Nobody to notify at {$displayName}: everyone connected already got this notice, or has since deleted their account. Use --resend to send it again.");
+
+            return self::SUCCESS;
+        }
+
+        $this->reportScope($users, $notices, $displayName);
+
+        $subject = (string) BankNoticeEmail::subjectOf($notices['en']);
+
+        if (! $this->shouldSend("Send \"{$subject}\" to {$users->count()} user(s) connected to {$displayName}?")) {
+            return self::SUCCESS;
+        }
+
+        $this->sendAndLog(
+            $users,
+            DripEmailType::BankNotice,
+            $identifier,
+            fn (User $user) => new BankNoticeEmail($user, $notices),
+        );
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * The path with any locale suffix dropped, so `my-notice`, `my-notice.en.md`
+     * and `my-notice.es.md` all name the same set of files.
+     */
+    private function noticeBase(string $path): string
+    {
+        return (string) preg_replace('/\.[A-Za-z]{2}([_-][A-Za-z]{2,4})?\.md$/', '', $path);
+    }
+
+    /**
+     * The notice as one Markdown body per locale, or null with the reason
+     * already reported.
+     *
+     * @return array<string, string>|null
+     */
+    private function readNotices(string $base): ?array
+    {
+        $notices = [];
+
+        foreach (File::glob($base.'.*.md') as $file) {
+            $notices[Str::afterLast(basename($file, '.md'), '.')] = (string) File::get($file);
+        }
+
+        if (! isset($notices['en'])) {
+            $this->error("No English notice at {$base}.en.md.");
+            $this->line('Every notice needs one: it is what anyone whose language has no file of its own receives.');
+
+            return null;
+        }
+
+        foreach ($notices as $locale => $notice) {
+            if (BankNoticeEmail::subjectOf($notice) === null) {
+                $this->error("{$base}.{$locale}.md does not start with a heading.");
+                $this->line('The first line must be "# Something", which is used as the email subject.');
+
+                return null;
+            }
+        }
+
+        return $notices;
+    }
+
+    /**
+     * Show what is about to go out, and to whom, in the recipient's own
+     * language: this copy was written outside the codebase, so the operator
+     * reviewing it is the only check it gets.
+     *
+     * @param  Collection<int, User>  $users
+     * @param  array<string, string>  $notices
+     */
+    private function reportScope(Collection $users, array $notices, string $displayName): void
+    {
+        $this->table(['Locale', 'Subject'], collect($notices)
+            ->map(fn (string $notice, string $locale) => [$locale, (string) BankNoticeEmail::subjectOf($notice)])
+            ->values()
+            ->all());
+
+        $this->table(['Email', 'Connections', 'Reads'], $users->map(fn (User $user) => [
+            $user->email,
+            (int) $user->getAttribute(self::MATCHED_CONNECTIONS),
+            BankNoticeEmail::localeFor($notices, $user->preferredLocale()),
+        ])->all());
+
+        $this->info("{$users->count()} user(s) connected to {$displayName} to notify.");
+    }
+}

--- a/app/Enums/DripEmailType.php
+++ b/app/Enums/DripEmailType.php
@@ -16,6 +16,7 @@ enum DripEmailType: string
     case Update = 'update';
     case BankOutage = 'bank_outage';
     case BankConnectFailed = 'bank_connect_failed';
+    case BankNotice = 'bank_notice';
     case InactiveNoBank = 'inactive_no_bank';
     case TrialEnding = 'trial_ending';
 }

--- a/app/Mail/BankNoticeEmail.php
+++ b/app/Mail/BankNoticeEmail.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\Middleware\RateLimited;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Str;
+
+/**
+ * A one-off notice about one bank, written by hand as a Markdown file and sent
+ * by `banking:notify-users`.
+ *
+ * The bodies travel as text rather than as a path: a queue worker is not
+ * guaranteed to have the file the operator ran the command with, and the file
+ * can be edited between dispatch and delivery.
+ *
+ * Reply-to is the shared founders inbox, because a notice about a bank invites
+ * people to write back.
+ */
+class BankNoticeEmail extends Mailable implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+
+    /** @var int */
+    public $tries = 5;
+
+    /** @var array<int, int> */
+    public $backoff = [2, 5, 10, 30];
+
+    /**
+     * @param  array<string, string>  $notices  Markdown bodies keyed by locale, always including `en`.
+     */
+    public function __construct(
+        public User $user,
+        public array $notices,
+    ) {
+        $this->onQueue('emails');
+    }
+
+    /**
+     * The subject is the heading the notice opens with, so it is written in the
+     * same file, and the same language, as the body it belongs to. Laravel
+     * hydrates the envelope inside withLocale(), so that is the recipient's
+     * language.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: (string) self::subjectOf($this->body()),
+            replyTo: [new Address(
+                config('mail.drip_from.address', 'hi@whisper.money'),
+                config('mail.drip_from.name', 'Whisper Money'),
+            )],
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'mail.bank-notice',
+            with: ['body' => $this->body()],
+        );
+    }
+
+    /**
+     * The notice this recipient reads: their own language when the operator
+     * wrote one, and the mandatory English file otherwise.
+     */
+    public function body(): string
+    {
+        $notice = $this->notices[self::localeFor($this->notices, app()->getLocale())];
+
+        return str_replace(':name', (string) $this->user->name, $notice);
+    }
+
+    /**
+     * Which of the notices a locale reads. Shared with the command so the
+     * recipient table it prints cannot disagree with what goes out.
+     *
+     * @param  array<string, string>  $notices
+     */
+    public static function localeFor(array $notices, string $locale): string
+    {
+        return isset($notices[$locale]) ? $locale : 'en';
+    }
+
+    /**
+     * The `# Heading` a notice opens with, or null when it does not open with
+     * one, which is what the command refuses to send.
+     */
+    public static function subjectOf(string $notice): ?string
+    {
+        $heading = trim(Str::before(ltrim($notice), "\n"));
+
+        return Str::startsWith($heading, '# ') ? trim(Str::after($heading, '# ')) : null;
+    }
+
+    /**
+     * Get the middleware the job should pass through.
+     *
+     * @return array<int, object>
+     */
+    public function middleware(): array
+    {
+        return [(new RateLimited('emails'))->releaseAfter(1)];
+    }
+}

--- a/resources/notices/trade-republic-descriptions.en.md
+++ b/resources/notices/trade-republic-descriptions.en.md
@@ -1,0 +1,15 @@
+# Your Trade Republic transactions arrive without a description
+
+Hi :name,
+
+If you have looked at your Trade Republic transactions lately, you will have seen that almost all of them say the same thing: "Bank transaction".
+
+That text is ours, not theirs. Trade Republic's connection sends us the date and the amount of each transaction and nothing else — no shop, no name, no concept — so there is nothing for us to show you, and rather than leave the line blank we fill it with a generic label.
+
+There is nothing wrong with your account, and nothing you can do to fix it. Reconnecting Trade Republic will not bring the descriptions back, because they never reach us in the first place.
+
+Everything else is right: the amounts, the dates, your balances, and every transaction is there. You can also rename any transaction by hand, and it keeps the name you give it.
+
+We have already reported this to the provider that connects us to Trade Republic, and we are pushing to have the missing information included. We are not going to promise you a date, because the fix is not on our side. If it changes, we will tell you.
+
+Thank you for your patience, and sorry for the inconvenience in the meantime.

--- a/resources/notices/trade-republic-descriptions.es.md
+++ b/resources/notices/trade-republic-descriptions.es.md
@@ -1,0 +1,15 @@
+# Tus movimientos de Trade Republic llegan sin concepto
+
+Hola :name,
+
+Si has mirado últimamente tus movimientos de Trade Republic, habrás visto que casi todos dicen lo mismo: "Bank transaction".
+
+Ese texto lo ponemos nosotros, no el banco. La conexión de Trade Republic nos envía la fecha y el importe de cada movimiento y nada más: ni comercio, ni nombre, ni concepto. No tenemos nada que mostrarte ahí, y en lugar de dejar la línea vacía la rellenamos con una etiqueta genérica.
+
+No hay nada mal en tu cuenta, y no hay nada que puedas hacer para arreglarlo. Volver a conectar Trade Republic no va a recuperar los conceptos, porque no nos llegan en ningún momento.
+
+Todo lo demás está bien: los importes, las fechas, tus saldos, y todos los movimientos están ahí. También puedes renombrar a mano cualquier movimiento, y se queda con el nombre que le pongas.
+
+Ya lo hemos reportado al proveedor que nos conecta con Trade Republic y estamos insistiendo para que incluyan la información que falta. No te vamos a prometer una fecha, porque la solución no está en nuestras manos. Si cambia, te lo contamos.
+
+Gracias por la paciencia y perdona las molestias mientras tanto.

--- a/resources/notices/trade-republic-descriptions.es.md
+++ b/resources/notices/trade-republic-descriptions.es.md
@@ -6,7 +6,7 @@ Si has mirado últimamente tus movimientos de Trade Republic, habrás visto que 
 
 Ese texto lo ponemos nosotros, no el banco. La conexión de Trade Republic nos envía la fecha y el importe de cada movimiento y nada más: ni comercio, ni nombre, ni concepto. No tenemos nada que mostrarte ahí, y en lugar de dejar la línea vacía la rellenamos con una etiqueta genérica.
 
-No hay nada mal en tu cuenta, y no hay nada que puedas hacer para arreglarlo. Volver a conectar Trade Republic no va a recuperar los conceptos, porque no nos llegan en ningún momento.
+No es un problema de tu cuenta, y no hay nada que puedas hacer para arreglarlo. Volver a conectar Trade Republic no va a recuperar los conceptos, porque no nos llegan en ningún momento.
 
 Todo lo demás está bien: los importes, las fechas, tus saldos, y todos los movimientos están ahí. También puedes renombrar a mano cualquier movimiento, y se queda con el nombre que le pongas.
 

--- a/resources/views/mail/bank-notice.blade.php
+++ b/resources/views/mail/bank-notice.blade.php
@@ -1,0 +1,10 @@
+{{-- The body is an operator-written Markdown file, echoed unescaped so the mail
+     layout parses it as Markdown. It is deliberately never compiled as Blade:
+     a file uploaded to production by hand must not be able to run code. --}}
+<x-mail::message>
+{!! $body !!}
+
+{{ __('Best,') }}<br>
+{{ __('Álvaro & Víctor') }}<br>
+{{ __('Founders of Whisper Money') }}
+</x-mail::message>

--- a/tests/Feature/Console/NotifyBankUsersCommandTest.php
+++ b/tests/Feature/Console/NotifyBankUsersCommandTest.php
@@ -1,0 +1,301 @@
+<?php
+
+use App\Enums\BankingProvider;
+use App\Enums\DripEmailType;
+use App\Mail\BankNoticeEmail;
+use App\Models\BankingConnection;
+use App\Models\User;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+
+use function Pest\Laravel\artisan;
+use function Pest\Laravel\assertDatabaseCount;
+use function Pest\Laravel\assertDatabaseHas;
+
+beforeEach(function () {
+    Mail::fake();
+
+    $this->notices = sys_get_temp_dir().'/notices-'.Str::random(8);
+    File::ensureDirectoryExists($this->notices);
+});
+
+afterEach(function () {
+    File::deleteDirectory($this->notices);
+});
+
+/**
+ * Writes one notice file, and returns the base path the command is given.
+ *
+ * @param  array<string, string>  $bodies  Markdown keyed by locale
+ */
+function notice(array $bodies, string $name = 'a-notice'): string
+{
+    $base = test()->notices.'/'.$name;
+
+    foreach ($bodies as $locale => $body) {
+        File::put("{$base}.{$locale}.md", $body);
+    }
+
+    return $base;
+}
+
+/**
+ * The notice used wherever the copy itself is not what is being tested.
+ */
+function englishNotice(string $name = 'a-notice'): string
+{
+    return notice(['en' => "# Heads up about your bank\n\nHi :name, here is the news."], $name);
+}
+
+/**
+ * A user with one Enable Banking connection to "QA Notice Bank" (ES).
+ *
+ * @param  array<string, mixed>  $connection
+ */
+function noticeUser(string $email, array $connection = [], array $attributes = []): User
+{
+    $user = User::factory()->create(['email' => $email, ...$attributes]);
+
+    BankingConnection::factory()->for($user)->create([
+        'aspsp_name' => 'QA Notice Bank',
+        'aspsp_country' => 'ES',
+        ...$connection,
+    ]);
+
+    return $user;
+}
+
+test('notifies every user connected to the bank', function () {
+    $first = noticeUser('first@example.com');
+    $second = noticeUser('second@example.com');
+
+    artisan('banking:notify-users', ['aspsp' => 'QA Notice Bank', 'notice' => englishNotice(), '--force' => true])
+        ->expectsOutputToContain('2 user(s) connected to QA Notice Bank (ES) to notify.')
+        ->assertSuccessful();
+
+    Mail::assertQueued(BankNoticeEmail::class, 2);
+
+    foreach ([$first, $second] as $user) {
+        Mail::assertQueued(BankNoticeEmail::class, fn (BankNoticeEmail $mail) => $mail->hasTo($user->email));
+    }
+});
+
+test('notifies a bank present in several countries in all of them', function () {
+    noticeUser('es@example.com');
+    noticeUser('de@example.com', ['aspsp_country' => 'DE']);
+
+    artisan('banking:notify-users', ['aspsp' => 'QA Notice Bank', 'notice' => englishNotice(), '--force' => true])
+        ->expectsOutputToContain('2 user(s) connected to QA Notice Bank (DE, ES) to notify.')
+        ->assertSuccessful();
+
+    Mail::assertQueued(BankNoticeEmail::class, 2);
+});
+
+test('the country option narrows a send to one country', function () {
+    $spanish = noticeUser('es@example.com');
+    noticeUser('de@example.com', ['aspsp_country' => 'DE']);
+
+    artisan('banking:notify-users', ['aspsp' => 'QA Notice Bank', 'notice' => englishNotice(), '--country' => 'es', '--force' => true])
+        ->expectsOutputToContain('1 user(s) connected to QA Notice Bank (ES) to notify.')
+        ->assertSuccessful();
+
+    Mail::assertQueued(BankNoticeEmail::class, 1);
+    Mail::assertQueued(BankNoticeEmail::class, fn (BankNoticeEmail $mail) => $mail->hasTo($spanish->email));
+});
+
+test('leaves users of other banks alone', function () {
+    noticeUser('other@example.com', ['aspsp_name' => 'CaixaBank']);
+
+    artisan('banking:notify-users', ['aspsp' => 'QA Notice Bank', 'notice' => englishNotice(), '--force' => true])
+        ->expectsOutputToContain('No Enable Banking connection to QA Notice Bank.')
+        ->assertSuccessful();
+
+    Mail::assertNothingOutgoing();
+});
+
+test('ignores connections a notice has no business reaching', function (string $case) {
+    $user = noticeUser('skipped@example.com', $case === 'other provider' ? ['provider' => BankingProvider::Wise] : []);
+
+    match ($case) {
+        'deleted connection' => $user->bankingConnections()->first()->delete(),
+        'deleted account' => $user->delete(),
+        default => null,
+    };
+
+    artisan('banking:notify-users', ['aspsp' => 'QA Notice Bank', 'notice' => englishNotice(), '--force' => true])
+        ->assertSuccessful();
+
+    Mail::assertNothingOutgoing();
+})->with(['other provider', 'deleted connection', 'deleted account']);
+
+test('sends a single email to a user with several connections to the same bank', function () {
+    $user = noticeUser('multi@example.com');
+    BankingConnection::factory()->for($user)->create([
+        'aspsp_name' => 'QA Notice Bank',
+        'aspsp_country' => 'ES',
+    ]);
+
+    artisan('banking:notify-users', ['aspsp' => 'QA Notice Bank', 'notice' => englishNotice(), '--force' => true])
+        ->expectsOutputToContain('1 user(s) connected to QA Notice Bank (ES) to notify.')
+        ->assertSuccessful();
+
+    Mail::assertQueued(BankNoticeEmail::class, 1);
+});
+
+test('the subject is the heading the notice opens with', function () {
+    noticeUser('subject@example.com');
+    $base = notice(['en' => "# Something happened at your bank\n\nHi :name."]);
+
+    artisan('banking:notify-users', ['aspsp' => 'QA Notice Bank', 'notice' => $base, '--force' => true])
+        ->expectsOutputToContain('Something happened at your bank')
+        ->assertSuccessful();
+
+    Mail::assertQueued(BankNoticeEmail::class, fn (BankNoticeEmail $mail) => $mail->envelope()->subject === 'Something happened at your bank');
+});
+
+test('refuses a notice with no English file', function () {
+    noticeUser('no-english@example.com');
+    $base = notice(['es' => "# Aviso\n\nHola :name."]);
+
+    artisan('banking:notify-users', ['aspsp' => 'QA Notice Bank', 'notice' => $base, '--force' => true])
+        ->expectsOutputToContain('No English notice at')
+        ->assertFailed();
+
+    Mail::assertNothingOutgoing();
+});
+
+test('refuses a notice that does not open with a heading', function (string $locale) {
+    noticeUser('no-heading@example.com');
+    $base = notice(['en' => "# Fine\n\nHi :name.", $locale => "No heading here.\n\nHola :name."]);
+
+    artisan('banking:notify-users', ['aspsp' => 'QA Notice Bank', 'notice' => $base, '--force' => true])
+        ->expectsOutputToContain('does not start with a heading')
+        ->assertFailed();
+
+    Mail::assertNothingOutgoing();
+})->with(['en', 'es']);
+
+test('refuses a notice that is not there at all', function () {
+    noticeUser('missing@example.com');
+
+    artisan('banking:notify-users', ['aspsp' => 'QA Notice Bank', 'notice' => $this->notices.'/nope', '--force' => true])
+        ->expectsOutputToContain('No English notice at')
+        ->assertFailed();
+
+    Mail::assertNothingOutgoing();
+});
+
+test('takes the path of any of the locale files, or of none of them', function (string $suffix) {
+    noticeUser('path@example.com');
+    $base = notice(['en' => "# Fine\n\nHi :name.", 'es' => "# Bien\n\nHola :name."]);
+
+    artisan('banking:notify-users', ['aspsp' => 'QA Notice Bank', 'notice' => $base.$suffix, '--force' => true])
+        ->assertSuccessful();
+
+    Mail::assertQueued(BankNoticeEmail::class, 1);
+})->with(['', '.en.md', '.es.md']);
+
+test('a dry run sends nothing, and says who would have received what', function () {
+    noticeUser('dry@example.com', attributes: ['locale' => 'es']);
+    $base = notice(['en' => "# Heads up\n\nHi :name.", 'es' => "# Atención\n\nHola :name."]);
+
+    artisan('banking:notify-users', ['aspsp' => 'QA Notice Bank', 'notice' => $base, '--dry-run' => true])
+        ->expectsOutputToContain('dry@example.com')
+        ->expectsOutputToContain('[dry-run] No emails sent.')
+        ->assertSuccessful();
+
+    Mail::assertNothingOutgoing();
+    assertDatabaseCount('user_mail_logs', 0);
+});
+
+test('a declined confirmation sends nothing', function () {
+    noticeUser('declined@example.com');
+
+    artisan('banking:notify-users', ['aspsp' => 'QA Notice Bank', 'notice' => englishNotice()])
+        ->expectsConfirmation('Send "Heads up about your bank" to 1 user(s) connected to QA Notice Bank (ES)?', 'no')
+        ->expectsOutputToContain('Cancelled.')
+        ->assertSuccessful();
+
+    Mail::assertNothingOutgoing();
+});
+
+test('records a mail log naming both the bank and the notice', function () {
+    $user = noticeUser('logged@example.com');
+
+    artisan('banking:notify-users', ['aspsp' => 'QA Notice Bank', 'notice' => englishNotice('july-outage'), '--force' => true])
+        ->assertSuccessful();
+
+    assertDatabaseHas('user_mail_logs', [
+        'user_id' => $user->id,
+        'email_type' => DripEmailType::BankNotice->value,
+        'email_identifier' => 'qa-notice-bank-july-outage',
+    ]);
+});
+
+test('does not send the same notice to the same user twice', function () {
+    noticeUser('once@example.com');
+    $base = englishNotice();
+
+    artisan('banking:notify-users', ['aspsp' => 'QA Notice Bank', 'notice' => $base, '--force' => true])->assertSuccessful();
+
+    artisan('banking:notify-users', ['aspsp' => 'QA Notice Bank', 'notice' => $base, '--force' => true])
+        ->expectsOutputToContain('everyone connected already got this notice')
+        ->assertSuccessful();
+
+    Mail::assertQueued(BankNoticeEmail::class, 1);
+    assertDatabaseCount('user_mail_logs', 1);
+});
+
+test('a second notice to the same bank is not suppressed by the first', function () {
+    noticeUser('twice@example.com');
+
+    artisan('banking:notify-users', ['aspsp' => 'QA Notice Bank', 'notice' => englishNotice('first-notice'), '--force' => true])->assertSuccessful();
+    artisan('banking:notify-users', ['aspsp' => 'QA Notice Bank', 'notice' => englishNotice('second-notice'), '--force' => true])->assertSuccessful();
+
+    Mail::assertQueued(BankNoticeEmail::class, 2);
+    assertDatabaseCount('user_mail_logs', 2);
+});
+
+test('resend asks for confirmation even with force, and sends again once given', function () {
+    noticeUser('again@example.com');
+    $base = englishNotice();
+
+    artisan('banking:notify-users', ['aspsp' => 'QA Notice Bank', 'notice' => $base, '--force' => true])->assertSuccessful();
+
+    artisan('banking:notify-users', ['aspsp' => 'QA Notice Bank', 'notice' => $base, '--force' => true, '--resend' => true])
+        ->expectsConfirmation('Send "Heads up about your bank" to 1 user(s) connected to QA Notice Bank (ES)?', 'yes')
+        ->assertSuccessful();
+
+    Mail::assertQueued(BankNoticeEmail::class, 2);
+    assertDatabaseCount('user_mail_logs', 1);
+});
+
+test('each recipient reads the notice in their own language, and English when they have none', function (string $locale, string $expected) {
+    $user = User::factory()->create(['locale' => $locale, 'name' => 'Marc']);
+    $notices = ['en' => "# Heads up\n\nHi :name.", 'es' => "# Atención\n\nHola :name."];
+
+    App::setLocale($user->preferredLocale());
+
+    expect((new BankNoticeEmail($user, $notices))->body())->toContain($expected);
+})->with([
+    'own language' => ['es', 'Hola Marc.'],
+    'no file of their own' => ['fr', 'Hi Marc.'],
+]);
+
+test('renders the file as markdown, and never as blade', function () {
+    $user = User::factory()->create(['name' => 'Marc']);
+    $notices = ['en' => "# Heads up\n\nHi :name, this is **important**.\n\n{{ 40 + 2 }}"];
+
+    $html = (string) (new BankNoticeEmail($user, $notices))->render();
+
+    expect($html)
+        ->toContain('Heads up')
+        ->toContain('important</strong>')
+        ->toContain('Hi Marc,')
+        // An operator-written file is data, not a template: it must not be able
+        // to run code just by being sent.
+        ->toContain('{{ 40 + 2 }}')
+        ->not->toContain('>42<');
+});


### PR DESCRIPTION
## Why

We keep running into one-off, bank-specific things worth telling people about, and
each one currently means a command, a mailable and a committed Blade view of its
own. `banking:notify-outage` and `banking:notify-connect-failure` earn that,
because they say the same thing every time. A one-off does not.

So this adds the general case: the recipients come from the data, and the copy
comes from a Markdown file written by hand and uploaded to production.

## What

```
php artisan banking:notify-users "Trade Republic" resources/notices/trade-republic-descriptions --dry-run
```

- **Recipients**: everyone with a live Enable Banking connection to that bank
  (`aspsp_name` + `aspsp_country`), via the existing `NotifiesBankUsers` trait —
  same recipient query, same already-notified ledger, same `--country`,
  `--dry-run`, `--force` and `--resend` as its siblings. Their behaviour is
  untouched.
- **Copy**: one file per locale, `<base>.<locale>.md`. `<base>.en.md` is
  mandatory and is what anyone whose language has no file of its own receives.
  Each file opens with an `# H1`, which becomes the subject, so the subject is
  written in the same file — and the same language — as the body it belongs to.
  `:name` is replaced with the recipient's name.
- **New ledger type** `DripEmailType::BankNotice`, keyed by bank + notice
  filename, so a second notice to the same bank is not suppressed by the first.

### Decisions worth arguing with

- **The file is read by the command and passed to the mailable as text**, never
  as a path: a queue worker is not guaranteed to have the file, and the file can
  be edited between dispatch and delivery.
- **The body is parsed as Markdown and never compiled as Blade.** Running an
  operator-uploaded file through Blade is remote code execution by another name,
  and nothing here needs it. There is a test that asserts `{{ 40 + 2 }}` in a
  notice stays `{{ 40 + 2 }}`.
- **The ledger key drops the country**, unlike `bankIdentifier()`. The ledger is
  per user, so a whole-bank run and a `--country` run of the same notice cannot
  overlap.
- **A bank present in several countries is notified in all of them by default**,
  where the outage command refuses to guess and demands `--country`. That check
  exists because an outage is a claim about one country's connector; a notice
  written by hand usually is not, and Trade Republic is a case in point — it is
  the same connector complaint in ES, FR and BE. `--country` is there when the
  notice really is per country.
- **Recipients are not filtered by connection status.** This notice makes no
  claim about the bank answering, so there is nothing to narrow them to. Worth
  knowing for the Trade Republic run: 2 of the 22 recipients only ever had a
  `pending` connection (they started the bank authorization and never finished),
  so they have no Trade Republic transactions to see the problem in. Say the word
  and I will add a way to leave those out.

## The Trade Republic notice

`resources/notices/trade-republic-descriptions.{en,es}.md`. Verified against
production before letting an email assert any of it:

- **575 of 609** transactions on live Trade Republic connections carry the
  description `Bank transaction`.
- That string is **ours**, not theirs: it is the fallback in
  `TransactionSyncService::parseDescription()`. Every one of those payloads has
  `remittance_information` and `creditor` as JSON `null` — there is nothing to
  show. The copy says so, rather than implying the bank sends us that text.
- **Recipients: 22 users, 27 connections** across ES, FR and BE. 20 read Spanish,
  2 English.
- No date is promised, because the fix is not ours to make.

### The command to paste on production

Run the dry run first, read the recipient table, then drop `--dry-run`:

```
php artisan banking:notify-users "Trade Republic" resources/notices/trade-republic-descriptions --dry-run
php artisan banking:notify-users "Trade Republic" resources/notices/trade-republic-descriptions
```

The second one prints the same table and then asks for confirmation, naming the
subject and the recipient count. I have not sent anything — that is yours.

## QA

Locally, against Mailhog, with two throwaway recipients (`locale=es` and
`locale=en`) on a fake bank, using the real notice files (all cleaned up after):

- `--dry-run` printed both recipients, their connection counts and which language
  each would read, and left no mail log and no email behind.
- The real send produced two emails: Spanish subject and body for the Spanish
  user, English for the other, `:name` substituted, sign-off translated, quotes
  and em dashes intact, no escaping artefacts.
- Re-running said everyone had already been notified. `--resend` asked for
  confirmation even with `--force`, and declining sent nothing.
- A notice set with no `en` file, and a file not starting with a heading, both
  failed before touching the recipients.

25 Pest tests cover the recipient resolution, the ledger, the mandatory `en`
file, per-locale selection with the `en` fallback, `--dry-run` sending nothing,
and Blade not being executed.
