### PR TITLE
fix(transactions): make the AI consent banner's Enable AI button readable in dark mode

### DIFF
--- a/resources/js/pages/transactions/index.tsx
+++ b/resources/js/pages/transactions/index.tsx
@@ -1496,7 +1496,7 @@ export default function Transactions({
                                                     onClick={handleEnableAi}
                                                     disabled={aiConsentSaving}
                                                     variant="secondary"
-                                                    className="max-w-[calc(var(--spacing)_*_86)] bg-white px-6!"
+                                                    className="max-w-[calc(var(--spacing)_*_86)] bg-white px-6! dark:bg-white/10"
                                                 >
                                                     {__('Enable AI')}
                                                     <ChevronRight />


### PR DESCRIPTION
On the transactions page, the AI-consent banner's "Enable AI" button was white text
on a white background in dark mode — completely unreadable.

The button uses `variant="secondary"` (`bg-secondary text-secondary-foreground`), but
carried a hardcoded `bg-white` that overrode the variant's background in **both** themes.
In dark mode `--secondary-foreground` is near-white, so the label disappeared into the
white pill.

```diff
- className="max-w-[calc(var(--spacing)_*_86)] bg-white px-6!"
+ className="max-w-[calc(var(--spacing)_*_86)] bg-white px-6! dark:bg-white/10"
```

The white pill is deliberate in light mode — it pops against the banner's pastel
gradient — so it stays. Dark mode now gets the same treatment as the sparkle icon chip
four lines above it (`bg-white/80 shadow-sm dark:bg-white/10`), so the banner reads as
one coherent unit in both themes.

`components/ui/button.tsx` is untouched: the `secondary` variant was always right, the
call-site override was the bug. A grep for `bg-white` without a `dark:` counterpart
across `resources/js` returns nothing else, so this was the only offender.

## Demo

<!-- PLACEHOLDER: drag the QA video here -->

Verified in the browser on both themes with the banner visible (Pro user, AI consent
neither granted nor dismissed). Computed styles on the button:

| State | background-color | color |
| --- | --- | --- |
| Dark, resting | white @ 10% | `oklch(0.985 0 0)` (near-white) |
| Dark, hover | white @ 10% (unchanged) | `oklch(0.985 0 0)` (unchanged) |
| Light, resting | `rgb(255, 255, 255)` | `oklch(0.205 0 0)` (near-black) |

Hover was checked explicitly: the variant's `hover:bg-secondary/80` does not win over
`dark:bg-white/10`, so the button does not flip to a low-contrast state on hover.

## Tests

No unit test. `pages/transactions/index.tsx` has no test file, and asserting a Tailwind
class string would mean standing up a render harness for the whole page to check a
colour — cost far above value for a one-line style fix. The browser QA above is the
verification.
