### PR TITLE
feat(docs): draw the documentation diagrams instead of rendering mermaid

### DIFF
--- a/.diagram-design
+++ b/.diagram-design
@@ -1,0 +1,1 @@
+profile: whisper-money

--- a/app/Support/Documentation/DocumentationMarkdown.php
+++ b/app/Support/Documentation/DocumentationMarkdown.php
@@ -17,6 +17,12 @@ final class DocumentationMarkdown
     private const MARKDOWN_OPTIONS = ['html_input' => 'strip', 'allow_unsafe_links' => false];
 
     /**
+     * The line inside a mermaid block that names the drawing the page shows in
+     * its place, as a mermaid comment so the block still renders anywhere else.
+     */
+    private const DIAGRAM_MARKER = '%% diagram:';
+
+    /**
      * Screenshots are taken at twice the size they are shown at, by
      * scripts/docs-screenshots.mjs, so that they stay sharp on a high-density
      * screen. Telling the browser the size it will really paint them at is what
@@ -30,10 +36,11 @@ final class DocumentationMarkdown
      */
     public static function render(string $markdown, array $levels): array
     {
-        $cards = self::extractCardBlocks($markdown);
+        $diagrams = self::extractDiagramBlocks($markdown);
+        $cards = self::extractCardBlocks($diagrams['markdown']);
         $headings = self::headings($markdown, $levels);
         $html = (string) Str::of(self::withoutTocPlaceholder($cards['markdown']))->markdown(self::MARKDOWN_OPTIONS);
-        $html = self::replaceCardPlaceholders($html, $cards['html']);
+        $html = self::replacePlaceholders($html, [...$cards['html'], ...$diagrams['html']]);
 
         return [
             'html' => self::withThemedImages(self::addHeadingIds($html, $headings, $levels)),
@@ -60,7 +67,57 @@ final class DocumentationMarkdown
 
     private static function isLayoutMarkup(string $line): bool
     {
-        return in_array($line, ['<div class="cards-wrapper">', '<div class="card">', '</div>'], true);
+        return in_array($line, ['<div class="cards-wrapper">', '<div class="card">', '</div>'], true)
+            || Str::startsWith($line, self::DIAGRAM_MARKER);
+    }
+
+    /**
+     * A page's mermaid block stays in the Markdown, because for an agent reading
+     * the `.md` twin it is the best description of the diagram there is. The
+     * page itself shows the drawing that was made for that block instead, named
+     * by the `%% diagram:` line inside it. The block is lifted out before the
+     * Markdown is rendered — raw HTML is stripped — and the SVG goes back in
+     * once the page around it is HTML.
+     *
+     * @return array{markdown: string, html: array<string, string>}
+     */
+    private static function extractDiagramBlocks(string $markdown): array
+    {
+        $diagrams = [];
+
+        $replaced = preg_replace_callback(
+            '/^```mermaid\R(.*?)^```$/ms',
+            function (array $match) use (&$diagrams): string {
+                $svg = self::diagramSvg($match[1]);
+
+                if ($svg === null) {
+                    return $match[0];
+                }
+
+                $placeholder = 'DOCUMENTATION_DIAGRAM_'.count($diagrams);
+                $diagrams[$placeholder] = '<div class="documentation-diagram">'.$svg.'</div>';
+
+                return $placeholder;
+            },
+            $markdown,
+        );
+
+        return ['markdown' => $replaced ?? $markdown, 'html' => $diagrams];
+    }
+
+    /**
+     * The drawing a mermaid block names, when it names one that has been drawn.
+     * Anything else keeps the block as it is written.
+     */
+    private static function diagramSvg(string $definition): ?string
+    {
+        if (preg_match('/^[ \t]*'.preg_quote(self::DIAGRAM_MARKER, '/').'[ \t]*([a-z0-9-]+)[ \t]*$/m', $definition, $match) !== 1) {
+            return null;
+        }
+
+        $file = resource_path('docs/diagrams/'.$match[1].'.svg');
+
+        return File::exists($file) ? trim(File::get($file)) : null;
     }
 
     /**
@@ -228,12 +285,12 @@ final class DocumentationMarkdown
     }
 
     /**
-     * @param  array<string, string>  $cardBlocks
+     * @param  array<string, string>  $blocks
      */
-    private static function replaceCardPlaceholders(string $html, array $cardBlocks): string
+    private static function replacePlaceholders(string $html, array $blocks): string
     {
-        foreach ($cardBlocks as $placeholder => $cardHtml) {
-            $html = str_replace(["<p>{$placeholder}</p>", $placeholder], $cardHtml, $html);
+        foreach ($blocks as $placeholder => $blockHtml) {
+            $html = str_replace(["<p>{$placeholder}</p>", $placeholder], $blockHtml, $html);
         }
 
         return $html;

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -378,3 +378,188 @@
         animation: icon-pulse 2s ease-in-out infinite;
     }
 }
+
+/*
+ * Documentation diagrams.
+ *
+ * Each diagram is an inline SVG under resources/docs/diagrams, drawn against
+ * the tokens below rather than against baked-in hex values, so one file serves
+ * both themes: the label masks are painted with the same paper the page is
+ * painted with, and the strokes follow the theme the reader chose. The type and
+ * shape classes live here too, which keeps the SVG files down to geometry.
+ */
+.documentation-diagram {
+    --dg-paper: #fdfdfc;
+    --dg-fill: #ffffff;
+    --dg-fill-2: rgba(27, 27, 24, 0.04);
+    --dg-ink: #1b1b18;
+    --dg-muted: #706f6c;
+    --dg-soft: #8f8e8a;
+    --dg-rule: #e3e3e0;
+    --dg-accent: #5e7a9b;
+    --dg-accent-tint: rgba(94, 122, 155, 0.1);
+    --dg-band: rgba(112, 111, 108, 0.18);
+    --dg-band-accent: rgba(94, 122, 155, 0.28);
+    --dg-solid: #1b1b18;
+    --dg-mono: ui-monospace, sfmono-regular, menlo, monospace;
+
+    margin: 2rem 0;
+    overflow-x: auto;
+}
+
+.dark .documentation-diagram {
+    --dg-paper: #0a0a0a;
+    --dg-fill: #131312;
+    --dg-fill-2: rgba(237, 237, 236, 0.07);
+    --dg-ink: #ededec;
+    --dg-muted: #a1a09a;
+    --dg-soft: #7c7b77;
+    --dg-rule: #3e3e3a;
+    --dg-accent: #82a0c0;
+    --dg-accent-tint: rgba(130, 160, 192, 0.14);
+    --dg-band: rgba(161, 160, 154, 0.2);
+    --dg-band-accent: rgba(130, 160, 192, 0.32);
+    --dg-solid: #a1a09a;
+}
+
+/*
+ * Below the minimum width a 12px label stops being readable, so the container
+ * scrolls sideways rather than the diagram shrinking any further.
+ */
+.documentation-diagram svg {
+    display: block;
+    width: 100%;
+    min-width: 34rem;
+    height: auto;
+}
+
+.documentation-diagram text {
+    font-family: var(--font-sans);
+}
+
+.documentation-diagram .dg-name {
+    font-size: 12px;
+    font-weight: 600;
+    fill: var(--dg-ink);
+}
+
+.documentation-diagram .dg-sub {
+    font-family: var(--dg-mono);
+    font-size: 9px;
+    fill: var(--dg-muted);
+}
+
+.documentation-diagram .dg-eyebrow,
+.documentation-diagram .dg-edge-label {
+    font-family: var(--dg-mono);
+    font-size: 8px;
+    font-weight: 500;
+    fill: var(--dg-soft);
+    letter-spacing: 0.14em;
+}
+
+.documentation-diagram .dg-edge-label {
+    fill: var(--dg-muted);
+    letter-spacing: 0.06em;
+}
+
+.documentation-diagram .dg-aside {
+    font-family: 'IBM Plex Serif', ui-serif, Georgia, serif;
+    font-size: 12px;
+    font-style: italic;
+    fill: var(--dg-muted);
+}
+
+.documentation-diagram .dg-mask {
+    fill: var(--dg-paper);
+}
+
+.documentation-diagram .dg-node {
+    fill: var(--dg-fill);
+    stroke: var(--dg-ink);
+    stroke-width: 1;
+}
+
+.documentation-diagram .dg-node-soft {
+    fill: var(--dg-fill-2);
+    stroke: var(--dg-muted);
+    stroke-width: 1;
+}
+
+.documentation-diagram .dg-node-focal {
+    fill: var(--dg-accent-tint);
+    stroke: var(--dg-accent);
+    stroke-width: 1.2;
+}
+
+.documentation-diagram .dg-edge {
+    fill: none;
+    stroke: var(--dg-muted);
+    stroke-width: 1.2;
+}
+
+.documentation-diagram .dg-edge-dashed {
+    stroke-dasharray: 4 3;
+    stroke-width: 1;
+}
+
+.documentation-diagram .dg-edge-accent {
+    stroke: var(--dg-accent);
+}
+
+.documentation-diagram .dg-hairline {
+    fill: none;
+    stroke: var(--dg-rule);
+    stroke-width: 0.8;
+}
+
+.documentation-diagram .dg-arrowhead {
+    fill: var(--dg-muted);
+}
+
+.documentation-diagram .dg-arrowhead-accent {
+    fill: var(--dg-accent);
+}
+
+.documentation-diagram .dg-band {
+    fill: var(--dg-band);
+}
+
+.documentation-diagram .dg-band-accent {
+    fill: var(--dg-band-accent);
+}
+
+.documentation-diagram .dg-bar {
+    fill: var(--dg-solid);
+}
+
+.documentation-diagram .dg-bar-accent {
+    fill: var(--dg-accent);
+}
+
+.documentation-diagram .dg-track {
+    fill: var(--dg-fill-2);
+}
+
+.documentation-diagram .dg-station {
+    fill: var(--dg-fill);
+    stroke: var(--dg-muted);
+    stroke-width: 1;
+}
+
+.documentation-diagram .dg-station-focal {
+    fill: var(--dg-accent);
+    stroke: var(--dg-accent);
+    stroke-width: 1;
+}
+
+.documentation-diagram .dg-station-number {
+    font-family: var(--dg-mono);
+    font-size: 9px;
+    font-weight: 600;
+    fill: var(--dg-muted);
+}
+
+.documentation-diagram .dg-station-number-focal {
+    fill: var(--dg-paper);
+}

--- a/resources/docs/diagrams/account-map-en.svg
+++ b/resources/docs/diagrams/account-map-en.svg
@@ -1,0 +1,34 @@
+<svg viewBox="0 0 720 200" role="img" aria-labelledby="account-map-en-title account-map-en-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="account-map-en-title">What an account records</title>
+    <desc id="account-map-en-desc">An account keeps a balance history and its transactions. The balance history explains net worth, and the transactions explain cashflow.</desc>
+    <defs>
+        <marker id="account-map-en-arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+            <polygon class="dg-arrowhead" points="0 0, 8 3, 0 6"/>
+        </marker>
+    </defs>
+    <text class="dg-eyebrow" x="40" y="16">THE ACCOUNT</text>
+    <line class="dg-hairline" x1="40" y1="24" x2="216" y2="24"/>
+    <text class="dg-eyebrow" x="272" y="16">WHAT IT RECORDS</text>
+    <line class="dg-hairline" x1="272" y1="24" x2="448" y2="24"/>
+    <text class="dg-eyebrow" x="504" y="16">WHAT IT EXPLAINS</text>
+    <line class="dg-hairline" x1="504" y1="24" x2="680" y2="24"/>
+    <path class="dg-edge" d="M216,100 H236 Q244,100 244,92 V84 Q244,76 252,76 H268" marker-end="url(#account-map-en-arrow)"/>
+    <path class="dg-edge" d="M216,124 H236 Q244,124 244,132 V140 Q244,148 252,148 H268" marker-end="url(#account-map-en-arrow)"/>
+    <path class="dg-edge" d="M448,76 H500" marker-end="url(#account-map-en-arrow)"/>
+    <path class="dg-edge" d="M448,148 H500" marker-end="url(#account-map-en-arrow)"/>
+    <rect class="dg-mask" x="40" y="84" width="176" height="56" rx="6"/>
+    <rect class="dg-node-focal" x="40" y="84" width="176" height="56" rx="6"/>
+    <text class="dg-name" x="128" y="116" text-anchor="middle">Account</text>
+    <rect class="dg-mask" x="272" y="48" width="176" height="56" rx="6"/>
+    <rect class="dg-node" x="272" y="48" width="176" height="56" rx="6"/>
+    <text class="dg-name" x="360" y="80" text-anchor="middle">Balance history</text>
+    <rect class="dg-mask" x="272" y="120" width="176" height="56" rx="6"/>
+    <rect class="dg-node" x="272" y="120" width="176" height="56" rx="6"/>
+    <text class="dg-name" x="360" y="152" text-anchor="middle">Transactions</text>
+    <rect class="dg-mask" x="504" y="48" width="176" height="56" rx="6"/>
+    <rect class="dg-node" x="504" y="48" width="176" height="56" rx="6"/>
+    <text class="dg-name" x="592" y="80" text-anchor="middle">Net worth</text>
+    <rect class="dg-mask" x="504" y="120" width="176" height="56" rx="6"/>
+    <rect class="dg-node" x="504" y="120" width="176" height="56" rx="6"/>
+    <text class="dg-name" x="592" y="152" text-anchor="middle">Cashflow</text>
+</svg>

--- a/resources/docs/diagrams/account-map-es.svg
+++ b/resources/docs/diagrams/account-map-es.svg
@@ -1,0 +1,35 @@
+<svg viewBox="0 0 720 200" role="img" aria-labelledby="account-map-es-title account-map-es-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="account-map-es-title">Qué registra una cuenta</title>
+    <desc id="account-map-es-desc">Una cuenta guarda un historial de saldos y sus transacciones. El historial de saldos explica el patrimonio neto y las transacciones explican el flujo de efectivo.</desc>
+    <defs>
+        <marker id="account-map-es-arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+            <polygon class="dg-arrowhead" points="0 0, 8 3, 0 6"/>
+        </marker>
+    </defs>
+    <text class="dg-eyebrow" x="40" y="16">LA CUENTA</text>
+    <line class="dg-hairline" x1="40" y1="24" x2="216" y2="24"/>
+    <text class="dg-eyebrow" x="272" y="16">LO QUE REGISTRA</text>
+    <line class="dg-hairline" x1="272" y1="24" x2="448" y2="24"/>
+    <text class="dg-eyebrow" x="504" y="16">LO QUE EXPLICA</text>
+    <line class="dg-hairline" x1="504" y1="24" x2="680" y2="24"/>
+    <path class="dg-edge" d="M216,100 H236 Q244,100 244,92 V84 Q244,76 252,76 H268" marker-end="url(#account-map-es-arrow)"/>
+    <path class="dg-edge" d="M216,124 H236 Q244,124 244,132 V140 Q244,148 252,148 H268" marker-end="url(#account-map-es-arrow)"/>
+    <path class="dg-edge" d="M448,76 H500" marker-end="url(#account-map-es-arrow)"/>
+    <path class="dg-edge" d="M448,148 H500" marker-end="url(#account-map-es-arrow)"/>
+    <rect class="dg-mask" x="40" y="84" width="176" height="56" rx="6"/>
+    <rect class="dg-node-focal" x="40" y="84" width="176" height="56" rx="6"/>
+    <text class="dg-name" x="128" y="116" text-anchor="middle">Cuenta</text>
+    <rect class="dg-mask" x="272" y="48" width="176" height="56" rx="6"/>
+    <rect class="dg-node" x="272" y="48" width="176" height="56" rx="6"/>
+    <text class="dg-name" x="360" y="72" text-anchor="middle">Historial de</text>
+    <text class="dg-name" x="360" y="88" text-anchor="middle">saldos</text>
+    <rect class="dg-mask" x="272" y="120" width="176" height="56" rx="6"/>
+    <rect class="dg-node" x="272" y="120" width="176" height="56" rx="6"/>
+    <text class="dg-name" x="360" y="152" text-anchor="middle">Transacciones</text>
+    <rect class="dg-mask" x="504" y="48" width="176" height="56" rx="6"/>
+    <rect class="dg-node" x="504" y="48" width="176" height="56" rx="6"/>
+    <text class="dg-name" x="592" y="80" text-anchor="middle">Patrimonio neto</text>
+    <rect class="dg-mask" x="504" y="120" width="176" height="56" rx="6"/>
+    <rect class="dg-node" x="504" y="120" width="176" height="56" rx="6"/>
+    <text class="dg-name" x="592" y="152" text-anchor="middle">Flujo de efectivo</text>
+</svg>

--- a/resources/docs/diagrams/budget-flow-en.svg
+++ b/resources/docs/diagrams/budget-flow-en.svg
@@ -1,0 +1,40 @@
+<svg viewBox="0 0 720 272" role="img" aria-labelledby="budget-flow-en-title budget-flow-en-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="budget-flow-en-title">How a budget progresses</title>
+    <desc id="budget-flow-en-desc">A budget and your transactions meet on the category or label the budget watches, and that produces the progress for the period that tells you whether to carry on, adjust or pause.</desc>
+    <defs>
+        <marker id="budget-flow-en-arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+            <polygon class="dg-arrowhead" points="0 0, 8 3, 0 6"/>
+        </marker>
+    </defs>
+    <text class="dg-eyebrow" x="24" y="16">WHAT YOU SET</text>
+    <line class="dg-hairline" x1="24" y1="24" x2="164" y2="24"/>
+    <text class="dg-eyebrow" x="204" y="16">WHAT IT WATCHES</text>
+    <line class="dg-hairline" x1="204" y1="24" x2="344" y2="24"/>
+    <text class="dg-eyebrow" x="384" y="16">WHAT YOU SEE</text>
+    <line class="dg-hairline" x1="384" y1="24" x2="696" y2="24"/>
+    <path class="dg-edge" d="M164,72 H176 Q184,72 184,80 V88 Q184,96 192,96 H200" marker-end="url(#budget-flow-en-arrow)"/>
+    <path class="dg-edge" d="M164,144 H176 Q184,144 184,136 V128 Q184,120 192,120 H200" marker-end="url(#budget-flow-en-arrow)"/>
+    <path class="dg-edge" d="M344,108 H380" marker-end="url(#budget-flow-en-arrow)"/>
+    <path class="dg-edge" d="M540,152 V196" marker-end="url(#budget-flow-en-arrow)"/>
+    <rect class="dg-mask" x="24" y="48" width="140" height="48" rx="6"/>
+    <rect class="dg-node" x="24" y="48" width="140" height="48" rx="6"/>
+    <text class="dg-name" x="94" y="76" text-anchor="middle">Budget</text>
+    <rect class="dg-mask" x="24" y="120" width="140" height="48" rx="6"/>
+    <rect class="dg-node" x="24" y="120" width="140" height="48" rx="6"/>
+    <text class="dg-name" x="94" y="148" text-anchor="middle">Transactions</text>
+    <rect class="dg-mask" x="204" y="80" width="140" height="56" rx="6"/>
+    <rect class="dg-node" x="204" y="80" width="140" height="56" rx="6"/>
+    <text class="dg-name" x="274" y="104" text-anchor="middle">Category or</text>
+    <text class="dg-name" x="274" y="120" text-anchor="middle">label</text>
+    <rect class="dg-mask" x="384" y="64" width="312" height="88" rx="6"/>
+    <rect class="dg-node-focal" x="384" y="64" width="312" height="88" rx="6"/>
+    <text class="dg-name" x="400" y="92">Progress this period</text>
+    <rect class="dg-track" x="400" y="104" width="280" height="16" rx="4"/>
+    <rect class="dg-bar-accent" x="400" y="104" width="168" height="16" rx="4"/>
+    <text class="dg-sub" x="400" y="140">480 spent</text>
+    <text class="dg-sub" x="680" y="140" text-anchor="end">800 budgeted</text>
+    <rect class="dg-mask" x="384" y="200" width="312" height="48" rx="6"/>
+    <rect class="dg-node-soft" x="384" y="200" width="312" height="48" rx="6"/>
+    <text class="dg-name" x="540" y="220" text-anchor="middle">Spend, pause, or adjust</text>
+    <text class="dg-sub" x="540" y="236" text-anchor="middle">when real spending changes</text>
+</svg>

--- a/resources/docs/diagrams/budget-flow-es.svg
+++ b/resources/docs/diagrams/budget-flow-es.svg
@@ -1,0 +1,40 @@
+<svg viewBox="0 0 720 272" role="img" aria-labelledby="budget-flow-es-title budget-flow-es-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="budget-flow-es-title">Cómo avanza un presupuesto</title>
+    <desc id="budget-flow-es-desc">Un presupuesto y las transacciones se encuentran en la categoría o etiqueta que el presupuesto sigue, y de ahí sale el progreso del periodo que te dice si seguir, ajustar o pausar.</desc>
+    <defs>
+        <marker id="budget-flow-es-arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+            <polygon class="dg-arrowhead" points="0 0, 8 3, 0 6"/>
+        </marker>
+    </defs>
+    <text class="dg-eyebrow" x="24" y="16">LO QUE DEFINES</text>
+    <line class="dg-hairline" x1="24" y1="24" x2="164" y2="24"/>
+    <text class="dg-eyebrow" x="204" y="16">LO QUE SIGUE</text>
+    <line class="dg-hairline" x1="204" y1="24" x2="344" y2="24"/>
+    <text class="dg-eyebrow" x="384" y="16">LO QUE VES</text>
+    <line class="dg-hairline" x1="384" y1="24" x2="696" y2="24"/>
+    <path class="dg-edge" d="M164,72 H176 Q184,72 184,80 V88 Q184,96 192,96 H200" marker-end="url(#budget-flow-es-arrow)"/>
+    <path class="dg-edge" d="M164,144 H176 Q184,144 184,136 V128 Q184,120 192,120 H200" marker-end="url(#budget-flow-es-arrow)"/>
+    <path class="dg-edge" d="M344,108 H380" marker-end="url(#budget-flow-es-arrow)"/>
+    <path class="dg-edge" d="M540,152 V196" marker-end="url(#budget-flow-es-arrow)"/>
+    <rect class="dg-mask" x="24" y="48" width="140" height="48" rx="6"/>
+    <rect class="dg-node" x="24" y="48" width="140" height="48" rx="6"/>
+    <text class="dg-name" x="94" y="76" text-anchor="middle">Presupuesto</text>
+    <rect class="dg-mask" x="24" y="120" width="140" height="48" rx="6"/>
+    <rect class="dg-node" x="24" y="120" width="140" height="48" rx="6"/>
+    <text class="dg-name" x="94" y="148" text-anchor="middle">Transacciones</text>
+    <rect class="dg-mask" x="204" y="80" width="140" height="56" rx="6"/>
+    <rect class="dg-node" x="204" y="80" width="140" height="56" rx="6"/>
+    <text class="dg-name" x="274" y="104" text-anchor="middle">Categoría o</text>
+    <text class="dg-name" x="274" y="120" text-anchor="middle">etiqueta</text>
+    <rect class="dg-mask" x="384" y="64" width="312" height="88" rx="6"/>
+    <rect class="dg-node-focal" x="384" y="64" width="312" height="88" rx="6"/>
+    <text class="dg-name" x="400" y="92">Progreso del periodo</text>
+    <rect class="dg-track" x="400" y="104" width="280" height="16" rx="4"/>
+    <rect class="dg-bar-accent" x="400" y="104" width="168" height="16" rx="4"/>
+    <text class="dg-sub" x="400" y="140">480 gastado</text>
+    <text class="dg-sub" x="680" y="140" text-anchor="end">800 presupuestado</text>
+    <rect class="dg-mask" x="384" y="200" width="312" height="48" rx="6"/>
+    <rect class="dg-node-soft" x="384" y="200" width="312" height="48" rx="6"/>
+    <text class="dg-name" x="540" y="220" text-anchor="middle">Gastar, pausar o ajustar</text>
+    <text class="dg-sub" x="540" y="236" text-anchor="middle">cuando el gasto real cambia</text>
+</svg>

--- a/resources/docs/diagrams/cashflow-sankey-en.svg
+++ b/resources/docs/diagrams/cashflow-sankey-en.svg
@@ -1,0 +1,33 @@
+<svg viewBox="0 0 720 344" role="img" aria-labelledby="cashflow-sankey-en-title cashflow-sankey-en-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="cashflow-sankey-en-title">How a month of income splits</title>
+    <desc id="cashflow-sankey-en-desc">Income for the period splits between spending and net cashflow, and net cashflow is what can end up saved or invested. Band width is the amount.</desc>
+    <text class="dg-eyebrow" x="212" y="24" text-anchor="end">COMES IN</text>
+    <text class="dg-eyebrow" x="426" y="24" text-anchor="middle">SPLITS</text>
+    <text class="dg-eyebrow" x="600" y="24">IS LEFT</text>
+    <path class="dg-band" d="M212,100 C316,100 316,80 420,80 L420,164 C316,164 316,184 212,184 Z"/>
+    <path class="dg-band-accent" d="M212,184 C316,184 316,204 420,204 L420,240 C316,240 316,220 212,220 Z"/>
+    <path class="dg-band-accent" d="M432,204 C516,204 516,196 600,196 L600,220 C516,220 516,228 432,228 Z"/>
+    <path class="dg-band-accent" d="M432,228 C516,228 516,236 600,236 L600,248 C516,248 516,240 432,240 Z"/>
+    <rect class="dg-bar" x="200" y="100" width="12" height="120"/>
+    <rect class="dg-bar" x="420" y="80" width="12" height="84"/>
+    <rect class="dg-bar-accent" x="420" y="204" width="12" height="36"/>
+    <rect class="dg-bar-accent" x="600" y="196" width="12" height="24"/>
+    <rect class="dg-bar-accent" x="600" y="236" width="12" height="12"/>
+    <text class="dg-name" x="192" y="156" text-anchor="end">Income</text>
+    <text class="dg-sub" x="192" y="168" text-anchor="end">3,000</text>
+    <text class="dg-name" x="426" y="56" text-anchor="middle">Expenses</text>
+    <text class="dg-sub" x="426" y="68" text-anchor="middle">2,100</text>
+    <text class="dg-name" x="426" y="182" text-anchor="middle">Net cashflow</text>
+    <text class="dg-sub" x="426" y="194" text-anchor="middle">900</text>
+    <text class="dg-name" x="620" y="204">Saved</text>
+    <text class="dg-sub" x="620" y="216">600</text>
+    <text class="dg-name" x="620" y="238">Invested</text>
+    <text class="dg-sub" x="620" y="250">300</text>
+    <line class="dg-hairline" x1="24" y1="284" x2="696" y2="284"/>
+    <text class="dg-eyebrow" x="24" y="304">LEGEND</text>
+    <rect class="dg-band" x="96" y="296" width="16" height="8" rx="1"/>
+    <text class="dg-edge-label" x="120" y="304">WIDTH = AMOUNT</text>
+    <rect class="dg-band-accent" x="288" y="296" width="16" height="8" rx="1"/>
+    <text class="dg-edge-label" x="312" y="304">WHAT YOU KEEP</text>
+    <text class="dg-aside" x="24" y="328">Savings rate = net cashflow ÷ income = 30%. Example figures.</text>
+</svg>

--- a/resources/docs/diagrams/cashflow-sankey-es.svg
+++ b/resources/docs/diagrams/cashflow-sankey-es.svg
@@ -1,0 +1,33 @@
+<svg viewBox="0 0 720 344" role="img" aria-labelledby="cashflow-sankey-es-title cashflow-sankey-es-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="cashflow-sankey-es-title">Cómo se reparten los ingresos de un mes</title>
+    <desc id="cashflow-sankey-es-desc">Los ingresos del periodo se reparten entre los gastos y el flujo neto, y el flujo neto es lo que puede acabar ahorrado o invertido. El ancho de cada banda es el importe.</desc>
+    <text class="dg-eyebrow" x="212" y="24" text-anchor="end">ENTRA</text>
+    <text class="dg-eyebrow" x="426" y="24" text-anchor="middle">SE REPARTE</text>
+    <text class="dg-eyebrow" x="600" y="24">SE QUEDA</text>
+    <path class="dg-band" d="M212,100 C316,100 316,80 420,80 L420,164 C316,164 316,184 212,184 Z"/>
+    <path class="dg-band-accent" d="M212,184 C316,184 316,204 420,204 L420,240 C316,240 316,220 212,220 Z"/>
+    <path class="dg-band-accent" d="M432,204 C516,204 516,196 600,196 L600,220 C516,220 516,228 432,228 Z"/>
+    <path class="dg-band-accent" d="M432,228 C516,228 516,236 600,236 L600,248 C516,248 516,240 432,240 Z"/>
+    <rect class="dg-bar" x="200" y="100" width="12" height="120"/>
+    <rect class="dg-bar" x="420" y="80" width="12" height="84"/>
+    <rect class="dg-bar-accent" x="420" y="204" width="12" height="36"/>
+    <rect class="dg-bar-accent" x="600" y="196" width="12" height="24"/>
+    <rect class="dg-bar-accent" x="600" y="236" width="12" height="12"/>
+    <text class="dg-name" x="192" y="156" text-anchor="end">Ingresos</text>
+    <text class="dg-sub" x="192" y="168" text-anchor="end">3.000</text>
+    <text class="dg-name" x="426" y="56" text-anchor="middle">Gastos</text>
+    <text class="dg-sub" x="426" y="68" text-anchor="middle">2.100</text>
+    <text class="dg-name" x="426" y="182" text-anchor="middle">Flujo neto</text>
+    <text class="dg-sub" x="426" y="194" text-anchor="middle">900</text>
+    <text class="dg-name" x="620" y="204">Ahorrado</text>
+    <text class="dg-sub" x="620" y="216">600</text>
+    <text class="dg-name" x="620" y="238">Invertido</text>
+    <text class="dg-sub" x="620" y="250">300</text>
+    <line class="dg-hairline" x1="24" y1="284" x2="696" y2="284"/>
+    <text class="dg-eyebrow" x="24" y="304">LEYENDA</text>
+    <rect class="dg-band" x="96" y="296" width="16" height="8" rx="1"/>
+    <text class="dg-edge-label" x="120" y="304">ANCHO = IMPORTE</text>
+    <rect class="dg-band-accent" x="288" y="296" width="16" height="8" rx="1"/>
+    <text class="dg-edge-label" x="312" y="304">LO QUE TE QUEDA</text>
+    <text class="dg-aside" x="24" y="328">Tasa de ahorro = flujo neto ÷ ingresos = 30 %. Cifras de ejemplo.</text>
+</svg>

--- a/resources/docs/diagrams/category-fanout-en.svg
+++ b/resources/docs/diagrams/category-fanout-en.svg
@@ -1,0 +1,30 @@
+<svg viewBox="0 0 720 272" role="img" aria-labelledby="category-fanout-en-title category-fanout-en-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="category-fanout-en-title">What a category is for</title>
+    <desc id="category-fanout-en-desc">The category on a transaction is what feeds cashflow, budgets and reports.</desc>
+    <defs>
+        <marker id="category-fanout-en-arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+            <polygon class="dg-arrowhead" points="0 0, 8 3, 0 6"/>
+        </marker>
+    </defs>
+    <text class="dg-eyebrow" x="40" y="16">ONE CATEGORY, THREE READINGS</text>
+    <line class="dg-hairline" x1="40" y1="24" x2="680" y2="24"/>
+    <path class="dg-edge" d="M216,152 H268" marker-end="url(#category-fanout-en-arrow)"/>
+    <path class="dg-edge" d="M448,136 H468 Q476,136 476,128 V88 Q476,80 484,80 H500" marker-end="url(#category-fanout-en-arrow)"/>
+    <path class="dg-edge" d="M448,152 H500" marker-end="url(#category-fanout-en-arrow)"/>
+    <path class="dg-edge" d="M448,168 H468 Q476,168 476,176 V216 Q476,224 484,224 H500" marker-end="url(#category-fanout-en-arrow)"/>
+    <rect class="dg-mask" x="40" y="124" width="176" height="56" rx="6"/>
+    <rect class="dg-node" x="40" y="124" width="176" height="56" rx="6"/>
+    <text class="dg-name" x="128" y="156" text-anchor="middle">Transaction</text>
+    <rect class="dg-mask" x="272" y="124" width="176" height="56" rx="6"/>
+    <rect class="dg-node-focal" x="272" y="124" width="176" height="56" rx="6"/>
+    <text class="dg-name" x="360" y="156" text-anchor="middle">Category</text>
+    <rect class="dg-mask" x="504" y="56" width="176" height="48" rx="6"/>
+    <rect class="dg-node" x="504" y="56" width="176" height="48" rx="6"/>
+    <text class="dg-name" x="592" y="84" text-anchor="middle">Cashflow</text>
+    <rect class="dg-mask" x="504" y="128" width="176" height="48" rx="6"/>
+    <rect class="dg-node" x="504" y="128" width="176" height="48" rx="6"/>
+    <text class="dg-name" x="592" y="156" text-anchor="middle">Budgets</text>
+    <rect class="dg-mask" x="504" y="200" width="176" height="48" rx="6"/>
+    <rect class="dg-node" x="504" y="200" width="176" height="48" rx="6"/>
+    <text class="dg-name" x="592" y="228" text-anchor="middle">Reports</text>
+</svg>

--- a/resources/docs/diagrams/category-fanout-es.svg
+++ b/resources/docs/diagrams/category-fanout-es.svg
@@ -1,0 +1,30 @@
+<svg viewBox="0 0 720 272" role="img" aria-labelledby="category-fanout-es-title category-fanout-es-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="category-fanout-es-title">Para qué sirve una categoría</title>
+    <desc id="category-fanout-es-desc">La categoría de una transacción es lo que alimenta el flujo de efectivo, los presupuestos y los informes.</desc>
+    <defs>
+        <marker id="category-fanout-es-arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+            <polygon class="dg-arrowhead" points="0 0, 8 3, 0 6"/>
+        </marker>
+    </defs>
+    <text class="dg-eyebrow" x="40" y="16">UNA CATEGORÍA, TRES LECTURAS</text>
+    <line class="dg-hairline" x1="40" y1="24" x2="680" y2="24"/>
+    <path class="dg-edge" d="M216,152 H268" marker-end="url(#category-fanout-es-arrow)"/>
+    <path class="dg-edge" d="M448,136 H468 Q476,136 476,128 V88 Q476,80 484,80 H500" marker-end="url(#category-fanout-es-arrow)"/>
+    <path class="dg-edge" d="M448,152 H500" marker-end="url(#category-fanout-es-arrow)"/>
+    <path class="dg-edge" d="M448,168 H468 Q476,168 476,176 V216 Q476,224 484,224 H500" marker-end="url(#category-fanout-es-arrow)"/>
+    <rect class="dg-mask" x="40" y="124" width="176" height="56" rx="6"/>
+    <rect class="dg-node" x="40" y="124" width="176" height="56" rx="6"/>
+    <text class="dg-name" x="128" y="156" text-anchor="middle">Transacción</text>
+    <rect class="dg-mask" x="272" y="124" width="176" height="56" rx="6"/>
+    <rect class="dg-node-focal" x="272" y="124" width="176" height="56" rx="6"/>
+    <text class="dg-name" x="360" y="156" text-anchor="middle">Categoría</text>
+    <rect class="dg-mask" x="504" y="56" width="176" height="48" rx="6"/>
+    <rect class="dg-node" x="504" y="56" width="176" height="48" rx="6"/>
+    <text class="dg-name" x="592" y="84" text-anchor="middle">Flujo de efectivo</text>
+    <rect class="dg-mask" x="504" y="128" width="176" height="48" rx="6"/>
+    <rect class="dg-node" x="504" y="128" width="176" height="48" rx="6"/>
+    <text class="dg-name" x="592" y="156" text-anchor="middle">Presupuestos</text>
+    <rect class="dg-mask" x="504" y="200" width="176" height="48" rx="6"/>
+    <rect class="dg-node" x="504" y="200" width="176" height="48" rx="6"/>
+    <text class="dg-name" x="592" y="228" text-anchor="middle">Informes</text>
+</svg>

--- a/resources/docs/diagrams/import-steps-en.svg
+++ b/resources/docs/diagrams/import-steps-en.svg
@@ -1,0 +1,30 @@
+<svg viewBox="0 0 720 208" role="img" aria-labelledby="import-steps-en-title import-steps-en-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="import-steps-en-title">The six steps of an import</title>
+    <desc id="import-steps-en-desc">Choose the account, upload the bank file, map the columns, check the preview, import what you selected, and review categories and duplicates afterwards.</desc>
+    <line class="dg-edge" x1="88" y1="104" x2="648" y2="104"/>
+    <text class="dg-name" x="88" y="52" text-anchor="middle">Choose account</text>
+    <text class="dg-sub" x="88" y="64" text-anchor="middle">where the file belongs</text>
+    <circle class="dg-station" cx="88" cy="104" r="16"/>
+    <text class="dg-station-number dg-station-number" x="88" y="107" text-anchor="middle">1</text>
+    <text class="dg-name" x="200" y="148" text-anchor="middle">Upload file</text>
+    <text class="dg-sub" x="200" y="160" text-anchor="middle">bank CSV</text>
+    <circle class="dg-station" cx="200" cy="104" r="16"/>
+    <text class="dg-station-number dg-station-number" x="200" y="107" text-anchor="middle">2</text>
+    <text class="dg-name" x="312" y="52" text-anchor="middle">Map columns</text>
+    <text class="dg-sub" x="312" y="64" text-anchor="middle">date · description · amount</text>
+    <circle class="dg-station" cx="312" cy="104" r="16"/>
+    <text class="dg-station-number dg-station-number" x="312" y="107" text-anchor="middle">3</text>
+    <text class="dg-name" x="424" y="148" text-anchor="middle">Preview</text>
+    <text class="dg-sub" x="424" y="160" text-anchor="middle">where mistakes get caught</text>
+    <circle class="dg-station-focal" cx="424" cy="104" r="16"/>
+    <text class="dg-station-number-focal dg-station-number" x="424" y="107" text-anchor="middle">4</text>
+    <text class="dg-name" x="536" y="52" text-anchor="middle">Import</text>
+    <text class="dg-sub" x="536" y="64" text-anchor="middle">selected rows only</text>
+    <circle class="dg-station" cx="536" cy="104" r="16"/>
+    <text class="dg-station-number dg-station-number" x="536" y="107" text-anchor="middle">5</text>
+    <text class="dg-name" x="648" y="148" text-anchor="middle">Review</text>
+    <text class="dg-sub" x="648" y="160" text-anchor="middle">categories and duplicates</text>
+    <circle class="dg-station" cx="648" cy="104" r="16"/>
+    <text class="dg-station-number dg-station-number" x="648" y="107" text-anchor="middle">6</text>
+    <text class="dg-aside" x="24" y="188">The preview is the last point where you can still fix the mapping.</text>
+</svg>

--- a/resources/docs/diagrams/import-steps-es.svg
+++ b/resources/docs/diagrams/import-steps-es.svg
@@ -1,0 +1,30 @@
+<svg viewBox="0 0 720 208" role="img" aria-labelledby="import-steps-es-title import-steps-es-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="import-steps-es-title">Los seis pasos de una importación</title>
+    <desc id="import-steps-es-desc">Elegir la cuenta, subir el archivo del banco, mapear las columnas, revisar la vista previa, importar lo seleccionado y revisar categorías y duplicados después.</desc>
+    <line class="dg-edge" x1="88" y1="104" x2="648" y2="104"/>
+    <text class="dg-name" x="88" y="52" text-anchor="middle">Elegir cuenta</text>
+    <text class="dg-sub" x="88" y="64" text-anchor="middle">a qué cuenta pertenece</text>
+    <circle class="dg-station" cx="88" cy="104" r="16"/>
+    <text class="dg-station-number dg-station-number" x="88" y="107" text-anchor="middle">1</text>
+    <text class="dg-name" x="200" y="148" text-anchor="middle">Subir archivo</text>
+    <text class="dg-sub" x="200" y="160" text-anchor="middle">CSV del banco</text>
+    <circle class="dg-station" cx="200" cy="104" r="16"/>
+    <text class="dg-station-number dg-station-number" x="200" y="107" text-anchor="middle">2</text>
+    <text class="dg-name" x="312" y="52" text-anchor="middle">Mapear columnas</text>
+    <text class="dg-sub" x="312" y="64" text-anchor="middle">fecha · descripción · importe</text>
+    <circle class="dg-station" cx="312" cy="104" r="16"/>
+    <text class="dg-station-number dg-station-number" x="312" y="107" text-anchor="middle">3</text>
+    <text class="dg-name" x="424" y="148" text-anchor="middle">Vista previa</text>
+    <text class="dg-sub" x="424" y="160" text-anchor="middle">aquí se corrigen los errores</text>
+    <circle class="dg-station-focal" cx="424" cy="104" r="16"/>
+    <text class="dg-station-number-focal dg-station-number" x="424" y="107" text-anchor="middle">4</text>
+    <text class="dg-name" x="536" y="52" text-anchor="middle">Importar</text>
+    <text class="dg-sub" x="536" y="64" text-anchor="middle">solo lo seleccionado</text>
+    <circle class="dg-station" cx="536" cy="104" r="16"/>
+    <text class="dg-station-number dg-station-number" x="536" y="107" text-anchor="middle">5</text>
+    <text class="dg-name" x="648" y="148" text-anchor="middle">Revisar</text>
+    <text class="dg-sub" x="648" y="160" text-anchor="middle">categorías y duplicados</text>
+    <circle class="dg-station" cx="648" cy="104" r="16"/>
+    <text class="dg-station-number dg-station-number" x="648" y="107" text-anchor="middle">6</text>
+    <text class="dg-aside" x="24" y="188">La vista previa es el último punto donde puedes corregir el mapeo.</text>
+</svg>

--- a/resources/docs/diagrams/money-map-en.svg
+++ b/resources/docs/diagrams/money-map-en.svg
@@ -1,0 +1,47 @@
+<svg viewBox="0 0 720 280" role="img" aria-labelledby="money-map-en-title money-map-en-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="money-map-en-title">How the pieces of Whisper Money fit together</title>
+    <desc id="money-map-en-desc">Accounts feed transactions; transactions get organised into categories and labels, and those produce cashflow and budgets. Automation rules act on a transaction as it arrives.</desc>
+    <defs>
+        <marker id="money-map-en-arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+            <polygon class="dg-arrowhead" points="0 0, 8 3, 0 6"/>
+        </marker>
+    </defs>
+    <text class="dg-eyebrow" x="24" y="16">COMES IN</text>
+    <line class="dg-hairline" x1="24" y1="24" x2="156" y2="24"/>
+    <text class="dg-eyebrow" x="204" y="16">GETS ORGANISED</text>
+    <line class="dg-hairline" x1="204" y1="24" x2="336" y2="24"/>
+    <text class="dg-eyebrow" x="384" y="16">MAKES SENSE</text>
+    <line class="dg-hairline" x1="384" y1="24" x2="696" y2="24"/>
+    <path class="dg-edge" d="M156,112 H200" marker-end="url(#money-map-en-arrow)"/>
+    <path class="dg-edge dg-edge-dashed" d="M270,176 V144" marker-end="url(#money-map-en-arrow)"/>
+    <rect class="dg-mask" x="278" y="152" width="64" height="12" rx="2"/>
+    <text class="dg-edge-label" x="282" y="161">ON ARRIVAL</text>
+    <path class="dg-edge" d="M336,100 H352 Q360,100 360,92 V84 Q360,76 368,76 H380" marker-end="url(#money-map-en-arrow)"/>
+    <path class="dg-edge" d="M336,124 H352 Q360,124 360,132 V140 Q360,148 368,148 H380" marker-end="url(#money-map-en-arrow)"/>
+    <path class="dg-edge" d="M516,76 H560" marker-end="url(#money-map-en-arrow)"/>
+    <path class="dg-edge" d="M516,92 H532 Q540,92 540,100 V128 Q540,136 548,136 H560" marker-end="url(#money-map-en-arrow)"/>
+    <path class="dg-edge" d="M516,156 H560" marker-end="url(#money-map-en-arrow)"/>
+    <rect class="dg-mask" x="24" y="84" width="132" height="56" rx="6"/>
+    <rect class="dg-node" x="24" y="84" width="132" height="56" rx="6"/>
+    <text class="dg-name" x="90" y="116" text-anchor="middle">Accounts</text>
+    <rect class="dg-mask" x="204" y="84" width="132" height="56" rx="6"/>
+    <rect class="dg-node-focal" x="204" y="84" width="132" height="56" rx="6"/>
+    <text class="dg-name" x="270" y="116" text-anchor="middle">Transactions</text>
+    <rect class="dg-mask" x="384" y="48" width="132" height="56" rx="6"/>
+    <rect class="dg-node" x="384" y="48" width="132" height="56" rx="6"/>
+    <text class="dg-name" x="450" y="80" text-anchor="middle">Categories</text>
+    <rect class="dg-mask" x="384" y="120" width="132" height="56" rx="6"/>
+    <rect class="dg-node" x="384" y="120" width="132" height="56" rx="6"/>
+    <text class="dg-name" x="450" y="152" text-anchor="middle">Labels</text>
+    <rect class="dg-mask" x="564" y="48" width="132" height="56" rx="6"/>
+    <rect class="dg-node" x="564" y="48" width="132" height="56" rx="6"/>
+    <text class="dg-name" x="630" y="80" text-anchor="middle">Cashflow</text>
+    <rect class="dg-mask" x="564" y="120" width="132" height="56" rx="6"/>
+    <rect class="dg-node" x="564" y="120" width="132" height="56" rx="6"/>
+    <text class="dg-name" x="630" y="152" text-anchor="middle">Budgets</text>
+    <rect class="dg-mask" x="204" y="176" width="132" height="48" rx="6"/>
+    <rect class="dg-node-soft" x="204" y="176" width="132" height="48" rx="6"/>
+    <text class="dg-name" x="270" y="196" text-anchor="middle">Automation</text>
+    <text class="dg-name" x="270" y="212" text-anchor="middle">rules</text>
+    <text class="dg-aside" x="24" y="264">It all starts with an account, and everything else leans on the transactions.</text>
+</svg>

--- a/resources/docs/diagrams/money-map-es.svg
+++ b/resources/docs/diagrams/money-map-es.svg
@@ -1,0 +1,48 @@
+<svg viewBox="0 0 720 280" role="img" aria-labelledby="money-map-es-title money-map-es-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="money-map-es-title">Cómo encajan las piezas de Whisper Money</title>
+    <desc id="money-map-es-desc">Las cuentas alimentan las transacciones; las transacciones se organizan en categorías y etiquetas, y de ahí salen el flujo de efectivo y los presupuestos. Las reglas de automatización actúan sobre la transacción al llegar.</desc>
+    <defs>
+        <marker id="money-map-es-arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+            <polygon class="dg-arrowhead" points="0 0, 8 3, 0 6"/>
+        </marker>
+    </defs>
+    <text class="dg-eyebrow" x="24" y="16">ENTRA</text>
+    <line class="dg-hairline" x1="24" y1="24" x2="156" y2="24"/>
+    <text class="dg-eyebrow" x="204" y="16">SE ORGANIZA</text>
+    <line class="dg-hairline" x1="204" y1="24" x2="336" y2="24"/>
+    <text class="dg-eyebrow" x="384" y="16">SE ENTIENDE</text>
+    <line class="dg-hairline" x1="384" y1="24" x2="696" y2="24"/>
+    <path class="dg-edge" d="M156,112 H200" marker-end="url(#money-map-es-arrow)"/>
+    <path class="dg-edge dg-edge-dashed" d="M270,176 V144" marker-end="url(#money-map-es-arrow)"/>
+    <rect class="dg-mask" x="278" y="152" width="60" height="12" rx="2"/>
+    <text class="dg-edge-label" x="282" y="161">AL LLEGAR</text>
+    <path class="dg-edge" d="M336,100 H352 Q360,100 360,92 V84 Q360,76 368,76 H380" marker-end="url(#money-map-es-arrow)"/>
+    <path class="dg-edge" d="M336,124 H352 Q360,124 360,132 V140 Q360,148 368,148 H380" marker-end="url(#money-map-es-arrow)"/>
+    <path class="dg-edge" d="M516,76 H560" marker-end="url(#money-map-es-arrow)"/>
+    <path class="dg-edge" d="M516,92 H532 Q540,92 540,100 V128 Q540,136 548,136 H560" marker-end="url(#money-map-es-arrow)"/>
+    <path class="dg-edge" d="M516,156 H560" marker-end="url(#money-map-es-arrow)"/>
+    <rect class="dg-mask" x="24" y="84" width="132" height="56" rx="6"/>
+    <rect class="dg-node" x="24" y="84" width="132" height="56" rx="6"/>
+    <text class="dg-name" x="90" y="116" text-anchor="middle">Cuentas</text>
+    <rect class="dg-mask" x="204" y="84" width="132" height="56" rx="6"/>
+    <rect class="dg-node-focal" x="204" y="84" width="132" height="56" rx="6"/>
+    <text class="dg-name" x="270" y="116" text-anchor="middle">Transacciones</text>
+    <rect class="dg-mask" x="384" y="48" width="132" height="56" rx="6"/>
+    <rect class="dg-node" x="384" y="48" width="132" height="56" rx="6"/>
+    <text class="dg-name" x="450" y="80" text-anchor="middle">Categorías</text>
+    <rect class="dg-mask" x="384" y="120" width="132" height="56" rx="6"/>
+    <rect class="dg-node" x="384" y="120" width="132" height="56" rx="6"/>
+    <text class="dg-name" x="450" y="152" text-anchor="middle">Etiquetas</text>
+    <rect class="dg-mask" x="564" y="48" width="132" height="56" rx="6"/>
+    <rect class="dg-node" x="564" y="48" width="132" height="56" rx="6"/>
+    <text class="dg-name" x="630" y="72" text-anchor="middle">Flujo de</text>
+    <text class="dg-name" x="630" y="88" text-anchor="middle">efectivo</text>
+    <rect class="dg-mask" x="564" y="120" width="132" height="56" rx="6"/>
+    <rect class="dg-node" x="564" y="120" width="132" height="56" rx="6"/>
+    <text class="dg-name" x="630" y="152" text-anchor="middle">Presupuestos</text>
+    <rect class="dg-mask" x="204" y="176" width="132" height="48" rx="6"/>
+    <rect class="dg-node-soft" x="204" y="176" width="132" height="48" rx="6"/>
+    <text class="dg-name" x="270" y="196" text-anchor="middle">Reglas de</text>
+    <text class="dg-name" x="270" y="212" text-anchor="middle">automatización</text>
+    <text class="dg-aside" x="24" y="264">Todo empieza en una cuenta, y todo lo demás se apoya en las transacciones.</text>
+</svg>

--- a/resources/docs/diagrams/rule-flow-en.svg
+++ b/resources/docs/diagrams/rule-flow-en.svg
@@ -1,0 +1,33 @@
+<svg viewBox="0 0 720 264" role="img" aria-labelledby="rule-flow-en-title rule-flow-en-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="rule-flow-en-title">How an automation rule decides</title>
+    <desc id="rule-flow-en-desc">When a transaction arrives, the rule checks its conditions. On a match it applies its actions: set a category, add labels, or add a note. Without a match the transaction is left unchanged.</desc>
+    <defs>
+        <marker id="rule-flow-en-arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+            <polygon class="dg-arrowhead" points="0 0, 8 3, 0 6"/>
+        </marker>
+    </defs>
+    <text class="dg-sub" x="300" y="48" text-anchor="middle">description · amount · bank · account</text>
+    <path class="dg-edge" d="M184,112 H232" marker-end="url(#rule-flow-en-arrow)"/>
+    <rect class="dg-mask" x="366" y="90" width="28" height="12" rx="2"/>
+    <text class="dg-edge-label" x="380" y="99" text-anchor="middle">YES</text>
+    <path class="dg-edge" d="M364,112 H396 Q404,112 404,104 V84 Q404,76 412,76 H436" marker-end="url(#rule-flow-en-arrow)"/>
+    <path class="dg-edge" d="M300,160 V192 Q300,200 308,200 H436" marker-end="url(#rule-flow-en-arrow)"/>
+    <rect class="dg-mask" x="308" y="170" width="24" height="12" rx="2"/>
+    <text class="dg-edge-label" x="312" y="179">NO</text>
+    <rect class="dg-mask" x="24" y="88" width="160" height="48" rx="24"/>
+    <rect class="dg-node" x="24" y="88" width="160" height="48" rx="24"/>
+    <text class="dg-name" x="104" y="116" text-anchor="middle">New transaction</text>
+    <polygon class="dg-mask" points="300,64 364,112 300,160 236,112"/>
+    <polygon class="dg-node" points="300,64 364,112 300,160 236,112"/>
+    <text class="dg-name" x="300" y="116" text-anchor="middle">Match?</text>
+    <rect class="dg-mask" x="440" y="32" width="248" height="88" rx="6"/>
+    <rect class="dg-node-focal" x="440" y="32" width="248" height="88" rx="6"/>
+    <text class="dg-name" x="464" y="60">Rule actions</text>
+    <text class="dg-sub" x="464" y="80">· Set category</text>
+    <text class="dg-sub" x="464" y="96">· Add labels</text>
+    <text class="dg-sub" x="464" y="112">· Add note</text>
+    <rect class="dg-mask" x="440" y="176" width="248" height="48" rx="6"/>
+    <rect class="dg-node-soft" x="440" y="176" width="248" height="48" rx="6"/>
+    <text class="dg-name" x="564" y="204" text-anchor="middle">Left unchanged</text>
+    <text class="dg-aside" x="24" y="244">Rules are checked in priority order: the first one that matches applies its actions.</text>
+</svg>

--- a/resources/docs/diagrams/rule-flow-es.svg
+++ b/resources/docs/diagrams/rule-flow-es.svg
@@ -1,0 +1,33 @@
+<svg viewBox="0 0 720 264" role="img" aria-labelledby="rule-flow-es-title rule-flow-es-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="rule-flow-es-title">Cómo decide una regla de automatización</title>
+    <desc id="rule-flow-es-desc">Cuando llega una transacción, la regla comprueba sus condiciones. Si coinciden, aplica sus acciones: asignar categoría, añadir etiquetas o añadir una nota. Si no coinciden, la transacción se queda sin cambios.</desc>
+    <defs>
+        <marker id="rule-flow-es-arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+            <polygon class="dg-arrowhead" points="0 0, 8 3, 0 6"/>
+        </marker>
+    </defs>
+    <text class="dg-sub" x="300" y="48" text-anchor="middle">descripción · importe · banco · cuenta</text>
+    <path class="dg-edge" d="M184,112 H232" marker-end="url(#rule-flow-es-arrow)"/>
+    <rect class="dg-mask" x="368" y="90" width="24" height="12" rx="2"/>
+    <text class="dg-edge-label" x="380" y="99" text-anchor="middle">SÍ</text>
+    <path class="dg-edge" d="M364,112 H396 Q404,112 404,104 V84 Q404,76 412,76 H436" marker-end="url(#rule-flow-es-arrow)"/>
+    <path class="dg-edge" d="M300,160 V192 Q300,200 308,200 H436" marker-end="url(#rule-flow-es-arrow)"/>
+    <rect class="dg-mask" x="308" y="170" width="24" height="12" rx="2"/>
+    <text class="dg-edge-label" x="312" y="179">NO</text>
+    <rect class="dg-mask" x="24" y="88" width="160" height="48" rx="24"/>
+    <rect class="dg-node" x="24" y="88" width="160" height="48" rx="24"/>
+    <text class="dg-name" x="104" y="116" text-anchor="middle">Nueva transacción</text>
+    <polygon class="dg-mask" points="300,64 364,112 300,160 236,112"/>
+    <polygon class="dg-node" points="300,64 364,112 300,160 236,112"/>
+    <text class="dg-name" x="300" y="116" text-anchor="middle">¿Coincide?</text>
+    <rect class="dg-mask" x="440" y="32" width="248" height="88" rx="6"/>
+    <rect class="dg-node-focal" x="440" y="32" width="248" height="88" rx="6"/>
+    <text class="dg-name" x="464" y="60">Acciones de la regla</text>
+    <text class="dg-sub" x="464" y="80">· Asignar categoría</text>
+    <text class="dg-sub" x="464" y="96">· Añadir etiquetas</text>
+    <text class="dg-sub" x="464" y="112">· Añadir nota</text>
+    <rect class="dg-mask" x="440" y="176" width="248" height="48" rx="6"/>
+    <rect class="dg-node-soft" x="440" y="176" width="248" height="48" rx="6"/>
+    <text class="dg-name" x="564" y="204" text-anchor="middle">Se queda sin cambios</text>
+    <text class="dg-aside" x="24" y="244">Las reglas se revisan por prioridad: la primera que coincide aplica sus acciones.</text>
+</svg>

--- a/resources/docs/diagrams/transaction-flow-en.svg
+++ b/resources/docs/diagrams/transaction-flow-en.svg
@@ -1,0 +1,47 @@
+<svg viewBox="0 0 720 280" role="img" aria-labelledby="transaction-flow-en-title transaction-flow-en-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="transaction-flow-en-title">The journey of a transaction</title>
+    <desc id="transaction-flow-en-desc">A new transaction goes through review, where it gets a category and labels, and ends up in the reports and budgets. Automation rules do part of that work up front.</desc>
+    <defs>
+        <marker id="transaction-flow-en-arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+            <polygon class="dg-arrowhead" points="0 0, 8 3, 0 6"/>
+        </marker>
+    </defs>
+    <text class="dg-eyebrow" x="24" y="16">ARRIVES</text>
+    <line class="dg-hairline" x1="24" y1="24" x2="156" y2="24"/>
+    <text class="dg-eyebrow" x="204" y="16">GETS REVIEWED</text>
+    <line class="dg-hairline" x1="204" y1="24" x2="336" y2="24"/>
+    <text class="dg-eyebrow" x="384" y="16">GETS ORGANISED</text>
+    <line class="dg-hairline" x1="384" y1="24" x2="516" y2="24"/>
+    <text class="dg-eyebrow" x="564" y="16">GETS USED</text>
+    <line class="dg-hairline" x1="564" y1="24" x2="696" y2="24"/>
+    <path class="dg-edge" d="M156,112 H200" marker-end="url(#transaction-flow-en-arrow)"/>
+    <path class="dg-edge dg-edge-dashed" d="M270,176 V144" marker-end="url(#transaction-flow-en-arrow)"/>
+    <rect class="dg-mask" x="278" y="152" width="60" height="12" rx="2"/>
+    <text class="dg-edge-label" x="282" y="161">AUTOMATIC</text>
+    <path class="dg-edge" d="M336,100 H352 Q360,100 360,92 V84 Q360,76 368,76 H380" marker-end="url(#transaction-flow-en-arrow)"/>
+    <path class="dg-edge" d="M336,124 H352 Q360,124 360,132 V140 Q360,148 368,148 H380" marker-end="url(#transaction-flow-en-arrow)"/>
+    <path class="dg-edge" d="M516,76 H532 Q540,76 540,84 V92 Q540,100 548,100 H560" marker-end="url(#transaction-flow-en-arrow)"/>
+    <path class="dg-edge" d="M516,148 H532 Q540,148 540,140 V132 Q540,124 548,124 H560" marker-end="url(#transaction-flow-en-arrow)"/>
+    <rect class="dg-mask" x="24" y="84" width="132" height="56" rx="6"/>
+    <rect class="dg-node" x="24" y="84" width="132" height="56" rx="6"/>
+    <text class="dg-name" x="90" y="108" text-anchor="middle">New</text>
+    <text class="dg-name" x="90" y="124" text-anchor="middle">transaction</text>
+    <rect class="dg-mask" x="204" y="84" width="132" height="56" rx="6"/>
+    <rect class="dg-node-focal" x="204" y="84" width="132" height="56" rx="6"/>
+    <text class="dg-name" x="270" y="116" text-anchor="middle">Review</text>
+    <rect class="dg-mask" x="384" y="48" width="132" height="56" rx="6"/>
+    <rect class="dg-node" x="384" y="48" width="132" height="56" rx="6"/>
+    <text class="dg-name" x="450" y="80" text-anchor="middle">Category</text>
+    <rect class="dg-mask" x="384" y="120" width="132" height="56" rx="6"/>
+    <rect class="dg-node" x="384" y="120" width="132" height="56" rx="6"/>
+    <text class="dg-name" x="450" y="152" text-anchor="middle">Labels</text>
+    <rect class="dg-mask" x="564" y="84" width="132" height="56" rx="6"/>
+    <rect class="dg-node" x="564" y="84" width="132" height="56" rx="6"/>
+    <text class="dg-name" x="630" y="108" text-anchor="middle">Reports and</text>
+    <text class="dg-name" x="630" y="124" text-anchor="middle">budgets</text>
+    <rect class="dg-mask" x="204" y="176" width="132" height="48" rx="6"/>
+    <rect class="dg-node-soft" x="204" y="176" width="132" height="48" rx="6"/>
+    <text class="dg-name" x="270" y="196" text-anchor="middle">Automation</text>
+    <text class="dg-name" x="270" y="212" text-anchor="middle">rules</text>
+    <text class="dg-aside" x="24" y="264">Reviewing is optional, but it is what makes the reports trustworthy.</text>
+</svg>

--- a/resources/docs/diagrams/transaction-flow-es.svg
+++ b/resources/docs/diagrams/transaction-flow-es.svg
@@ -1,0 +1,47 @@
+<svg viewBox="0 0 720 280" role="img" aria-labelledby="transaction-flow-es-title transaction-flow-es-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="transaction-flow-es-title">El recorrido de una transacción</title>
+    <desc id="transaction-flow-es-desc">Una transacción nueva pasa por la revisión, donde recibe categoría y etiquetas, y termina en los informes y los presupuestos. Las reglas de automatización adelantan parte de ese trabajo.</desc>
+    <defs>
+        <marker id="transaction-flow-es-arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+            <polygon class="dg-arrowhead" points="0 0, 8 3, 0 6"/>
+        </marker>
+    </defs>
+    <text class="dg-eyebrow" x="24" y="16">LLEGA</text>
+    <line class="dg-hairline" x1="24" y1="24" x2="156" y2="24"/>
+    <text class="dg-eyebrow" x="204" y="16">SE REVISA</text>
+    <line class="dg-hairline" x1="204" y1="24" x2="336" y2="24"/>
+    <text class="dg-eyebrow" x="384" y="16">SE ORGANIZA</text>
+    <line class="dg-hairline" x1="384" y1="24" x2="516" y2="24"/>
+    <text class="dg-eyebrow" x="564" y="16">SE USA</text>
+    <line class="dg-hairline" x1="564" y1="24" x2="696" y2="24"/>
+    <path class="dg-edge" d="M156,112 H200" marker-end="url(#transaction-flow-es-arrow)"/>
+    <path class="dg-edge dg-edge-dashed" d="M270,176 V144" marker-end="url(#transaction-flow-es-arrow)"/>
+    <rect class="dg-mask" x="278" y="152" width="64" height="12" rx="2"/>
+    <text class="dg-edge-label" x="282" y="161">AUTOMÁTICO</text>
+    <path class="dg-edge" d="M336,100 H352 Q360,100 360,92 V84 Q360,76 368,76 H380" marker-end="url(#transaction-flow-es-arrow)"/>
+    <path class="dg-edge" d="M336,124 H352 Q360,124 360,132 V140 Q360,148 368,148 H380" marker-end="url(#transaction-flow-es-arrow)"/>
+    <path class="dg-edge" d="M516,76 H532 Q540,76 540,84 V92 Q540,100 548,100 H560" marker-end="url(#transaction-flow-es-arrow)"/>
+    <path class="dg-edge" d="M516,148 H532 Q540,148 540,140 V132 Q540,124 548,124 H560" marker-end="url(#transaction-flow-es-arrow)"/>
+    <rect class="dg-mask" x="24" y="84" width="132" height="56" rx="6"/>
+    <rect class="dg-node" x="24" y="84" width="132" height="56" rx="6"/>
+    <text class="dg-name" x="90" y="108" text-anchor="middle">Nueva</text>
+    <text class="dg-name" x="90" y="124" text-anchor="middle">transacción</text>
+    <rect class="dg-mask" x="204" y="84" width="132" height="56" rx="6"/>
+    <rect class="dg-node-focal" x="204" y="84" width="132" height="56" rx="6"/>
+    <text class="dg-name" x="270" y="116" text-anchor="middle">Revisión</text>
+    <rect class="dg-mask" x="384" y="48" width="132" height="56" rx="6"/>
+    <rect class="dg-node" x="384" y="48" width="132" height="56" rx="6"/>
+    <text class="dg-name" x="450" y="80" text-anchor="middle">Categoría</text>
+    <rect class="dg-mask" x="384" y="120" width="132" height="56" rx="6"/>
+    <rect class="dg-node" x="384" y="120" width="132" height="56" rx="6"/>
+    <text class="dg-name" x="450" y="152" text-anchor="middle">Etiquetas</text>
+    <rect class="dg-mask" x="564" y="84" width="132" height="56" rx="6"/>
+    <rect class="dg-node" x="564" y="84" width="132" height="56" rx="6"/>
+    <text class="dg-name" x="630" y="108" text-anchor="middle">Informes y</text>
+    <text class="dg-name" x="630" y="124" text-anchor="middle">presupuestos</text>
+    <rect class="dg-mask" x="204" y="176" width="132" height="48" rx="6"/>
+    <rect class="dg-node-soft" x="204" y="176" width="132" height="48" rx="6"/>
+    <text class="dg-name" x="270" y="196" text-anchor="middle">Reglas de</text>
+    <text class="dg-name" x="270" y="212" text-anchor="middle">automatización</text>
+    <text class="dg-aside" x="24" y="264">Revisar es opcional, pero es lo que hace fiables los informes.</text>
+</svg>

--- a/resources/docs/documentation/10-getting-started-en.md
+++ b/resources/docs/documentation/10-getting-started-en.md
@@ -19,6 +19,7 @@ Follow this order if you are setting things up for the first time.
 
 ```mermaid
 flowchart TD
+    %% diagram: money-map-en
     accounts[Accounts] --> transactions[Transactions]
     transactions --> categories[Categories]
     transactions --> labels[Labels]

--- a/resources/docs/documentation/10-getting-started-es.md
+++ b/resources/docs/documentation/10-getting-started-es.md
@@ -19,6 +19,7 @@ Sigue este orden si estás configurando todo por primera vez.
 
 ```mermaid
 flowchart TD
+    %% diagram: money-map-es
     accounts[Cuentas] --> transactions[Transacciones]
     transactions --> categories[Categorías]
     transactions --> labels[Etiquetas]

--- a/resources/docs/documentation/20-your-data/10-accounts-en.md
+++ b/resources/docs/documentation/20-your-data/10-accounts-en.md
@@ -16,6 +16,7 @@ Accounts are the foundation of Whisper Money. They hold balances, transactions, 
 
 ```mermaid
 flowchart TD
+    %% diagram: account-map-en
     account[Account] --> balances[Balance history]
     account --> transactions[Transactions]
     balances --> networth[Net worth]

--- a/resources/docs/documentation/20-your-data/10-accounts-es.md
+++ b/resources/docs/documentation/20-your-data/10-accounts-es.md
@@ -16,6 +16,7 @@ Las cuentas son la base de Whisper Money. Guardan saldos, transacciones e histor
 
 ```mermaid
 flowchart TD
+    %% diagram: account-map-es
     account[Cuenta] --> balances[Historial de saldos]
     account --> transactions[Transacciones]
     balances --> networth[Patrimonio neto]

--- a/resources/docs/documentation/20-your-data/20-transactions-en.md
+++ b/resources/docs/documentation/20-your-data/20-transactions-en.md
@@ -16,13 +16,13 @@ Transactions are the individual money movements in your accounts. They power cat
 
 ```mermaid
 flowchart TD
+    %% diagram: transaction-flow-en
     new[New transaction] --> review[Review]
     review --> category[Category]
     review --> labels[Labels]
-    category --> reports[Reports]
-    labels --> filters[Filters and budgets]
-    rules[Automation rules] --> category
-    rules --> labels
+    category --> reports[Reports and budgets]
+    labels --> reports
+    rules[Automation rules] --> review
 ```
 
 ## What a transaction contains

--- a/resources/docs/documentation/20-your-data/20-transactions-es.md
+++ b/resources/docs/documentation/20-your-data/20-transactions-es.md
@@ -16,13 +16,13 @@ Las transacciones son los movimientos individuales de dinero en tus cuentas. Ali
 
 ```mermaid
 flowchart TD
+    %% diagram: transaction-flow-es
     new[Nueva transacción] --> review[Revisión]
     review --> category[Categoría]
     review --> labels[Etiquetas]
-    category --> reports[Informes]
-    labels --> filters[Filtros y presupuestos]
-    rules[Reglas de automatización] --> category
-    rules --> labels
+    category --> reports[Informes y presupuestos]
+    labels --> reports
+    rules[Reglas de automatización] --> review
 ```
 
 ## Qué contiene una transacción

--- a/resources/docs/documentation/20-your-data/20-transactions/20-import-en.md
+++ b/resources/docs/documentation/20-your-data/20-transactions/20-import-en.md
@@ -17,6 +17,7 @@ Importing brings a bank file into Whisper Money when automatic syncing is not av
 
 ```mermaid
 flowchart TD
+    %% diagram: import-steps-en
     account[Choose account] --> file[Upload file]
     file --> mapping[Map columns]
     mapping --> preview[Preview]

--- a/resources/docs/documentation/20-your-data/20-transactions/20-import-es.md
+++ b/resources/docs/documentation/20-your-data/20-transactions/20-import-es.md
@@ -17,6 +17,7 @@ Importar trae un archivo del banco a Whisper Money cuando la sincronización aut
 
 ```mermaid
 flowchart TD
+    %% diagram: import-steps-es
     account[Elegir cuenta] --> file[Subir archivo]
     file --> mapping[Mapear columnas]
     mapping --> preview[Vista previa]

--- a/resources/docs/documentation/30-organization/10-categories-en.md
+++ b/resources/docs/documentation/30-organization/10-categories-en.md
@@ -17,6 +17,7 @@ Categories explain what each transaction means. Pick the right category and your
 
 ```mermaid
 flowchart TD
+    %% diagram: category-fanout-en
     transaction[Transaction] --> category[Category]
     category --> cashflow[Cashflow]
     category --> budgets[Budgets]

--- a/resources/docs/documentation/30-organization/10-categories-es.md
+++ b/resources/docs/documentation/30-organization/10-categories-es.md
@@ -17,6 +17,7 @@ Las categorías explican qué significa cada transacción. Elige bien la categor
 
 ```mermaid
 flowchart TD
+    %% diagram: category-fanout-es
     transaction[Transacción] --> category[Categoría]
     category --> cashflow[Flujo de efectivo]
     category --> budgets[Presupuestos]

--- a/resources/docs/documentation/30-organization/20-automation-rules-en.md
+++ b/resources/docs/documentation/30-organization/20-automation-rules-en.md
@@ -16,8 +16,10 @@ Automation rules save time by updating matching transactions for you. They can s
 
 ```mermaid
 flowchart TD
-    transaction[Transaction] --> conditions[Rule conditions]
-    conditions -->|matches| actions[Rule actions]
+    %% diagram: rule-flow-en
+    transaction[New transaction] --> conditions{Match the conditions?}
+    conditions -->|yes| actions[Rule actions]
+    conditions -->|no| unchanged[Left unchanged]
     actions --> category[Set category]
     actions --> labels[Add labels]
     actions --> note[Add note]

--- a/resources/docs/documentation/30-organization/20-automation-rules-es.md
+++ b/resources/docs/documentation/30-organization/20-automation-rules-es.md
@@ -16,8 +16,10 @@ Las reglas de automatización ahorran tiempo actualizando transacciones coincide
 
 ```mermaid
 flowchart TD
-    transaction[Transacción] --> conditions[Condiciones de la regla]
-    conditions -->|coincide| actions[Acciones]
+    %% diagram: rule-flow-es
+    transaction[Nueva transacción] --> conditions{¿Coincide con las condiciones?}
+    conditions -->|sí| actions[Acciones de la regla]
+    conditions -->|no| unchanged[Se queda sin cambios]
     actions --> category[Asignar categoría]
     actions --> labels[Añadir etiquetas]
     actions --> note[Añadir nota]

--- a/resources/docs/documentation/40-analysis/10-cashflow-en.md
+++ b/resources/docs/documentation/40-analysis/10-cashflow-en.md
@@ -16,9 +16,11 @@ Cashflow shows how money moves in and out during a period. It helps you understa
 
 ```mermaid
 flowchart LR
-    income[Income] --> net[Net cashflow]
-    expenses[Expenses] --> net
-    net --> savings[Savings rate]
+    %% diagram: cashflow-sankey-en
+    income[Income] --> expenses[Expenses]
+    income --> net[Net cashflow]
+    net --> saved[Saved]
+    net --> invested[Invested]
 ```
 
 The basic formula is:

--- a/resources/docs/documentation/40-analysis/10-cashflow-es.md
+++ b/resources/docs/documentation/40-analysis/10-cashflow-es.md
@@ -16,9 +16,11 @@ Flujo de efectivo muestra cómo entra y sale el dinero durante un periodo. Te ay
 
 ```mermaid
 flowchart LR
-    income[Ingresos] --> net[Flujo neto]
-    expenses[Gastos] --> net
-    net --> savings[Tasa de ahorro]
+    %% diagram: cashflow-sankey-es
+    income[Ingresos] --> expenses[Gastos]
+    income --> net[Flujo neto]
+    net --> saved[Ahorrado]
+    net --> invested[Invertido]
 ```
 
 La fórmula básica es:

--- a/resources/docs/documentation/40-analysis/20-budgets-en.md
+++ b/resources/docs/documentation/40-analysis/20-budgets-en.md
@@ -16,6 +16,7 @@ Budgets help you plan spending and see how much room is left in a period.
 
 ```mermaid
 flowchart TD
+    %% diagram: budget-flow-en
     budget[Budget] --> target[Category or label]
     transactions[Transactions] --> target
     target --> progress[Progress]

--- a/resources/docs/documentation/40-analysis/20-budgets-es.md
+++ b/resources/docs/documentation/40-analysis/20-budgets-es.md
@@ -16,6 +16,7 @@ Los presupuestos te ayudan a planificar gastos y ver cuánto margen queda en un 
 
 ```mermaid
 flowchart TD
+    %% diagram: budget-flow-es
     budget[Presupuesto] --> target[Categoría o etiqueta]
     transactions[Transacciones] --> target
     target --> progress[Progreso]

--- a/resources/js/components/documentation/doc-article.tsx
+++ b/resources/js/components/documentation/doc-article.tsx
@@ -1,16 +1,10 @@
 import { scrollToAnchor } from '@/lib/documentation';
 import { useEffect, useRef } from 'react';
 
-type MermaidModule = {
-    default: {
-        initialize: (options: { startOnLoad: boolean; theme: string }) => void;
-        render: (id: string, definition: string) => Promise<{ svg: string }>;
-    };
-};
-
 /**
- * The rendered page. Anchor clicks inside it scroll rather than reload, and any
- * mermaid block in the Markdown is drawn once the page is on screen.
+ * The rendered page. Anchor clicks inside it scroll rather than reload; the
+ * diagrams arrive as inline SVG, drawn against the tokens in app.css, so there
+ * is nothing to render on the client.
  */
 export default function DocArticle({ html }: { html: string }) {
     const articleRef = useRef<HTMLElement>(null);
@@ -42,66 +36,10 @@ export default function DocArticle({ html }: { html: string }) {
         return () => article.removeEventListener('click', handleClick);
     }, [html]);
 
-    useEffect(() => {
-        let cancelled = false;
-
-        async function renderMermaidDiagrams() {
-            const article = articleRef.current;
-
-            if (!article) {
-                return;
-            }
-
-            const blocks = Array.from(
-                article.querySelectorAll<HTMLElement>('code.language-mermaid'),
-            );
-
-            if (blocks.length === 0) {
-                return;
-            }
-
-            const { default: mermaid } = (await import(
-                /* @vite-ignore */ 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs'
-            )) as MermaidModule;
-
-            if (cancelled) {
-                return;
-            }
-
-            mermaid.initialize({
-                startOnLoad: false,
-                theme: document.documentElement.classList.contains('dark')
-                    ? 'dark'
-                    : 'default',
-            });
-
-            await Promise.all(
-                blocks.map(async (block, index) => {
-                    const container = document.createElement('div');
-                    const source = block.textContent ?? '';
-                    const { svg } = await mermaid.render(
-                        `documentation-mermaid-${index}-${crypto.randomUUID()}`,
-                        source,
-                    );
-
-                    container.className = 'documentation-mermaid';
-                    container.innerHTML = svg;
-                    block.closest('pre')?.replaceWith(container);
-                }),
-            );
-        }
-
-        void renderMermaidDiagrams();
-
-        return () => {
-            cancelled = true;
-        };
-    }, [html]);
-
     return (
         <article
             ref={articleRef}
-            className="max-w-3xl [&_.card]:rounded-xl [&_.card]:border [&_.card]:border-[#e3e3e0] [&_.card]:bg-black/[0.02] [&_.card]:p-5 dark:[&_.card]:border-[#3E3E3A] dark:[&_.card]:bg-white/[0.03] [&_.card_h3]:mt-0 [&_.card_h3]:mb-3 [&_.card_p]:mb-4 [&_.card_ul]:mb-0 [&_.cards-wrapper]:my-8 [&_.cards-wrapper]:grid [&_.cards-wrapper]:grid-cols-1 [&_.cards-wrapper]:gap-4 md:[&_.cards-wrapper]:grid-cols-2 [&_.documentation-mermaid]:my-6 [&_.documentation-mermaid]:overflow-x-auto [&_.documentation-mermaid]:p-5 [&_.documentation-shot]:h-auto [&_.documentation-shot]:max-w-full [&_.documentation-shot]:rounded-xl [&_.documentation-shot]:border [&_.documentation-shot]:border-[#e3e3e0] dark:[&_.documentation-shot]:border-[#3E3E3A] [&_.documentation-shot--dark]:hidden dark:[&_.documentation-shot--dark]:block [&_.documentation-shot--light]:block dark:[&_.documentation-shot--light]:hidden [&_a]:font-medium [&_a]:text-[#1b1b18] [&_a]:underline dark:[&_a]:text-[#EDEDEC] [&_blockquote]:my-6 [&_blockquote]:rounded-xl [&_blockquote]:bg-black/[0.03] [&_blockquote]:px-5 [&_blockquote]:py-4 dark:[&_blockquote]:bg-white/[0.04] [&_blockquote_p]:mb-0 [&_code]:rounded [&_code]:bg-black/5 [&_code]:px-1.5 [&_code]:py-0.5 dark:[&_code]:bg-white/10 [&_h1]:mb-4 [&_h1]:text-4xl [&_h1]:leading-tight [&_h1]:font-semibold [&_h1]:tracking-tight [&_h1+p]:mb-8 [&_h1+p]:text-[17px] [&_h1+p]:leading-8 [&_h2]:mt-12 [&_h2]:mb-4 [&_h2]:scroll-mt-24 [&_h2]:border-t [&_h2]:border-[#e3e3e0] [&_h2]:pt-8 [&_h2]:text-2xl [&_h2]:font-semibold dark:[&_h2]:border-[#3E3E3A] [&_h3]:mt-8 [&_h3]:mb-3 [&_h3]:scroll-mt-24 [&_h3]:text-xl [&_h3]:font-semibold [&_li]:pl-1 [&_ol]:mb-5 [&_ol]:list-decimal [&_ol]:space-y-2 [&_ol]:pl-6 [&_p]:mb-5 [&_p]:leading-7 [&_p]:text-[#706f6c] dark:[&_p]:text-[#A1A09A] [&_pre]:my-6 [&_pre]:overflow-x-auto [&_pre]:rounded-xl [&_pre]:border [&_pre]:border-[#e3e3e0] [&_pre]:bg-black/[0.03] [&_pre]:p-5 [&_pre]:text-sm dark:[&_pre]:border-[#3E3E3A] dark:[&_pre]:bg-white/[0.04] [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_ul]:mb-5 [&_ul]:list-disc [&_ul]:space-y-2 [&_ul]:pl-6"
+            className="max-w-3xl [&_.card]:rounded-xl [&_.card]:border [&_.card]:border-[#e3e3e0] [&_.card]:bg-black/[0.02] [&_.card]:p-5 dark:[&_.card]:border-[#3E3E3A] dark:[&_.card]:bg-white/[0.03] [&_.card_h3]:mt-0 [&_.card_h3]:mb-3 [&_.card_p]:mb-4 [&_.card_ul]:mb-0 [&_.cards-wrapper]:my-8 [&_.cards-wrapper]:grid [&_.cards-wrapper]:grid-cols-1 [&_.cards-wrapper]:gap-4 md:[&_.cards-wrapper]:grid-cols-2 [&_.documentation-shot]:h-auto [&_.documentation-shot]:max-w-full [&_.documentation-shot]:rounded-xl [&_.documentation-shot]:border [&_.documentation-shot]:border-[#e3e3e0] dark:[&_.documentation-shot]:border-[#3E3E3A] [&_.documentation-shot--dark]:hidden dark:[&_.documentation-shot--dark]:block [&_.documentation-shot--light]:block dark:[&_.documentation-shot--light]:hidden [&_a]:font-medium [&_a]:text-[#1b1b18] [&_a]:underline dark:[&_a]:text-[#EDEDEC] [&_blockquote]:my-6 [&_blockquote]:rounded-xl [&_blockquote]:bg-black/[0.03] [&_blockquote]:px-5 [&_blockquote]:py-4 dark:[&_blockquote]:bg-white/[0.04] [&_blockquote_p]:mb-0 [&_code]:rounded [&_code]:bg-black/5 [&_code]:px-1.5 [&_code]:py-0.5 dark:[&_code]:bg-white/10 [&_h1]:mb-4 [&_h1]:text-4xl [&_h1]:leading-tight [&_h1]:font-semibold [&_h1]:tracking-tight [&_h1+p]:mb-8 [&_h1+p]:text-[17px] [&_h1+p]:leading-8 [&_h2]:mt-12 [&_h2]:mb-4 [&_h2]:scroll-mt-24 [&_h2]:border-t [&_h2]:border-[#e3e3e0] [&_h2]:pt-8 [&_h2]:text-2xl [&_h2]:font-semibold dark:[&_h2]:border-[#3E3E3A] [&_h3]:mt-8 [&_h3]:mb-3 [&_h3]:scroll-mt-24 [&_h3]:text-xl [&_h3]:font-semibold [&_li]:pl-1 [&_ol]:mb-5 [&_ol]:list-decimal [&_ol]:space-y-2 [&_ol]:pl-6 [&_p]:mb-5 [&_p]:leading-7 [&_p]:text-[#706f6c] dark:[&_p]:text-[#A1A09A] [&_pre]:my-6 [&_pre]:overflow-x-auto [&_pre]:rounded-xl [&_pre]:border [&_pre]:border-[#e3e3e0] [&_pre]:bg-black/[0.03] [&_pre]:p-5 [&_pre]:text-sm dark:[&_pre]:border-[#3E3E3A] dark:[&_pre]:bg-white/[0.04] [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_ul]:mb-5 [&_ul]:list-disc [&_ul]:space-y-2 [&_ul]:pl-6"
             dangerouslySetInnerHTML={{ __html: html }}
         />
     );

--- a/tests/Feature/DocumentationTest.php
+++ b/tests/Feature/DocumentationTest.php
@@ -2,6 +2,7 @@
 
 use App\Support\Documentation\DocumentationTree;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\File;
 use Inertia\Testing\AssertableInertia;
 
 /**
@@ -133,8 +134,10 @@ it('renders headings, cards and diagrams in the page html', function () {
             fn (AssertableInertia $page) => $page
                 ->where('document.html', fn (string $html): bool => str_contains($html, '<h2 id="category-map">')
                     && str_contains($html, '<h3 id="expense">')
-                    && str_contains($html, 'language-mermaid')
-                    && str_contains($html, 'flowchart TD')
+                    && str_contains($html, '<div class="documentation-diagram">')
+                    && str_contains($html, '<svg viewBox="0 0 720 272"')
+                    && str_contains($html, '<title id="category-fanout-en-title">What a category is for</title>')
+                    && ! str_contains($html, 'language-mermaid')
                     && str_contains($html, '<div class="cards-wrapper">')
                     && str_contains($html, '<section class="card">')
                     && ! str_contains($html, '<div class="card">'))
@@ -165,6 +168,7 @@ it('serves every page as markdown for agents', function () {
     expect($body)->toStartWith('# Cuentas')
         ->and($body)->toContain('## Tipos de cuenta')
         ->and($body)->toContain('```mermaid')
+        ->and($body)->not->toContain('%% diagram:')
         ->and($body)->not->toContain('{{TOC}}')
         ->and($body)->not->toContain('<div class="cards-wrapper">')
         ->and($body)->not->toContain('<div class="card">');
@@ -273,4 +277,29 @@ it('lists every documentation page in the sitemap, with its other languages', fu
 it('returns not found for unknown pages, in html and in markdown', function () {
     $this->get('/documentation/unknown')->assertNotFound();
     $this->get('/documentation/unknown.md')->assertNotFound();
+});
+
+it('draws every mermaid block in the documentation as inline svg', function () {
+    $pages = File::allFiles(resource_path('docs/documentation'));
+    $markers = 0;
+
+    foreach ($pages as $page) {
+        $markdown = File::get($page->getPathname());
+
+        if (! str_contains($markdown, '```mermaid')) {
+            continue;
+        }
+
+        preg_match_all('/^\s*%% diagram: ([a-z0-9-]+)$/m', $markdown, $matches);
+
+        expect($matches[1])
+            ->toHaveCount(substr_count($markdown, '```mermaid'), "{$page->getRelativePathname()} has a mermaid block without a diagram marker");
+
+        foreach ($matches[1] as $diagram) {
+            expect(resource_path("docs/diagrams/{$diagram}.svg"))->toBeFile();
+            $markers++;
+        }
+    }
+
+    expect($markers)->toBeGreaterThan(0);
 });


### PR DESCRIPTION
## What

Every diagram in the public documentation was a mermaid flowchart drawn in the browser. The page imported `mermaid@11` from **jsdelivr** — a third-party CDN request in a privacy-first app — shipped ~500 KB of JavaScript, only showed the diagram once that had loaded, and gave all eight pages the same row of grey boxes.

They are now inline SVG, drawn for the page they sit on, in the product's own palette.

## How it fits together

- The ```mermaid block **stays** in the Markdown. For an agent reading the `.md` twin of a page it is still the best description of a diagram there is, so it remains the source of truth; a `%% diagram: <name>` comment inside it names the drawing the HTML page shows in its place.
- `DocumentationMarkdown` lifts the block out before the Markdown is rendered (raw HTML is stripped) and puts the SVG back once the page around it is HTML — the same mechanism the `cards` blocks already used. The marker is filtered out of the Markdown served to agents.
- `doc-article.tsx` loses the mermaid loader (-70 lines). The diagrams now render with JavaScript disabled and no longer reflow the page as they appear.
- Colours are tokens (`--dg-*`) in `app.css`, so **one file per diagram and language serves both themes**, and the mask behind an arrow label is painted with the same paper as the page. `min-width` on the figure keeps a 12px label readable on a phone: the container scrolls sideways instead of the diagram shrinking.

## What each page gained

| Page | Now | Why |
|---|---|---|
| getting started | Architecture in three labelled phases | Reads as a direction, not a graph |
| accounts | Two legible branches | Balances → net worth, transactions → cashflow |
| transactions | Four phases, fan out and back in | "Reports" and "Filters and budgets" merged; they always travelled together |
| transactions/import | Numbered timeline of the six steps | Each step says what it is for; the preview is called out as the last place a mistake can be caught |
| categories | Fan-out with separated attach points | Three readings of one category |
| automation rules | A real decision | **Adds the "does not match" branch** the old diagram left out, and the condition fields the product actually offers |
| cashflow | **Sankey** — band width is the amount | The split between what is spent and what is left is visible instead of stated |
| budgets | A progress bar as the focal element | Rather than a box that says "progress" |

## Checks

- Full suite green (2710 passed), plus a new test that fails if a mermaid block is left without a marker or names a drawing that does not exist.
- `pint`, `format`, `lint`, `dry`, `crap` all clean.
- Reviewed in Chrome on the real pages, light and dark.

## Note for review

`.diagram-design` is the palette marker for the `diagram-design` skill, so the next person or agent drawing a diagram here inherits these tokens instead of the skill's default orange. It points at a profile stored outside the repo; without it the skill only warns and falls back. Happy to drop the file if you would rather not carry it.