### PR TITLE
fix(session): recover the whole app from an expired session

### DIFF
--- a/lang/es.json
+++ b/lang/es.json
@@ -2596,5 +2596,6 @@
     "Link transactions": "Vincular transacciones",
     "Tick the transactions that count toward this goal. Unticking one removes it from the goal.": "Marca las transacciones que cuentan para este objetivo. Al desmarcarlas se quitan del objetivo.",
     "Failed to load more transactions.": "No se pudieron cargar más transacciones.",
-    "Its transactions will become uncategorized.": "Sus transacciones quedar\u00e1n sin categor\u00eda."
+    "Its transactions will become uncategorized.": "Sus transacciones quedar\u00e1n sin categor\u00eda.",
+    "We could not create your rules. Try again in a moment.": "No hemos podido crear tus reglas. Vuelve a intentarlo en un momento."
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2224,5 +2224,6 @@
     "Billing management is not available on this shared account.": "La gestion de la facturation n'est pas disponible sur ce compte partagé.",
     "Link transactions": "Associer des transactions",
     "Tick the transactions that count toward this goal. Unticking one removes it from the goal.": "Cochez les transactions qui comptent pour cet objectif. Les décocher les retire de l’objectif.",
-    "Failed to load more transactions.": "Impossible de charger plus de transactions."
+    "Failed to load more transactions.": "Impossible de charger plus de transactions.",
+    "We could not create your rules. Try again in a moment.": "Nous n\u2019avons pas pu cr\u00e9er vos r\u00e8gles. R\u00e9essayez dans un instant."
 }

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -39,12 +39,14 @@ import {
     isSafariCashbackExtensionNoise,
     isUnattendedRequestNoise,
 } from './lib/sentry';
+import { installSessionExpiryRecovery } from './lib/session-expiry-recovery';
 import { trackUnattendedRequests } from './lib/unattended-requests';
 import type { ExpiredBankingConnectionNotification, SharedData } from './types';
 import { __, setTranslations } from './utils/i18n';
 
 installChunkLoadRecovery();
 installDeferredPropsRecovery();
+installSessionExpiryRecovery();
 trackUnattendedRequests();
 installFailedNavigationToast();
 

--- a/resources/js/components/onboarding/step-ai-suggestions-submit.test.tsx
+++ b/resources/js/components/onboarding/step-ai-suggestions-submit.test.tsx
@@ -1,0 +1,118 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { StepAiSuggestions } from './step-ai-suggestions';
+
+const { get, post, toastError, isRecovering } = vi.hoisted(() => ({
+    get: vi.fn(),
+    post: vi.fn(),
+    toastError: vi.fn(),
+    isRecovering: vi.fn(),
+}));
+
+vi.mock('axios', () => ({
+    default: { get, post, isAxiosError: () => false },
+}));
+
+vi.mock('@inertiajs/react', () => ({
+    router: { reload: vi.fn() },
+    usePage: () => ({ props: {} }),
+}));
+
+vi.mock('sonner', () => ({ toast: { error: toastError } }));
+
+vi.mock('@/lib/session-expiry-recovery', () => ({
+    isRecoveringFromExpiredSession: isRecovering,
+}));
+
+const readyState = {
+    available: true,
+    consented: true,
+    requires_upgrade: false,
+    eligible: true,
+    transaction_count: 4000,
+    min_transactions: 50,
+    auto_select_confidence: 0.8,
+    throttled: false,
+    throttled_until: null,
+    run: { id: 'run-1', status: 'completed', suggestions_count: 1 },
+    suggestions: [
+        {
+            id: 'suggestion-1',
+            confidence: 0.95,
+            match_count: 12,
+            summary: 'Mercadona',
+            proposed_category: { id: 'category-1', name: 'Groceries' },
+            new_category_name: null,
+            new_category_direction: null,
+            values: [
+                {
+                    id: 'value-1',
+                    match_field: 'description',
+                    match_operator: 'contains',
+                    match_token: 'MERCADONA',
+                },
+            ],
+        },
+    ],
+};
+
+async function renderReviewScreen() {
+    render(
+        <StepAiSuggestions
+            categories={[]}
+            hasConnectedAccount={false}
+            onComplete={vi.fn()}
+        />,
+    );
+
+    await act(async () => {
+        await Promise.resolve();
+    });
+
+    return screen.getByRole('button', { name: /Create 1 rules & apply/ });
+}
+
+describe('StepAiSuggestions submit failures', () => {
+    beforeEach(() => {
+        get.mockResolvedValue({ data: readyState });
+        isRecovering.mockReturnValue(false);
+    });
+
+    afterEach(() => {
+        get.mockReset();
+        post.mockReset();
+        toastError.mockReset();
+        isRecovering.mockReset();
+    });
+
+    // The reported bug: the catch was empty, so a failed POST left the button
+    // looking like it simply did nothing.
+    it('tells the user when the rules could not be created', async () => {
+        post.mockRejectedValue(new Error('Server Error'));
+        const button = await renderReviewScreen();
+
+        await act(async () => {
+            button.click();
+        });
+
+        expect(toastError).toHaveBeenCalledWith(
+            'We could not create your rules. Try again in a moment.',
+        );
+    });
+
+    // An expired session is already answered by a reload, and "try again in a
+    // moment" is the wrong thing to say on the way to the login screen.
+    it('stays quiet when the session expired and a reload is coming', async () => {
+        post.mockRejectedValue(
+            new Error('Request failed with status code 401'),
+        );
+        isRecovering.mockReturnValue(true);
+        const button = await renderReviewScreen();
+
+        await act(async () => {
+            button.click();
+        });
+
+        expect(toastError).not.toHaveBeenCalled();
+    });
+});

--- a/resources/js/components/onboarding/step-ai-suggestions.tsx
+++ b/resources/js/components/onboarding/step-ai-suggestions.tsx
@@ -19,6 +19,7 @@ import { router, usePage } from '@inertiajs/react';
 import axios from 'axios';
 import { Loader2, Sparkles } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
 
 // Client-side give-up: the backend marks the run failed on timeout/crash, but
 // this guarantees the spinner resolves even if the worker dies before it can.
@@ -259,6 +260,13 @@ export function StepAiSuggestions({
                 },
             });
         } catch {
+            // Silence here read as a dead button: the most common way this fails
+            // is an expired session, whose 419 the recovery reloads out from
+            // under us - but a 5xx or a lost connection leaves the user on this
+            // screen, and they need to know the rules were not created.
+            toast.error(
+                __('We could not create your rules. Try again in a moment.'),
+            );
             setSubmitting(false);
         }
     };

--- a/resources/js/components/onboarding/step-ai-suggestions.tsx
+++ b/resources/js/components/onboarding/step-ai-suggestions.tsx
@@ -8,6 +8,7 @@ import { StepList } from '@/components/onboarding/step-list';
 import { StepNote, StepScreen } from '@/components/onboarding/step-screen';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useCheapestMonthlyPrice } from '@/hooks/use-cheapest-monthly-price';
+import { isRecoveringFromExpiredSession } from '@/lib/session-expiry-recovery';
 import { store as storeConsent } from '@/routes/ai/consent';
 import { accept, generate, show } from '@/routes/ai/rule-suggestions';
 import { type SharedData } from '@/types';
@@ -260,13 +261,19 @@ export function StepAiSuggestions({
                 },
             });
         } catch {
-            // Silence here read as a dead button: the most common way this fails
-            // is an expired session, whose 419 the recovery reloads out from
-            // under us - but a 5xx or a lost connection leaves the user on this
-            // screen, and they need to know the rules were not created.
-            toast.error(
-                __('We could not create your rules. Try again in a moment.'),
-            );
+            // Silence here read as a dead button. An expired session is already
+            // being answered by a reload, and "try again in a moment" would be
+            // the wrong thing to say on the way to the login screen - but a 5xx
+            // or a lost connection leaves the user on this screen, and they need
+            // to know the rules were not created.
+            if (!isRecoveringFromExpiredSession()) {
+                toast.error(
+                    __(
+                        'We could not create your rules. Try again in a moment.',
+                    ),
+                );
+            }
+
             setSubmitting(false);
         }
     };

--- a/resources/js/lib/session-expiry-recovery.test.ts
+++ b/resources/js/lib/session-expiry-recovery.test.ts
@@ -1,0 +1,153 @@
+import { afterAll, describe, expect, it, vi } from 'vitest';
+
+const reload = vi.fn();
+const realFetch = window.fetch;
+
+type Listener = (event: unknown) => unknown;
+
+async function freshModules(networkFetch?: typeof window.fetch) {
+    vi.resetModules();
+    reload.mockClear();
+    window.fetch = networkFetch ?? realFetch;
+
+    const listeners: Record<string, Listener> = {};
+    const interceptors: ((error: unknown) => unknown)[] = [];
+
+    vi.doMock('@inertiajs/react', () => ({
+        router: {
+            on: (name: string, callback: Listener) => {
+                listeners[name] = callback;
+
+                return () => delete listeners[name];
+            },
+        },
+    }));
+    vi.doMock('axios', () => ({
+        default: {
+            interceptors: {
+                response: {
+                    use: (_ok: unknown, onError: (error: unknown) => unknown) =>
+                        interceptors.push(onError),
+                },
+            },
+            isAxiosError: (error: unknown) =>
+                Boolean((error as { isAxiosError?: boolean }).isAxiosError),
+        },
+    }));
+
+    const { installSessionExpiryRecovery } =
+        await import('./session-expiry-recovery');
+
+    installSessionExpiryRecovery({ reload });
+
+    return {
+        listeners,
+        rejectAxios: async (status: number | undefined) => {
+            const error = { isAxiosError: true, response: { status } };
+
+            await expect(interceptors[0](error)).rejects.toBe(error);
+        },
+    };
+}
+
+/** A `fetch` for {@link freshModules} to wrap, standing in for the network. */
+function answering(status: number, body: string | null = null) {
+    return (async () =>
+        new Response(body, { status })) as unknown as typeof window.fetch;
+}
+
+describe('installSessionExpiryRecovery', () => {
+    afterAll(() => {
+        window.fetch = realFetch;
+    });
+
+    it('reloads when an axios request comes back with a dead CSRF token', async () => {
+        const { rejectAxios } = await freshModules();
+
+        await rejectAxios(419);
+
+        expect(reload).toHaveBeenCalledOnce();
+    });
+
+    it('reloads when an axios request expecting JSON finds no session', async () => {
+        const { rejectAxios } = await freshModules();
+
+        await rejectAxios(401);
+
+        expect(reload).toHaveBeenCalledOnce();
+    });
+
+    it('leaves other failures alone', async () => {
+        const { rejectAxios } = await freshModules();
+
+        // A 403 is a permission the user does not have and a 422 is their input:
+        // both answered by a live session.
+        await rejectAxios(403);
+        await rejectAxios(422);
+        await rejectAxios(500);
+        await rejectAxios(undefined);
+
+        expect(reload).not.toHaveBeenCalled();
+    });
+
+    it('reloads only once when several requests expire together', async () => {
+        const { rejectAxios } = await freshModules();
+
+        await rejectAxios(419);
+        await rejectAxios(419);
+        await rejectAxios(401);
+
+        expect(reload).toHaveBeenCalledOnce();
+    });
+
+    // What the ~12 call sites building their own `X-XSRF-TOKEN` header go
+    // through, none of which was edited.
+    it('reloads on a same-origin fetch that lost its token', async () => {
+        await freshModules(answering(419));
+
+        const response = await window.fetch('/onboarding/rules');
+
+        expect(response.status).toBe(419);
+        expect(reload).toHaveBeenCalledOnce();
+    });
+
+    it('passes the response through untouched', async () => {
+        await freshModules(answering(200, '{"rules_created":5}'));
+
+        const response = await window.fetch('/onboarding/rules');
+
+        await expect(response.json()).resolves.toEqual({ rules_created: 5 });
+        expect(reload).not.toHaveBeenCalled();
+    });
+
+    it('ignores a cross-origin fetch answering 401 for its own reasons', async () => {
+        await freshModules(answering(401));
+
+        // What partials/header.tsx does: the GitHub API's auth is not ours.
+        await window.fetch('https://api.github.com/repos/whisper-money');
+
+        expect(reload).not.toHaveBeenCalled();
+    });
+
+    it('reloads instead of showing Inertia its error page', async () => {
+        const { listeners } = await freshModules();
+
+        expect(
+            listeners.httpException?.({
+                detail: { response: { status: 419 } },
+            }),
+        ).toBe(false);
+        expect(reload).toHaveBeenCalledOnce();
+    });
+
+    it('lets Inertia handle the exceptions that are not an expired session', async () => {
+        const { listeners } = await freshModules();
+
+        expect(
+            listeners.httpException?.({
+                detail: { response: { status: 500 } },
+            }),
+        ).toBeUndefined();
+        expect(reload).not.toHaveBeenCalled();
+    });
+});

--- a/resources/js/lib/session-expiry-recovery.test.ts
+++ b/resources/js/lib/session-expiry-recovery.test.ts
@@ -35,13 +35,14 @@ async function freshModules(networkFetch?: typeof window.fetch) {
         },
     }));
 
-    const { installSessionExpiryRecovery } =
+    const { installSessionExpiryRecovery, isRecoveringFromExpiredSession } =
         await import('./session-expiry-recovery');
 
     installSessionExpiryRecovery({ reload });
 
     return {
         listeners,
+        isRecoveringFromExpiredSession,
         rejectAxios: async (status: number | undefined) => {
             const error = { isAxiosError: true, response: { status } };
 
@@ -129,6 +130,28 @@ describe('installSessionExpiryRecovery', () => {
         expect(reload).not.toHaveBeenCalled();
     });
 
+    // Every `catch` in the app that has its own message to show asks this before
+    // showing it: "try again in a moment" is wrong on the way to a login screen.
+    it('tells the callers waiting on a reload that one is coming', async () => {
+        const { rejectAxios, isRecoveringFromExpiredSession } =
+            await freshModules();
+
+        expect(isRecoveringFromExpiredSession()).toBe(false);
+
+        await rejectAxios(419);
+
+        expect(isRecoveringFromExpiredSession()).toBe(true);
+    });
+
+    it('leaves the callers of an ordinary failure to speak for themselves', async () => {
+        const { rejectAxios, isRecoveringFromExpiredSession } =
+            await freshModules();
+
+        await rejectAxios(500);
+
+        expect(isRecoveringFromExpiredSession()).toBe(false);
+    });
+
     it('reloads instead of showing Inertia its error page', async () => {
         const { listeners } = await freshModules();
 
@@ -137,6 +160,17 @@ describe('installSessionExpiryRecovery', () => {
                 detail: { response: { status: 419 } },
             }),
         ).toBe(false);
+        expect(reload).toHaveBeenCalledOnce();
+    });
+
+    // The once-guard is on the reload, not on the answer: a second expired
+    // request must still be told to keep Inertia's error modal off the screen.
+    it('keeps Inertia quiet for every request that expired together', async () => {
+        const { listeners } = await freshModules();
+        const expired = { detail: { response: { status: 419 } } };
+
+        expect(listeners.httpException?.(expired)).toBe(false);
+        expect(listeners.httpException?.(expired)).toBe(false);
         expect(reload).toHaveBeenCalledOnce();
     });
 

--- a/resources/js/lib/session-expiry-recovery.ts
+++ b/resources/js/lib/session-expiry-recovery.ts
@@ -19,9 +19,19 @@ import { reloadPage } from './leave-page';
  * silence for a bug the user was staring at.
  *
  * Reloading is the whole fix: Laravel answers the fresh load by redirecting to
- * wherever {@link \App\Services\AuthEntryPointService} sends guests, so the user
- * logs back in and lands somewhere real instead of poking a dead screen. Hence
- * no hardcoded `/login` here — that would skip `guestRedirectRoute`.
+ * wherever it sends guests, so the user logs back in and lands somewhere real
+ * instead of poking a dead screen. Hence no hardcoded `/login` here — that would
+ * skip `AuthEntryPointService::guestRedirectRoute`, which is what decides where
+ * a given guest actually belongs.
+ *
+ * Which of the two statuses you actually get depends on the Laravel version, so
+ * both are handled. `PreventRequestForgery` (Laravel 13, replacing
+ * `ValidateCsrfToken`) accepts any request carrying `Sec-Fetch-Site:
+ * same-origin` without looking at the token at all — so a real browser tab now
+ * gets past CSRF with a dead token and is turned away one middleware later by
+ * `Authenticate`, as a `401` on anything asking for JSON. Verified in a browser
+ * against a session deleted underneath it: `401`, not `419`. The `419` is still
+ * what a request without that header gets, and what production reported.
  *
  * All three transports are covered, because all three break the same way and
  * none of them can tell the user why:
@@ -42,10 +52,12 @@ import { reloadPage } from './leave-page';
  * page Laravel then serves fires no authenticated request to expire.
  */
 const SESSION_EXPIRED_STATUSES = [
-    // The CSRF token died with the session. What a stale tab's writes get.
+    // The CSRF token died with the session, and the token is what was checked.
     419,
     // No session left, on a request that asked for JSON — Laravel cannot answer
-    // an XHR with a redirect, so it says so with a status instead.
+    // an XHR with a redirect, so it says so with a status instead. What a stale
+    // browser tab gets once the origin check has waved the missing token
+    // through.
     401,
 ];
 
@@ -56,23 +68,37 @@ interface SessionExpiryRecoveryOptions {
 }
 
 /**
- * Reloads if this status says the session is gone, and reports whether it did so
- * the caller can suppress whatever it would otherwise have shown.
+ * Whether a recovery reload is already on its way.
+ *
+ * For the `catch` blocks that have their own error message to show. An axios
+ * response interceptor runs before the promise reaches the caller, so this is
+ * already true by the time they ask - and "try again in a moment" is the wrong
+ * thing to tell someone whose page is being replaced by a login screen.
+ */
+export function isRecoveringFromExpiredSession(): boolean {
+    return recovering;
+}
+
+/**
+ * Reloads if this status says the session is gone.
+ *
+ * Reports whether the status *was* an expired session rather than whether it
+ * reloaded, so a caller can suppress what it would otherwise have shown even
+ * when it is the second of several requests to expire at once. Only the reload
+ * itself is once-per-page.
  */
 function recoverFromExpiredSession(
     status: number | undefined,
     options: SessionExpiryRecoveryOptions,
 ): boolean {
-    if (status === undefined || recovering) {
+    if (status === undefined || !SESSION_EXPIRED_STATUSES.includes(status)) {
         return false;
     }
 
-    if (!SESSION_EXPIRED_STATUSES.includes(status)) {
-        return false;
+    if (!recovering) {
+        recovering = true;
+        (options.reload ?? reloadPage)();
     }
-
-    recovering = true;
-    (options.reload ?? reloadPage)();
 
     return true;
 }

--- a/resources/js/lib/session-expiry-recovery.ts
+++ b/resources/js/lib/session-expiry-recovery.ts
@@ -1,0 +1,127 @@
+import { router } from '@inertiajs/react';
+import axios from 'axios';
+import { reloadPage } from './leave-page';
+
+/**
+ * Reloads the page when the session behind it has already died.
+ *
+ * `SESSION_LIFETIME` is two hours, and nothing in the app notices when it
+ * passes. A tab left open longer than that keeps rendering whatever the last
+ * successful `GET` put into React state, so the screen stays perfectly intact
+ * while every write from it comes back `419 CSRF token mismatch` — the
+ * `XSRF-TOKEN` cookie expires with the session, so the token the request sends
+ * is one the server no longer knows.
+ *
+ * That is what the onboarding AI-suggestions report turned out to be: a run that
+ * completed fine, a review screen that looked fine 3.5 hours later, and a
+ * "create the rules" button whose `POST` never got past the CSRF check. Laravel
+ * does not report `HttpException`, so Sentry had nothing either — thirty days of
+ * silence for a bug the user was staring at.
+ *
+ * Reloading is the whole fix: Laravel answers the fresh load by redirecting to
+ * wherever {@link \App\Services\AuthEntryPointService} sends guests, so the user
+ * logs back in and lands somewhere real instead of poking a dead screen. Hence
+ * no hardcoded `/login` here — that would skip `guestRedirectRoute`.
+ *
+ * All three transports are covered, because all three break the same way and
+ * none of them can tell the user why:
+ *
+ * - **axios**, which had no interceptor at all, so every `catch` in the app saw
+ *   a 419 as an anonymous failure.
+ * - **`fetch`**, wrapped once here rather than at each of the dozen call sites
+ *   that build their own `X-XSRF-TOKEN` header. Only same-origin responses are
+ *   looked at: `partials/header.tsx` calls the GitHub API, which answers 401 for
+ *   its own reasons, and a bank's authorization endpoints are not ours to judge.
+ *   The response is passed through untouched — this only reads `status`.
+ * - **Inertia**, whose `httpException` event (v2's `invalid`) would otherwise pop
+ *   the raw error-page modal over the app.
+ *
+ * The once-guard matters because a page usually has several requests in flight,
+ * and five expiring together must not mean five reloads. It lives in memory, so
+ * it resets on the reload it caused — which is fine, and cannot loop: the login
+ * page Laravel then serves fires no authenticated request to expire.
+ */
+const SESSION_EXPIRED_STATUSES = [
+    // The CSRF token died with the session. What a stale tab's writes get.
+    419,
+    // No session left, on a request that asked for JSON — Laravel cannot answer
+    // an XHR with a redirect, so it says so with a status instead.
+    401,
+];
+
+let recovering = false;
+
+interface SessionExpiryRecoveryOptions {
+    reload?: () => void;
+}
+
+/**
+ * Reloads if this status says the session is gone, and reports whether it did so
+ * the caller can suppress whatever it would otherwise have shown.
+ */
+function recoverFromExpiredSession(
+    status: number | undefined,
+    options: SessionExpiryRecoveryOptions,
+): boolean {
+    if (status === undefined || recovering) {
+        return false;
+    }
+
+    if (!SESSION_EXPIRED_STATUSES.includes(status)) {
+        return false;
+    }
+
+    recovering = true;
+    (options.reload ?? reloadPage)();
+
+    return true;
+}
+
+export function installSessionExpiryRecovery(
+    options: SessionExpiryRecoveryOptions = {},
+): void {
+    // Rejecting anyway: the caller's `catch` still runs its cleanup while the
+    // reload is getting under way.
+    axios.interceptors.response.use(undefined, (error: unknown) => {
+        if (axios.isAxiosError(error)) {
+            recoverFromExpiredSession(error.response?.status, options);
+        }
+
+        return Promise.reject(error);
+    });
+
+    const originalFetch = window.fetch;
+
+    window.fetch = async (...args) => {
+        const response = await originalFetch(...args);
+
+        if (isSameOrigin(args[0])) {
+            recoverFromExpiredSession(response.status, options);
+        }
+
+        return response;
+    };
+
+    router.on('httpException', (event) => {
+        if (recoverFromExpiredSession(event.detail.response.status, options)) {
+            // Cancels Inertia's error modal. The page is on its way out.
+            return false;
+        }
+    });
+}
+
+function isSameOrigin(input: RequestInfo | URL): boolean {
+    try {
+        const url =
+            typeof input === 'string' || input instanceof URL
+                ? input
+                : input.url;
+
+        return (
+            new URL(url, window.location.href).origin === window.location.origin
+        );
+    } catch {
+        // An input we cannot resolve is not one we are willing to act on.
+        return false;
+    }
+}


### PR DESCRIPTION
## The finding

A user reported that on the onboarding "Review your suggested rules" screen, "View N matching transactions" answered "We couldn't check which transactions match" and "Create 5 rules & apply" did nothing. The suggestions feature was innocent:

- The run completed fine (9 suggestions, counters matching the user's screenshot), the 9 suggestions are still `pending`, and the user has 0 `automation_rules` — the accept `POST` never landed.
- Sentry has **zero** errors from these endpoints in 30 days, while it does capture other production errors.
- The timeline in `users` tells the real story: verified 12:28, run 12:33, `last_logged_in_at` 16:02, `onboarded_at` 16:03. The tab sat open ~3.5 h and the user had to log back in.

`SESSION_LIFETIME=120`: the session and the `XSRF-TOKEN` cookie died around 14:35. Every `POST` from that stale tab came back **419 CSRF token mismatch**, which Laravel doesn't report (it's an `HttpException`) — hence the total silence. The screen kept looking perfect because the initial `GET` was already in React state.

## Why the fix is global, not screen-local

Any tab outliving the session breaks exactly the same way on every screen: axios calls, the ~12 `fetch` call sites that build their own `X-XSRF-TOKEN` header, and Inertia visits (which would pop the raw error-page modal). Patching the suggestions screen would fix one symptom of a whole-app failure mode.

`installSessionExpiryRecovery()` (new `lib/session-expiry-recovery.ts`, installed in `app.tsx` next to its sibling `install*()` recoveries) watches all three transports:

- an **axios** response interceptor (the app had none);
- a **`window.fetch` wrapper** — one wrapper instead of editing the ~12 manual call sites; it only inspects the status of **same-origin** responses (the GitHub API and bank endpoints answer 401 for their own reasons) and passes the response through untouched;
- **Inertia's `httpException`** event (v3's rename of `invalid`), returning `false` to keep the error modal off the screen.

On a same-origin **419 or 401** it reloads once per page — via `reloadPage()` from `lib/leave-page.ts`, so the page-leave bookkeeping (Sentry noise filters, failed-navigation toast) stays correct — and Laravel redirects the fresh load through `AuthEntryPointService::guestRedirectRoute`, so no hardcoded `/login`. The original promise still rejects, so callers run their cleanup; `isRecoveringFromExpiredSession()` lets a caller with its own error message stay quiet while the reload is on its way.

One thing QA against a real dead session surfaced: Laravel 13's `PreventRequestForgery` accepts `Sec-Fetch-Site: same-origin` requests without checking the token, so a real browser tab now gets a **401** from `Authenticate` rather than the 419 production reported. Both are handled; the module comment documents why.

## The silent CTA

`submit()` in `step-ai-suggestions.tsx` had an empty `catch {}` — the reported "button does nothing". It now shows a toast for real failures (5xx, lost connection) and stays quiet when the failure is the expired session itself, since "try again in a moment" is the wrong thing to say on the way to the login screen.

## Out of scope

- Backend: `RuleSuggestionController` / `UncategorizedTransactionMatcher` work correctly (they produced the exact counters in the user's screenshot).
- `SESSION_LIFETIME` / session config — separate decision.
- The suggestions screen copy/design: with 419s handled, its error dialog only shows on genuine failures.

## Tests

- `lib/session-expiry-recovery.test.ts`: 12 cases — statuses, once-guard, concurrent expiry, same-/cross-origin fetch, response pass-through, Inertia modal suppression, the `isRecoveringFromExpiredSession` predicate.
- `step-ai-suggestions-submit.test.tsx`: the toast on failure, and its silence during session recovery (both mutation-tested).
- Full local CI green: `bun run build`, Pest (2 709 passed), `pint --test`, `bun run format`, `bun run lint`, `bun run dry`, `bun run test` (493 passed).

## Demo

<!-- PLACEHOLDER: drag session-expiry-recovery-qa.mp4 here -->

*(QA video: logged in as the demo user, session deleted server-side, next interaction from the stale tab lands on the login page automatically; 404s and cross-origin 401s don't trigger it.)*

https://github.com/user-attachments/assets/9822e8cf-4202-4ac5-af19-23ab25810cff


