### PR TITLE
feat(planning): merge budgets and savings goals into one list

### DIFF
--- a/lang/es.json
+++ b/lang/es.json
@@ -1713,6 +1713,7 @@
     "To comply with legal obligations and enforce our terms": "Para cumplir con obligaciones legales y hacer cumplir nuestros términos",
     "To comply with legal obligations and enforce\\n                                    our terms": "Para cumplir con las obligaciones legales y hacer cumplir nuestros términos",
     "To continue, you need to categorize at least :count transactions.": "Para continuar, debes categorizar al menos :count transacciones.",
+    "To go": "Por ahorrar",
     "To enable cloud synchronization of your encrypted financial data across devices": "Para habilitar la sincronización en la nube de tus datos financieros encriptados entre dispositivos",
     "To enable cloud synchronization of your\\n                                    encrypted financial data across devices": "Para habilitar la sincronización en la nube de tus datos financieros cifrados entre dispositivos",
     "To exercise any of these rights, please contact us at victor@whisper.money. We will respond to your request within 30 days.": "Para ejercer cualquiera de estos derechos, por favor contáctanos en victor@whisper.money. Responderemos a tu solicitud dentro de 30 días.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1621,6 +1621,7 @@
     "To comply with legal obligations and enforce our terms": "Pour respecter les obligations légales et faire respecter nos conditions",
     "To comply with legal obligations and enforce\\n                                    our terms": "Pour respecter les obligations légales et faire respecter nos conditions",
     "To continue, you need to categorize at least :count transactions.": "Pour continuer, vous devez catégoriser au moins :count transactions.",
+    "To go": "À épargner",
     "To enable cloud synchronization of your encrypted financial data across devices": "Pour activer la synchronisation cloud de vos données financières cryptées entre appareils",
     "To enable cloud synchronization of your\\n                                    encrypted financial data across devices": "Pour activer la synchronisation cloud de vos données financières cryptées entre appareils",
     "To exercise any of these rights, please contact us at victor@whisper.money. We will respond to your request within 30 days.": "Pour exercer l'un de ces droits, veuillez nous contacter à victor@whisper.money. Nous répondrons à votre demande dans un délai de 30 jours.",

--- a/resources/js/components/budgets/budget-list-card.tsx
+++ b/resources/js/components/budgets/budget-list-card.tsx
@@ -1,21 +1,19 @@
 import { show } from '@/actions/App/Http/Controllers/BudgetController';
+import { PlanningCard } from '@/components/shared/planning-card';
 import { AmountDisplay } from '@/components/ui/amount-display';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import {
-    Card,
-    CardContent,
-    CardDescription,
-    CardHeader,
-    CardTitle,
-} from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
 import { useLocale } from '@/hooks/use-locale';
-import { Budget, getBudgetPeriodTypeLabel } from '@/types/budget';
+import {
+    Budget,
+    budgetPercentageUsed,
+    budgetSeverity,
+    getBudgetPeriodTypeLabel,
+    getBudgetSeverityColor,
+} from '@/types/budget';
 import { formatDate } from '@/utils/date';
 import { __ } from '@/utils/i18n';
-import { Link } from '@inertiajs/react';
-import { ArrowRight, Calendar } from 'lucide-react';
+import { Calendar } from 'lucide-react';
 import { useMemo } from 'react';
 
 interface Props {
@@ -45,16 +43,14 @@ export function BudgetListCard({ budget, currencyCode }: Props) {
             ) ?? 0;
 
         const remaining = totalAllocated - totalSpent;
-        const percentageUsed =
-            totalAllocated > 0 ? (totalSpent / totalAllocated) * 100 : 0;
 
         return {
             totalAllocated,
             totalSpent,
             remaining,
-            percentageUsed,
+            percentageUsed: budgetPercentageUsed(budget),
         };
-    }, [currentPeriod]);
+    }, [budget, currentPeriod]);
 
     const periodLabel = useMemo(() => {
         if (!currentPeriod) return __('No active period');
@@ -65,13 +61,10 @@ export function BudgetListCard({ budget, currencyCode }: Props) {
         return `${start} - ${end}`;
     }, [currentPeriod, locale]);
 
-    const statusColor = useMemo(() => {
-        if (stats.percentageUsed >= 100)
-            return 'text-red-600 dark:text-red-400';
-        if (stats.percentageUsed >= 80)
-            return 'text-yellow-600 dark:text-yellow-400';
-        return 'text-green-600 dark:text-green-400';
-    }, [stats.percentageUsed]);
+    const statusColor = useMemo(
+        () => getBudgetSeverityColor(budgetSeverity(budget)),
+        [budget],
+    );
 
     const trackingNames = useMemo(() => {
         return [
@@ -81,107 +74,86 @@ export function BudgetListCard({ budget, currencyCode }: Props) {
     }, [budget]);
 
     return (
-        <Card>
-            <CardHeader>
-                <div className="flex items-start justify-between">
-                    <div className="space-y-1">
-                        <CardTitle className="text-xl">
-                            <Link
-                                href={show({ budget: budget.id }).url}
-                                className="-my-1 -ml-1.5 inline-flex items-center rounded-md px-1.5 py-1 transition-colors hover:bg-muted"
-                            >
-                                {budget.name}
-                            </Link>
-                        </CardTitle>
-                        <CardDescription className="flex items-center gap-2">
-                            <Calendar className="h-3 w-3" />
-                            {periodLabel}
-                        </CardDescription>
-                    </div>
-                    <Badge variant="outline">
-                        {__(getBudgetPeriodTypeLabel(budget.period_type))}
-                    </Badge>
-                </div>
-            </CardHeader>
-            <CardContent className="space-y-4">
-                <div className="space-y-2">
-                    <div className="flex items-center justify-between text-sm">
-                        <span className="text-muted-foreground">
-                            {__('Spent')}
-                        </span>
-                        <span className={statusColor}>
-                            <AmountDisplay
-                                amountInCents={stats.totalSpent}
-                                currencyCode={currencyCode}
-                            />{' '}
-                            {__('of')}{' '}
-                            <AmountDisplay
-                                amountInCents={stats.totalAllocated}
-                                currencyCode={currencyCode}
-                            />
-                        </span>
-                    </div>
-                    <Progress
-                        value={Math.min(stats.percentageUsed, 100)}
-                        className="h-2"
-                    />
-
-                    <div className="flex items-center justify-between text-sm">
-                        <span className="text-muted-foreground">
-                            {__('Remaining')}
-                        </span>
-                        <span className={statusColor}>
-                            <AmountDisplay
-                                amountInCents={stats.remaining}
-                                currencyCode={currencyCode}
-                            />
-                        </span>
-                    </div>
-                </div>
-
-                <div className="flex items-center justify-between gap-2 border-t pt-4">
-                    <div className="flex flex-wrap items-center gap-1">
+        <PlanningCard
+            href={show({ budget: budget.id }).url}
+            title={budget.name}
+            badge={
+                <Badge variant="outline">
+                    {__(getBudgetPeriodTypeLabel(budget.period_type))}
+                </Badge>
+            }
+            description={
+                <>
+                    <Calendar className="h-3 w-3" />
+                    {periodLabel}
+                </>
+            }
+            footerStart={
+                <div className="flex flex-wrap items-center gap-1">
+                    <span className="text-sm text-muted-foreground">
+                        {__('Tracking:')}
+                    </span>
+                    {budget.is_catch_all ? (
+                        <Badge variant="secondary">
+                            {__('All untracked expenses')}
+                        </Badge>
+                    ) : trackingNames.length > 0 ? (
+                        <>
+                            {trackingNames.slice(0, 2).map((name) => (
+                                <Badge key={name} variant="secondary">
+                                    {name}
+                                </Badge>
+                            ))}
+                            {trackingNames.length > 2 && (
+                                <Badge variant="secondary">
+                                    {__('+:count', {
+                                        count: trackingNames.length - 2,
+                                    })}
+                                </Badge>
+                            )}
+                        </>
+                    ) : (
                         <span className="text-sm text-muted-foreground">
-                            {__('Tracking:')}
+                            {__('No tracking')}
                         </span>
-                        {budget.is_catch_all ? (
-                            <Badge variant="secondary">
-                                {__('All untracked expenses')}
-                            </Badge>
-                        ) : trackingNames.length > 0 ? (
-                            <>
-                                {trackingNames.slice(0, 2).map((name) => (
-                                    <Badge key={name} variant="secondary">
-                                        {name}
-                                    </Badge>
-                                ))}
-                                {trackingNames.length > 2 && (
-                                    <Badge variant="secondary">
-                                        {__('+:count', {
-                                            count: trackingNames.length - 2,
-                                        })}
-                                    </Badge>
-                                )}
-                            </>
-                        ) : (
-                            <span className="text-sm text-muted-foreground">
-                                {__('No tracking')}
-                            </span>
-                        )}
-                    </div>
-                    <Link href={show({ budget: budget.id }).url}>
-                        <Button
-                            className="cursor-pointer"
-                            variant="ghost"
-                            size="sm"
-                        >
-                            {__('View Details')}
-
-                            <ArrowRight className="ml-2 h-4 w-4" />
-                        </Button>
-                    </Link>
+                    )}
                 </div>
-            </CardContent>
-        </Card>
+            }
+        >
+            {/* A budget spends down, so it reads as a bar draining left to
+                right. The savings goal card fills a ring instead. */}
+            <div className="space-y-2">
+                <div className="flex items-center justify-between text-sm">
+                    <span className="text-muted-foreground">{__('Spent')}</span>
+                    <span className={statusColor}>
+                        <AmountDisplay
+                            amountInCents={stats.totalSpent}
+                            currencyCode={currencyCode}
+                        />{' '}
+                        {__('of')}{' '}
+                        <AmountDisplay
+                            amountInCents={stats.totalAllocated}
+                            currencyCode={currencyCode}
+                        />
+                    </span>
+                </div>
+                <Progress
+                    value={Math.min(stats.percentageUsed, 100)}
+                    className="h-2"
+                />
+
+                <div className="flex items-center justify-between text-sm">
+                    <span className="text-muted-foreground">
+                        {__('Remaining')}
+                    </span>
+                    <span className={statusColor}>
+                        <AmountDisplay
+                            amountInCents={stats.remaining}
+                            currencyCode={currencyCode}
+                        />
+                    </span>
+                </div>
+            </div>
+        </PlanningCard>
     );
 }

--- a/resources/js/components/budgets/create-budget-dialog.tsx
+++ b/resources/js/components/budgets/create-budget-dialog.tsx
@@ -1,4 +1,5 @@
 import { store } from '@/actions/App/Http/Controllers/BudgetController';
+import { CreatePlaceholderCard } from '@/components/shared/create-placeholder-card';
 import { LabelIcon } from '@/components/shared/label-icon';
 import { AmountInput } from '@/components/ui/amount-input';
 import { Button } from '@/components/ui/button';
@@ -39,9 +40,7 @@ import { getLabelColorClasses, Label } from '@/types/label';
 import { __ } from '@/utils/i18n';
 import { router, usePage } from '@inertiajs/react';
 import * as Icons from 'lucide-react';
-import { Plus } from 'lucide-react';
 import React, { useState } from 'react';
-import { Card, CardContent } from '../ui/card';
 
 interface Props {
     className?: string;
@@ -143,19 +142,9 @@ export function CreateBudgetDialog({
                 <DialogTrigger asChild>{trigger}</DialogTrigger>
             ) : isControlled ? null : (
                 <DialogTrigger asChild>
-                    <Card
-                        className={cn(
-                            'cursor-pointer opacity-50 transition-opacity duration-200 hover:opacity-100',
-                            className,
-                        )}
-                    >
-                        <CardContent className="flex h-full items-center justify-center">
-                            <div className="flex flex-row items-center justify-center gap-1">
-                                <Plus className="mr-2 h-4 w-4" />
-                                {__('Create Budget')}
-                            </div>
-                        </CardContent>
-                    </Card>
+                    <CreatePlaceholderCard className={className}>
+                        {__('Create Budget')}
+                    </CreatePlaceholderCard>
                 </DialogTrigger>
             )}
             <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[600px]">

--- a/resources/js/components/savings-goals/create-savings-goal-dialog.tsx
+++ b/resources/js/components/savings-goals/create-savings-goal-dialog.tsx
@@ -1,7 +1,7 @@
 import { store } from '@/actions/App/Http/Controllers/SavingsGoalController';
+import { CreatePlaceholderCard } from '@/components/shared/create-placeholder-card';
 import { AmountInput } from '@/components/ui/amount-input';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
 import {
     Dialog,
     DialogContent,
@@ -14,10 +14,8 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label as UILabel } from '@/components/ui/label';
 import { useControllableOpen } from '@/hooks/use-controllable-open';
-import { cn } from '@/lib/utils';
 import { __ } from '@/utils/i18n';
 import { router } from '@inertiajs/react';
-import { Plus } from 'lucide-react';
 import React, { useState } from 'react';
 
 interface Props {
@@ -86,19 +84,9 @@ export function CreateSavingsGoalDialog({
                 <DialogTrigger asChild>{trigger}</DialogTrigger>
             ) : isControlled ? null : (
                 <DialogTrigger asChild>
-                    <Card
-                        className={cn(
-                            'cursor-pointer opacity-50 transition-opacity duration-200 hover:opacity-100',
-                            className,
-                        )}
-                    >
-                        <CardContent className="flex h-full items-center justify-center">
-                            <div className="flex flex-row items-center justify-center gap-1">
-                                <Plus className="mr-2 h-4 w-4" />
-                                {__('Create Savings Goal')}
-                            </div>
-                        </CardContent>
-                    </Card>
+                    <CreatePlaceholderCard className={className}>
+                        {__('Create Savings Goal')}
+                    </CreatePlaceholderCard>
                 </DialogTrigger>
             )}
             <DialogContent className="sm:max-w-[500px]">

--- a/resources/js/components/savings-goals/savings-goal-list-card.tsx
+++ b/resources/js/components/savings-goals/savings-goal-list-card.tsx
@@ -1,15 +1,7 @@
 import { show } from '@/actions/App/Http/Controllers/SavingsGoalController';
+import { PlanningCard } from '@/components/shared/planning-card';
 import { AmountDisplay } from '@/components/ui/amount-display';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import {
-    Card,
-    CardContent,
-    CardDescription,
-    CardHeader,
-    CardTitle,
-} from '@/components/ui/card';
-import { Progress } from '@/components/ui/progress';
 import { useLocale } from '@/hooks/use-locale';
 import {
     getSavingsGoalStatusColor,
@@ -18,8 +10,46 @@ import {
 } from '@/types/savings-goal';
 import { formatDate } from '@/utils/date';
 import { __ } from '@/utils/i18n';
-import { Link } from '@inertiajs/react';
-import { ArrowRight, Target } from 'lucide-react';
+import { Target } from 'lucide-react';
+
+const RING_SIZE = 64;
+const RING_STROKE = 6;
+const RING_RADIUS = (RING_SIZE - RING_STROKE) / 2;
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
+
+function ProgressRing({ percentage }: { percentage: number }) {
+    return (
+        <div className="relative h-16 w-16 shrink-0">
+            <svg
+                viewBox={`0 0 ${RING_SIZE} ${RING_SIZE}`}
+                className="h-16 w-16 -rotate-90"
+                aria-hidden="true"
+            >
+                <circle
+                    cx={RING_SIZE / 2}
+                    cy={RING_SIZE / 2}
+                    r={RING_RADIUS}
+                    fill="none"
+                    strokeWidth={RING_STROKE}
+                    className="stroke-secondary"
+                />
+                <circle
+                    cx={RING_SIZE / 2}
+                    cy={RING_SIZE / 2}
+                    r={RING_RADIUS}
+                    fill="none"
+                    strokeWidth={RING_STROKE}
+                    strokeLinecap="round"
+                    className="stroke-primary"
+                    strokeDasharray={`${(RING_CIRCUMFERENCE * percentage) / 100} ${RING_CIRCUMFERENCE}`}
+                />
+            </svg>
+            <div className="absolute inset-0 flex items-center justify-center text-sm font-semibold tabular-nums">
+                {Math.round(percentage)}%
+            </div>
+        </div>
+    );
+}
 
 interface Props {
     savingsGoal: SavingsGoal;
@@ -29,8 +59,9 @@ interface Props {
 export function SavingsGoalListCard({ savingsGoal, currencyCode }: Props) {
     const locale = useLocale();
     const stats = savingsGoal.stats;
-    const percentage = stats?.percentage ?? 0;
+    const percentage = Math.min(Math.max(stats?.percentage ?? 0, 0), 100);
     const saved = stats?.saved ?? 0;
+    const toGo = Math.max(savingsGoal.target_amount - saved, 0);
     const status = stats?.status ?? null;
 
     const statusColor = status
@@ -38,40 +69,37 @@ export function SavingsGoalListCard({ savingsGoal, currencyCode }: Props) {
         : 'text-muted-foreground';
 
     return (
-        <Card>
-            <CardHeader>
-                <div className="flex items-start justify-between">
-                    <div className="space-y-1">
-                        <CardTitle className="text-xl">
-                            <Link
-                                href={show({ savingsGoal: savingsGoal.id }).url}
-                                className="-my-1 -ml-1.5 inline-flex items-center rounded-md px-1.5 py-1 transition-colors hover:bg-muted"
-                            >
-                                {savingsGoal.name}
-                            </Link>
-                        </CardTitle>
-                        {savingsGoal.target_date && (
-                            <CardDescription className="flex items-center gap-2">
-                                <Target className="h-3 w-3" />
-                                {__('By :date', {
-                                    date: formatDate(
-                                        savingsGoal.target_date,
-                                        'MMM d, yyyy',
-                                        locale,
-                                    ),
-                                })}
-                            </CardDescription>
-                        )}
-                    </div>
-                    {status && (
-                        <Badge variant="outline" className={statusColor}>
-                            {getSavingsGoalStatusLabel(status)}
-                        </Badge>
-                    )}
-                </div>
-            </CardHeader>
-            <CardContent className="space-y-4">
-                <div className="space-y-2">
+        <PlanningCard
+            href={show({ savingsGoal: savingsGoal.id }).url}
+            title={savingsGoal.name}
+            badge={
+                status ? (
+                    <Badge variant="outline" className={statusColor}>
+                        {getSavingsGoalStatusLabel(status)}
+                    </Badge>
+                ) : undefined
+            }
+            description={
+                savingsGoal.target_date ? (
+                    <>
+                        <Target className="h-3 w-3" />
+                        {__('By :date', {
+                            date: formatDate(
+                                savingsGoal.target_date,
+                                'MMM d, yyyy',
+                                locale,
+                            ),
+                        })}
+                    </>
+                ) : undefined
+            }
+        >
+            {/* A savings goal fills up, so it reads as a ring closing rather
+                than the draining bar the budget card uses. That difference is
+                what tells the two apart in the mixed list. */}
+            <div className="flex items-center gap-4">
+                <ProgressRing percentage={percentage} />
+                <div className="flex flex-1 flex-col gap-2">
                     <div className="flex items-center justify-between text-sm">
                         <span className="text-muted-foreground">
                             {__('Saved')}
@@ -88,28 +116,17 @@ export function SavingsGoalListCard({ savingsGoal, currencyCode }: Props) {
                             />
                         </span>
                     </div>
-                    <Progress
-                        value={Math.min(Math.max(percentage, 0), 100)}
-                        className="h-2"
-                    />
-                    <div className="text-right text-sm text-muted-foreground">
-                        {Math.max(0, Math.round(percentage))}%
+                    <div className="flex items-center justify-between text-sm">
+                        <span className="text-muted-foreground">
+                            {__('To go')}
+                        </span>
+                        <AmountDisplay
+                            amountInCents={toGo}
+                            currencyCode={currencyCode}
+                        />
                     </div>
                 </div>
-
-                <div className="flex items-center justify-end border-t pt-4">
-                    <Link href={show({ savingsGoal: savingsGoal.id }).url}>
-                        <Button
-                            className="cursor-pointer"
-                            variant="ghost"
-                            size="sm"
-                        >
-                            {__('View Details')}
-                            <ArrowRight className="ml-2 h-4 w-4" />
-                        </Button>
-                    </Link>
-                </div>
-            </CardContent>
-        </Card>
+            </div>
+        </PlanningCard>
     );
 }

--- a/resources/js/components/shared/create-placeholder-card.tsx
+++ b/resources/js/components/shared/create-placeholder-card.tsx
@@ -1,0 +1,37 @@
+import { Card, CardContent } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+import { Plus } from 'lucide-react';
+import { ComponentProps } from 'react';
+
+/**
+ * The dimmed "add another one" card that trails a list of cards. Shared so the
+ * budget dialog, the savings goal dialog and the Planning list's combined
+ * create card cannot drift apart.
+ *
+ * It spreads the rest of its props onto the card because every call site wraps
+ * it in an `asChild` trigger — a Radix `DialogTrigger` or `DropdownMenuTrigger`
+ * hands the child its onClick and ref, and swallowing them leaves a card that
+ * looks right and opens nothing.
+ */
+export function CreatePlaceholderCard({
+    children,
+    className,
+    ...props
+}: ComponentProps<'div'>) {
+    return (
+        <Card
+            className={cn(
+                'cursor-pointer opacity-50 transition-opacity duration-200 hover:opacity-100',
+                className,
+            )}
+            {...props}
+        >
+            <CardContent className="flex h-full items-center justify-center">
+                <div className="flex flex-row items-center justify-center gap-1">
+                    <Plus className="mr-2 h-4 w-4" />
+                    {children}
+                </div>
+            </CardContent>
+        </Card>
+    );
+}

--- a/resources/js/components/shared/planning-card.tsx
+++ b/resources/js/components/shared/planning-card.tsx
@@ -1,0 +1,89 @@
+import { Button } from '@/components/ui/button';
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+import { __ } from '@/utils/i18n';
+import { Link } from '@inertiajs/react';
+import { ArrowRight } from 'lucide-react';
+import { ReactNode } from 'react';
+
+interface Props {
+    /** Detail page the title and the footer button both link to. */
+    href: string;
+    title: string;
+    /** Rendered top-right: the budget's period type, the goal's status. */
+    badge?: ReactNode;
+    /** Rendered under the title, already laid out as an icon + text row. */
+    description?: ReactNode;
+    /** Rendered footer-left, opposite "View Details". */
+    footerStart?: ReactNode;
+    /** The progress readout: a bar for budgets, a ring for savings goals. */
+    children: ReactNode;
+}
+
+/**
+ * The shell both cards on the Planning list share. They sit in one mixed grid,
+ * so everything except the progress readout has to be identical between them —
+ * keeping that in one place is also what stops the duplication check tripping.
+ */
+export function PlanningCard({
+    href,
+    title,
+    badge,
+    description,
+    footerStart,
+    children,
+}: Props) {
+    return (
+        <Card>
+            <CardHeader>
+                <div className="flex items-start justify-between">
+                    <div className="space-y-1">
+                        <CardTitle className="text-xl">
+                            <Link
+                                href={href}
+                                className="-my-1 -ml-1.5 inline-flex items-center rounded-md px-1.5 py-1 transition-colors hover:bg-muted"
+                            >
+                                {title}
+                            </Link>
+                        </CardTitle>
+                        {description && (
+                            <CardDescription className="flex items-center gap-2">
+                                {description}
+                            </CardDescription>
+                        )}
+                    </div>
+                    {badge}
+                </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                {children}
+
+                <div
+                    className={cn(
+                        'flex items-center gap-2 border-t pt-4',
+                        footerStart ? 'justify-between' : 'justify-end',
+                    )}
+                >
+                    {footerStart}
+                    <Link href={href}>
+                        <Button
+                            className="cursor-pointer"
+                            variant="ghost"
+                            size="sm"
+                        >
+                            {__('View Details')}
+
+                            <ArrowRight className="ml-2 h-4 w-4" />
+                        </Button>
+                    </Link>
+                </div>
+            </CardContent>
+        </Card>
+    );
+}

--- a/resources/js/lib/planning-items.test.ts
+++ b/resources/js/lib/planning-items.test.ts
@@ -1,0 +1,136 @@
+import { Budget } from '@/types/budget';
+import { SavingsGoal, SavingsGoalStatus } from '@/types/savings-goal';
+import { describe, expect, it } from 'vitest';
+import {
+    mergePlanningItems,
+    planningAttentionTier,
+    PlanningItem,
+} from './planning-items';
+
+function budget(name: string, allocated: number, spent: number): Budget {
+    return {
+        id: name,
+        name,
+        periods: [
+            {
+                allocated_amount: allocated,
+                budget_transactions: [{ amount: spent }],
+            },
+        ],
+    } as unknown as Budget;
+}
+
+function budgetWithoutPeriod(name: string): Budget {
+    return { id: name, name, periods: [] } as unknown as Budget;
+}
+
+function goal(name: string, status: SavingsGoalStatus | null): SavingsGoal {
+    return {
+        id: name,
+        name,
+        stats: { status },
+    } as unknown as SavingsGoal;
+}
+
+const item = (value: Budget | SavingsGoal, type: 'budget' | 'goal') =>
+    (type === 'budget'
+        ? { type, id: value.id, name: value.name, budget: value }
+        : {
+              type,
+              id: value.id,
+              name: value.name,
+              goal: value,
+          }) as PlanningItem;
+
+describe('planningAttentionTier', () => {
+    it('puts a budget past its limit first', () => {
+        expect(
+            planningAttentionTier(item(budget('a', 100, 120), 'budget')),
+        ).toBe(0);
+        expect(
+            planningAttentionTier(item(budget('a', 100, 100), 'budget')),
+        ).toBe(0);
+    });
+
+    it('puts a budget close to its limit in the middle tier', () => {
+        expect(
+            planningAttentionTier(item(budget('a', 100, 80), 'budget')),
+        ).toBe(1);
+        expect(
+            planningAttentionTier(item(budget('a', 100, 79), 'budget')),
+        ).toBe(2);
+    });
+
+    it('treats a budget with no active period as fine rather than breached', () => {
+        expect(
+            planningAttentionTier(item(budgetWithoutPeriod('a'), 'budget')),
+        ).toBe(2);
+    });
+
+    it('never puts a savings goal in the breached tier', () => {
+        expect(planningAttentionTier(item(goal('a', 'behind'), 'goal'))).toBe(
+            1,
+        );
+        expect(planningAttentionTier(item(goal('a', 'on_track'), 'goal'))).toBe(
+            2,
+        );
+        expect(planningAttentionTier(item(goal('a', 'ahead'), 'goal'))).toBe(2);
+        expect(
+            planningAttentionTier(item(goal('a', 'completed'), 'goal')),
+        ).toBe(2);
+        expect(planningAttentionTier(item(goal('a', null), 'goal'))).toBe(2);
+    });
+});
+
+describe('mergePlanningItems', () => {
+    it('orders by attention first and interleaves the two types', () => {
+        const merged = mergePlanningItems(
+            [budget('Groceries', 100, 85), budget('Eating out', 100, 130)],
+            [goal('Japan trip', 'on_track'), goal('Emergency fund', 'behind')],
+        );
+
+        expect(merged.map((i) => i.name)).toEqual([
+            'Eating out', // tier 0, over its limit
+            'Emergency fund', // tier 1, behind schedule
+            'Groceries', // tier 1, close to its limit
+            'Japan trip', // tier 2
+        ]);
+    });
+
+    it('sorts healthy items by name rather than grouping them by type', () => {
+        const merged = mergePlanningItems(
+            [budget('Zoo', 100, 10), budget('Bills', 100, 10)],
+            [goal('Car', 'on_track'), goal('Attic', 'on_track')],
+        );
+
+        expect(merged.map((i) => i.name)).toEqual([
+            'Attic',
+            'Bills',
+            'Car',
+            'Zoo',
+        ]);
+    });
+
+    it('tags each item with the type the list renders it as', () => {
+        const merged = mergePlanningItems(
+            [budget('Bills', 100, 10)],
+            [goal('Attic', 'on_track')],
+        );
+
+        expect(merged.map((i) => i.type)).toEqual(['goal', 'budget']);
+    });
+
+    it('returns only the type it was given when the list is filtered', () => {
+        expect(
+            mergePlanningItems([budget('Bills', 100, 10)], []).map(
+                (i) => i.type,
+            ),
+        ).toEqual(['budget']);
+        expect(
+            mergePlanningItems([], [goal('Attic', 'on_track')]).map(
+                (i) => i.type,
+            ),
+        ).toEqual(['goal']);
+        expect(mergePlanningItems([], [])).toEqual([]);
+    });
+});

--- a/resources/js/lib/planning-items.ts
+++ b/resources/js/lib/planning-items.ts
@@ -1,0 +1,66 @@
+import { Budget, budgetSeverity } from '@/types/budget';
+import { SavingsGoal } from '@/types/savings-goal';
+
+export type PlanningItem =
+    | { type: 'budget'; id: string; name: string; budget: Budget }
+    | { type: 'goal'; id: string; name: string; goal: SavingsGoal };
+
+/**
+ * How badly an item wants to be looked at. Lower sorts first.
+ *
+ * The tiers come straight from the status each card already shows, so the
+ * ordering can never disagree with the colour the user is reading: a budget
+ * past its limit, then anything close to its limit or behind schedule, then
+ * everything that is fine. A savings goal cannot breach the way a budget can,
+ * so it never reaches tier 0.
+ */
+export function planningAttentionTier(item: PlanningItem): number {
+    if (item.type === 'budget') {
+        const severity = budgetSeverity(item.budget);
+
+        if (severity === 'over') {
+            return 0;
+        }
+
+        return severity === 'near' ? 1 : 2;
+    }
+
+    return item.goal.stats?.status === 'behind' ? 1 : 2;
+}
+
+/**
+ * Merges budgets and savings goals into the single Planning list, ordered by
+ * attention and then by name. Sorting by name rather than by type is what
+ * keeps the two kinds interleaved — grouping the leftovers by type would just
+ * rebuild the two sections this list replaced.
+ */
+export function mergePlanningItems(
+    budgets: Budget[],
+    savingsGoals: SavingsGoal[],
+    locale?: string,
+): PlanningItem[] {
+    const items: PlanningItem[] = [
+        ...budgets.map(
+            (budget): PlanningItem => ({
+                type: 'budget',
+                id: budget.id,
+                name: budget.name,
+                budget,
+            }),
+        ),
+        ...savingsGoals.map(
+            (goal): PlanningItem => ({
+                type: 'goal',
+                id: goal.id,
+                name: goal.name,
+                goal,
+            }),
+        ),
+    ];
+
+    return items.sort((a, b) => {
+        const byTier = planningAttentionTier(a) - planningAttentionTier(b);
+
+        return byTier !== 0 ? byTier : a.name.localeCompare(b.name, locale);
+    });
+}

--- a/resources/js/pages/budgets/index.test.tsx
+++ b/resources/js/pages/budgets/index.test.tsx
@@ -2,6 +2,11 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import BudgetsIndex, { budgetTypeFilterFromUrl } from './index';
 
+interface DialogMockProps {
+    trigger?: React.ReactNode;
+    onOpenChange?: (open: boolean) => void;
+}
+
 const replace = vi.fn();
 let pageUrl = '/budgets';
 
@@ -31,16 +36,29 @@ vi.mock('@/components/savings-goals/savings-goal-list-card', () => ({
     SavingsGoalListCard: () => <div>goal-card</div>,
 }));
 
+// The page mounts each dialog up to three times: once as the header button,
+// once as the list's trailing card, and once controlled at the bottom. Only the
+// uncontrolled ones render a trigger, so the mocks mirror that.
 vi.mock('@/components/budgets/create-budget-dialog', () => ({
-    CreateBudgetDialog: () => <div>create-budget</div>,
+    CreateBudgetDialog: ({ trigger, onOpenChange }: DialogMockProps) =>
+        onOpenChange ? null : (
+            <div>{trigger ? 'create-budget-header' : 'create-budget'}</div>
+        ),
 }));
 
 vi.mock('@/components/savings-goals/create-savings-goal-dialog', () => ({
-    CreateSavingsGoalDialog: () => <div>create-goal</div>,
+    CreateSavingsGoalDialog: ({ onOpenChange }: DialogMockProps) =>
+        onOpenChange ? null : <div>create-goal</div>,
 }));
 
-const budget = { id: '1' } as never;
-const goal = { id: '2' } as never;
+vi.mock('@/components/shared/create-placeholder-card', () => ({
+    CreatePlaceholderCard: ({ children }: { children: React.ReactNode }) => (
+        <div>create-either: {children}</div>
+    ),
+}));
+
+const budget = { id: '1', name: 'Groceries' } as never;
+const goal = { id: '2', name: 'Japan trip' } as never;
 
 function renderPage() {
     return render(
@@ -70,11 +88,22 @@ describe('budgetTypeFilterFromUrl', () => {
 });
 
 describe('BudgetsIndex filter', () => {
-    it('shows both sections by default', () => {
+    it('shows both types in one list by default', () => {
         renderPage();
 
         expect(screen.getByText('budget-card')).toBeInTheDocument();
         expect(screen.getByText('goal-card')).toBeInTheDocument();
+    });
+
+    it('does not split the list into per-type sections', () => {
+        renderPage();
+
+        expect(
+            screen.queryByRole('heading', { name: 'Budgets' }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole('heading', { name: 'Savings Goals' }),
+        ).not.toBeInTheDocument();
     });
 
     it('shows only savings goals and updates the URL when filtering', () => {
@@ -126,5 +155,37 @@ describe('BudgetsIndex filter', () => {
             preserveScroll: true,
             preserveState: true,
         });
+    });
+});
+
+describe('BudgetsIndex create card', () => {
+    it('offers both types when the list is unfiltered', () => {
+        renderPage();
+
+        expect(screen.getByText(/create-either/)).toBeInTheDocument();
+    });
+
+    it('creates the type being filtered on instead of asking again', () => {
+        renderPage();
+
+        fireEvent.click(screen.getByRole('radio', { name: 'Budgets' }));
+        expect(screen.getByText('create-budget')).toBeInTheDocument();
+        expect(screen.queryByText(/create-either/)).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('radio', { name: 'Savings Goals' }));
+        expect(screen.getByText('create-goal')).toBeInTheDocument();
+    });
+
+    it('keeps the budget-only create card when savings goals are disabled', () => {
+        render(
+            <BudgetsIndex
+                budgets={[budget]}
+                savingsGoalsEnabled={false}
+                currencyCode="EUR"
+            />,
+        );
+
+        expect(screen.getByText('create-budget')).toBeInTheDocument();
+        expect(screen.queryByText(/create-either/)).not.toBeInTheDocument();
     });
 });

--- a/resources/js/pages/budgets/index.tsx
+++ b/resources/js/pages/budgets/index.tsx
@@ -4,6 +4,7 @@ import { CreateBudgetDialog } from '@/components/budgets/create-budget-dialog';
 import HeadingSmall from '@/components/heading-small';
 import { CreateSavingsGoalDialog } from '@/components/savings-goals/create-savings-goal-dialog';
 import { SavingsGoalListCard } from '@/components/savings-goals/savings-goal-list-card';
+import { CreatePlaceholderCard } from '@/components/shared/create-placeholder-card';
 import { Button } from '@/components/ui/button';
 import { CreateButton } from '@/components/ui/create-button';
 import {
@@ -13,14 +14,16 @@ import {
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { useLocale } from '@/hooks/use-locale';
 import AppSidebarLayout from '@/layouts/app/app-sidebar-layout';
+import { mergePlanningItems } from '@/lib/planning-items';
 import { BreadcrumbItem } from '@/types';
 import { Budget } from '@/types/budget';
 import { SavingsGoal } from '@/types/savings-goal';
 import { __ } from '@/utils/i18n';
 import { Head, router, usePage } from '@inertiajs/react';
 import { ChevronDown, Plus } from 'lucide-react';
-import { useState } from 'react';
+import { ReactNode, useMemo, useState } from 'react';
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
@@ -54,8 +57,10 @@ export default function BudgetsIndex({
         null,
     );
     const { url } = usePage();
+    const locale = useLocale();
     // Without savings goals there is no toggle to undo a ?show= filter coming
-    // from a stale bookmark, so clamp it to 'all' instead of hiding sections.
+    // from a stale bookmark, so clamp it to 'all' instead of serving a list
+    // the user has no way to unfilter.
     const [filter, setFilter] = useState<BudgetTypeFilter>(() =>
         savingsGoalsEnabled ? budgetTypeFilterFromUrl(url) : 'all',
     );
@@ -72,6 +77,18 @@ export default function BudgetsIndex({
         });
     };
 
+    // Budgets and savings goals share one list: whichever needs attention
+    // first leads it, and neither type is stuck below the other.
+    const items = useMemo(
+        () =>
+            mergePlanningItems(
+                filter === 'goals' ? [] : budgets,
+                savingsGoalsEnabled && filter !== 'budgets' ? savingsGoals : [],
+                locale,
+            ),
+        [budgets, savingsGoals, savingsGoalsEnabled, filter, locale],
+    );
+
     return (
         <AppSidebarLayout breadcrumbs={breadcrumbs}>
             <Head title={__('Planning')} />
@@ -85,39 +102,16 @@ export default function BudgetsIndex({
                         )}
                     />
                     {savingsGoalsEnabled ? (
-                        <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
+                        <CreateMenu
+                            onCreate={setCreateType}
+                            trigger={
                                 <Button>
                                     <Plus />
                                     {__('Create')}
                                     <ChevronDown className="ml-1 h-4 w-4" />
                                 </Button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                                {/* Let the menu close itself (no preventDefault, or
-                                    it leaves pointer-events locked on the body), and
-                                    defer opening the dialog to the next frame so it
-                                    doesn't race the menu's close. */}
-                                <DropdownMenuItem
-                                    onSelect={() =>
-                                        requestAnimationFrame(() =>
-                                            setCreateType('budget'),
-                                        )
-                                    }
-                                >
-                                    {__('Budget')}
-                                </DropdownMenuItem>
-                                <DropdownMenuItem
-                                    onSelect={() =>
-                                        requestAnimationFrame(() =>
-                                            setCreateType('goal'),
-                                        )
-                                    }
-                                >
-                                    {__('Savings Goal')}
-                                </DropdownMenuItem>
-                            </DropdownMenuContent>
-                        </DropdownMenu>
+                            }
+                        />
                     ) : (
                         <CreateBudgetDialog
                             currencyCode={currencyCode}
@@ -160,55 +154,30 @@ export default function BudgetsIndex({
                     </ToggleGroup>
                 )}
 
-                {filter !== 'goals' && (
-                    <section className="space-y-4">
-                        {savingsGoalsEnabled && filter === 'all' && (
-                            <h2 className="text-lg font-medium">
-                                {__('Budgets')}
-                            </h2>
-                        )}
-                        <div className="grid gap-4 lg:grid-cols-2">
-                            {budgets.map((budget) => (
-                                <BudgetListCard
-                                    key={budget.id}
-                                    budget={budget}
-                                    currencyCode={currencyCode}
-                                />
-                            ))}
-                            <CreateBudgetDialog
+                <div className="grid gap-4 lg:grid-cols-2">
+                    {items.map((item) =>
+                        item.type === 'budget' ? (
+                            <BudgetListCard
+                                key={item.id}
+                                budget={item.budget}
                                 currencyCode={currencyCode}
-                                className={
-                                    budgets.length ? '' : 'min-h-[260px]'
-                                }
                             />
-                        </div>
-                    </section>
-                )}
-
-                {savingsGoalsEnabled && filter !== 'budgets' && (
-                    <section className="space-y-4">
-                        {filter === 'all' && (
-                            <h2 className="text-lg font-medium">
-                                {__('Savings Goals')}
-                            </h2>
-                        )}
-                        <div className="grid gap-4 lg:grid-cols-2">
-                            {savingsGoals.map((goal) => (
-                                <SavingsGoalListCard
-                                    key={goal.id}
-                                    savingsGoal={goal}
-                                    currencyCode={currencyCode}
-                                />
-                            ))}
-                            <CreateSavingsGoalDialog
+                        ) : (
+                            <SavingsGoalListCard
+                                key={item.id}
+                                savingsGoal={item.goal}
                                 currencyCode={currencyCode}
-                                className={
-                                    savingsGoals.length ? '' : 'min-h-[260px]'
-                                }
                             />
-                        </div>
-                    </section>
-                )}
+                        ),
+                    )}
+                    <CreateCard
+                        currencyCode={currencyCode}
+                        savingsGoalsEnabled={savingsGoalsEnabled}
+                        filter={filter}
+                        isListEmpty={items.length === 0}
+                        onCreate={setCreateType}
+                    />
+                </div>
             </div>
 
             {savingsGoalsEnabled && (
@@ -226,5 +195,98 @@ export default function BudgetsIndex({
                 </>
             )}
         </AppSidebarLayout>
+    );
+}
+
+interface CreateCardProps {
+    currencyCode: string;
+    savingsGoalsEnabled: boolean;
+    filter: BudgetTypeFilter;
+    isListEmpty: boolean;
+    onCreate: (type: 'budget' | 'goal') => void;
+}
+
+/**
+ * The card that trails the list. Without savings goals it is the budget
+ * dialog's own placeholder, exactly as before. With them it offers both types
+ * — unless the list is filtered, in which case it creates the type the user is
+ * already looking at instead of asking again.
+ */
+function CreateCard({
+    currencyCode,
+    savingsGoalsEnabled,
+    filter,
+    isListEmpty,
+    onCreate,
+}: CreateCardProps) {
+    const className = isListEmpty ? 'min-h-[260px]' : '';
+
+    if (!savingsGoalsEnabled || filter === 'budgets') {
+        return (
+            <CreateBudgetDialog
+                currencyCode={currencyCode}
+                className={className}
+            />
+        );
+    }
+
+    if (filter === 'goals') {
+        return (
+            <CreateSavingsGoalDialog
+                currencyCode={currencyCode}
+                className={className}
+            />
+        );
+    }
+
+    return (
+        <CreateMenu
+            align="start"
+            onCreate={onCreate}
+            trigger={
+                <CreatePlaceholderCard className={className}>
+                    {__('Create')}
+                    <ChevronDown className="ml-1 h-4 w-4" />
+                </CreatePlaceholderCard>
+            }
+        />
+    );
+}
+
+interface CreateMenuProps {
+    trigger: ReactNode;
+    onCreate: (type: 'budget' | 'goal') => void;
+    align?: 'start' | 'end';
+}
+
+/**
+ * The Budget / Savings Goal choice, offered from both the header button and
+ * the list's trailing card.
+ *
+ * Let the menu close itself (no preventDefault, or it leaves pointer-events
+ * locked on the body), and defer opening the dialog to the next frame so it
+ * doesn't race the menu's close.
+ */
+function CreateMenu({ trigger, onCreate, align = 'end' }: CreateMenuProps) {
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
+            <DropdownMenuContent align={align}>
+                <DropdownMenuItem
+                    onSelect={() =>
+                        requestAnimationFrame(() => onCreate('budget'))
+                    }
+                >
+                    {__('Budget')}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                    onSelect={() =>
+                        requestAnimationFrame(() => onCreate('goal'))
+                    }
+                >
+                    {__('Savings Goal')}
+                </DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
     );
 }

--- a/resources/js/types/budget.ts
+++ b/resources/js/types/budget.ts
@@ -105,3 +105,48 @@ export function getRolloverTypeDescription(type: RolloverType): string {
     };
     return descriptions[type];
 }
+
+/**
+ * How much of the current period's allocation is already spent, as a
+ * percentage. The card and the Planning list's ordering both read it, so it
+ * has to be computed in one place.
+ */
+export function budgetPercentageUsed(budget: Budget): number {
+    const period = budget.periods?.[0];
+
+    if (!period || period.allocated_amount <= 0) {
+        return 0;
+    }
+
+    const spent =
+        period.budget_transactions?.reduce((sum, t) => sum + t.amount, 0) ?? 0;
+
+    return (spent / period.allocated_amount) * 100;
+}
+
+export type BudgetSeverity = 'over' | 'near' | 'ok';
+
+/**
+ * Where a budget sits against its allocation. The card's colour and the
+ * Planning list's ordering both read it, so the position an item takes in the
+ * list can never disagree with the colour the user is looking at.
+ */
+export function budgetSeverity(budget: Budget): BudgetSeverity {
+    const used = budgetPercentageUsed(budget);
+
+    if (used >= 100) {
+        return 'over';
+    }
+
+    return used >= 80 ? 'near' : 'ok';
+}
+
+export function getBudgetSeverityColor(severity: BudgetSeverity): string {
+    const colors: Record<BudgetSeverity, string> = {
+        over: 'text-red-600 dark:text-red-400',
+        near: 'text-yellow-600 dark:text-yellow-400',
+        ok: 'text-green-600 dark:text-green-400',
+    };
+
+    return colors[severity];
+}


### PR DESCRIPTION
Budgets and savings goals were two stacked sections on the Planning page, one
under the other. That layout permanently buried savings goals below the budgets
no matter how many of either you had. They are now one mixed list.

## Telling the two apart

The differentiation is the **shape of the progress readout**, not an icon, a
colour or a tinted surface:

- A **budget spends down**, so it keeps the horizontal bar — `Spent X of Y`
  above it, `Remaining` below.
- A **savings goal fills up**, so it gets a ring with the percentage in the
  middle — `Saved X of Y` and `To go` beside it.

Different silhouette, so the two read apart at a glance, and the difference
carries information rather than status. Neither type is subordinate: they are
different kinds of thing, not one thing and its dimmed cousin.

Two directions were considered and dropped:

- **An icon per type.** The piggy bank already means "savings goal" in the
  transactions UI (`label-icon.tsx`), but it is also the nav icon for the whole
  Planning section, so using it for one half reads oddly — and it would force a
  nav icon change. It also only works if you read the card; the grid still looks
  uniform from a distance.
- **A tinted surface for goals.** Cheapest and the most legible at a glance, but
  tone reads as hierarchy. In light the tinted card sits back, which recreates
  the second-class feeling this change exists to remove; in dark, where `--card`
  equals `--background`, the same rule makes it sit forward instead.

## Ordering

`mergePlanningItems` sorts by an **attention tier**, then by name:

| Tier | What lands there |
| --- | --- |
| 0 | A budget at or past 100% of its allocation |
| 1 | A budget at 80% or more, or a goal behind schedule |
| 2 | Everything else |

A savings goal cannot breach the way a budget can, so it never reaches tier 0.
The tiers come from `budgetSeverity()` and the goal's own `stats.status` — the
same values the cards colour themselves with, so the order can never disagree
with the colour you are looking at.

Within a tier it sorts by name, using the app locale. That is what keeps the two
types interleaved: grouping the healthy leftovers by type would just rebuild the
two sections this replaces.

All of it runs client-side from props the page already receives, so there is no
controller change.

## The create card

One card trails the list. Unfiltered it offers Budget / Savings Goal from the
same menu as the header button; with the list filtered it creates the type you
are already looking at instead of asking again. With the feature flag off it is
the plain "Create Budget" placeholder it has always been.

## Duplication

The two cards were already near-identical and making them one visual family
would have tripped `bun run dry`, which is a required check. Both are now built
on a shared `PlanningCard` shell that owns the header, the title link, the badge
and the footer; each card supplies only its own readout. `CreatePlaceholderCard`
does the same for the dimmed trailing card, which was duplicated across both
create dialogs before this — so this removes more duplication than it adds. The
threshold is untouched.

## Feature flag

Savings goals sit behind `App\Features\SavingsGoals`, which resolves false by
default. With the flag off the page is budgets only, with no filter toggle, and
the budget card is exactly what it was — the ring and the mixed-list chrome only
ever belong to goals, so the flag-off state costs nothing.

## Worth a product call

A user who already has budgets and no goals no longer gets a tall, dedicated
"add your first savings goal" placeholder — the old layout gave each section its
own empty state, and the single trailing card cannot. The header Create dropdown
still offers Savings Goal prominently. Flagging it because it affects
discoverability of savings goals for exactly the users most likely to have
budgets already; happy to add a nudge if that matters for the rollout.

Separately: the goal card reuses the existing `Saved` translation key, which
renders as "Guardado" / "Enregistré" — closer to "saved a file" than "saved
toward a goal". Pre-existing and shared with other screens, so left alone here.

## Tests

- `resources/js/lib/planning-items.test.ts` — new: tier boundaries (including a
  budget with no active period, and that a goal never reaches tier 0), ordering,
  and that healthy items interleave by name instead of regrouping by type.
- `resources/js/pages/budgets/index.test.tsx` — updated: no per-type section
  headings, the mixed list, all three filter positions and their URLs, and the
  create card in each of its three shapes.

## Demo

<!-- PLACEHOLDER: drag the QA video in here -->

Uploading planning-unified-list-qa.mp4…


