### PR TITLE
fix(sentry): let a hung request outlast its attribution window

### DIFF
--- a/resources/js/lib/failed-navigation-toast.test.ts
+++ b/resources/js/lib/failed-navigation-toast.test.ts
@@ -25,11 +25,32 @@ async function freshModules() {
     const leavePageModule = await import('./leave-page');
     const { installFailedNavigationToast } =
         await import('./failed-navigation-toast');
+    // The other half of what `app.tsx` wires to this tracker. The two read the same
+    // entries at different moments of the same failure, so they have to be able to
+    // be asked together.
+    const sentry = await import('./sentry');
 
     tracker.trackUnattendedRequests();
     installFailedNavigationToast();
 
-    return { listeners, leavePage: leavePageModule.leavePage };
+    return {
+        listeners,
+        leavePage: leavePageModule.leavePage,
+        isUnattendedRequestNoise: sentry.isUnattendedRequestNoise,
+    };
+}
+
+function sentryEvent(url: string) {
+    return {
+        exception: {
+            values: [
+                {
+                    type: 'HttpNetworkError',
+                    value: `Network error (${url})`,
+                },
+            ],
+        },
+    };
 }
 
 function failure(url: string) {
@@ -194,14 +215,50 @@ describe('installFailedNavigationToast', () => {
             const { listeners } = await freshModules();
 
             // The poll stopped - the step moved on, the page unmounted - so the
-            // next failure at that url belongs to whoever asked for it next.
+            // next failure at that url belongs to whoever asked for it next. Its
+            // last tick has to have come back for the window to be running at all:
+            // while a request is still out there, no amount of elapsed time makes
+            // it somebody's.
             listeners.before?.(polling('https://whisper.money/onboarding'));
+            listeners.finish?.(polling('https://whisper.money/onboarding'));
             vi.setSystemTime(Date.now() + 31_000);
             listeners.networkError?.(
                 failure('https://whisper.money/onboarding'),
             );
 
             expect(toastError).toHaveBeenCalledOnce();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('keeps both readers of a hung poll in step, in the order they ask', async () => {
+        vi.useFakeTimers();
+
+        try {
+            const { listeners, isUnattendedRequestNoise } =
+                await freshModules();
+            const url = 'https://whisper.money/onboarding';
+
+            listeners.before?.(polling(url));
+
+            // Inertia sets no XHR timeout, so a dropped connection leaves the
+            // browser on the socket long past any window. This is the failure in
+            // PHP-LARAVEL-5E: eleven users, one event each, on a url only the 4s
+            // poll ever requests.
+            vi.setSystemTime(Date.now() + 61_000);
+
+            // The order `app.tsx` really produces. `networkError` is a synchronous
+            // dispatch from inside the rejecting `catch`, so the toast asks while
+            // the request is still unfinished; `finish` comes from the `finally`
+            // after it; Sentry's beforeSend asks last, off the unhandled rejection.
+            // A disagreement here is not two answers - the first reader deletes the
+            // lapsed entry the second one needs.
+            listeners.networkError?.(failure(url));
+            listeners.finish?.(polling(url));
+
+            expect(toastError).not.toHaveBeenCalled();
+            expect(isUnattendedRequestNoise(sentryEvent(url))).toBe(true);
         } finally {
             vi.useRealTimers();
         }

--- a/resources/js/lib/sentry.test.ts
+++ b/resources/js/lib/sentry.test.ts
@@ -522,6 +522,82 @@ describe('isUnattendedRequestNoise', () => {
         ).toBe(false);
     });
 
+    it('keeps a hung poll that a real visit claimed while it was out', async () => {
+        const { isUnattendedRequestNoise, listeners } =
+            await freshModulesWithFakedRouter();
+
+        const url = new URL('https://whisper.money/onboarding');
+
+        listeners.before?.({
+            detail: { visit: { url, prefetch: false, poll: true } },
+        });
+        // Somebody asks for the page themselves while the tick is still out. From
+        // here the url is theirs, and the poll's late failure must not be waved
+        // through on the strength of a claim the visit already revoked.
+        listeners.before?.({ detail: { visit: { url, prefetch: false } } });
+        listeners.finish?.({
+            detail: { visit: { url, prefetch: false, poll: true } },
+        });
+
+        expect(
+            isUnattendedRequestNoise(
+                networkError('https://whisper.money/onboarding'),
+            ),
+        ).toBe(false);
+    });
+
+    it('drops a poll that hung for longer than its window before dying', async () => {
+        const { isUnattendedRequestNoise, listeners } =
+            await freshModulesWithFakedRouter();
+
+        const visit = {
+            detail: {
+                visit: {
+                    url: new URL('https://whisper.money/onboarding'),
+                    prefetch: false,
+                    poll: true,
+                },
+            },
+        };
+
+        listeners.before?.(visit);
+
+        // A connection that dies mid-flight does not fail fast - the browser sits on
+        // the socket for minutes before giving up, which is how a poll nobody asked
+        // for used to outlive the window and get reported as a real navigation.
+        vi.setSystemTime(Date.now() + 61_000);
+        listeners.finish?.(visit);
+
+        expect(
+            isUnattendedRequestNoise(
+                networkError('https://whisper.money/onboarding'),
+            ),
+        ).toBe(true);
+    });
+
+    it('does not resurrect a prefetch a real click has already claimed', async () => {
+        const { isUnattendedRequestNoise, listeners } =
+            await freshModulesWithFakedRouter();
+
+        const url = new URL('https://whisper.money/cashflow');
+
+        listeners.prefetching?.({ detail: { visit: { url } } });
+        listeners.before?.({
+            detail: { visit: { url, prefetch: false } },
+        });
+        // The request Inertia handed to the click is still flagged as a prefetch
+        // when it ends, so `finish` must not undo the claim the click made.
+        listeners.finish?.({
+            detail: { visit: { url, prefetch: true } },
+        });
+
+        expect(
+            isUnattendedRequestNoise(
+                networkError('https://whisper.money/cashflow'),
+            ),
+        ).toBe(false);
+    });
+
     it('keeps a network error that is not Inertia-shaped', async () => {
         const { isUnattendedRequestNoise } =
             await freshModulesWithFakedRouter();

--- a/resources/js/lib/sentry.test.ts
+++ b/resources/js/lib/sentry.test.ts
@@ -512,6 +512,58 @@ describe('isUnattendedRequestNoise', () => {
         ).toBe(false);
     });
 
+    it('drops a poll that hung for longer than its window before dying', async () => {
+        const { isUnattendedRequestNoise, listeners } =
+            await freshModulesWithFakedRouter();
+
+        const visit = {
+            detail: {
+                visit: {
+                    url: new URL('https://whisper.money/onboarding'),
+                    prefetch: false,
+                    poll: true,
+                },
+            },
+        };
+
+        listeners.before?.(visit);
+
+        // A connection that dies mid-flight does not fail fast - the browser sits on
+        // the socket for minutes before giving up, which is how a poll nobody asked
+        // for used to outlive the window and get reported as a real navigation.
+        vi.setSystemTime(Date.now() + 61_000);
+        listeners.finish?.(visit);
+
+        expect(
+            isUnattendedRequestNoise(
+                networkError('https://whisper.money/onboarding'),
+            ),
+        ).toBe(true);
+    });
+
+    it('does not resurrect a prefetch a real click has already claimed', async () => {
+        const { isUnattendedRequestNoise, listeners } =
+            await freshModulesWithFakedRouter();
+
+        const url = new URL('https://whisper.money/cashflow');
+
+        listeners.prefetching?.({ detail: { visit: { url } } });
+        listeners.before?.({
+            detail: { visit: { url, prefetch: false } },
+        });
+        // The request Inertia handed to the click is still flagged as a prefetch
+        // when it ends, so `finish` must not undo the claim the click made.
+        listeners.finish?.({
+            detail: { visit: { url, prefetch: true } },
+        });
+
+        expect(
+            isUnattendedRequestNoise(
+                networkError('https://whisper.money/cashflow'),
+            ),
+        ).toBe(false);
+    });
+
     it('keeps a network error that is not Inertia-shaped', async () => {
         const { isUnattendedRequestNoise } =
             await freshModulesWithFakedRouter();

--- a/resources/js/lib/sentry.test.ts
+++ b/resources/js/lib/sentry.test.ts
@@ -502,60 +502,18 @@ describe('isUnattendedRequestNoise', () => {
                 visit: { url: new URL('https://whisper.money/cashflow') },
             },
         });
-
-        vi.setSystemTime(Date.now() + 61_000);
-
-        expect(
-            isUnattendedRequestNoise(
-                networkError('https://whisper.money/cashflow'),
-            ),
-        ).toBe(false);
-    });
-
-    it('drops a poll that hung for longer than its window before dying', async () => {
-        const { isUnattendedRequestNoise, listeners } =
-            await freshModulesWithFakedRouter();
-
-        const visit = {
+        // The window only starts once the prefetch has come back: an entry whose
+        // request is still out there cannot go stale, however long it takes.
+        listeners.finish?.({
             detail: {
                 visit: {
-                    url: new URL('https://whisper.money/onboarding'),
-                    prefetch: false,
-                    poll: true,
+                    url: new URL('https://whisper.money/cashflow'),
+                    prefetch: true,
                 },
             },
-        };
+        });
 
-        listeners.before?.(visit);
-
-        // A connection that dies mid-flight does not fail fast - the browser sits on
-        // the socket for minutes before giving up, which is how a poll nobody asked
-        // for used to outlive the window and get reported as a real navigation.
         vi.setSystemTime(Date.now() + 61_000);
-        listeners.finish?.(visit);
-
-        expect(
-            isUnattendedRequestNoise(
-                networkError('https://whisper.money/onboarding'),
-            ),
-        ).toBe(true);
-    });
-
-    it('does not resurrect a prefetch a real click has already claimed', async () => {
-        const { isUnattendedRequestNoise, listeners } =
-            await freshModulesWithFakedRouter();
-
-        const url = new URL('https://whisper.money/cashflow');
-
-        listeners.prefetching?.({ detail: { visit: { url } } });
-        listeners.before?.({
-            detail: { visit: { url, prefetch: false } },
-        });
-        // The request Inertia handed to the click is still flagged as a prefetch
-        // when it ends, so `finish` must not undo the claim the click made.
-        listeners.finish?.({
-            detail: { visit: { url, prefetch: true } },
-        });
 
         expect(
             isUnattendedRequestNoise(

--- a/resources/js/lib/unattended-requests.ts
+++ b/resources/js/lib/unattended-requests.ts
@@ -35,8 +35,9 @@ const awaitedUrls = new Set<string>();
  * Backstop for a request nobody ever asked for afterwards. Matched to Inertia's own
  * `cacheFor` default: past that a successful prefetch has been evicted, so a click
  * issues a fresh request and its failure is the user's, not ours to explain away.
- * Inertia sets no XHR timeout, so a hung request can still fail after this and be
- * reported - which is the safe direction to be wrong in.
+ *
+ * Measured from the moment the request *ended*, not the moment it started - see the
+ * `finish` listener below.
  */
 const ATTRIBUTION_WINDOW_MS = 30_000;
 
@@ -80,10 +81,28 @@ export function trackUnattendedRequests(): void {
     // to, and `finish` is the one event that fires on every outcome.
     router.on('finish', (event) => {
         const { visit } = event.detail;
+        const key = requestKey(visit.url);
 
-        if (!isPoll(visit) && !visit.prefetch) {
-            awaitedUrls.delete(requestKey(visit.url));
+        if (isPoll(visit) || visit.prefetch) {
+            // Restart the window from when the request ended rather than when it
+            // started. A connection that dies mid-flight does not fail fast: the
+            // browser holds the socket open and only gives up long afterwards, so a
+            // window measured from `before` has already lapsed by the time the
+            // rejection arrives - and a poll nobody asked for reads as a navigation
+            // somebody was waiting for. `finish` runs on the rejecting chain, ahead
+            // of the unhandled rejection, so the stamp is in place when beforeSend
+            // asks.
+            //
+            // Only ever refresh an entry that is still ours: a real visit to the same
+            // URL deletes it, and that deletion has to stick.
+            if (unattendedAt.has(key)) {
+                unattendedAt.set(key, Date.now());
+            }
+
+            return;
         }
+
+        awaitedUrls.delete(key);
     });
 }
 

--- a/resources/js/lib/unattended-requests.ts
+++ b/resources/js/lib/unattended-requests.ts
@@ -22,8 +22,23 @@ import { router } from '@inertiajs/react';
  * Kept by timestamp rather than cleared on completion, because `finish` fires on the
  * rejecting chain before the unhandled rejection is captured — anything cleared
  * there would already be gone by the time beforeSend asks.
+ *
+ * The timestamp is when the request *ended*, or {@link STILL_IN_FLIGHT} while it is
+ * running.
  */
 const unattendedAt = new Map<string, number>();
+
+/**
+ * The stamp on a request that has not come back yet, which no window can outlast.
+ *
+ * A request nobody asked for stays a request nobody asked for however long it takes
+ * to die, and dying is exactly what takes long: Inertia sets no XHR timeout, so a
+ * connection that drops mid-flight leaves the browser sitting on the socket for
+ * minutes before it gives up. Ageing an entry out from the moment the request
+ * *started* meant the hung ones - the only ones slow enough to matter - were the ones
+ * that lapsed, and a 4s poll came back as a navigation someone was waiting for.
+ */
+const STILL_IN_FLIGHT = Infinity;
 
 /**
  * URLs a real request is in flight for right now, which a poll to the same URL
@@ -43,7 +58,7 @@ const ATTRIBUTION_WINDOW_MS = 30_000;
 
 export function trackUnattendedRequests(): void {
     router.on('prefetching', (event) => {
-        unattendedAt.set(requestKey(event.detail.visit.url), Date.now());
+        unattendedAt.set(requestKey(event.detail.visit.url), STILL_IN_FLIGHT);
     });
 
     // The moment someone asks for the page themselves, its failure is theirs and not
@@ -65,7 +80,7 @@ export function trackUnattendedRequests(): void {
             // and its failure, and re-arm the very entry that decides whether that
             // failure is worth telling anyone about.
             if (!awaitedUrls.has(key)) {
-                unattendedAt.set(key, Date.now());
+                unattendedAt.set(key, STILL_IN_FLIGHT);
             }
 
             return;
@@ -84,16 +99,11 @@ export function trackUnattendedRequests(): void {
         const key = requestKey(visit.url);
 
         if (isPoll(visit) || visit.prefetch) {
-            // Restart the window from when the request ended rather than when it
-            // started. A connection that dies mid-flight does not fail fast: the
-            // browser holds the socket open and only gives up long afterwards, so a
-            // window measured from `before` has already lapsed by the time the
-            // rejection arrives - and a poll nobody asked for reads as a navigation
-            // somebody was waiting for. `finish` runs on the rejecting chain, ahead
-            // of the unhandled rejection, so the stamp is in place when beforeSend
-            // asks.
+            // Start the window here, now that there is an end to measure from. Until
+            // this point the entry was {@link STILL_IN_FLIGHT} and no elapsed time
+            // could age it out.
             //
-            // Only ever refresh an entry that is still ours: a real visit to the same
+            // Only ever stamp an entry that is still ours: a real visit to the same
             // URL deletes it, and that deletion has to stick.
             if (unattendedAt.has(key)) {
                 unattendedAt.set(key, Date.now());
@@ -127,6 +137,20 @@ function requestKey(url: URL): string {
     return withoutHash.href;
 }
 
+/**
+ * Two callers ask this about the same failure, and they do not get to disagree.
+ *
+ * Inertia's `networkError` event is a synchronous `dispatchEvent` inside the
+ * rejecting `.catch()`, so the toast in {@link installFailedNavigationToast} asks
+ * first - before the `.finally()` that fires `finish`. Sentry's beforeSend asks last,
+ * off the unhandled rejection. An entry has to read the same way at both moments, and
+ * the expiry below deletes as it reports, so a disagreement is not merely two
+ * different answers: the first caller destroys the entry the second one needed.
+ *
+ * {@link STILL_IN_FLIGHT} is what keeps them in step. The request is unfinished when
+ * the toast asks and freshly stamped when beforeSend does, and neither reading can
+ * age out.
+ */
 export function wasUnattended(url: string): boolean {
     const at = unattendedAt.get(url);
 


### PR DESCRIPTION
Fixes PHP-LARAVEL-5E, and the same mechanism behind PHP-LARAVEL-5D.

## The issue

`HttpNetworkError: Network error (https://whisper.money/onboarding?step=create-account)` — 11 users, 11 events over 7 days, exactly one each.

That url is only ever requested by one thing. The onboarding page moves between steps with `history.replaceState`, not an Inertia visit, so nothing navigates to `?step=create-account`; the only request that carries it is the 4s poll the create-account step runs to notice a bank that finished connecting somewhere else. Those are supposed to be suppressed — `unattended-requests` exists to tell a request nobody asked for apart from one someone is waiting on.

`PHP-LARAVEL-5D` (`/transactions`, 3 users, one event each) is the prefetch version of the same thing: every sidebar item is a `<Link prefetch>`, so sitting on `/transactions/categorize` and passing the nav fetches `/transactions`.

## Why the suppression missed them

The entry was stamped when the request *started* and aged out after 30s. Inertia sets no XHR timeout, so a connection that drops mid-flight does not fail fast — the browser holds the socket and gives up long afterwards. The hung requests are therefore the only ones slow enough to outlive the window, and they are exactly the ones that end up reported. One per user, because the ticks after the connection is properly gone fail fast and are suppressed normally.

The user-facing half is worse than the Sentry noise: they get "We could not reach the server. Check your connection." for a background poll they never asked for.

## The fix

Stamp the entry `STILL_IN_FLIGHT` while the request is out, and start the window at `finish`, so it measures how long ago the request *ended*.

This matters for a reason that is not obvious from the module alone. `wasUnattended()` has two callers at two different moments of the same failure:

```
.catch(error => {
  fireNetworkErrorEvent(error)   // synchronous dispatchEvent -> the toast asks HERE
  return Promise.reject(error)   // -> Sentry beforeSend asks LAST
}).finally(() => {
  this.finish()                  // -> fires `finish`, in between
})
```

The toast reads first, while the request is still unfinished, and `wasUnattended()` *deletes* as it expires — so a disagreement between the two readers is not merely two different answers, it is the first reader destroying the entry the second one needed. An in-flight stamp is what keeps them in step: unfinished when the toast asks, freshly ended when beforeSend does, and neither reading can age out.

## Commits

1. First attempt — restamp on `finish`. **Wrong**, kept for the trail: the restamp ran after the toast had already read and deleted the entry, so neither half was fixed.
2. The actual fix, plus a cross-module test that drives `before → networkError → finish` through both consumers in the order `app.tsx` really produces. It fails against `origin/main` *and* against commit 1.
3. Coverage for the poll-vs-real-visit race, which is the shape the production bug had.

Two existing tests asserted the old semantics — a window running while the request was still out — and now fire `finish` before jumping the clock, which is what their own comments always described.

## Why draft

The logic is small and pinned down red/green, but this is a suppression path: being wrong here means silently swallowing a failure someone was waiting for — a save that did not save. My first pass at this exact change looked right and was not, so a second pair of eyes on the ordering argument is worth more than the speed.

One known edge case left alone, no worse than before: if a real visit to the same url claims an entry while an older poll to that url is still hanging, that poll's late failure reads as user-awaited and gets reported. Over-reporting is the safe direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
