### PR TITLE
fix(accounts): disconnect a connected account when it is archived

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Actions\OpenBanking\DisconnectBankingConnection;
 use App\Enums\AccountType;
 use App\Http\Requests\ArchiveAccountRequest;
 use App\Http\Requests\ReorderAccountsRequest;
@@ -74,14 +75,46 @@ class AccountController extends Controller
      * Archiving records the day it happened so the account stops counting from
      * then on without touching the history it already has; unarchiving clears
      * the date and the account goes back to counting.
+     *
+     * A connected account also stops syncing: sync runs off the connection's
+     * accounts, so detaching it is what ends the new transactions and balances
+     * the dialog warns about. Reconnecting means going through the bank again,
+     * which is why unarchiving cannot undo this half.
      */
-    public function updateArchived(ArchiveAccountRequest $request, Account $account): RedirectResponse
-    {
+    public function updateArchived(
+        ArchiveAccountRequest $request,
+        Account $account,
+        DisconnectBankingConnection $disconnectBankingConnection,
+    ): RedirectResponse {
+        $archiving = $request->validated('archived');
+
         $account->update([
-            'archived_at' => $request->validated('archived') ? now() : null,
+            'archived_at' => $archiving ? now() : null,
         ]);
 
+        if ($archiving && $account->isConnected()) {
+            $this->disconnectFromBank($account, $disconnectBankingConnection);
+        }
+
         return back();
+    }
+
+    /**
+     * The connection itself is only revoked once nothing hangs off it any more:
+     * the other accounts of the same bank must keep syncing.
+     */
+    private function disconnectFromBank(Account $account, DisconnectBankingConnection $disconnectBankingConnection): void
+    {
+        $connection = $account->bankingConnection;
+
+        $account->update([
+            'banking_connection_id' => null,
+            'external_account_id' => null,
+        ]);
+
+        if ($connection && $connection->accounts()->doesntExist()) {
+            $disconnectBankingConnection->handle($connection);
+        }
     }
 
     public function show(Request $request, Account $account): Response

--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -9,6 +9,7 @@ use App\Http\Requests\ReorderAccountsRequest;
 use App\Http\Requests\UpdateAccountVisibilityRequest;
 use App\Models\Account;
 use App\Models\AccountBalance;
+use App\Models\BankingConnection;
 use App\Models\LoanDetail;
 use App\Models\Transaction;
 use App\Services\AccountMetricsService;
@@ -16,6 +17,7 @@ use App\Services\LoanAmortizationService;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -86,35 +88,45 @@ class AccountController extends Controller
         Account $account,
         DisconnectBankingConnection $disconnectBankingConnection,
     ): RedirectResponse {
-        $archiving = $request->validated('archived');
+        $archiving = $request->boolean('archived');
 
-        $account->update([
-            'archived_at' => $archiving ? now() : null,
-        ]);
+        $orphanedConnection = DB::transaction(function () use ($account, $archiving): ?BankingConnection {
+            $account->update([
+                'archived_at' => $archiving ? now() : null,
+            ]);
 
-        if ($archiving && $account->isConnected()) {
-            $this->disconnectFromBank($account, $disconnectBankingConnection);
+            return $archiving ? $this->detachFromBank($account) : null;
+        });
+
+        // Revoking talks to the provider, so it stays outside the transaction:
+        // a slow bank would otherwise hold the connection row locked.
+        if ($orphanedConnection) {
+            $disconnectBankingConnection->handle($orphanedConnection);
         }
 
         return back();
     }
 
     /**
-     * The connection itself is only revoked once nothing hangs off it any more:
-     * the other accounts of the same bank must keep syncing.
+     * Returns the connection only when this was the last account hanging off it,
+     * so it can be revoked — the other accounts of the same bank must keep
+     * syncing. The row is locked because two accounts archived at once would
+     * otherwise both see it as empty and revoke it twice.
      */
-    private function disconnectFromBank(Account $account, DisconnectBankingConnection $disconnectBankingConnection): void
+    private function detachFromBank(Account $account): ?BankingConnection
     {
-        $connection = $account->bankingConnection;
+        if (! $account->isConnected()) {
+            return null;
+        }
+
+        $connection = $account->bankingConnection()->lockForUpdate()->first();
 
         $account->update([
             'banking_connection_id' => null,
             'external_account_id' => null,
         ]);
 
-        if ($connection && $connection->accounts()->doesntExist()) {
-            $disconnectBankingConnection->handle($connection);
-        }
+        return $connection && $connection->accounts()->doesntExist() ? $connection : null;
     }
 
     public function show(Request $request, Account $account): Response

--- a/lang/es.json
+++ b/lang/es.json
@@ -740,7 +740,7 @@
     "Unarchive account": "Desarchivar cuenta",
     "Archiving...": "Archivando...",
     "Archiving :name puts it away without deleting anything:": "Archivar :name la guarda sin borrar nada:",
-    "It will be disconnected from the bank: no new transactions or balances will come in, and bringing it back later means connecting the bank again.": "Se desconectar\u00e1 del banco: no entrar\u00e1n nuevas transacciones ni balances, y para recuperarla m\u00e1s adelante tendr\u00e1s que volver a conectar el banco.",
+    "It will be disconnected from the bank: no new transactions or balances will come in. Unarchiving brings the account back, not the connection \u2014 you would have to connect the bank again.": "Se desconectar\u00e1 del banco: no entrar\u00e1n nuevas transacciones ni balances. Al desarchivarla recuperas la cuenta, no la conexi\u00f3n \u2014 tendr\u00edas que volver a conectar el banco.",
     "It disappears from the dashboard and from the accounts page.": "Desaparece del panel y de la p\u00e1gina de cuentas.",
     "It stops counting towards your net worth from today. The months before today keep the figures they already have.": "Deja de contar en tu patrimonio a partir de hoy. Los meses anteriores mantienen las cifras que ya ten\u00edan.",
     "You will not be able to pick it for new transactions, but the ones it already has stay in your history and stay editable.": "No podr\u00e1s elegirla para nuevas transacciones, pero las que ya tiene siguen en tu historial y siguen siendo editables.",

--- a/lang/es.json
+++ b/lang/es.json
@@ -740,6 +740,7 @@
     "Unarchive account": "Desarchivar cuenta",
     "Archiving...": "Archivando...",
     "Archiving :name puts it away without deleting anything:": "Archivar :name la guarda sin borrar nada:",
+    "It will be disconnected from the bank: no new transactions or balances will come in, and bringing it back later means connecting the bank again.": "Se desconectar\u00e1 del banco: no entrar\u00e1n nuevas transacciones ni balances, y para recuperarla m\u00e1s adelante tendr\u00e1s que volver a conectar el banco.",
     "It disappears from the dashboard and from the accounts page.": "Desaparece del panel y de la p\u00e1gina de cuentas.",
     "It stops counting towards your net worth from today. The months before today keep the figures they already have.": "Deja de contar en tu patrimonio a partir de hoy. Los meses anteriores mantienen las cifras que ya ten\u00edan.",
     "You will not be able to pick it for new transactions, but the ones it already has stay in your history and stay editable.": "No podr\u00e1s elegirla para nuevas transacciones, pero las que ya tiene siguen en tu historial y siguen siendo editables.",

--- a/resources/js/components/accounts/archive-account-dialog.test.tsx
+++ b/resources/js/components/accounts/archive-account-dialog.test.tsx
@@ -54,6 +54,36 @@ describe('ArchiveAccountDialog', () => {
         expect(screen.getByText(/bring it back any time/)).toBeInTheDocument();
     });
 
+    it('warns a connected account will be disconnected', () => {
+        render(
+            <ArchiveAccountDialog
+                account={
+                    { ...account, banking_connection_id: 'conn-1' } as Account
+                }
+                open={true}
+                onOpenChange={() => {}}
+            />,
+        );
+
+        expect(
+            screen.getByText(/disconnected from the bank/),
+        ).toBeInTheDocument();
+    });
+
+    it('does not mention the bank for a manual account', () => {
+        render(
+            <ArchiveAccountDialog
+                account={account}
+                open={true}
+                onOpenChange={() => {}}
+            />,
+        );
+
+        expect(
+            screen.queryByText(/disconnected from the bank/),
+        ).not.toBeInTheDocument();
+    });
+
     it('submits archived=1 to the account it was given', () => {
         render(
             <ArchiveAccountDialog

--- a/resources/js/components/accounts/archive-account-dialog.tsx
+++ b/resources/js/components/accounts/archive-account-dialog.tsx
@@ -50,7 +50,7 @@ export function ArchiveAccountDialog({
                     {!!account.banking_connection_id && (
                         <li className="font-medium text-foreground">
                             {__(
-                                'It will be disconnected from the bank: no new transactions or balances will come in, and bringing it back later means connecting the bank again.',
+                                'It will be disconnected from the bank: no new transactions or balances will come in. Unarchiving brings the account back, not the connection — you would have to connect the bank again.',
                             )}
                         </li>
                     )}

--- a/resources/js/components/accounts/archive-account-dialog.tsx
+++ b/resources/js/components/accounts/archive-account-dialog.tsx
@@ -23,6 +23,9 @@ interface ArchiveAccountDialogProps {
  * Archiving is reversible, so it asks for a plain confirmation rather than a
  * typed one — but it reaches enough of the app that it has to say what it does.
  * Unarchiving needs no dialog at all.
+ *
+ * The one half that is not reversible is the bank connection: archiving a
+ * connected account detaches it, so that consequence is spelled out first.
  */
 export function ArchiveAccountDialog({
     account,
@@ -44,6 +47,13 @@ export function ArchiveAccountDialog({
                 </DialogHeader>
 
                 <ul className="list-disc space-y-2 pl-5 text-sm text-muted-foreground">
+                    {!!account.banking_connection_id && (
+                        <li className="font-medium text-foreground">
+                            {__(
+                                'It will be disconnected from the bank: no new transactions or balances will come in, and bringing it back later means connecting the bank again.',
+                            )}
+                        </li>
+                    )}
                     <li>
                         {__(
                             'It disappears from the dashboard and from the accounts page.',

--- a/tests/Feature/AccountControllerTest.php
+++ b/tests/Feature/AccountControllerTest.php
@@ -1,10 +1,13 @@
 <?php
 
+use App\Contracts\BankingProviderInterface;
 use App\Enums\AccountType;
+use App\Enums\BankingConnectionStatus;
 use App\Models\Account;
 use App\Models\AccountBalance;
 use App\Models\AutomationRule;
 use App\Models\Bank;
+use App\Models\BankingConnection;
 use App\Models\Category;
 use App\Models\Label;
 use App\Models\RealEstateDetail;
@@ -180,6 +183,66 @@ test('archiving leaves the dashboard visibility flag alone', function () {
 
     expect($account->archived_at)->not->toBeNull();
     expect($account->hidden_on_dashboard)->toBeTrue();
+});
+
+test('archiving a connected account detaches it and revokes a connection nothing else uses', function () {
+    $provider = Mockery::mock(BankingProviderInterface::class);
+    $provider->shouldReceive('revokeSession')->once();
+    app()->instance(BankingProviderInterface::class, $provider);
+
+    $connection = BankingConnection::factory()->create(['user_id' => $this->user->id]);
+    $account = Account::factory()->create([
+        'user_id' => $this->user->id,
+        'banking_connection_id' => $connection->id,
+        'external_account_id' => 'ext-1',
+    ]);
+
+    $this->patch(route('accounts.archived', $account), ['archived' => true])
+        ->assertRedirect();
+
+    $account->refresh();
+
+    expect($account->archived_at)->not->toBeNull();
+    expect($account->banking_connection_id)->toBeNull();
+    expect($account->external_account_id)->toBeNull();
+    expect(BankingConnection::query()->whereKey($connection->id)->exists())->toBeFalse();
+});
+
+test('archiving a connected account keeps the connection alive for its other accounts', function () {
+    $provider = Mockery::mock(BankingProviderInterface::class);
+    $provider->shouldNotReceive('revokeSession');
+    app()->instance(BankingProviderInterface::class, $provider);
+
+    $connection = BankingConnection::factory()->create(['user_id' => $this->user->id]);
+    $archived = Account::factory()->create([
+        'user_id' => $this->user->id,
+        'banking_connection_id' => $connection->id,
+    ]);
+    $sibling = Account::factory()->create([
+        'user_id' => $this->user->id,
+        'banking_connection_id' => $connection->id,
+    ]);
+
+    $this->patch(route('accounts.archived', $archived), ['archived' => true])
+        ->assertRedirect();
+
+    expect($archived->fresh()->banking_connection_id)->toBeNull();
+    expect($sibling->fresh()->banking_connection_id)->toBe($connection->id);
+    expect($connection->fresh()->status)->toBe(BankingConnectionStatus::Active);
+});
+
+test('unarchiving does not touch the bank connection', function () {
+    $connection = BankingConnection::factory()->create(['user_id' => $this->user->id]);
+    $account = Account::factory()->create([
+        'user_id' => $this->user->id,
+        'banking_connection_id' => $connection->id,
+        'archived_at' => now(),
+    ]);
+
+    $this->patch(route('accounts.archived', $account), ['archived' => false])
+        ->assertRedirect();
+
+    expect($account->fresh()->banking_connection_id)->toBe($connection->id);
 });
 
 test('the archived flag is required when archiving', function () {


### PR DESCRIPTION
## Why

Archiving a bank account did not stop it syncing. Sync runs off
`BankingConnection::accounts` and never looks at `archived_at`, so an archived
account kept pulling new transactions and balances, kept burning provider
quota, and kept triggering reauth/expiry mail. This was the known follow-up left
open by #807.

## What

**The dialog warns first.** `ArchiveAccountDialog` gains a bullet, shown only
when the account has a `banking_connection_id`: it will be disconnected, no new
transactions or balances will come in, and unarchiving brings the account back
but not the connection.

**Confirming actually disconnects it.** `AccountController::updateArchived` now
nulls `banking_connection_id` / `external_account_id` — detaching is what ends
the sync — and revokes the connection through the existing
`DisconnectBankingConnection` action **only when no account is left on it**. The
other accounts of the same bank keep syncing.

The `archived_at` write and the detach share one transaction, with the
connection row locked so two accounts archived at the same moment cannot both
see it as empty and revoke it twice. The provider call stays outside the
transaction: a slow bank would otherwise hold that lock.

Unarchiving deliberately does not restore the connection — there is no way to
un-revoke a provider session, which is exactly what the dialog says.

## Tests

- `archiving a connected account detaches it and revokes a connection nothing else uses`
- `archiving a connected account keeps the connection alive for its other accounts`
- `unarchiving does not touch the bank connection`
- Two dialog tests: the warning shows for a connected account, and stays away for a manual one.

## Demo

<!-- PLACEHOLDER: drag the QA video here -->

https://github.com/user-attachments/assets/c39955c5-075b-49e6-9f9c-347e59a9a20a


Browser QA covered both entry points (Settings → Bank accounts and the account
screen's More options), cancel, the sole-account case, the shared-connection
case, and unarchiving — verified against the database each time.
