### PR TITLE
feat(savings-goals): link transactions from the goal page, and mark goal labels with a piggy bank

### DIFF
--- a/app/Http/Controllers/SavingsGoalController.php
+++ b/app/Http/Controllers/SavingsGoalController.php
@@ -145,7 +145,7 @@ class SavingsGoalController extends Controller implements HasMiddleware
         $label = $savingsGoal->label;
 
         if ($label === null) {
-            return back();
+            return redirect()->route('savings-goals.show', $savingsGoal);
         }
 
         // Ids the user does not own are dropped by the scope rather than trusted.
@@ -166,7 +166,9 @@ class SavingsGoalController extends Controller implements HasMiddleware
             ReassignTransactionsToBudgets::dispatch($touched, notify: false);
         }
 
-        return back();
+        // Named route, not back(): the dialog only exists on this page, and the
+        // previous-url redirect resolves to the app's internal host behind a proxy.
+        return redirect()->route('savings-goals.show', $savingsGoal);
     }
 
     public function update(UpdateSavingsGoalRequest $request, SavingsGoal $savingsGoal): RedirectResponse

--- a/app/Http/Controllers/SavingsGoalController.php
+++ b/app/Http/Controllers/SavingsGoalController.php
@@ -6,12 +6,15 @@ use App\Enums\LabelColor;
 use App\Enums\LabelSource;
 use App\Features\SavingsGoals;
 use App\Http\Requests\StoreSavingsGoalRequest;
+use App\Http\Requests\SyncSavingsGoalTransactionsRequest;
 use App\Http\Requests\UpdateSavingsGoalRequest;
+use App\Jobs\ReassignTransactionsToBudgets;
 use App\Models\Account;
 use App\Models\Bank;
 use App\Models\Category;
 use App\Models\Label;
 use App\Models\SavingsGoal;
+use App\Models\Transaction;
 use Closure;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\RedirectResponse;
@@ -25,6 +28,10 @@ use Laravel\Pennant\Feature;
 class SavingsGoalController extends Controller implements HasMiddleware
 {
     use AuthorizesRequests;
+
+    // ponytail: a flat window, no search. If people can't find older contributions
+    // in it, the dialog needs a search box hitting the transactions query instead.
+    private const RECENT_TRANSACTIONS_LIMIT = 50;
 
     /**
      * Hide the whole savings-goals surface behind the rollout feature flag.
@@ -106,7 +113,51 @@ class SavingsGoalController extends Controller implements HasMiddleware
                 ->orderBy('name')
                 ->get(),
             'currencyCode' => $user->currency_code ?? 'USD',
+            // Only fetched when the link-transactions dialog asks for it.
+            'recentTransactions' => Inertia::optional(fn () => Transaction::query()
+                ->where('user_id', $user->id)
+                ->with(['account.bank', 'category', 'labels'])
+                ->orderByDesc('transaction_date')
+                ->orderByDesc('created_at')
+                ->limit(self::RECENT_TRANSACTIONS_LIMIT)
+                ->get()),
         ]);
+    }
+
+    /**
+     * Replace the set of transactions carrying this goal's label. The dialog always
+     * shows every already-tagged transaction alongside the recent ones, so the ids it
+     * sends back are the complete intended set.
+     */
+    public function syncTransactions(SyncSavingsGoalTransactionsRequest $request, SavingsGoal $savingsGoal): RedirectResponse
+    {
+        $this->authorize('update', $savingsGoal);
+
+        $label = $savingsGoal->label;
+
+        if ($label === null) {
+            return back();
+        }
+
+        // Ids the user does not own are dropped by the scope rather than trusted.
+        $ids = Transaction::query()
+            ->where('user_id', $request->user()->id)
+            ->whereIn('id', $request->array('transaction_ids'))
+            ->pluck('id')
+            ->all();
+
+        $changes = $label->transactions()->sync($ids);
+
+        $touched = array_merge($changes['attached'], $changes['detached']);
+
+        if ($touched !== []) {
+            // Pivot writes fire no model event, so nothing would re-derive which
+            // budgets track these transactions by label. Silently: relabelling an
+            // existing transaction is not new spending.
+            ReassignTransactionsToBudgets::dispatch($touched, notify: false);
+        }
+
+        return back();
     }
 
     public function update(UpdateSavingsGoalRequest $request, SavingsGoal $savingsGoal): RedirectResponse

--- a/app/Http/Controllers/SavingsGoalController.php
+++ b/app/Http/Controllers/SavingsGoalController.php
@@ -34,6 +34,14 @@ class SavingsGoalController extends Controller implements HasMiddleware
     private const RECENT_TRANSACTIONS_LIMIT = 50;
 
     /**
+     * What a transaction row needs to render, both in the page's list and in the
+     * link dialog. Keep the two in step: the dialog merges both sets.
+     *
+     * @var list<string>
+     */
+    private const TRANSACTION_RELATIONS = ['account.bank', 'category', 'labels'];
+
+    /**
      * Hide the whole savings-goals surface behind the rollout feature flag.
      *
      * @return array<int, Closure>
@@ -78,7 +86,7 @@ class SavingsGoalController extends Controller implements HasMiddleware
 
         $transactions = $savingsGoal->label
             ? $savingsGoal->label->transactions()
-                ->with(['account.bank', 'category', 'labels'])
+                ->with(self::TRANSACTION_RELATIONS)
                 ->orderBy('transaction_date')
                 ->get()
             : collect();
@@ -116,7 +124,7 @@ class SavingsGoalController extends Controller implements HasMiddleware
             // Only fetched when the link-transactions dialog asks for it.
             'recentTransactions' => Inertia::optional(fn () => Transaction::query()
                 ->where('user_id', $user->id)
-                ->with(['account.bank', 'category', 'labels'])
+                ->with(self::TRANSACTION_RELATIONS)
                 ->orderByDesc('transaction_date')
                 ->orderByDesc('created_at')
                 ->limit(self::RECENT_TRANSACTIONS_LIMIT)
@@ -133,6 +141,7 @@ class SavingsGoalController extends Controller implements HasMiddleware
     {
         $this->authorize('update', $savingsGoal);
 
+        // A goal whose label was soft-deleted has nothing to tag with.
         $label = $savingsGoal->label;
 
         if ($label === null) {

--- a/app/Http/Requests/SyncSavingsGoalTransactionsRequest.php
+++ b/app/Http/Requests/SyncSavingsGoalTransactionsRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class SyncSavingsGoalTransactionsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'transaction_ids' => ['present', 'array'],
+            'transaction_ids.*' => ['uuid'],
+        ];
+    }
+}

--- a/app/Models/Label.php
+++ b/app/Models/Label.php
@@ -55,7 +55,6 @@ class Label extends Model
     protected $hidden = [
         'pivot',
         'space_id',
-        'source',
     ];
 
     /** @return BelongsTo<User, $this> */

--- a/lang/es.json
+++ b/lang/es.json
@@ -2551,5 +2551,7 @@
     "Track your spending and save toward your goals": "Controla tus gastos y ahorra para tus objetivos",
     "When you’d like to reach 100% of your goal.": "Cuándo te gustaría alcanzar el 100 % de tu objetivo.",
     "e.g., New car": "p. ej., Coche nuevo",
-    "You already have a label or goal with this name.": "Ya tienes una etiqueta u objetivo con este nombre."
+    "You already have a label or goal with this name.": "Ya tienes una etiqueta u objetivo con este nombre.",
+    "Link transactions": "Vincular transacciones",
+    "Tick the transactions that count toward this goal. Unticking one removes it from the goal.": "Marca las transacciones que cuentan para este objetivo. Al desmarcarlas se quitan del objetivo."
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2220,5 +2220,7 @@
     "This shared account cannot be deleted.": "Ce compte partagé ne peut pas être supprimé.",
     "Two-factor authentication cannot be changed on this shared account.": "L'authentification à deux facteurs ne peut pas être modifiée sur ce compte partagé.",
     "Password changes are disabled on this shared account.": "Le changement de mot de passe est désactivé sur ce compte partagé.",
-    "Billing management is not available on this shared account.": "La gestion de la facturation n'est pas disponible sur ce compte partagé."
+    "Billing management is not available on this shared account.": "La gestion de la facturation n'est pas disponible sur ce compte partagé.",
+    "Link transactions": "Associer des transactions",
+    "Tick the transactions that count toward this goal. Unticking one removes it from the goal.": "Cochez les transactions qui comptent pour cet objectif. Les décocher les retire de l’objectif."
 }

--- a/resources/js/components/budgets/create-budget-dialog.tsx
+++ b/resources/js/components/budgets/create-budget-dialog.tsx
@@ -1,4 +1,5 @@
 import { store } from '@/actions/App/Http/Controllers/BudgetController';
+import { LabelIcon } from '@/components/shared/label-icon';
 import { AmountInput } from '@/components/ui/amount-input';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -38,7 +39,7 @@ import { getLabelColorClasses, Label } from '@/types/label';
 import { __ } from '@/utils/i18n';
 import { router, usePage } from '@inertiajs/react';
 import * as Icons from 'lucide-react';
-import { Plus, Tag } from 'lucide-react';
+import { Plus } from 'lucide-react';
 import React, { useState } from 'react';
 import { Card, CardContent } from '../ui/card';
 
@@ -343,7 +344,10 @@ export function CreateBudgetDialog({
                                                     value: label.id,
                                                     label: label.name,
                                                     icon: (
-                                                        <Tag className="h-3 w-3 opacity-80" />
+                                                        <LabelIcon
+                                                            label={label}
+                                                            className="h-3 w-3 opacity-80"
+                                                        />
                                                     ),
                                                     badgeClassName: cn(
                                                         colorClasses.bg,

--- a/resources/js/components/savings-goals/link-transactions-dialog.tsx
+++ b/resources/js/components/savings-goals/link-transactions-dialog.tsx
@@ -1,4 +1,5 @@
 import { syncTransactions } from '@/actions/App/Http/Controllers/SavingsGoalController';
+import { LabelBadge } from '@/components/shared/label-combobox';
 import { AmountDisplay } from '@/components/ui/amount-display';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -14,18 +15,19 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { useLocale } from '@/hooks/use-locale';
 import { cn } from '@/lib/utils';
 import { SavingsGoal } from '@/types/savings-goal';
-import { Transaction } from '@/types/transaction';
+import { ServerTransaction } from '@/types/transaction';
 import { formatDate } from '@/utils/date';
 import { __ } from '@/utils/i18n';
 import { router } from '@inertiajs/react';
 import { useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
 
 interface Props {
     savingsGoal: SavingsGoal;
     /** Everything already carrying the goal's label, straight from the page. */
-    transactions: Transaction[];
+    transactions: ServerTransaction[];
     /** The user's latest transactions, loaded on demand when the dialog opens. */
-    recentTransactions?: Transaction[];
+    recentTransactions?: ServerTransaction[];
     currencyCode: string;
     open: boolean;
     onOpenChange: (open: boolean) => void;
@@ -46,7 +48,7 @@ export function LinkTransactionsDialog({
     // The already-tagged ones come first so nothing you can untick is ever off
     // the list — that is what makes sending the whole set back safe.
     const candidates = useMemo(() => {
-        const byId = new Map<string, Transaction>();
+        const byId = new Map<string, ServerTransaction>();
 
         for (const transaction of [
             ...transactions,
@@ -74,6 +76,15 @@ export function LinkTransactionsDialog({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [open]);
 
+    // A transaction can back more than one goal, and then it counts toward both.
+    // Surfacing the other goals' labels is what makes that visible before ticking.
+    const otherGoalLabels = (transaction: ServerTransaction) =>
+        (transaction.labels ?? []).filter(
+            (label) =>
+                label.source === 'saving_goal' &&
+                label.id !== savingsGoal.label_id,
+        );
+
     const toggle = (id: string) => {
         setSelected((previous) => {
             const next = new Set(previous);
@@ -97,6 +108,10 @@ export function LinkTransactionsDialog({
             {
                 preserveScroll: true,
                 onSuccess: () => onOpenChange(false),
+                onError: () =>
+                    toast.error(
+                        __('Failed to update transactions with labels'),
+                    ),
                 onFinish: () => setIsSubmitting(false),
             },
         );
@@ -115,14 +130,6 @@ export function LinkTransactionsDialog({
                 </DialogHeader>
 
                 <div className="-mx-2 max-h-[50vh] overflow-y-auto px-2">
-                    {recentTransactions === undefined && (
-                        <div className="space-y-2 py-2">
-                            {Array.from({ length: 5 }).map((_, index) => (
-                                <Skeleton key={index} className="h-10 w-full" />
-                            ))}
-                        </div>
-                    )}
-
                     {recentTransactions !== undefined &&
                         candidates.length === 0 && (
                             <p className="py-6 text-center text-sm text-muted-foreground">
@@ -141,7 +148,6 @@ export function LinkTransactionsDialog({
                                     onCheckedChange={() =>
                                         toggle(transaction.id)
                                     }
-                                    aria-label={transaction.description}
                                 />
                                 <span className="w-16 shrink-0 text-muted-foreground">
                                     {formatDate(
@@ -153,6 +159,9 @@ export function LinkTransactionsDialog({
                                 <span className="min-w-0 flex-1 truncate">
                                     {transaction.description}
                                 </span>
+                                {otherGoalLabels(transaction).map((label) => (
+                                    <LabelBadge key={label.id} label={label} />
+                                ))}
                                 <AmountDisplay
                                     amountInCents={transaction.amount}
                                     currencyCode={currencyCode}
@@ -165,6 +174,14 @@ export function LinkTransactionsDialog({
                             </label>
                         ))}
                     </div>
+
+                    {recentTransactions === undefined && (
+                        <div className="space-y-2 py-2">
+                            {Array.from({ length: 5 }).map((_, index) => (
+                                <Skeleton key={index} className="h-10 w-full" />
+                            ))}
+                        </div>
+                    )}
                 </div>
 
                 <DialogFooter className="sm:items-center sm:justify-between">

--- a/resources/js/components/savings-goals/link-transactions-dialog.tsx
+++ b/resources/js/components/savings-goals/link-transactions-dialog.tsx
@@ -1,0 +1,196 @@
+import { syncTransactions } from '@/actions/App/Http/Controllers/SavingsGoalController';
+import { AmountDisplay } from '@/components/ui/amount-display';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useLocale } from '@/hooks/use-locale';
+import { cn } from '@/lib/utils';
+import { SavingsGoal } from '@/types/savings-goal';
+import { Transaction } from '@/types/transaction';
+import { formatDate } from '@/utils/date';
+import { __ } from '@/utils/i18n';
+import { router } from '@inertiajs/react';
+import { useEffect, useMemo, useState } from 'react';
+
+interface Props {
+    savingsGoal: SavingsGoal;
+    /** Everything already carrying the goal's label, straight from the page. */
+    transactions: Transaction[];
+    /** The user's latest transactions, loaded on demand when the dialog opens. */
+    recentTransactions?: Transaction[];
+    currencyCode: string;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}
+
+export function LinkTransactionsDialog({
+    savingsGoal,
+    transactions,
+    recentTransactions,
+    currencyCode,
+    open,
+    onOpenChange,
+}: Props) {
+    const locale = useLocale();
+    const [selected, setSelected] = useState<Set<string>>(new Set());
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    // The already-tagged ones come first so nothing you can untick is ever off
+    // the list — that is what makes sending the whole set back safe.
+    const candidates = useMemo(() => {
+        const byId = new Map<string, Transaction>();
+
+        for (const transaction of [
+            ...transactions,
+            ...(recentTransactions ?? []),
+        ]) {
+            byId.set(transaction.id, transaction);
+        }
+
+        return Array.from(byId.values()).sort((a, b) =>
+            b.transaction_date.localeCompare(a.transaction_date),
+        );
+    }, [transactions, recentTransactions]);
+
+    useEffect(() => {
+        if (!open) {
+            return;
+        }
+
+        setSelected(new Set(transactions.map((transaction) => transaction.id)));
+
+        if (recentTransactions === undefined) {
+            router.reload({ only: ['recentTransactions'] });
+        }
+        // Re-seeding on every recentTransactions change would wipe the user's ticks.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [open]);
+
+    const toggle = (id: string) => {
+        setSelected((previous) => {
+            const next = new Set(previous);
+
+            if (next.has(id)) {
+                next.delete(id);
+            } else {
+                next.add(id);
+            }
+
+            return next;
+        });
+    };
+
+    const handleSubmit = () => {
+        setIsSubmitting(true);
+
+        router.put(
+            syncTransactions({ savingsGoal: savingsGoal.id }).url,
+            { transaction_ids: Array.from(selected) },
+            {
+                preserveScroll: true,
+                onSuccess: () => onOpenChange(false),
+                onFinish: () => setIsSubmitting(false),
+            },
+        );
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="sm:max-w-[560px]">
+                <DialogHeader>
+                    <DialogTitle>{__('Link transactions')}</DialogTitle>
+                    <DialogDescription>
+                        {__(
+                            'Tick the transactions that count toward this goal. Unticking one removes it from the goal.',
+                        )}
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="-mx-2 max-h-[50vh] overflow-y-auto px-2">
+                    {recentTransactions === undefined && (
+                        <div className="space-y-2 py-2">
+                            {Array.from({ length: 5 }).map((_, index) => (
+                                <Skeleton key={index} className="h-10 w-full" />
+                            ))}
+                        </div>
+                    )}
+
+                    {recentTransactions !== undefined &&
+                        candidates.length === 0 && (
+                            <p className="py-6 text-center text-sm text-muted-foreground">
+                                {__('No transactions found.')}
+                            </p>
+                        )}
+
+                    <div className="divide-y">
+                        {candidates.map((transaction) => (
+                            <label
+                                key={transaction.id}
+                                className="flex cursor-pointer items-center gap-3 py-2 text-sm"
+                            >
+                                <Checkbox
+                                    checked={selected.has(transaction.id)}
+                                    onCheckedChange={() =>
+                                        toggle(transaction.id)
+                                    }
+                                    aria-label={transaction.description}
+                                />
+                                <span className="w-16 shrink-0 text-muted-foreground">
+                                    {formatDate(
+                                        transaction.transaction_date,
+                                        'MMM d',
+                                        locale,
+                                    )}
+                                </span>
+                                <span className="min-w-0 flex-1 truncate">
+                                    {transaction.description}
+                                </span>
+                                <AmountDisplay
+                                    amountInCents={transaction.amount}
+                                    currencyCode={currencyCode}
+                                    className={cn(
+                                        'shrink-0 tabular-nums',
+                                        transaction.amount > 0 &&
+                                            'text-emerald-600 dark:text-emerald-400',
+                                    )}
+                                />
+                            </label>
+                        ))}
+                    </div>
+                </div>
+
+                <DialogFooter className="sm:items-center sm:justify-between">
+                    <span className="text-sm text-muted-foreground">
+                        {__(':count selected', { count: selected.size })}
+                    </span>
+                    <div className="flex gap-2">
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => onOpenChange(false)}
+                        >
+                            {__('Cancel')}
+                        </Button>
+                        <Button
+                            type="button"
+                            onClick={handleSubmit}
+                            disabled={isSubmitting}
+                        >
+                            {isSubmitting
+                                ? __('Saving...')
+                                : __('Save changes')}
+                        </Button>
+                    </div>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/resources/js/components/shared/label-combobox.tsx
+++ b/resources/js/components/shared/label-combobox.tsx
@@ -1,5 +1,6 @@
 import { store } from '@/actions/App/Http/Controllers/Settings/LabelController';
 import { normalizeLabelComboboxState } from '@/components/shared/label-combobox-state';
+import { LabelIcon } from '@/components/shared/label-icon';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -18,7 +19,7 @@ import { getCsrfToken } from '@/lib/csrf';
 import { cn } from '@/lib/utils';
 import { getLabelColorClasses, LABEL_COLORS, type Label } from '@/types/label';
 import { __ } from '@/utils/i18n';
-import { Check, ChevronsUpDown, Plus, Tag, X } from 'lucide-react';
+import { Check, ChevronsUpDown, Plus, X } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 interface LabelComboboxProps {
@@ -180,7 +181,10 @@ export function LabelCombobox({
                                             colorClasses.text,
                                         )}
                                     >
-                                        <Tag className="h-3 w-3" />
+                                        <LabelIcon
+                                            label={label}
+                                            className="h-3 w-3"
+                                        />
                                         {label.name}
                                         <span
                                             role="button"
@@ -282,7 +286,8 @@ export function LabelCombobox({
                                                     colorClasses.bg,
                                                 )}
                                             >
-                                                <Tag
+                                                <LabelIcon
+                                                    label={label}
                                                     className={cn(
                                                         'h-3 w-3',
                                                         colorClasses.text,
@@ -321,7 +326,7 @@ export function LabelBadge({ label }: { label: Label }) {
                 colorClasses.text,
             )}
         >
-            <Tag className="h-3 w-3" />
+            <LabelIcon label={label} className="h-3 w-3" />
             {label.name}
         </Badge>
     );

--- a/resources/js/components/shared/label-icon.tsx
+++ b/resources/js/components/shared/label-icon.tsx
@@ -1,0 +1,18 @@
+import { type Label } from '@/types/label';
+import { PiggyBank, Tag } from 'lucide-react';
+
+/**
+ * Labels backing a savings goal read as a piggy bank so they stand apart from
+ * the labels a user manages by hand.
+ */
+export function LabelIcon({
+    label,
+    className,
+}: {
+    label: Pick<Label, 'source'>;
+    className?: string;
+}) {
+    const Icon = label.source === 'saving_goal' ? PiggyBank : Tag;
+
+    return <Icon className={className} />;
+}

--- a/resources/js/components/transactions/transaction-filters.tsx
+++ b/resources/js/components/transactions/transaction-filters.tsx
@@ -1,11 +1,12 @@
 import { __ } from '@/utils/i18n';
 import { format } from 'date-fns';
 import * as Icons from 'lucide-react';
-import { ChevronsUpDown, Tag, X } from 'lucide-react';
+import { ChevronsUpDown, X } from 'lucide-react';
 import { type ReactNode, useEffect, useMemo, useState } from 'react';
 
 import { AccountName } from '@/components/accounts/account-name';
 import { BankLogo } from '@/components/bank-logo';
+import { LabelIcon } from '@/components/shared/label-icon';
 import { SavedFilters } from '@/components/transactions/saved-filters';
 import { AiSparkleIcon } from '@/components/ui/ai-sparkle-icon';
 import { Badge } from '@/components/ui/badge';
@@ -613,7 +614,10 @@ export function TransactionFilters({
                                                                                 colorClasses.bg,
                                                                             )}
                                                                         >
-                                                                            <Tag
+                                                                            <LabelIcon
+                                                                                label={
+                                                                                    label
+                                                                                }
                                                                                 className={cn(
                                                                                     'h-3 w-3',
                                                                                     colorClasses.text,

--- a/resources/js/pages/savings-goals/show.tsx
+++ b/resources/js/pages/savings-goals/show.tsx
@@ -4,6 +4,7 @@ import HeadingSmall from '@/components/heading-small';
 import { MobileBackButton } from '@/components/mobile-back-button';
 import { DeleteSavingsGoalDialog } from '@/components/savings-goals/delete-savings-goal-dialog';
 import { EditSavingsGoalDialog } from '@/components/savings-goals/edit-savings-goal-dialog';
+import { LinkTransactionsDialog } from '@/components/savings-goals/link-transactions-dialog';
 import { SavingsGoalProgressChart } from '@/components/savings-goals/savings-goal-progress-chart';
 import { LabelBadge } from '@/components/shared/label-combobox';
 import { TransactionList } from '@/components/transactions/transaction-list';
@@ -46,6 +47,7 @@ interface Props {
     banks: Bank[];
     labels: Label[];
     currencyCode: string;
+    recentTransactions?: Transaction[];
 }
 
 export default function SavingsGoalShow({
@@ -57,8 +59,10 @@ export default function SavingsGoalShow({
     banks,
     labels,
     currencyCode,
+    recentTransactions,
 }: Props) {
     const locale = useLocale();
+    const [linkOpen, setLinkOpen] = useState(false);
     const [editOpen, setEditOpen] = useState(false);
     const [deleteOpen, setDeleteOpen] = useState(false);
 
@@ -108,28 +112,36 @@ export default function SavingsGoalShow({
                         }
                     />
 
-                    <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                            <Button
-                                variant="outline"
-                                size="icon"
-                                aria-label={__('More options')}
-                            >
-                                <ChevronDown className="h-4 w-4" />
-                            </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
-                            <DropdownMenuItem onClick={() => setEditOpen(true)}>
-                                {__('Edit goal')}
-                            </DropdownMenuItem>
-                            <DropdownMenuItem
-                                onClick={() => setDeleteOpen(true)}
-                                variant="destructive"
-                            >
-                                {__('Delete goal')}
-                            </DropdownMenuItem>
-                        </DropdownMenuContent>
-                    </DropdownMenu>
+                    <div className="flex items-center gap-2">
+                        <Button onClick={() => setLinkOpen(true)}>
+                            {__('Link transactions')}
+                        </Button>
+
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                                <Button
+                                    variant="outline"
+                                    size="icon"
+                                    aria-label={__('More options')}
+                                >
+                                    <ChevronDown className="h-4 w-4" />
+                                </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                                <DropdownMenuItem
+                                    onClick={() => setEditOpen(true)}
+                                >
+                                    {__('Edit goal')}
+                                </DropdownMenuItem>
+                                <DropdownMenuItem
+                                    onClick={() => setDeleteOpen(true)}
+                                    variant="destructive"
+                                >
+                                    {__('Delete goal')}
+                                </DropdownMenuItem>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+                    </div>
                 </div>
 
                 <Card>
@@ -225,6 +237,15 @@ export default function SavingsGoalShow({
                     maxHeight={600}
                 />
             </div>
+
+            <LinkTransactionsDialog
+                savingsGoal={savingsGoal}
+                transactions={transactions}
+                recentTransactions={recentTransactions}
+                currencyCode={currencyCode}
+                open={linkOpen}
+                onOpenChange={setLinkOpen}
+            />
 
             <EditSavingsGoalDialog
                 savingsGoal={savingsGoal}

--- a/resources/js/pages/savings-goals/show.tsx
+++ b/resources/js/pages/savings-goals/show.tsx
@@ -31,7 +31,7 @@ import {
     SavingsGoal,
     SavingsGoalStats,
 } from '@/types/savings-goal';
-import { Transaction } from '@/types/transaction';
+import { ServerTransaction } from '@/types/transaction';
 import { formatDate } from '@/utils/date';
 import { __ } from '@/utils/i18n';
 import { Head } from '@inertiajs/react';
@@ -40,14 +40,14 @@ import { useState } from 'react';
 
 interface Props {
     savingsGoal: SavingsGoal;
-    transactions: Transaction[];
+    transactions: ServerTransaction[];
     stats: SavingsGoalStats;
     categories: Category[];
     accounts: Account[];
     banks: Bank[];
     labels: Label[];
     currencyCode: string;
-    recentTransactions?: Transaction[];
+    recentTransactions?: ServerTransaction[];
 }
 
 export default function SavingsGoalShow({

--- a/resources/js/types/label.ts
+++ b/resources/js/types/label.ts
@@ -1,10 +1,14 @@
 import { UUID } from './uuid';
 
+// Mirrors App\Enums\LabelSource (PHP). Keep both in sync.
+export type LabelSource = 'user' | 'saving_goal';
+
 export interface Label {
     id: UUID;
     user_id: UUID;
     name: string;
     color: string;
+    source?: LabelSource;
     created_at: string;
     updated_at: string;
     deleted_at: string | null;

--- a/routes/web.php
+++ b/routes/web.php
@@ -245,6 +245,7 @@ Route::middleware(['auth', 'verified', 'onboarded', 'subscribed'])->group(functi
     Route::post('savings-goals', [SavingsGoalController::class, 'store'])->name('savings-goals.store');
     Route::get('savings-goals/{savingsGoal}', [SavingsGoalController::class, 'show'])->name('savings-goals.show');
     Route::patch('savings-goals/{savingsGoal}', [SavingsGoalController::class, 'update'])->name('savings-goals.update');
+    Route::put('savings-goals/{savingsGoal}/transactions', [SavingsGoalController::class, 'syncTransactions'])->name('savings-goals.transactions.sync');
     Route::delete('savings-goals/{savingsGoal}', [SavingsGoalController::class, 'destroy'])->name('savings-goals.destroy');
 });
 

--- a/tests/Feature/AutomationRuleTest.php
+++ b/tests/Feature/AutomationRuleTest.php
@@ -451,7 +451,7 @@ test('automation rules serialize full nested category and labels', function () {
     expect(array_keys($serialized['category']))
         ->toEqualCanonicalizing(['id', 'name', 'icon', 'color', 'type', 'cashflow_direction', 'parent_id']);
     expect(array_keys($serialized['labels'][0]))
-        ->toEqualCanonicalizing(['id', 'user_id', 'name', 'color', 'created_at', 'updated_at', 'deleted_at']);
+        ->toEqualCanonicalizing(['id', 'user_id', 'name', 'color', 'source', 'created_at', 'updated_at', 'deleted_at']);
 });
 
 test('a generated title is truncated to fit the column instead of failing the write', function () {

--- a/tests/Feature/LabelTest.php
+++ b/tests/Feature/LabelTest.php
@@ -209,5 +209,5 @@ test('labels index returns the standard label field set', function () {
     $props = $response->viewData('page')['props'];
 
     expect(array_keys($props['labels'][0]))
-        ->toEqualCanonicalizing(['id', 'user_id', 'name', 'color', 'created_at', 'updated_at', 'deleted_at']);
+        ->toEqualCanonicalizing(['id', 'user_id', 'name', 'color', 'source', 'created_at', 'updated_at', 'deleted_at']);
 });

--- a/tests/Feature/SavingsGoalTest.php
+++ b/tests/Feature/SavingsGoalTest.php
@@ -211,3 +211,104 @@ test('effective start keeps creation date when no earlier contribution exists', 
     expect(SavingsGoal::effectiveStart($created, null)->toDateString())->toBe('2026-07-20')
         ->and(SavingsGoal::effectiveStart($created, '2026-08-01')->toDateString())->toBe('2026-07-20');
 });
+
+test('syncing transactions attaches the ticked ones and detaches the rest', function () {
+    $user = onboardedSavingsUser();
+    Feature::for($user)->activate(SavingsGoals::class);
+
+    $goal = SavingsGoal::factory()->create(['user_id' => $user->id]);
+    $account = Account::factory()->create(['user_id' => $user->id]);
+
+    $alreadyTagged = Transaction::factory()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'amount' => -50000,
+    ]);
+    $newlyTicked = Transaction::factory()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'amount' => -20000,
+    ]);
+    $alreadyTagged->labels()->attach($goal->label_id);
+
+    $response = $this->actingAs($user)->put("/savings-goals/{$goal->id}/transactions", [
+        'transaction_ids' => [$newlyTicked->id],
+    ]);
+
+    $response->assertRedirect();
+
+    expect($goal->fresh()->savedAmountInCents())->toBe(20000);
+    $this->assertDatabaseMissing('label_transaction', [
+        'label_id' => $goal->label_id,
+        'transaction_id' => $alreadyTagged->id,
+    ]);
+});
+
+test('syncing transactions ignores ids belonging to someone else', function () {
+    $user = onboardedSavingsUser();
+    Feature::for($user)->activate(SavingsGoals::class);
+
+    $goal = SavingsGoal::factory()->create(['user_id' => $user->id]);
+    $stranger = User::factory()->create();
+    $theirTransaction = Transaction::factory()->create([
+        'user_id' => $stranger->id,
+        'account_id' => Account::factory()->create(['user_id' => $stranger->id])->id,
+        'amount' => -50000,
+    ]);
+
+    $this->actingAs($user)->put("/savings-goals/{$goal->id}/transactions", [
+        'transaction_ids' => [$theirTransaction->id],
+    ])->assertRedirect();
+
+    $this->assertDatabaseMissing('label_transaction', [
+        'label_id' => $goal->label_id,
+        'transaction_id' => $theirTransaction->id,
+    ]);
+});
+
+test('another user cannot sync transactions on a goal that is not theirs', function () {
+    $owner = onboardedSavingsUser();
+    $intruder = onboardedSavingsUser();
+    Feature::for($intruder)->activate(SavingsGoals::class);
+
+    $goal = SavingsGoal::factory()->create(['user_id' => $owner->id]);
+
+    $this->actingAs($intruder)
+        ->put("/savings-goals/{$goal->id}/transactions", ['transaction_ids' => []])
+        ->assertForbidden();
+});
+
+test('the goal page only loads recent transactions when asked for them', function () {
+    $user = onboardedSavingsUser();
+    Feature::for($user)->activate(SavingsGoals::class);
+
+    $goal = SavingsGoal::factory()->create(['user_id' => $user->id]);
+    $account = Account::factory()->create(['user_id' => $user->id]);
+    Transaction::factory()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'amount' => -10000,
+    ]);
+
+    $this->actingAs($user)->get("/savings-goals/{$goal->id}")
+        ->assertInertia(fn ($page) => $page->missing('recentTransactions'));
+
+    $this->actingAs($user)->withoutVite()
+        ->get("/savings-goals/{$goal->id}", [
+            'X-Inertia' => 'true',
+            'X-Inertia-Partial-Component' => 'savings-goals/show',
+            'X-Inertia-Partial-Data' => 'recentTransactions',
+        ])
+        ->assertOk()
+        ->assertJsonCount(1, 'props.recentTransactions');
+});
+
+test('the goal label carries its source so the UI can mark it as a savings goal', function () {
+    $user = onboardedSavingsUser();
+    Feature::for($user)->activate(SavingsGoals::class);
+
+    $goal = SavingsGoal::factory()->create(['user_id' => $user->id]);
+
+    $this->actingAs($user)->get("/savings-goals/{$goal->id}")
+        ->assertInertia(fn ($page) => $page->where('savingsGoal.label.source', LabelSource::SavingsGoal->value));
+});


### PR DESCRIPTION
Two follow-ups on the savings goals that just shipped in #704.

## A piggy bank on the labels that back a goal

Savings goals track their transactions with a per-goal label, so the goal's label sat in the same visual bucket as every hand-made one. `Label::$hidden` was hiding `source` from serialization, so the frontend had no way to tell them apart in the first place.

`source` is now exposed and a small `<LabelIcon>` picks the glyph — `PiggyBank` for `saving_goal`, `Tag` for everything else. It replaces the hard-coded tag at all five render sites: the combobox badge, the combobox option, `LabelBadge` (goal header + every transactions table), the transactions label filter, and the budget dialog's label picker. Labels settings is untouched — goal labels are filtered out of that screen already.

## Linking transactions from the goal itself

Tagging a contribution meant leaving the goal, finding the transaction on `/transactions` and applying the label by hand. The goal page now has a **Link transactions** button that opens a dialog with the already-linked transactions plus the 50 most recent, each with a checkbox, and tags or untags them in one save.

- The recent list is an `Inertia::optional` prop, fetched only when the dialog opens, so the goal page itself costs nothing extra.
- `PUT /savings-goals/{goal}/transactions` replaces the tagged set with `sync()`. That is only safe because the dialog is guaranteed to show every already-tagged transaction (the page loads them all, uncapped, and the dialog merges them with the recent window) — so the ids it sends back are the complete intended set. Ids the caller doesn't own are dropped by the `user_id` scope rather than trusted.
- Pivot writes fire no model event, so `ReassignTransactionsToBudgets` is dispatched for the rows that actually changed, silently — relabelling an existing transaction is not new spending.
- A transaction can back more than one goal, and then it counts toward both. Rows show the labels of any other goal already claiming them, so that is visible before you tick.
- `back()` re-renders the page, so saved amount, progress, chart and the transactions table all reflect the change.

### What this leaves out on purpose

The dialog is a flat 50-transaction window with no search — marked with a `ponytail:` comment on the constant. If people can't reach older contributions from it, the fix is a search box hitting the transactions query, not a bigger number.

## Tests

Five new cases in `SavingsGoalTest`: the sync attaches and detaches in one call, ignores ids belonging to someone else, is forbidden for a goal that isn't yours, the recent list is absent until a partial visit asks for it, and the goal's label carries its source. `LabelTest`'s field-set assertion was updated for the newly visible `source`.

## Demo

<!-- PLACEHOLDER: drag the QA video here -->
**📎 VIDEO GOES HERE** — login → goal page → *Link transactions* → tick → save → the page updates → the piggy label on `/transactions`.

https://github.com/user-attachments/assets/f64ddb65-2a5a-4b55-923b-8d84f2d2a842



## QA

Browser QA against the running app, 10/10 checks passing: piggy icon on the goal header, the goal's transactions table, the `/transactions` label column and filter dropdown, and the budget dialog's label picker — with a plain label alongside for contrast, still showing a tag. Linking and unlinking both update saved amount, progress, chart and table with no manual refresh, and the `label_transaction` rows were checked against the UI figures after every save. Console clean apart from pre-existing placeholder-image 404s and Laravel Boost dev tooling.

One bug was found and fixed during QA: the endpoint returned `back()`, whose previous-URL resolves to the app's internal host behind a proxy, so the Inertia client could not follow the redirect — the save succeeded but surfaced an error and left the page stale. It now redirects to the named route like the sibling actions.
