### PR TITLE
feat(currencies): add the Honduran Lempira (HNL)

### DIFF
--- a/config/currencies.php
+++ b/config/currencies.php
@@ -183,6 +183,12 @@ return [
             'allows_account' => true,
         ],
         [
+            'code' => 'HNL',
+            'name' => 'Honduran Lempira',
+            'allows_primary' => true,
+            'allows_account' => true,
+        ],
+        [
             'code' => 'HKD',
             'name' => 'Hong Kong Dollar',
             'allows_primary' => true,

--- a/lang/es.json
+++ b/lang/es.json
@@ -1624,6 +1624,7 @@
     "Saudi Riyal": "Riyal saudí",
     "Kuwaiti Dinar": "Dinar kuwaití",
     "Guatemalan Quetzal": "Quetzal guatemalteco",
+    "Honduran Lempira": "Lempira hondureño",
     "Hong Kong Dollar": "Dólar de Hong Kong",
     "Take control of your finances with privacy-first money tracking. Let's set up your account in just a few minutes.": "Toma el control de tus finanzas con un seguimiento privado de tu dinero. Vamos a configurar tu cuenta en pocos minutos.",
     "Tap": "Toca",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1535,6 +1535,7 @@
     "Saudi Riyal": "Riyal saoudien",
     "Kuwaiti Dinar": "Dinar koweïtien",
     "Guatemalan Quetzal": "Quetzal guatémaltèque",
+    "Honduran Lempira": "Lempira hondurien",
     "Hong Kong Dollar": "Dollar de Hong Kong",
     "Take control of your finances with privacy-first money tracking. Let's set up your account in just a few minutes.": "Prenez le contrôle de vos finances grâce au suivi de l'argent privé. Nous créerons votre compte dans quelques minutes.",
     "Tap": "Touche",


### PR DESCRIPTION
A user in Honduras cannot use the app at all today: HNL is not among the
currencies offered for a profile or for an account, so there is no way to
record money in the currency they actually hold.

The rate source we already use (`@fawazahmed0/currency-api`, via
`ExchangeRateService` / `CurrencyConversionService`) publishes HNL, so
conversion, net worth and the charts work with no code change. That makes this
config plus the two translations `tests/Feature/LocalizationTest.php` requires —
it reads the currency names straight out of `config/currencies.php` and fails
for any name missing from a locale JSON.

Same shape as #832 (Kuwaiti dinar).

## Changes

- `config/currencies.php` — `HNL` / `Honduran Lempira`, `allows_primary` and
  `allows_account` both `true`, like every other fiat entry. Placed right after
  `GTQ`, its Central American neighbour, following the file's loose regional
  grouping.
- `lang/es.json` — `"Honduran Lempira": "Lempira hondureño"`
- `lang/fr.json` — `"Honduran Lempira": "Lempira hondurien"`

## Notes

- No new test. Nothing asserts a currency count or an exact list
  (`InertiaSharedDataTest` only uses `toContain`), and `LocalizationTest`
  already covers the part that can break.
- `getCurrencySymbol` in `resources/js/utils/currency.ts` was deliberately left
  alone. Some older currency PRs (#794, #740) added a symbol there, but that
  function has zero call sites in the repo — `formatCurrency` goes through
  `Intl.NumberFormat`, which renders the lempira on its own. #832 skipped it
  too. If we want a symbol map, it should come with a caller.