### PR TITLE
fix(transactions): stop the split dialog scrolling sideways on a phone

### DIFF
--- a/resources/js/components/transactions/split-transaction-dialog.tsx
+++ b/resources/js/components/transactions/split-transaction-dialog.tsx
@@ -161,7 +161,7 @@ export function SplitTransactionDialog({
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="sm:max-w-[640px]">
+            <DialogContent className="p-4 sm:max-w-[640px] sm:p-6">
                 <DialogHeader>
                     <DialogTitle>{__('Split transaction')}</DialogTitle>
                     <DialogDescription>
@@ -171,7 +171,9 @@ export function SplitTransactionDialog({
                     </DialogDescription>
                 </DialogHeader>
 
-                <form onSubmit={handleSubmit}>
+                {/* min-w-0: the dialog is a grid, so a nowrap child (the truncated
+                    description below) would otherwise stretch it past the viewport. */}
+                <form onSubmit={handleSubmit} className="min-w-0">
                     <div className="rounded-md border border-border bg-muted/40 p-3 text-sm">
                         <div className="flex items-center justify-between gap-3">
                             <span className="truncate font-medium">
@@ -202,7 +204,7 @@ export function SplitTransactionDialog({
                                 key={draft.key}
                                 className="flex flex-col gap-1.5"
                             >
-                                <div className="flex items-center gap-2">
+                                <div className="flex flex-wrap items-center gap-2">
                                     <span className="w-4 shrink-0 text-right text-xs text-muted-foreground">
                                         {index + 1}
                                     </span>
@@ -224,7 +226,14 @@ export function SplitTransactionDialog({
                                             showUncategorized={true}
                                         />
                                     </div>
-                                    <div className="flex w-[150px] shrink-0 items-center gap-1">
+                                    {/* The four controls do not fit on one
+                                        line on a phone, so the amount drops
+                                        below the category. `order-last` moves
+                                        it there without reordering the DOM,
+                                        which would leave the desktop tab order
+                                        out of step with what is on screen;
+                                        `pl-6` lines it up with the labels. */}
+                                    <div className="order-last flex w-full items-center gap-1 pl-6 sm:order-none sm:w-[150px] sm:shrink-0 sm:pl-0">
                                         {isExpense && (
                                             <span
                                                 aria-hidden="true"


### PR DESCRIPTION
## Why

On a phone the **Split transaction** dialog scrolled sideways: the description, the amount
column, the footer link and the submit button were all cut off on the right, and the modal
had to be dragged horizontally to be used.

`DialogContent` is a CSS grid, and the transaction description in the summary card uses
`truncate` (`white-space: nowrap`). A nowrap child's min-content width is the *whole*
string, so the grid track grew to the full description and pushed every row past the
viewport — the description never truncated, it just dragged the dialog with it.

## What changed

One file, classes only — no logic, no copy.

- `min-w-0` on the form, so the grid track stops sizing to the description and `truncate`
  does its job.
- The amount input drops onto its own line under the category on a phone
  (`flex-wrap` + `order-last` + `w-full`). With four controls on one 360px line the
  category select was down to its icon with no readable text. `order-last` (rather than
  moving the element in the DOM) keeps the desktop tab order in step with what is on
  screen: category → amount → remove.
- `p-4 sm:p-6` on the dialog — 24px of padding each side is a lot of a 360px screen.

At `sm:` and up the row is unchanged: `[index] [category] [amount] [X]`.

## Verified

In a real browser against the running app:

| Width | Result |
| --- | --- |
| 320px | no horizontal overflow (`scrollWidth === clientWidth`), also with 4 splits |
| 360px | no horizontal overflow, also with a long amount typed and with 4 splits |
| 1280px | layout identical to before the fix |

Splitting still works end to end from the phone layout (parts written with
`split_parent_id`, original soft-deleted), keyboard tab order on desktop is
category → amount → remove, and `tests/Browser/SplitTransactionTest.php` selects by
`#split-amount-*` / `[data-testid=submit-split]`, so it is unaffected by the reflow.

## Demo

https://github.com/user-attachments/assets/f7fdbaab-88e9-491c-834c-85c9c8db5ce9


<!-- PLACEHOLDER — drag the QA video in here (recorded at 360px: opening the dialog
from the row menu, scrolling it, adding a split, filling both amounts, submitting) -->

## Note for a follow-up

`DialogContent` being a `grid` makes this a trap for any dialog with a `truncate` child —
the same bug can be reintroduced elsewhere. Fixing it once on the shared component (or
recording it as a rule) is worth considering, but it needs every dialog re-checked, so it
is out of scope here.
