### PR TITLE
fix(ui): stop toggle group shadow spanning full width

### DIFF
--- a/resources/js/components/ui/toggle-group.tsx
+++ b/resources/js/components/ui/toggle-group.tsx
@@ -26,7 +26,7 @@ function ToggleGroup({
       data-variant={variant}
       data-size={size}
       className={cn(
-        "group/toggle-group flex items-center rounded-md data-[variant=outline]:shadow-xs",
+        "group/toggle-group flex w-fit items-center rounded-md data-[variant=outline]:shadow-xs",
         className
       )}
       {...props}


### PR DESCRIPTION
## What

The Planning page's type filter (All / Budgets / Savings Goals) drew its shadow across the full page width, well past the buttons themselves.

`ToggleGroup`'s root is a block-level `flex` container, so it stretched to 100% and took `data-[variant=outline]:shadow-xs` with it. Added `w-fit` to the root, which is what upstream shadcn does.

## Scope

The fix is in the shared `ToggleGroup` component, so the other `variant="outline"` groups (chart view/currency toggles, settings/mcp) get the same correct box.

## Testing

Class-only change; no test asserts on it. Worth a quick visual check on Planning and the chart toggles.