### PR TITLE
feat(savings-goals): hide the goal's own label on its rows, and page the link dialog

### DIFF
--- a/app/Http/Controllers/SavingsGoalController.php
+++ b/app/Http/Controllers/SavingsGoalController.php
@@ -29,9 +29,16 @@ class SavingsGoalController extends Controller implements HasMiddleware
 {
     use AuthorizesRequests;
 
-    // ponytail: a flat window, no search. If people can't find older contributions
-    // in it, the dialog needs a search box hitting the transactions query instead.
+    // ponytail: a flat window the dialog widens with its load-more link, no search.
+    // If people still can't find older contributions, it needs a search box hitting
+    // the transactions query instead.
     private const RECENT_TRANSACTIONS_LIMIT = 50;
+
+    /**
+     * How far the dialog's load-more link may widen the window. Past this, the flat
+     * list stops being a usable way to find anything.
+     */
+    private const RECENT_TRANSACTIONS_MAX = 500;
 
     /**
      * What a transaction row needs to render, both in the page's list and in the
@@ -121,15 +128,29 @@ class SavingsGoalController extends Controller implements HasMiddleware
                 ->orderBy('name')
                 ->get(),
             'currencyCode' => $user->currency_code ?? 'USD',
-            // Only fetched when the link-transactions dialog asks for it.
+            // Only fetched when the link-transactions dialog asks for it, which also
+            // decides how wide a window it wants.
             'recentTransactions' => Inertia::optional(fn () => Transaction::query()
                 ->where('user_id', $user->id)
                 ->with(self::TRANSACTION_RELATIONS)
                 ->orderByDesc('transaction_date')
                 ->orderByDesc('created_at')
-                ->limit(self::RECENT_TRANSACTIONS_LIMIT)
+                ->limit($this->recentTransactionsLimit($request))
                 ->get()),
         ]);
+    }
+
+    /**
+     * The window the link dialog asked for, clamped to a size the flat list can still
+     * carry. Anything unusable falls back to the first page instead of to no rows.
+     */
+    private function recentTransactionsLimit(Request $request): int
+    {
+        $requested = $request->integer('recent');
+
+        return $requested < 1
+            ? self::RECENT_TRANSACTIONS_LIMIT
+            : min($requested, self::RECENT_TRANSACTIONS_MAX);
     }
 
     /**

--- a/app/Http/Controllers/SavingsGoalController.php
+++ b/app/Http/Controllers/SavingsGoalController.php
@@ -128,6 +128,10 @@ class SavingsGoalController extends Controller implements HasMiddleware
                 ->orderBy('name')
                 ->get(),
             'currencyCode' => $user->currency_code ?? 'USD',
+            // The dialog widens its window by this much per click. Sent rather than
+            // hardcoded there: a client-side copy that drifted below this one would
+            // silently hide the load-more link while more rows still existed.
+            'recentPageSize' => self::RECENT_TRANSACTIONS_LIMIT,
             // Only fetched when the link-transactions dialog asks for it, which also
             // decides how wide a window it wants.
             'recentTransactions' => Inertia::optional(fn () => Transaction::query()

--- a/lang/es.json
+++ b/lang/es.json
@@ -2592,5 +2592,6 @@
     "Resources": "Recursos",
     "Compatible banks and apps": "Bancos y apps compatibles",
     "Link transactions": "Vincular transacciones",
-    "Tick the transactions that count toward this goal. Unticking one removes it from the goal.": "Marca las transacciones que cuentan para este objetivo. Al desmarcarlas se quitan del objetivo."
+    "Tick the transactions that count toward this goal. Unticking one removes it from the goal.": "Marca las transacciones que cuentan para este objetivo. Al desmarcarlas se quitan del objetivo.",
+    "Failed to load more transactions.": "No se pudieron cargar más transacciones."
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2222,5 +2222,6 @@
     "Password changes are disabled on this shared account.": "Le changement de mot de passe est désactivé sur ce compte partagé.",
     "Billing management is not available on this shared account.": "La gestion de la facturation n'est pas disponible sur ce compte partagé.",
     "Link transactions": "Associer des transactions",
-    "Tick the transactions that count toward this goal. Unticking one removes it from the goal.": "Cochez les transactions qui comptent pour cet objectif. Les décocher les retire de l’objectif."
+    "Tick the transactions that count toward this goal. Unticking one removes it from the goal.": "Cochez les transactions qui comptent pour cet objectif. Les décocher les retire de l’objectif.",
+    "Failed to load more transactions.": "Impossible de charger plus de transactions."
 }

--- a/resources/js/components/savings-goals/link-transactions-dialog.test.tsx
+++ b/resources/js/components/savings-goals/link-transactions-dialog.test.tsx
@@ -1,0 +1,121 @@
+import { SavingsGoal } from '@/types/savings-goal';
+import { ServerTransaction } from '@/types/transaction';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { LinkTransactionsDialog } from './link-transactions-dialog';
+
+const reload = vi.fn();
+
+vi.mock('@inertiajs/react', () => ({
+    router: {
+        reload: (...args: unknown[]) => reload(...args),
+        put: vi.fn(),
+    },
+}));
+
+vi.mock('@/hooks/use-locale', () => ({
+    useLocale: () => 'en-US',
+}));
+
+vi.mock('@/components/shared/label-combobox', () => ({
+    LabelBadge: () => <div />,
+}));
+
+vi.mock('@/components/ui/amount-display', () => ({
+    AmountDisplay: () => <span />,
+}));
+
+vi.mock('sonner', () => ({
+    toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+const PAGE_SIZE = 2;
+
+const savingsGoal = {
+    id: 'goal-1',
+    label_id: 'label-goal',
+    name: 'Trip to Japan',
+} as SavingsGoal;
+
+const transaction = (id: string): ServerTransaction =>
+    ({
+        id,
+        description: `Transaction ${id}`,
+        transaction_date: '2026-08-01',
+        amount: -1000,
+        labels: [],
+    }) as unknown as ServerTransaction;
+
+const renderDialog = (recentTransactions?: ServerTransaction[]) =>
+    render(
+        <LinkTransactionsDialog
+            savingsGoal={savingsGoal}
+            transactions={[]}
+            recentTransactions={recentTransactions}
+            recentPageSize={PAGE_SIZE}
+            currencyCode="EUR"
+            open
+            onOpenChange={vi.fn()}
+        />,
+    );
+
+describe('LinkTransactionsDialog load more', () => {
+    beforeEach(() => {
+        reload.mockClear();
+    });
+
+    it('offers to load more only while a page comes back full', () => {
+        const { unmount } = renderDialog([transaction('a'), transaction('b')]);
+
+        expect(screen.getByText('Load more')).toBeInTheDocument();
+        unmount();
+
+        renderDialog([transaction('a')]);
+
+        expect(screen.queryByText('Load more')).not.toBeInTheDocument();
+    });
+
+    it('asks for one more page without leaving it in the address bar', () => {
+        renderDialog([transaction('a'), transaction('b')]);
+        reload.mockClear();
+
+        fireEvent.click(screen.getByText('Load more'));
+
+        expect(reload).toHaveBeenCalledWith(
+            expect.objectContaining({
+                only: ['recentTransactions'],
+                data: { recent: PAGE_SIZE * 2 },
+                preserveUrl: true,
+            }),
+        );
+    });
+
+    // Losing the ticks mid-dialog would be silent data loss: saving then detaches
+    // the label from everything the user had already linked.
+    it('keeps what the user ticked when a wider page arrives', () => {
+        const { rerender } = renderDialog([transaction('a'), transaction('b')]);
+
+        fireEvent.click(screen.getAllByRole('checkbox')[0]);
+        expect(screen.getByText('1 selected')).toBeInTheDocument();
+
+        rerender(
+            <LinkTransactionsDialog
+                savingsGoal={savingsGoal}
+                transactions={[]}
+                recentTransactions={[
+                    transaction('a'),
+                    transaction('b'),
+                    transaction('c'),
+                    transaction('d'),
+                ]}
+                recentPageSize={PAGE_SIZE}
+                currencyCode="EUR"
+                open
+                onOpenChange={vi.fn()}
+            />,
+        );
+
+        expect(screen.getAllByRole('checkbox')).toHaveLength(4);
+        expect(screen.getByText('1 selected')).toBeInTheDocument();
+    });
+});

--- a/resources/js/components/savings-goals/link-transactions-dialog.tsx
+++ b/resources/js/components/savings-goals/link-transactions-dialog.tsx
@@ -23,15 +23,14 @@ import { router } from '@inertiajs/react';
 import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
-/** Has to match the controller's RECENT_TRANSACTIONS_LIMIT. */
-const RECENT_PAGE_SIZE = 50;
-
 interface Props {
     savingsGoal: SavingsGoal;
     /** Everything already carrying the goal's label, straight from the page. */
     transactions: ServerTransaction[];
     /** The user's latest transactions, loaded on demand when the dialog opens. */
     recentTransactions?: ServerTransaction[];
+    /** How many more the load-more link asks for, straight from the controller. */
+    recentPageSize: number;
     currencyCode: string;
     open: boolean;
     onOpenChange: (open: boolean) => void;
@@ -41,6 +40,7 @@ export function LinkTransactionsDialog({
     savingsGoal,
     transactions,
     recentTransactions,
+    recentPageSize,
     currencyCode,
     open,
     onOpenChange,
@@ -48,7 +48,7 @@ export function LinkTransactionsDialog({
     const locale = useLocale();
     const [selected, setSelected] = useState<Set<string>>(new Set());
     const [isSubmitting, setIsSubmitting] = useState(false);
-    const [recentLimit, setRecentLimit] = useState(RECENT_PAGE_SIZE);
+    const [recentLimit, setRecentLimit] = useState(recentPageSize);
     const [isLoadingMore, setIsLoadingMore] = useState(false);
 
     // The already-tagged ones come first so nothing you can untick is ever off
@@ -89,14 +89,27 @@ export function LinkTransactionsDialog({
         recentTransactions.length >= recentLimit;
 
     const loadMore = () => {
-        const nextLimit = recentLimit + RECENT_PAGE_SIZE;
+        const nextLimit = recentLimit + recentPageSize;
+
+        // A spinner that just stops leaves the user thinking nothing happened, and
+        // Inertia's own error handling would tear the page down under the dialog.
+        const reportFailure = (): false => {
+            toast.error(__('Failed to load more transactions.'));
+
+            return false;
+        };
 
         setIsLoadingMore(true);
 
         router.reload({
             only: ['recentTransactions'],
             data: { recent: nextLimit },
+            // The window the dialog wants is not something to leave in the address
+            // bar: a reopen would then load a wider window than it thinks it has.
+            preserveUrl: true,
             onSuccess: () => setRecentLimit(nextLimit),
+            onHttpException: reportFailure,
+            onNetworkError: reportFailure,
             onFinish: () => setIsLoadingMore(false),
         });
     };

--- a/resources/js/components/savings-goals/link-transactions-dialog.tsx
+++ b/resources/js/components/savings-goals/link-transactions-dialog.tsx
@@ -12,6 +12,7 @@ import {
     DialogTitle,
 } from '@/components/ui/dialog';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Spinner } from '@/components/ui/spinner';
 import { useLocale } from '@/hooks/use-locale';
 import { cn } from '@/lib/utils';
 import { SavingsGoal } from '@/types/savings-goal';
@@ -21,6 +22,9 @@ import { __ } from '@/utils/i18n';
 import { router } from '@inertiajs/react';
 import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
+
+/** Has to match the controller's RECENT_TRANSACTIONS_LIMIT. */
+const RECENT_PAGE_SIZE = 50;
 
 interface Props {
     savingsGoal: SavingsGoal;
@@ -44,6 +48,8 @@ export function LinkTransactionsDialog({
     const locale = useLocale();
     const [selected, setSelected] = useState<Set<string>>(new Set());
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const [recentLimit, setRecentLimit] = useState(RECENT_PAGE_SIZE);
+    const [isLoadingMore, setIsLoadingMore] = useState(false);
 
     // The already-tagged ones come first so nothing you can untick is ever off
     // the list — that is what makes sending the whole set back safe.
@@ -75,6 +81,25 @@ export function LinkTransactionsDialog({
         // Re-seeding on every recentTransactions change would wipe the user's ticks.
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [open]);
+
+    // A short page means the query ran out of transactions, so there is nothing
+    // left to widen the window for.
+    const hasMore =
+        recentTransactions !== undefined &&
+        recentTransactions.length >= recentLimit;
+
+    const loadMore = () => {
+        const nextLimit = recentLimit + RECENT_PAGE_SIZE;
+
+        setIsLoadingMore(true);
+
+        router.reload({
+            only: ['recentTransactions'],
+            data: { recent: nextLimit },
+            onSuccess: () => setRecentLimit(nextLimit),
+            onFinish: () => setIsLoadingMore(false),
+        });
+    };
 
     // A transaction can back more than one goal, and then it counts toward both.
     // Surfacing the other goals' labels is what makes that visible before ticking.
@@ -181,6 +206,26 @@ export function LinkTransactionsDialog({
                                 <Skeleton key={index} className="h-10 w-full" />
                             ))}
                         </div>
+                    )}
+
+                    {hasMore && (
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="w-full"
+                            onClick={loadMore}
+                            disabled={isLoadingMore}
+                        >
+                            {isLoadingMore ? (
+                                <>
+                                    <Spinner />
+                                    {__('Loading')}
+                                </>
+                            ) : (
+                                __('Load more')
+                            )}
+                        </Button>
                     )}
                 </div>
 

--- a/resources/js/components/transactions/transaction-columns.tsx
+++ b/resources/js/components/transactions/transaction-columns.tsx
@@ -54,6 +54,8 @@ interface CreateColumnsOptions {
     isDateHidden?: boolean;
     /** Ids of transactions AI is categorizing in the background right now. */
     categorizingIds?: Set<string>;
+    /** A label every row already carries, so showing it would say nothing. */
+    hiddenLabelId?: string;
 }
 
 export function createTransactionColumns({
@@ -72,6 +74,7 @@ export function createTransactionColumns({
     splitsEnabled = false,
     isDateHidden = false,
     categorizingIds,
+    hiddenLabelId,
 }: CreateColumnsOptions): ColumnDef<DecryptedTransaction>[] {
     return [
         {
@@ -222,6 +225,7 @@ export function createTransactionColumns({
                 const showNotes = columnVisibility.notes !== false;
 
                 const transactionLabels = (transaction.label_ids || [])
+                    .filter((id) => id !== hiddenLabelId)
                     .map((id) => labels.find((l) => l.id === id))
                     .filter(Boolean) as Label[];
 

--- a/resources/js/components/transactions/transaction-list.tsx
+++ b/resources/js/components/transactions/transaction-list.tsx
@@ -294,6 +294,8 @@ export interface TransactionListProps {
     maxHeight?: number;
     hideColumns?: string[];
     onBalanceUpdated?: () => void;
+    /** A label every listed transaction already carries; hidden from the rows. */
+    hiddenLabelId?: UUID;
 }
 
 export function TransactionList({
@@ -311,6 +313,7 @@ export function TransactionList({
     maxHeight,
     hideColumns = [],
     onBalanceUpdated,
+    hiddenLabelId,
 }: TransactionListProps) {
     const locale = useLocale();
     const { features } = usePage<SharedData>().props;
@@ -783,6 +786,7 @@ export function TransactionList({
             onUnsplit: setUnsplitTransaction,
             splitsEnabled: features.splitTransactions,
             isDateHidden: columnVisibility.transaction_date === false,
+            hiddenLabelId,
         });
 
         if (hideColumns.length === 0) {
@@ -806,6 +810,7 @@ export function TransactionList({
         hideColumns,
         columnVisibility,
         features.splitTransactions,
+        hiddenLabelId,
     ]);
 
     const table = useReactTable({

--- a/resources/js/pages/savings-goals/show.tsx
+++ b/resources/js/pages/savings-goals/show.tsx
@@ -48,6 +48,7 @@ interface Props {
     labels: Label[];
     currencyCode: string;
     recentTransactions?: ServerTransaction[];
+    recentPageSize: number;
 }
 
 export default function SavingsGoalShow({
@@ -60,6 +61,7 @@ export default function SavingsGoalShow({
     labels,
     currencyCode,
     recentTransactions,
+    recentPageSize,
 }: Props) {
     const locale = useLocale();
     const [linkOpen, setLinkOpen] = useState(false);
@@ -243,6 +245,7 @@ export default function SavingsGoalShow({
                 savingsGoal={savingsGoal}
                 transactions={transactions}
                 recentTransactions={recentTransactions}
+                recentPageSize={recentPageSize}
                 currencyCode={currencyCode}
                 open={linkOpen}
                 onOpenChange={setLinkOpen}

--- a/resources/js/pages/savings-goals/show.tsx
+++ b/resources/js/pages/savings-goals/show.tsx
@@ -235,6 +235,7 @@ export default function SavingsGoalShow({
                     pageSize={10}
                     showActionsMenu={false}
                     maxHeight={600}
+                    hiddenLabelId={savingsGoal.label_id ?? undefined}
                 />
             </div>
 

--- a/tests/Feature/SavingsGoalTest.php
+++ b/tests/Feature/SavingsGoalTest.php
@@ -333,6 +333,9 @@ test('the link dialog can widen the recent transactions window, up to a cap', fu
             ->json('props.recentTransactions');
     };
 
+    $this->actingAs($user)->get("/savings-goals/{$goal->id}")
+        ->assertInertia(fn ($page) => $page->where('recentPageSize', 50));
+
     expect($recentTransactions(null))->toHaveCount(50);
     expect($recentTransactions(100))->toHaveCount(55);
     // Garbage falls back to the default page rather than to an unbounded query.

--- a/tests/Feature/SavingsGoalTest.php
+++ b/tests/Feature/SavingsGoalTest.php
@@ -3,11 +3,13 @@
 use App\Enums\LabelSource;
 use App\Features\SavingsGoals;
 use App\Models\Account;
+use App\Models\Category;
 use App\Models\Label;
 use App\Models\SavingsGoal;
 use App\Models\Transaction;
 use App\Models\User;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 use Laravel\Pennant\Feature;
 
 function onboardedSavingsUser(): User
@@ -301,6 +303,50 @@ test('the goal page only loads recent transactions when asked for them', functio
         ])
         ->assertOk()
         ->assertJsonCount(1, 'props.recentTransactions');
+});
+
+test('the link dialog can widen the recent transactions window, up to a cap', function () {
+    $user = onboardedSavingsUser();
+    Feature::for($user)->activate(SavingsGoals::class);
+
+    $goal = SavingsGoal::factory()->create(['user_id' => $user->id]);
+    $account = Account::factory()->create(['user_id' => $user->id]);
+    // One shared category: the factory only has a handful of unique names to give.
+    $category = Category::factory()->create(['user_id' => $user->id]);
+    Transaction::factory()->count(55)->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'category_id' => $category->id,
+        'amount' => -1000,
+    ]);
+
+    $recentTransactions = function (int|string|null $recent) use ($user, $goal) {
+        $url = "/savings-goals/{$goal->id}".($recent === null ? '' : "?recent={$recent}");
+
+        return $this->actingAs($user)->withoutVite()
+            ->get($url, [
+                'X-Inertia' => 'true',
+                'X-Inertia-Partial-Component' => 'savings-goals/show',
+                'X-Inertia-Partial-Data' => 'recentTransactions',
+            ])
+            ->assertOk()
+            ->json('props.recentTransactions');
+    };
+
+    expect($recentTransactions(null))->toHaveCount(50);
+    expect($recentTransactions(100))->toHaveCount(55);
+    // Garbage falls back to the default page rather than to an unbounded query.
+    expect($recentTransactions('nonsense'))->toHaveCount(50);
+
+    // Asking past the cap is clamped to it, which only the query itself can show
+    // without seeding hundreds of rows.
+    DB::enableQueryLog();
+    $recentTransactions(10000);
+
+    $clamped = collect(DB::getQueryLog())
+        ->contains(fn (array $entry) => str_contains($entry['query'], 'limit 500'));
+
+    expect($clamped)->toBeTrue();
 });
 
 test('the goal label carries its source so the UI can mark it as a savings goal', function () {


### PR DESCRIPTION
Two small improvements to how savings goals behave.

## The goal's own label is gone from its transaction rows

Every transaction listed on a goal's page carries that goal's label by definition — that is what puts it there. So the badge repeated on every single row and told nobody anything. It is now filtered out of that list only. Other labels still render, the goal's own badge still sits next to the page heading, and `label_ids` itself is untouched, so nothing downstream sees a different transaction.

Threaded as an optional `hiddenLabelId` prop: `show.tsx` → `TransactionList` → `createTransactionColumns`. Per `.ai/rules/transactions-table.md` the transactions table exists twice, but that rule is about row *actions*; `/transactions` keeps its own copy and needs no wiring here, because a label is only redundant on a page scoped to one goal.

## The link-transactions dialog can reach further back

The dialog's window was a flat 50 most-recent transactions with no way past it, so a contribution older than that was simply unreachable. There is now a load-more control at the end of the list which widens the window 50 at a time. The server clamps the requested window to 500 and falls back to the first page for unusable input, so `?recent=99999999` cannot turn it into an unbounded query.

Notes on the details, since a couple of them are deliberate:

- The page size comes from the controller rather than being hardcoded a second time in the dialog. A client-side copy that drifted *below* the server's would have silently hidden the load-more link while rows still existed — the failure mode is invisible, so the constant only lives in one place.
- The reload passes `preserveUrl: true`. Without it the window the dialog wants leaks into the address bar, and a refresh with `?recent=150` still attached would then serve a wider window than the reopened dialog thinks it has.
- A failed load-more toasts and returns `false`, so Inertia's own error handling does not tear the page down underneath the open dialog.
- 500 stays a hard ceiling with no message when you hit it. The pre-existing `ponytail:` comment already names the real fix if people run into it: a search box hitting the transactions query, not an ever-wider flat list.
- At an exact page boundary (a user with precisely 50 transactions, or at the 500 cap) the link shows once more and the click returns nothing new before it disappears. Left alone: it self-corrects on that one click, and removing it means threading the cap down as a second prop to save a click.

## Tests

- `SavingsGoalTest`: default window, a widened window, garbage input falling back to the first page, the page size reaching the page, and the 500 clamp asserted against the query itself (there is no honest way to check it without seeding hundreds of rows).
- `link-transactions-dialog.test.tsx` covers the load-more state machine, including that the user's ticks survive a wider page arriving. That one is not cosmetic: losing them and then saving would detach the label from everything already linked. Fail-verified before keeping it.

## QA

Browser QA against the dev server with a seeded goal (6 tagged transactions, two also carrying an ordinary label, plus 120 untagged ones so the dialog has to page). Confirmed: the goal's badge is absent from every row while the other label survives; load-more appears after the last row and widens the list; `window.location.search` stays empty across clicks; ticks and the selected counter survive the reload; saving adds the newly linked rows to the goal (€1,800.00 → €1,861.45) still without the goal's own badge; the control reads correctly in dark mode. No console errors beyond a pre-existing placeholder-avatar request that fails locally.

## Demo

<!-- PLACEHOLDER: drag the QA video in here -->

https://github.com/user-attachments/assets/550d33b7-6d91-4734-a7da-fcd7c1eaa860


