### PR TITLE
fix(budgets): render period dates correctly at negative UTC offsets

### DIFF
--- a/app/Models/BudgetPeriod.php
+++ b/app/Models/BudgetPeriod.php
@@ -31,8 +31,8 @@ class BudgetPeriod extends Model
     protected function casts(): array
     {
         return [
-            'start_date' => 'date',
-            'end_date' => 'date',
+            'start_date' => 'date:Y-m-d',
+            'end_date' => 'date:Y-m-d',
             'allocated_amount' => 'integer',
             'carried_over_amount' => 'integer',
             'processing_historical' => 'boolean',

--- a/resources/js/utils/date.test.ts
+++ b/resources/js/utils/date.test.ts
@@ -1,0 +1,27 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { formatDate } from './date';
+
+describe('formatDate', () => {
+    // Reported from America/Buenos_Aires: budget periods rendered a day early
+    // because a bare YYYY-MM-DD parses as UTC midnight.
+    const originalTimeZone = process.env.TZ;
+
+    beforeAll(() => {
+        process.env.TZ = 'America/Argentina/Buenos_Aires';
+    });
+
+    afterAll(() => {
+        process.env.TZ = originalTimeZone;
+    });
+
+    it('keeps the calendar day of a bare date key at a negative UTC offset', () => {
+        expect(formatDate('2026-08-01', 'yyyy-MM-dd')).toBe('2026-08-01');
+        expect(formatDate('2026-08-31', 'yyyy-MM-dd')).toBe('2026-08-31');
+    });
+
+    it('still formats a full instant in the local time zone', () => {
+        expect(formatDate('2026-08-01T12:00:00.000000Z', 'yyyy-MM-dd')).toBe(
+            '2026-08-01',
+        );
+    });
+});

--- a/resources/js/utils/date.ts
+++ b/resources/js/utils/date.ts
@@ -19,6 +19,20 @@ function getDateFnsLocale(locale: string) {
 }
 
 /**
+ * `new Date('2026-08-01')` is UTC midnight per the ECMAScript spec, so at a
+ * negative UTC offset it formats as the previous day. Appending a time makes
+ * the same string parse as local midnight, which is what a date-only value
+ * from the server (a budget period, a transaction date) actually means.
+ */
+function toLocalDate(date: Date | string | number): Date {
+    if (typeof date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(date)) {
+        return new Date(`${date}T00:00:00`);
+    }
+
+    return date instanceof Date ? date : new Date(date);
+}
+
+/**
  * Format a date using the user's locale
  */
 export function formatDate(
@@ -26,10 +40,7 @@ export function formatDate(
     formatStr: string,
     locale: string = 'en-US',
 ): string {
-    const dateObj =
-        typeof date === 'string' || typeof date === 'number'
-            ? new Date(date)
-            : date;
+    const dateObj = toLocalDate(date);
 
     const dateFnsLocale = getDateFnsLocale(locale);
 

--- a/tests/Feature/BudgetPeriodDateTest.php
+++ b/tests/Feature/BudgetPeriodDateTest.php
@@ -111,7 +111,36 @@ test('budget show finds current period on last day of period', function () {
     $response->assertInertia(fn ($page) => $page
         ->component('budgets/show')
         ->has('currentPeriod')
-        ->where('currentPeriod.start_date', '2026-01-01T00:00:00.000000Z')
+        ->where('currentPeriod.start_date', '2026-01-01')
+    );
+
+    Carbon::setTestNow();
+});
+
+test('budget show serializes period dates as bare date keys', function () {
+    Carbon::setTestNow(Carbon::parse('2026-01-15 12:00:00'));
+
+    $user = User::factory()->create(['onboarded_at' => now()]);
+
+    $budget = Budget::factory()->create([
+        'user_id' => $user->id,
+        'period_type' => BudgetPeriodType::Monthly,
+        'period_start_day' => 1,
+    ]);
+
+    BudgetPeriod::factory()->create([
+        'budget_id' => $budget->id,
+        'start_date' => '2026-01-01',
+        'end_date' => '2026-01-31',
+        'allocated_amount' => 100000,
+    ]);
+
+    $response = $this->actingAs($user)->get("/budgets/{$budget->id}");
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page
+        ->where('currentPeriod.start_date', '2026-01-01')
+        ->where('currentPeriod.end_date', '2026-01-31')
     );
 
     Carbon::setTestNow();

--- a/tests/Feature/BudgetTest.php
+++ b/tests/Feature/BudgetTest.php
@@ -202,7 +202,7 @@ test('budget show returns previous period when it exists', function () {
         ->component('budgets/show')
         ->has('currentPeriod')
         ->has('previousPeriod')
-        ->where('previousPeriod.start_date', now()->subMonthNoOverflow()->startOfMonth()->toJSON())
+        ->where('previousPeriod.start_date', now()->subMonthNoOverflow()->startOfMonth()->toDateString())
     );
 });
 
@@ -276,7 +276,7 @@ test('budget show returns next period only when it starts on or before today', f
         ->component('budgets/show')
         ->has('currentPeriod')
         ->has('nextPeriod')
-        ->where('nextPeriod.start_date', now()->startOfMonth()->toJSON())
+        ->where('nextPeriod.start_date', now()->startOfMonth()->toDateString())
     );
 });
 


### PR DESCRIPTION
Budget periods rendered one day early for anyone west of UTC. A monthly budget anchored on day 1 showed as **"Jul 31 – Aug 30"** instead of **"Aug 1 – Aug 31"**. Reported from `America/Buenos_Aires` (UTC-3) on budget `019fc9e2-a6c9-72a7-b1dc-d241d16c5f2d`.

The stored dates were never wrong — I checked prod, the periods are exactly `2026-08-01 → 2026-08-31`. Period generation is untouched. Both causes were on the display path.

## Cause 1 — the cast serialized a date as an instant

`BudgetPeriod` cast `start_date`/`end_date` as a plain `date`, which serializes a date-only column as a full UTC instant:

```
{"start_date":"2026-08-01T00:00:00.000000Z"}
```

`date:Y-m-d` is what the rest of the app already uses for date-only columns that reach the frontend — `Transaction::transaction_date`, `SavingsGoal::target_date`, `RealEstateDetail::purchase_date`. It now serializes as `{"start_date":"2026-08-01"}`.

## Cause 2 — `formatDate()` parsed a bare date as UTC

The cast alone did **not** fix the symptom, which is worth spelling out because it's counter-intuitive. `formatDate()` builds its Date with `new Date(value)`, and per the ECMAScript spec a date-only string is parsed as **UTC** midnight while a date-*time* string without a zone is parsed as **local**:

```js
// TZ=America/Argentina/Buenos_Aires
new Date('2026-08-01')           // → Fri Jul 31 2026 21:00:00 GMT-0300  ✗
new Date('2026-08-01T00:00:00')  // → Sat Aug 01 2026 00:00:00 GMT-0300  ✓
```

So `formatDate` rendered Jul 31 from both the old and the new payload. It now appends a time to date-only strings — the same trick `formatRelativeDate()` and `formatDayFromDate()` already use a few lines below in that file. Full instants and `Date` objects go through unchanged.

Fixing the shared utility rather than the call sites means the three budget surfaces are fixed by one change, and the next caller doesn't re-step on it.

## What this fixes

| Surface | Before (UTC-3) | After |
| --- | --- | --- |
| Period navigation (`budget-period-navigation.tsx`) | `Jul 31, '26 – Aug 30, '26` | `Aug 1, '26 – Aug 31, '26` |
| Budget list card (`budget-list-card.tsx`) | `Jul 31 - Aug 30` | `Aug 1 - Aug 31` |
| Spending chart header (`budget-spending-chart.tsx`) | `Jul 31 - Aug 30, 2026` | `Aug 1 - Aug 31, 2026` |

The chart's X axis and its "today" marker were fixed by the cast alone — they parse via date-fns `parseISO`, which handles a bare date key correctly.

## Tests

- `tests/Feature/BudgetPeriodDateTest.php` — new test pinning the Inertia prop for both `start_date` and `end_date` to a bare `Y-m-d`. Confirmed red on the old cast (`'2026-08-01T00:00:00.000000Z'` vs `'2026-08-01'`).
- `resources/js/utils/date.test.ts` — new, runs with `TZ` forced to `America/Argentina/Buenos_Aires`. Confirmed red without the parsing fix (`expected '2026-07-31' to be '2026-08-01'`).
- Two existing assertions updated to the new shape: `BudgetPeriodDateTest.php` (a literal ISO string) and `BudgetTest.php` ×2, which used `->toJSON()` and so didn't turn up in a grep for the literal.

## Verification

Driven in Chrome via Playwright with `timezoneId: 'America/Argentina/Buenos_Aires'` (confirmed in-page: `Intl…timeZone = America/Buenos_Aires`, offset 180 min). Captured with the fix reverted and then re-applied against the same seeded budget, so the before column above is a real observation, not a prediction. `Jul 31`/`Aug 30` appear nowhere on the page afterwards.

## Demo

<img width="1400" height="1800" alt="budget-period-dates-before-after" src="https://github.com/user-attachments/assets/ad2dbc42-4225-4008-917f-c5707f5a1457" />



## Scope

Five other models carry the same plain `'date'` cast and the same latent bug — `LoanDetail::start_date`, `AccountBalance::balance_date`, `ExchangeRate::date`, `StuckCohortSnapshot::date`, `Account::transactions_paginate_before`. Deliberately left out; they have their own blast radius and deserve their own PR. Note the `formatDate` fix already removes the off-by-one for any of them that render through it (`edit-loan-detail-dialog.tsx`'s `.slice(0, 10)` workaround keeps working either way).

`formatDateMedium()` and `formatDateLong()` still build their own `new Date(dateStr)` and so keep the old behaviour. None of their callers are budget surfaces (transactions, imports, roadmap, accounts), so they're part of that follow-up rather than this fix.

No data migration: only the JSON shape changed.

## Local gate

`pint --test` · `bun run build` · `lint` · `format` · `dry` (4.34% vs 5.4%) · `crap` · vitest 513/513 · pest 2737/2744.

The 7 non-passing pest tests are 6 pre-existing `409`s in `DashboardTest`, `SavingsGoalTest` and `SharedAccountOwnershipTest` (Inertia asset-version mismatch from a local build). I verified they're unrelated: they fail identically with both source files reverted to `origin/main`. CI builds fresh, so they should be green there.
