### PR TITLE
feat(budgets): rename nav to Planning and add a type filter

### DIFF
--- a/lang/es.json
+++ b/lang/es.json
@@ -1309,6 +1309,8 @@
     "Peruvian Sol": "Sol peruano",
     "Pick whichever plan fits you, paste the matching code at checkout, and you are set.": "Elige el plan que prefieras, pega el código correspondiente al pagar y listo.",
     "Pink": "Rosa",
+    "Filter by type": "Filtrar por tipo",
+    "Planning": "Planificación",
     "Platform": "Plataforma",
     "Please describe the problem and what you were doing when it happened. Keep the details below — they help us debug.": "Describe el problema y qué estabas haciendo cuando ocurrió. Conserva los detalles de abajo: nos ayudan a depurar.",
     "Please enter a bank name.": "Por favor, ingresa un nombre de banco.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1222,6 +1222,8 @@
     "Peruvian Sol": "Soleil péruvien",
     "Pick whichever plan fits you, paste the matching code at checkout, and you are set.": "Choisissez le forfait que vous préférez, collez le code correspondant lors du paiement et le tour est joué.",
     "Pink": "Rose",
+    "Filter by type": "Filtrer par type",
+    "Planning": "Planification",
     "Platform": "Plate-forme",
     "Please describe the problem and what you were doing when it happened. Keep the details below — they help us debug.": "Décrivez le problème et ce que vous faisiez lorsqu'il s'est produit. Conservez les détails ci-dessous : ils nous aident à déboguer.",
     "Please enter a bank name.": "Veuillez saisir un nom de banque.",

--- a/resources/js/pages/budgets/index.test.tsx
+++ b/resources/js/pages/budgets/index.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import BudgetsIndex, { budgetTypeFilterFromUrl } from './index';
+
+const replace = vi.fn();
+let pageUrl = '/budgets';
+
+vi.mock('@inertiajs/react', () => ({
+    Head: () => null,
+    router: {
+        replace: (...args: unknown[]) => replace(...args),
+    },
+    usePage: () => ({ url: pageUrl, props: {} }),
+}));
+
+vi.mock('@/actions/App/Http/Controllers/BudgetController', () => ({
+    index: () => ({ url: '/budgets' }),
+}));
+
+vi.mock('@/layouts/app/app-sidebar-layout', () => ({
+    default: ({ children }: { children: React.ReactNode }) => (
+        <div>{children}</div>
+    ),
+}));
+
+vi.mock('@/components/budgets/budget-list-card', () => ({
+    BudgetListCard: () => <div>budget-card</div>,
+}));
+
+vi.mock('@/components/savings-goals/savings-goal-list-card', () => ({
+    SavingsGoalListCard: () => <div>goal-card</div>,
+}));
+
+vi.mock('@/components/budgets/create-budget-dialog', () => ({
+    CreateBudgetDialog: () => <div>create-budget</div>,
+}));
+
+vi.mock('@/components/savings-goals/create-savings-goal-dialog', () => ({
+    CreateSavingsGoalDialog: () => <div>create-goal</div>,
+}));
+
+const budget = { id: '1' } as never;
+const goal = { id: '2' } as never;
+
+function renderPage() {
+    return render(
+        <BudgetsIndex
+            budgets={[budget]}
+            savingsGoals={[goal]}
+            savingsGoalsEnabled
+            currencyCode="EUR"
+        />,
+    );
+}
+
+beforeEach(() => {
+    replace.mockClear();
+    pageUrl = '/budgets';
+});
+
+describe('budgetTypeFilterFromUrl', () => {
+    it('parses the show query param', () => {
+        expect(budgetTypeFilterFromUrl('/budgets')).toBe('all');
+        expect(budgetTypeFilterFromUrl('/budgets?show=budgets')).toBe(
+            'budgets',
+        );
+        expect(budgetTypeFilterFromUrl('/budgets?show=goals')).toBe('goals');
+        expect(budgetTypeFilterFromUrl('/budgets?show=nonsense')).toBe('all');
+    });
+});
+
+describe('BudgetsIndex filter', () => {
+    it('shows both sections by default', () => {
+        renderPage();
+
+        expect(screen.getByText('budget-card')).toBeInTheDocument();
+        expect(screen.getByText('goal-card')).toBeInTheDocument();
+    });
+
+    it('shows only savings goals and updates the URL when filtering', () => {
+        renderPage();
+
+        fireEvent.click(screen.getByRole('radio', { name: 'Savings Goals' }));
+
+        expect(screen.queryByText('budget-card')).not.toBeInTheDocument();
+        expect(screen.getByText('goal-card')).toBeInTheDocument();
+        expect(replace).toHaveBeenCalledWith({
+            url: '/budgets?show=goals',
+            preserveScroll: true,
+            preserveState: true,
+        });
+    });
+
+    it('restores the filter from the URL on load', () => {
+        pageUrl = '/budgets?show=budgets';
+        renderPage();
+
+        expect(screen.getByText('budget-card')).toBeInTheDocument();
+        expect(screen.queryByText('goal-card')).not.toBeInTheDocument();
+    });
+
+    it('ignores the show param when savings goals are disabled', () => {
+        pageUrl = '/budgets?show=goals';
+        render(
+            <BudgetsIndex
+                budgets={[budget]}
+                savingsGoalsEnabled={false}
+                currencyCode="EUR"
+            />,
+        );
+
+        expect(screen.getByText('budget-card')).toBeInTheDocument();
+    });
+
+    it('falls back to all when the active filter is deselected', () => {
+        renderPage();
+
+        const budgetsItem = screen.getByRole('radio', { name: 'Budgets' });
+        fireEvent.click(budgetsItem);
+        fireEvent.click(budgetsItem);
+
+        expect(screen.getByText('budget-card')).toBeInTheDocument();
+        expect(screen.getByText('goal-card')).toBeInTheDocument();
+        expect(replace).toHaveBeenLastCalledWith({
+            url: '/budgets',
+            preserveScroll: true,
+            preserveState: true,
+        });
+    });
+});

--- a/resources/js/pages/budgets/index.tsx
+++ b/resources/js/pages/budgets/index.tsx
@@ -12,21 +12,30 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import AppSidebarLayout from '@/layouts/app/app-sidebar-layout';
 import { BreadcrumbItem } from '@/types';
 import { Budget } from '@/types/budget';
 import { SavingsGoal } from '@/types/savings-goal';
 import { __ } from '@/utils/i18n';
-import { Head } from '@inertiajs/react';
+import { Head, router, usePage } from '@inertiajs/react';
 import { ChevronDown, Plus } from 'lucide-react';
 import { useState } from 'react';
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
-        title: 'Budgets',
+        title: 'Planning',
         href: index().url,
     },
 ];
+
+export type BudgetTypeFilter = 'all' | 'budgets' | 'goals';
+
+export function budgetTypeFilterFromUrl(url: string): BudgetTypeFilter {
+    const show = new URL(url, 'https://localhost').searchParams.get('show');
+
+    return show === 'budgets' || show === 'goals' ? show : 'all';
+}
 
 interface Props {
     budgets: Budget[];
@@ -44,15 +53,33 @@ export default function BudgetsIndex({
     const [createType, setCreateType] = useState<'budget' | 'goal' | null>(
         null,
     );
+    const { url } = usePage();
+    // Without savings goals there is no toggle to undo a ?show= filter coming
+    // from a stale bookmark, so clamp it to 'all' instead of hiding sections.
+    const [filter, setFilter] = useState<BudgetTypeFilter>(() =>
+        savingsGoalsEnabled ? budgetTypeFilterFromUrl(url) : 'all',
+    );
+
+    const changeFilter = (value: string) => {
+        const next = (value || 'all') as BudgetTypeFilter;
+        setFilter(next);
+        // preserveState defaults to false on client-side visits, which would
+        // remount the page and reset local state (see use-period-url-sync.ts).
+        router.replace({
+            url: next === 'all' ? index().url : `${index().url}?show=${next}`,
+            preserveScroll: true,
+            preserveState: true,
+        });
+    };
 
     return (
         <AppSidebarLayout breadcrumbs={breadcrumbs}>
-            <Head title={__('Budgets')} />
+            <Head title={__('Planning')} />
 
             <div className="space-y-8 p-6">
                 <div className="flex items-center justify-between gap-2">
                     <HeadingSmall
-                        title={__('Budgets')}
+                        title={__('Planning')}
                         description={__(
                             'Track your spending and save toward your goals',
                         )}
@@ -103,30 +130,68 @@ export default function BudgetsIndex({
                     )}
                 </div>
 
-                <section className="space-y-4">
-                    {savingsGoalsEnabled && (
-                        <h2 className="text-lg font-medium">{__('Budgets')}</h2>
-                    )}
-                    <div className="grid gap-4 lg:grid-cols-2">
-                        {budgets.map((budget) => (
-                            <BudgetListCard
-                                key={budget.id}
-                                budget={budget}
-                                currencyCode={currencyCode}
-                            />
-                        ))}
-                        <CreateBudgetDialog
-                            currencyCode={currencyCode}
-                            className={budgets.length ? '' : 'min-h-[260px]'}
-                        />
-                    </div>
-                </section>
-
                 {savingsGoalsEnabled && (
-                    <section className="space-y-4">
-                        <h2 className="text-lg font-medium">
+                    <ToggleGroup
+                        type="single"
+                        variant="outline"
+                        size="sm"
+                        value={filter}
+                        onValueChange={changeFilter}
+                        aria-label={__('Filter by type')}
+                    >
+                        <ToggleGroupItem
+                            value="all"
+                            className="cursor-pointer px-3 aria-checked:bg-primary/10"
+                        >
+                            {__('All')}
+                        </ToggleGroupItem>
+                        <ToggleGroupItem
+                            value="budgets"
+                            className="cursor-pointer px-3 aria-checked:bg-primary/10"
+                        >
+                            {__('Budgets')}
+                        </ToggleGroupItem>
+                        <ToggleGroupItem
+                            value="goals"
+                            className="cursor-pointer px-3 aria-checked:bg-primary/10"
+                        >
                             {__('Savings Goals')}
-                        </h2>
+                        </ToggleGroupItem>
+                    </ToggleGroup>
+                )}
+
+                {filter !== 'goals' && (
+                    <section className="space-y-4">
+                        {savingsGoalsEnabled && filter === 'all' && (
+                            <h2 className="text-lg font-medium">
+                                {__('Budgets')}
+                            </h2>
+                        )}
+                        <div className="grid gap-4 lg:grid-cols-2">
+                            {budgets.map((budget) => (
+                                <BudgetListCard
+                                    key={budget.id}
+                                    budget={budget}
+                                    currencyCode={currencyCode}
+                                />
+                            ))}
+                            <CreateBudgetDialog
+                                currencyCode={currencyCode}
+                                className={
+                                    budgets.length ? '' : 'min-h-[260px]'
+                                }
+                            />
+                        </div>
+                    </section>
+                )}
+
+                {savingsGoalsEnabled && filter !== 'budgets' && (
+                    <section className="space-y-4">
+                        {filter === 'all' && (
+                            <h2 className="text-lg font-medium">
+                                {__('Savings Goals')}
+                            </h2>
+                        )}
                         <div className="grid gap-4 lg:grid-cols-2">
                             {savingsGoals.map((goal) => (
                                 <SavingsGoalListCard

--- a/resources/js/pages/budgets/show.tsx
+++ b/resources/js/pages/budgets/show.tsx
@@ -71,7 +71,7 @@ export default function BudgetShow({
 
     const breadcrumbs: BreadcrumbItem[] = [
         {
-            title: 'Budgets',
+            title: 'Planning',
             href: index().url,
         },
         {

--- a/resources/js/pages/savings-goals/show.tsx
+++ b/resources/js/pages/savings-goals/show.tsx
@@ -74,7 +74,7 @@ export default function SavingsGoalShow({
 
     const breadcrumbs: BreadcrumbItem[] = [
         {
-            title: 'Budgets',
+            title: 'Planning',
             href: index().url,
         },
         {

--- a/resources/js/providers/menu-item-provider.tsx
+++ b/resources/js/providers/menu-item-provider.tsx
@@ -17,14 +17,14 @@ const mobileLabels: Record<string, Record<string, string>> = {
         cashflow: 'Cashflow',
         accounts: 'Accounts',
         transactions: 'Movements',
-        budgets: 'Budget',
+        budgets: 'Plan',
     },
     es: {
         dashboard: 'Inicio',
         cashflow: 'Cashflow',
         accounts: 'Cuentas',
         transactions: 'Movim.',
-        budgets: 'Presup.',
+        budgets: 'Plan',
     },
 };
 
@@ -70,7 +70,7 @@ export function getMainNavItems(features: Features, locale: string): NavItem[] {
         },
         {
             type: 'nav-item',
-            title: 'Budgets',
+            title: 'Planning',
             mobileTitle: getMobileLabel('budgets', locale),
             href: budgetsIndex(),
             icon: PiggyBank,

--- a/tests/Browser/BudgetCrudTest.php
+++ b/tests/Browser/BudgetCrudTest.php
@@ -15,7 +15,7 @@ test('user can create a budget with category', function () {
     $page = $this->actingAs($user)->visit('/budgets');
     $page->wait(2); // Wait for page to fully load
 
-    $page->assertSee('Budgets')
+    $page->assertSee('Planning')
         ->waitForText('Create Budget', 10)
         ->wait(1) // Extra wait before clicking
         ->click('Create Budget')
@@ -133,7 +133,7 @@ test('budget creation validates required fields', function () {
     $page = $this->actingAs($user)->visit('/budgets');
     $page->wait(2); // Wait for page to fully load
 
-    $page->assertSee('Budgets')
+    $page->assertSee('Planning')
         ->waitForText('Create Budget', 10)
         ->wait(1) // Extra wait before clicking
         ->click('Create Budget')
@@ -172,9 +172,9 @@ test('user can navigate back to budgets list from budget detail', function () {
 
     $page->assertSee($budget->name)
         ->wait(2)
-        ->waitForText('Budgets', 10)
+        ->waitForText('Planning', 10)
         ->wait(1) // Extra wait before clicking
-        ->click('nav[aria-label="breadcrumb"] a:has-text("Budgets")')
+        ->click('nav[aria-label="breadcrumb"] a:has-text("Planning")')
         ->wait(4) // Wait for navigation
         ->assertPathIs('/budgets')
         ->assertNoJavascriptErrors();

--- a/tests/Browser/BudgetsFeatureNavigationTest.php
+++ b/tests/Browser/BudgetsFeatureNavigationTest.php
@@ -9,7 +9,7 @@ test('budgets menu item visible when feature enabled', function () {
 
     $page = $this->actingAs($user)->visit('/dashboard');
 
-    $page->assertSee('Budgets')
+    $page->assertSee('Planning')
         ->assertNoJavascriptErrors();
 });
 
@@ -19,7 +19,7 @@ test('user can navigate to budgets index page', function () {
     $page = $this->actingAs($user)->visit('/budgets');
 
     $page->assertPathIs('/budgets')
-        ->assertSee('Budgets')
+        ->assertSee('Planning')
         ->assertNoJavascriptErrors();
 });
 
@@ -28,7 +28,7 @@ test('user can view empty budgets list', function () {
 
     $page = $this->actingAs($user)->visit('/budgets');
 
-    $page->assertSee('Budgets')
+    $page->assertSee('Planning')
         ->assertNoJavascriptErrors();
 });
 
@@ -43,7 +43,7 @@ test('user can view budgets list with existing budgets', function () {
 
     $page = $this->actingAs($user)->visit('/budgets');
 
-    $page->waitForText('Budgets', 10)
+    $page->waitForText('Planning', 10)
         ->assertSee('Test Budget')
         ->assertNoJavascriptErrors();
 });
@@ -55,7 +55,7 @@ test('user can open create budget dialog', function () {
 
     $page = $this->actingAs($user)->visit('/budgets');
 
-    $page->waitForText('Budgets', 10)
+    $page->waitForText('Planning', 10)
         ->click('Create Budget')
         ->wait(1)
         ->assertSee('Create Budget')
@@ -139,7 +139,7 @@ test('budgets navigation works from sidebar', function () {
 
     $page = $this->actingAs($user)->visit('/dashboard');
 
-    $page->assertSee('Budgets')
+    $page->assertSee('Planning')
         ->assertNoJavascriptErrors();
 });
 
@@ -148,7 +148,7 @@ test('budgets page shows correct feature flag state', function () {
 
     $page = $this->actingAs($user)->visit('/budgets');
 
-    $page->assertSee('Budgets')
+    $page->assertSee('Planning')
         ->assertNoJavascriptErrors()
         ->assertNoConsoleLogs();
 });

--- a/tests/Browser/CatchAllBudgetCrudTest.php
+++ b/tests/Browser/CatchAllBudgetCrudTest.php
@@ -16,7 +16,7 @@ test('catch-all toggle hides category and label selection', function () {
     $page = $this->actingAs($user)->visit('/budgets');
     $page->wait(2);
 
-    $page->assertSee('Budgets')
+    $page->assertSee('Planning')
         ->waitForText('Create Budget', 10)
         ->wait(1)
         ->click('Create Budget')


### PR DESCRIPTION
## What

The budgets screen now hosts both budgets and savings goals, so the old "Budgets" naming no longer fit.

- **Rename**: the sidebar nav item, page heading, `<Head>` title and breadcrumbs (including the budget/savings-goal detail pages) go from **Budgets** to **Planning** (new i18n key — es: *Planificación*, fr: *Planification*). The mobile footer label goes from *Presup./Budget* to **Plan**.
- **Type filter**: a `ToggleGroup` (same outline style as the chart toggles) below the heading with **All / Budgets / Savings Goals**, rendered only when savings goals are enabled. Filtering to a single type hides the now-redundant section headings.
- **URL persistence**: the selection is stored as `?show=budgets|goals` via Inertia's client-side `router.replace` (no server round-trip — the data is already in props) with `preserveState`/`preserveScroll` so the page doesn't remount or jump. The filter is restored from the URL on load, invalid values fall back to *All*, and the param is clamped to *All* when savings goals are disabled so a stale bookmark can't render a blank page.

## Tests

- New `resources/js/pages/budgets/index.test.tsx` (6 vitest cases): query-param parsing incl. invalid fallback, default rendering, filtering + `router.replace` payload, restore-from-URL, deselect-to-All, and the disabled-feature clamp.
- Browser tests asserting the old "Budgets" nav/breadcrumb label updated to "Planning".

## Demo

<!-- PLACEHOLDER: drag & drop the QA video here (local path: ~/Downloads/budgets-planning-filter-qa.mp4) -->

https://github.com/user-attachments/assets/3224ad7f-50cd-4cf2-b2d7-dc2afbb3eb0c


## QA

Browser QA against the dev server (desktop + 390px mobile viewport): rename verified in sidebar/heading/breadcrumb and mobile tab bar, all filter behaviors and URL persistence verified (including refresh, deselect and `?show=nonsense`), no horizontal overflow on mobile, zero console errors.