### PR TITLE
fix(savings-goals): count savings-account inflows as contributions

### DIFF
--- a/app/Models/SavingsGoal.php
+++ b/app/Models/SavingsGoal.php
@@ -2,15 +2,18 @@
 
 namespace App\Models;
 
+use App\Enums\AccountType;
 use App\Models\Concerns\Archivable;
 use App\Models\Concerns\BelongsToSpace;
 use Database\Factories\SavingsGoalFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 
 /**
  * @property Carbon $created_at
@@ -64,15 +67,41 @@ class SavingsGoal extends Model
     }
 
     /**
+     * What a tagged transaction contributes to a goal, as SQL. On a savings
+     * account the money arriving IS the contribution, so the amount counts as
+     * it stands (+ adds, a withdrawal subtracts). On any other account type the
+     * tagged transaction is the outflow that funded the goal, so its sign is
+     * negated: a transfer out (−) adds, a transfer back (+) subtracts.
+     *
+     * Only valid on queries that ran {@see Transaction::scopeJoinOwningAccount()}.
+     */
+    public const CONTRIBUTION_AMOUNT_SQL = "case when accounts.type = '".AccountType::Savings->value."' then transactions.amount else -transactions.amount end";
+
+    /**
+     * Transactions tagged with any of the given labels, joined to their owning
+     * account so {@see self::CONTRIBUTION_AMOUNT_SQL} can read its type.
+     *
+     * @param  iterable<int, string>  $labelIds
+     * @return Builder<Transaction>
+     */
+    private static function taggedContributions(iterable $labelIds): Builder
+    {
+        return Transaction::query()
+            ->join('label_transaction', 'label_transaction.transaction_id', '=', 'transactions.id')
+            ->joinOwningAccount()
+            ->whereIn('label_transaction.label_id', $labelIds);
+    }
+
+    /**
      * Money set aside toward the goal, in cents: whatever was already saved when
-     * the goal was created plus its tagged transactions. Contributions are
-     * outflows, so the natural transaction sign is negated (same convention as
-     * budgets): a transfer out (−) adds, a withdrawal back (+) subtracts.
+     * the goal was created plus what its tagged transactions contribute.
      *
      * An archived goal reads its snapshot instead. Recomputing would drift:
      * archiving deletes the label, so the sum would collapse to the starting
      * balance, and re-tagging one of those transactions afterwards would move a
      * figure that is meant to be final.
+     *
+     * @see self::CONTRIBUTION_AMOUNT_SQL for the sign rule.
      */
     public function savedAmountInCents(): int
     {
@@ -84,7 +113,8 @@ class SavingsGoal extends Model
             return $this->initial_amount;
         }
 
-        return $this->initial_amount - (int) $this->label->transactions()->sum('transactions.amount');
+        return $this->initial_amount + (int) self::taggedContributions([$this->label_id])
+            ->sum(DB::raw(self::CONTRIBUTION_AMOUNT_SQL));
     }
 
     /**
@@ -101,21 +131,20 @@ class SavingsGoal extends Model
         $goals = $user->savingsGoals()->with(['label' => fn ($query) => $query->withTrashed()])->get();
 
         // ponytail: one grouped sum+min for all goals' labels avoids N+1 across the list.
-        $aggByLabel = Transaction::query()
-            ->join('label_transaction', 'label_transaction.transaction_id', '=', 'transactions.id')
-            ->whereIn('label_transaction.label_id', $goals->pluck('label_id')->filter())
+        $aggByLabel = self::taggedContributions($goals->pluck('label_id')->filter())
             ->groupBy('label_transaction.label_id')
-            ->selectRaw('label_transaction.label_id as label_id, SUM(transactions.amount) as total, MIN(transactions.transaction_date) as earliest')
+            ->selectRaw('label_transaction.label_id as label_id, SUM('.self::CONTRIBUTION_AMOUNT_SQL.') as total, MIN(transactions.transaction_date) as earliest')
             ->get()
             ->keyBy('label_id');
 
         return $goals->map(function (SavingsGoal $goal) use ($aggByLabel): array {
             $agg = $aggByLabel->get($goal->label_id);
-            // Starting balance plus negated net flow, mirroring savedAmountInCents();
-            // batched to avoid N+1. An archived goal keeps the snapshot it froze.
+            // Starting balance plus the tagged contributions, mirroring
+            // savedAmountInCents(); batched to avoid N+1. An archived goal keeps
+            // the snapshot it froze.
             $saved = $goal->isArchived()
                 ? (int) $goal->archived_saved_amount
-                : $goal->initial_amount - (int) ($agg->total ?? 0);
+                : $goal->initial_amount + (int) ($agg->total ?? 0);
 
             return array_merge($goal->toArray(), [
                 'stats' => self::project(

--- a/resources/js/components/savings-goals/savings-goal-progress-chart.tsx
+++ b/resources/js/components/savings-goals/savings-goal-progress-chart.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/chart';
 import { usePrivacyMode } from '@/contexts/privacy-mode-context';
 import { useLocale } from '@/hooks/use-locale';
+import { savingsContributionAmount } from '@/types/account';
 import { SavingsGoal, SavingsGoalStats } from '@/types/savings-goal';
 import { Transaction } from '@/types/transaction';
 import { formatCurrency } from '@/utils/currency';
@@ -131,13 +132,15 @@ export function SavingsGoalProgressChart({
             : null;
         const rate = stats.rate_per_day;
 
-        // Contributions are outflows, so the natural sign is negated.
         const byDate = new Map<string, number>();
         let earliest: Date | null = null;
         transactions.forEach((t) => {
             const day = startOfDay(parseISO(t.transaction_date));
             const key = toKey(day);
-            byDate.set(key, (byDate.get(key) ?? 0) + -t.amount);
+            byDate.set(
+                key,
+                (byDate.get(key) ?? 0) + savingsContributionAmount(t),
+            );
             if (!earliest || day < earliest) {
                 earliest = day;
             }

--- a/resources/js/types/account.ts
+++ b/resources/js/types/account.ts
@@ -165,6 +165,23 @@ export function supportsInvestedAmount(
     return INVESTED_AMOUNT_ACCOUNT_TYPES.includes(account.type);
 }
 
+/**
+ * What a transaction tagged to a savings goal contributes to it. On a savings
+ * account the money arriving IS the contribution, so the amount counts as it
+ * stands. On any other account type the transaction is the outflow that funded
+ * the goal, so its sign is negated.
+ *
+ * Mirrors the backend `SavingsGoal::CONTRIBUTION_AMOUNT_SQL`.
+ */
+export function savingsContributionAmount(transaction: {
+    amount: number;
+    account?: Pick<Account, 'type'> | null;
+}): number {
+    return transaction.account?.type === 'savings'
+        ? transaction.amount
+        : -transaction.amount;
+}
+
 export function accountIconByType(type: AccountType): LucideIcon {
     const typeMap: Record<AccountType, LucideIcon> = {
         checking: Wallet,

--- a/tests/Feature/SavingsGoalTest.php
+++ b/tests/Feature/SavingsGoalTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\AccountType;
 use App\Enums\LabelSource;
 use App\Features\SavingsGoals;
 use App\Models\Account;
@@ -16,6 +17,15 @@ use Laravel\Pennant\Feature;
 function onboardedSavingsUser(): User
 {
     return User::factory()->create(['onboarded_at' => now()]);
+}
+
+/**
+ * The account factory picks a random type, and the contribution sign depends on
+ * it, so every test spells out the type it means.
+ */
+function savingsGoalAccount(User $user, AccountType $type = AccountType::Checking): Account
+{
+    return Account::factory()->create(['user_id' => $user->id, 'type' => $type]);
 }
 
 test('creating a goal creates a linked hidden label with the same name', function () {
@@ -59,10 +69,10 @@ test('goal-backed labels are hidden from the labels settings screen', function (
     );
 });
 
-test('saved amount is the negated net flow of tagged transactions', function () {
+test('saved amount is the negated net flow of transactions outside a savings account', function () {
     $user = onboardedSavingsUser();
     $goal = SavingsGoal::factory()->create(['user_id' => $user->id]);
-    $account = Account::factory()->create(['user_id' => $user->id]);
+    $account = savingsGoalAccount($user);
 
     // Outflow to savings (−500) contributes +500; a withdrawal back (+200) subtracts.
     $outflow = Transaction::factory()->create([
@@ -82,6 +92,91 @@ test('saved amount is the negated net flow of tagged transactions', function () 
     expect($goal->savedAmountInCents())->toBe(30000);
 });
 
+test('saved amount counts a savings account inflow as the contribution', function () {
+    $user = onboardedSavingsUser();
+    $goal = SavingsGoal::factory()->create(['user_id' => $user->id]);
+    $account = savingsGoalAccount($user, AccountType::Savings);
+
+    // On the savings account itself the arriving money (+500) IS the contribution,
+    // and taking it back out (−200) subtracts.
+    $deposit = Transaction::factory()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'amount' => 50000,
+    ]);
+    $withdrawal = Transaction::factory()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'amount' => -20000,
+    ]);
+
+    $deposit->labels()->attach($goal->label_id);
+    $withdrawal->labels()->attach($goal->label_id);
+
+    expect($goal->savedAmountInCents())->toBe(30000);
+});
+
+test('each leg of a transfer counts on its own terms', function () {
+    $user = onboardedSavingsUser();
+    $goal = SavingsGoal::factory()->create(['user_id' => $user->id]);
+
+    // Both legs of the same 500 transfer: −500 leaving checking and +500
+    // arriving in savings each read as +500. Tagging both therefore counts the
+    // transfer twice — the sign is per transaction, and it is up to the user to
+    // tag the leg they mean, exactly as it was before this rule existed.
+    $checkingLeg = Transaction::factory()->create([
+        'user_id' => $user->id,
+        'account_id' => savingsGoalAccount($user)->id,
+        'amount' => -50000,
+    ]);
+    $savingsLeg = Transaction::factory()->create([
+        'user_id' => $user->id,
+        'account_id' => savingsGoalAccount($user, AccountType::Savings)->id,
+        'amount' => 50000,
+    ]);
+
+    $checkingLeg->labels()->attach($goal->label_id);
+    $savingsLeg->labels()->attach($goal->label_id);
+
+    expect($goal->savedAmountInCents())->toBe(100000);
+});
+
+test('the goals list applies the same sign rule per account type', function () {
+    $user = onboardedSavingsUser();
+    $goal = SavingsGoal::factory()->create([
+        'user_id' => $user->id,
+        'target_amount' => 400000,
+        'initial_amount' => 0,
+    ]);
+
+    $checkingOutflow = Transaction::factory()->create([
+        'user_id' => $user->id,
+        'account_id' => savingsGoalAccount($user)->id,
+        'amount' => -50000,
+    ]);
+    $savingsDeposit = Transaction::factory()->create([
+        'user_id' => $user->id,
+        'account_id' => savingsGoalAccount($user, AccountType::Savings)->id,
+        'amount' => 30000,
+    ]);
+    $savingsWithdrawal = Transaction::factory()->create([
+        'user_id' => $user->id,
+        'account_id' => savingsGoalAccount($user, AccountType::Savings)->id,
+        'amount' => -10000,
+    ]);
+
+    $checkingOutflow->labels()->attach($goal->label_id);
+    $savingsDeposit->labels()->attach($goal->label_id);
+    $savingsWithdrawal->labels()->attach($goal->label_id);
+
+    // The grouped query behind the list is separate code from savedAmountInCents(),
+    // so it gets its own assertion.
+    $goals = SavingsGoal::withStatsForUser($user);
+
+    expect($goals[0]['stats']['saved'])->toBe(70000)
+        ->and($goal->savedAmountInCents())->toBe(70000);
+});
+
 test('show exposes computed progress stats', function () {
     $user = onboardedSavingsUser();
     Feature::for($user)->activate(SavingsGoals::class);
@@ -91,7 +186,7 @@ test('show exposes computed progress stats', function () {
         'target_amount' => 100000,
         'target_date' => null,
     ]);
-    $account = Account::factory()->create(['user_id' => $user->id]);
+    $account = savingsGoalAccount($user);
     $transaction = Transaction::factory()->create([
         'user_id' => $user->id,
         'account_id' => $account->id,
@@ -119,7 +214,7 @@ test('the goal page stats include the starting amount', function () {
         'initial_amount' => 100000,
         'target_date' => null,
     ]);
-    $account = Account::factory()->create(['user_id' => $user->id]);
+    $account = savingsGoalAccount($user);
     $contribution = Transaction::factory()->create([
         'user_id' => $user->id,
         'account_id' => $account->id,
@@ -160,7 +255,7 @@ test('the starting amount adds to the tagged transactions', function () {
         'user_id' => $user->id,
         'initial_amount' => 100000,
     ]);
-    $account = Account::factory()->create(['user_id' => $user->id]);
+    $account = savingsGoalAccount($user);
 
     $contribution = Transaction::factory()->create([
         'user_id' => $user->id,
@@ -256,7 +351,7 @@ test('the goals list adds the starting amount to its progress', function () {
         'target_amount' => 400000,
         'initial_amount' => 100000,
     ]);
-    $account = Account::factory()->create(['user_id' => $user->id]);
+    $account = savingsGoalAccount($user);
     $contribution = Transaction::factory()->create([
         'user_id' => $user->id,
         'account_id' => $account->id,
@@ -367,7 +462,7 @@ test('syncing transactions attaches the ticked ones and detaches the rest', func
     Feature::for($user)->activate(SavingsGoals::class);
 
     $goal = SavingsGoal::factory()->create(['user_id' => $user->id]);
-    $account = Account::factory()->create(['user_id' => $user->id]);
+    $account = savingsGoalAccount($user);
 
     $alreadyTagged = Transaction::factory()->create([
         'user_id' => $user->id,
@@ -402,7 +497,7 @@ test('syncing transactions ignores ids belonging to someone else', function () {
     $stranger = User::factory()->create();
     $theirTransaction = Transaction::factory()->create([
         'user_id' => $stranger->id,
-        'account_id' => Account::factory()->create(['user_id' => $stranger->id])->id,
+        'account_id' => savingsGoalAccount($stranger)->id,
         'amount' => -50000,
     ]);
 
@@ -433,7 +528,7 @@ test('the goal page only loads recent transactions when asked for them', functio
     Feature::for($user)->activate(SavingsGoals::class);
 
     $goal = SavingsGoal::factory()->create(['user_id' => $user->id]);
-    $account = Account::factory()->create(['user_id' => $user->id]);
+    $account = savingsGoalAccount($user);
     Transaction::factory()->create([
         'user_id' => $user->id,
         'account_id' => $account->id,
@@ -458,7 +553,7 @@ test('the link dialog can widen the recent transactions window, up to a cap', fu
     Feature::for($user)->activate(SavingsGoals::class);
 
     $goal = SavingsGoal::factory()->create(['user_id' => $user->id]);
-    $account = Account::factory()->create(['user_id' => $user->id]);
+    $account = savingsGoalAccount($user);
     // One shared category: the factory only has a handful of unique names to give.
     $category = Category::factory()->create(['user_id' => $user->id]);
     Transaction::factory()->count(55)->create([


### PR DESCRIPTION
## Problem

A tagged transaction's contribution to a savings goal was **always negated**: an outflow (−) added to the goal, an inflow (+) subtracted.

That is right for a transfer leaving a checking account — the money left the account but went into the savings bucket. It is wrong when the tagged transaction sits on the **savings account itself**: there the money arriving *is* the contribution, and a withdrawal is what takes it away. Tagging deposits on a savings account made the goal go *backwards*.

## The rule now

A tagged transaction contributes:

- `+amount` when its account type is `savings`
- `-amount` for every other account type (unchanged)

Only `AccountType::Savings` flips. Investment/retirement/real-estate are balance-tracking types (`isNonTransactional()`) or can't sync transactions, so they have no meaningful ledger to tag; credit cards and everything else keep the negated behaviour.

## Implementation

The sign rule lives in exactly one place per language:

- **PHP** — `SavingsGoal::CONTRIBUTION_AMOUNT_SQL`, a `case when accounts.type = 'savings' …` expression built off the enum value, shared by both aggregate paths through a new `taggedContributions()` query builder. The planning list stays **one grouped query** (no N+1), and the sign is applied **per row before summing**, so the list and the detail page cannot disagree.
- **TypeScript** — `savingsContributionAmount()` in `resources/js/types/account.ts`, next to the existing `isTransactionalAccount` / `supportsInvestedAmount` mirrors, used by the progress chart. The chart's solid line and the server-side `stats.saved` can no longer diverge.

No migration, no new column, no config — the sign is derived from the account type.

## Notes for review

- **Existing goals whose tagged transactions live on a savings account will change value**, potentially flipping sign. That is the point of the fix, but it is a visible one-time jump in "Saved" and progress % for affected users — worth a line in the release notes.
- **Tagging both legs of the same transfer now counts it twice** (−500 on checking reads as +500, +500 on savings also reads as +500). Before, the uniform negation made them cancel to 0 — neither is "one contribution", and the sign is per transaction by design. Left as is: tagging both legs is user error, and adding dedup would be speculative machinery. Flagging it so the behaviour is a decision rather than a surprise.
- `AccountFactory` picks a **random** account type, which the assertions now depend on. Every savings-goal test goes through a `savingsGoalAccount($user, $type)` helper that spells out the type it means — without this the existing tests would have been flaky.
- Ownership-percentage weighting of these sums is still not applied, unchanged and out of scope.

## Tests

`tests/Feature/SavingsGoalTest.php` — new coverage for a savings-account inflow adding, a savings-account withdrawal subtracting, both legs of a transfer counting on their own terms, and the mixed case through `withStatsForUser()` (the grouped query is separate code from `savedAmountInCents()`, so it is asserted separately). Existing negated-outflow behaviour still asserted.

Full suite: 2720 passed / 2721. `pint`, `phpstan`, `lint`, `format`, `dry` and `crap` all clean.

## QA

Verified in the browser against the running app on a demo account with three goals:

| Case | Result |
| --- | --- |
| Savings-account inflow + withdrawal | `+$300 − $50` → Saved **$250.00** (5%) |
| Chart tooltip vs. card | tooltip `$250.00` = card `$250.00`, on all three goals |
| Checking outflow (unchanged) | `−$150` → Saved **$150.00** (8%) |
| Planning list vs. detail pages | identical figures for all three goals |
| Mixed (checking `−$400` + savings `+$200`) | Saved **$600.00** (6%) |

No console errors on any page.

## Demo

<!-- PLACEHOLDER: drag the video in here -->

**Video to attach:** `~/Downloads/savings-goal-savings-inflows-qa.mp4`

https://github.com/user-attachments/assets/cb12e235-caab-43b3-8086-ea1c20285249



> Caveat, stated plainly: Playwright's native video recording could not be used (its bundled ffmpeg download was blocked, HTTP 403). This file is an H.264 **slideshow of real screenshots** taken at each step of the flow in the running app — every frame is genuine, but it is not continuous footage.