### PR TITLE
fix(analysis): break spending down by sub-category when filtering a parent

### DIFF
--- a/app/Http/Controllers/Api/TransactionAnalysisController.php
+++ b/app/Http/Controllers/Api/TransactionAnalysisController.php
@@ -62,7 +62,7 @@ class TransactionAnalysisController extends Controller
 
         $this->preloadExchangeRates($transactions, $currency);
 
-        $byCategory = $this->categoryBreakdown($transactions, $currency, $user->id);
+        $byCategory = $this->categoryBreakdown($transactions, $currency, $user->id, $this->drillParentId($filters));
         $byTag = $this->tagBreakdown($transactions, $currency);
         $byPayee = $this->payeeBreakdown($transactions, $currency);
         $byAccount = $this->accountBreakdown($transactions, $currency);
@@ -128,11 +128,35 @@ class TransactionAnalysisController extends Controller
     }
 
     /**
-     * Expenses grouped by their top-level category, with the sub-categories
-     * that carry spending nested beneath each parent so the split is visible
-     * instead of folded into the parent total.
+     * The category the breakdown is rooted at: the selected one whenever the
+     * filter narrows to exactly one real category, so its sub-categories are
+     * compared against each other instead of collapsing into a single row.
+     *
+     * @param  array<string, mixed>  $filters
      */
-    private function categoryBreakdown(Collection $transactions, string $currency, string $userId): Collection
+    private function drillParentId(array $filters): ?string
+    {
+        // Categories and labels are ORed, so a label filter pulls in transactions
+        // from outside the subtree. Drilling would drop them from the breakdown
+        // while they still count towards the totals, so leave the rollup alone.
+        if (! empty($filters['label_ids'])) {
+            return null;
+        }
+
+        $categoryIds = array_values(array_filter(
+            $filters['category_ids'] ?? [],
+            fn (string $id): bool => $id !== 'uncategorized',
+        ));
+
+        return count($categoryIds) === 1 ? $categoryIds[0] : null;
+    }
+
+    /**
+     * Expenses grouped by their top-level category — or, when drilling into a
+     * selected category, by its sub-categories — with the level below nested
+     * beneath each row so the split is visible instead of folded into the total.
+     */
+    private function categoryBreakdown(Collection $transactions, string $currency, string $userId, ?string $drillParentId = null): Collection
     {
         $expenses = $transactions->filter(
             fn (Transaction $transaction): bool => $transaction->isExpenseSide(),
@@ -162,7 +186,7 @@ class TransactionAnalysisController extends Controller
                 'icon' => $child['category']->icon,
                 'amount' => $child['amount'],
             ], $node['children']),
-        ], $this->tree->spendingBreakdown($grouped, $userId));
+        ], $this->tree->spendingBreakdown($grouped, $userId, $drillParentId));
 
         $uncategorized = -$expenses
             ->filter(fn (Transaction $transaction): bool => $transaction->category_id === null)

--- a/app/Services/CategoryTree.php
+++ b/app/Services/CategoryTree.php
@@ -228,10 +228,15 @@ class CategoryTree
      * sub-categories surfaces as a "Direct" child so the children always sum
      * to the parent total. Uncategorized items are left for the caller.
      *
+     * Pass $drillParentId to re-root the breakdown at that category: its
+     * children become the rows, their own children the nested level, and items
+     * outside the subtree drop out. Spend booked on the drilled parent itself
+     * has no child to sit under, so it becomes a "Direct" row of its own.
+     *
      * @param  array<int, array{category_id: ?string, amount: int}>  $categorized
      * @return array<int, array{category_id: string, category: Category, amount: int, children: array<int, array{category_id: string, category: Category, amount: int}>}>
      */
-    public function spendingBreakdown(array $categorized, string $userId): array
+    public function spendingBreakdown(array $categorized, string $userId, ?string $drillParentId = null): array
     {
         $categories = Category::query()
             ->where('user_id', $userId)
@@ -250,30 +255,43 @@ class CategoryTree
             }
 
             $chain = $this->chainFromRoot($categoryId, $parentMap);
-            $rootId = $chain[0];
+            $offset = $this->chainOffsetAfter($chain, $drillParentId);
 
-            $roots[$rootId] ??= [
-                'category_id' => $rootId,
-                'category' => $categories->get($rootId),
+            if ($offset === null) {
+                continue;
+            }
+
+            // Nothing left in the chain means the spend sits on the drilled
+            // parent itself, so it gets a "Direct" row instead of a child.
+            $isDirectRow = ! isset($chain[$offset]);
+            $rowId = $chain[$offset] ?? $drillParentId;
+            $key = $isDirectRow ? $rowId.':direct' : $rowId;
+
+            $roots[$key] ??= [
+                'category_id' => $rowId,
+                'category' => $isDirectRow
+                    ? $this->renamedCopy($categories->get($rowId), __('Direct'))
+                    : $categories->get($rowId),
                 'amount' => 0,
                 'direct' => 0,
                 'children' => [],
             ];
-            $roots[$rootId]['amount'] += $item['amount'];
+            $roots[$key]['amount'] += $item['amount'];
 
-            if (count($chain) === 1) {
-                $roots[$rootId]['direct'] += $item['amount'];
+            $childId = $chain[$offset + 1] ?? null;
+
+            if ($childId === null) {
+                $roots[$key]['direct'] += $item['amount'];
 
                 continue;
             }
 
-            $childId = $chain[1];
-            $roots[$rootId]['children'][$childId] ??= [
+            $roots[$key]['children'][$childId] ??= [
                 'category_id' => $childId,
                 'category' => $categories->get($childId),
                 'amount' => 0,
             ];
-            $roots[$rootId]['children'][$childId]['amount'] += $item['amount'];
+            $roots[$key]['children'][$childId]['amount'] += $item['amount'];
         }
 
         return collect($roots)
@@ -281,18 +299,9 @@ class CategoryTree
                 $children = collect($root['children'])->values();
 
                 if ($root['direct'] > 0 && $children->isNotEmpty()) {
-                    $parent = $root['category'];
                     $children->push([
                         'category_id' => $root['category_id'],
-                        'category' => (new Category)->forceFill([
-                            'id' => $parent->id,
-                            'name' => __('Direct'),
-                            'icon' => $parent->icon,
-                            'color' => $parent->color,
-                            'type' => $parent->type,
-                            'cashflow_direction' => $parent->cashflow_direction,
-                            'parent_id' => $parent->id,
-                        ]),
+                        'category' => $this->renamedCopy($root['category'], __('Direct')),
                         'amount' => $root['direct'],
                     ]);
                 }
@@ -306,6 +315,41 @@ class CategoryTree
             })
             ->values()
             ->all();
+    }
+
+    /**
+     * Where the breakdown's own rows start inside a category chain: the top for
+     * an undrilled breakdown, the position right after the drilled parent
+     * otherwise. Null when the chain never passes through that parent.
+     *
+     * @param  array<int, string>  $chain
+     */
+    private function chainOffsetAfter(array $chain, ?string $drillParentId): ?int
+    {
+        if ($drillParentId === null) {
+            return 0;
+        }
+
+        $index = array_search($drillParentId, $chain, true);
+
+        return $index === false ? null : $index + 1;
+    }
+
+    /**
+     * A detached copy of a category under a different name, used for the
+     * synthetic "Direct" nodes that carry a parent's own spending.
+     */
+    private function renamedCopy(Category $category, string $name): Category
+    {
+        return (new Category)->forceFill([
+            'id' => $category->id,
+            'name' => $name,
+            'icon' => $category->icon,
+            'color' => $category->color,
+            'type' => $category->type,
+            'cashflow_direction' => $category->cashflow_direction,
+            'parent_id' => $category->id,
+        ]);
     }
 
     /**
@@ -337,22 +381,16 @@ class CategoryTree
     private function displayNodeFor(string $categoryId, array $parentMap, ?string $drillParentId): ?array
     {
         $chain = $this->chainFromRoot($categoryId, $parentMap);
+        $offset = $this->chainOffsetAfter($chain, $drillParentId);
 
-        if ($drillParentId === null) {
-            return ['id' => $chain[0], 'is_direct' => false];
-        }
-
-        $index = array_search($drillParentId, $chain, true);
-
-        if ($index === false) {
+        if ($offset === null) {
             return null;
         }
 
-        if ($index === count($chain) - 1) {
-            return ['id' => $drillParentId, 'is_direct' => true];
-        }
-
-        return ['id' => $chain[$index + 1], 'is_direct' => false];
+        // Nothing left in the chain means the spend sits on the drilled parent.
+        return isset($chain[$offset])
+            ? ['id' => $chain[$offset], 'is_direct' => false]
+            : ['id' => $drillParentId, 'is_direct' => true];
     }
 
     /**

--- a/tests/Feature/TransactionAnalysisTest.php
+++ b/tests/Feature/TransactionAnalysisTest.php
@@ -132,6 +132,93 @@ test('spend booked directly on a split parent surfaces as a Direct child', funct
     expect($children->firstWhere('name', 'Direct')['amount'])->toBe(5000);
 });
 
+test('filtering by a parent category breaks the spending down by sub-category', function () {
+    $subscriptions = Category::factory()->create(['user_id' => $this->user->id, 'type' => CategoryType::Expense, 'name' => 'Subscriptions']);
+    $windy = Category::factory()->create(['user_id' => $this->user->id, 'type' => CategoryType::Expense, 'name' => 'Windy', 'parent_id' => $subscriptions->id]);
+    $rainAlarm = Category::factory()->create(['user_id' => $this->user->id, 'type' => CategoryType::Expense, 'name' => 'Rain Alarm', 'parent_id' => $subscriptions->id]);
+
+    makeTransaction(['amount' => -3000, 'category_id' => $windy->id, 'transaction_date' => '2026-01-10']);
+    makeTransaction(['amount' => -1000, 'category_id' => $rainAlarm->id, 'transaction_date' => '2026-01-11']);
+
+    $response = $this->getJson('/api/transactions/analysis?category_ids[]='.$subscriptions->id);
+
+    $response->assertOk();
+    expect($response->json('distinct_category_count'))->toBe(2);
+    expect($response->json('by_category.0'))->toMatchArray(['name' => 'Windy', 'amount' => 3000, 'children' => []]);
+    expect($response->json('by_category.1'))->toMatchArray(['name' => 'Rain Alarm', 'amount' => 1000, 'children' => []]);
+});
+
+test('drilled breakdown nests grand-children under the sub-category rows', function () {
+    $subscriptions = Category::factory()->create(['user_id' => $this->user->id, 'type' => CategoryType::Expense, 'name' => 'Subscriptions']);
+    $streaming = Category::factory()->create(['user_id' => $this->user->id, 'type' => CategoryType::Expense, 'name' => 'Streaming', 'parent_id' => $subscriptions->id]);
+    $netflix = Category::factory()->create(['user_id' => $this->user->id, 'type' => CategoryType::Expense, 'name' => 'Netflix', 'parent_id' => $streaming->id]);
+    $software = Category::factory()->create(['user_id' => $this->user->id, 'type' => CategoryType::Expense, 'name' => 'Software', 'parent_id' => $subscriptions->id]);
+
+    makeTransaction(['amount' => -2000, 'category_id' => $netflix->id, 'transaction_date' => '2026-01-10']);
+    makeTransaction(['amount' => -1500, 'category_id' => $software->id, 'transaction_date' => '2026-01-11']);
+
+    $response = $this->getJson('/api/transactions/analysis?category_ids[]='.$subscriptions->id);
+
+    $response->assertOk();
+    expect($response->json('distinct_category_count'))->toBe(2);
+    expect($response->json('by_category.0'))->toMatchArray(['name' => 'Streaming', 'amount' => 2000]);
+    expect($response->json('by_category.0.children.0'))->toMatchArray(['name' => 'Netflix', 'amount' => 2000]);
+    expect($response->json('by_category.1'))->toMatchArray(['name' => 'Software', 'amount' => 1500, 'children' => []]);
+});
+
+test('spend booked on the drilled parent itself surfaces as its own Direct row', function () {
+    $subscriptions = Category::factory()->create(['user_id' => $this->user->id, 'type' => CategoryType::Expense, 'name' => 'Subscriptions']);
+    $windy = Category::factory()->create(['user_id' => $this->user->id, 'type' => CategoryType::Expense, 'name' => 'Windy', 'parent_id' => $subscriptions->id]);
+
+    makeTransaction(['amount' => -3000, 'category_id' => $windy->id, 'transaction_date' => '2026-01-10']);
+    makeTransaction(['amount' => -800, 'category_id' => $subscriptions->id, 'transaction_date' => '2026-01-11']);
+
+    $response = $this->getJson('/api/transactions/analysis?category_ids[]='.$subscriptions->id);
+
+    $response->assertOk();
+    expect($response->json('distinct_category_count'))->toBe(2);
+    expect($response->json('by_category.0'))->toMatchArray(['name' => 'Windy', 'amount' => 3000]);
+    expect($response->json('by_category.1'))->toMatchArray(['name' => 'Direct', 'amount' => 800, 'children' => []]);
+});
+
+test('a label filter alongside a category keeps the top-level rollup', function () {
+    $subscriptions = Category::factory()->create(['user_id' => $this->user->id, 'type' => CategoryType::Expense, 'name' => 'Subscriptions']);
+    $windy = Category::factory()->create(['user_id' => $this->user->id, 'type' => CategoryType::Expense, 'name' => 'Windy', 'parent_id' => $subscriptions->id]);
+    $travel = Category::factory()->create(['user_id' => $this->user->id, 'type' => CategoryType::Expense, 'name' => 'Travel']);
+    $work = Label::factory()->create(['user_id' => $this->user->id, 'name' => 'Work']);
+
+    makeTransaction(['amount' => -3000, 'category_id' => $windy->id, 'transaction_date' => '2026-01-10']);
+    makeTransaction(['amount' => -5000, 'category_id' => $travel->id, 'transaction_date' => '2026-01-11'])
+        ->labels()->attach($work);
+
+    $response = $this->getJson('/api/transactions/analysis?category_ids[]='.$subscriptions->id.'&label_ids[]='.$work->id);
+
+    // Labels are ORed with categories, so the Travel expense is part of the
+    // filtered set and has to stay visible in the breakdown.
+    $response->assertOk();
+    expect($response->json('summary.expense'))->toBe(8000);
+    expect(collect($response->json('by_category'))->sum('amount'))->toBe(8000);
+    expect($response->json('by_category.0'))->toMatchArray(['name' => 'Travel', 'amount' => 5000]);
+    expect($response->json('by_category.1'))->toMatchArray(['name' => 'Subscriptions', 'amount' => 3000]);
+});
+
+test('filtering by several categories keeps the top-level rollup', function () {
+    $food = Category::factory()->create(['user_id' => $this->user->id, 'type' => CategoryType::Expense, 'name' => 'Food']);
+    $groceries = Category::factory()->create(['user_id' => $this->user->id, 'type' => CategoryType::Expense, 'name' => 'Groceries', 'parent_id' => $food->id]);
+    $travel = Category::factory()->create(['user_id' => $this->user->id, 'type' => CategoryType::Expense, 'name' => 'Travel']);
+
+    makeTransaction(['amount' => -30000, 'category_id' => $groceries->id, 'transaction_date' => '2026-01-10']);
+    makeTransaction(['amount' => -10000, 'category_id' => $travel->id, 'transaction_date' => '2026-01-11']);
+
+    $response = $this->getJson('/api/transactions/analysis?category_ids[]='.$food->id.'&category_ids[]='.$travel->id);
+
+    $response->assertOk();
+    expect($response->json('distinct_category_count'))->toBe(2);
+    expect($response->json('by_category.0'))->toMatchArray(['name' => 'Food', 'amount' => 30000]);
+    expect($response->json('by_category.0.children.0'))->toMatchArray(['name' => 'Groceries', 'amount' => 30000]);
+    expect($response->json('by_category.1'))->toMatchArray(['name' => 'Travel', 'amount' => 10000]);
+});
+
 test('grand-children fold into their level-two sub-category', function () {
     $food = Category::factory()->create(['user_id' => $this->user->id, 'type' => CategoryType::Expense, 'name' => 'Food']);
     $groceries = Category::factory()->create(['user_id' => $this->user->id, 'type' => CategoryType::Expense, 'name' => 'Groceries', 'parent_id' => $food->id]);


### PR DESCRIPTION
## The problem

The Analysis drawer already has a **"Spending by category"** panel, but it was silently hidden in exactly the case where it is most useful.

`CategoryTree::spendingBreakdown()` always folded every amount into its **top-level ancestor**. Filtering transactions by a single parent category (say *Subscriptions*) therefore collapsed every matching transaction into that one root row, `distinct_category_count` came back as `1`, and the frontend gate `distinct_category_count > 1` hid the panel entirely. The user got *Spending by tag* but no way to see how the spend split across the branch they had just filtered into.

Reported by a user who wanted to spot unusual spend per sub-category, and pointed out that labels are for other axes ("necessary" / "optional" spending), not for mirroring the category tree.

## The fix

`spendingBreakdown()` takes an optional drill parent and re-roots the breakdown there:

- the drilled parent's children become the rows,
- grandchildren nest beneath them (same two-level UI contract as before),
- items outside the subtree drop out,
- spend booked directly on the drilled parent surfaces as a **"Direct"** row, so the rows still sum to the filtered total.

`TransactionAnalysisController::drillParentId()` derives it from the request filters the drawer already sends, so there is **no new endpoint, no new request param and no frontend change**. With no drill it is the previous behaviour byte for byte — the dashboard and every other consumer are untouched.

### When the drill kicks in

Only when the filter narrows to **exactly one real category** (the `uncategorized` pseudo-id is ignored) **and no label filter is active**.

That second condition is deliberate: `applyCategoryAndLabelFilters()` ORs categories and labels together, so a label filter can pull in transactions from outside the subtree. Drilling would silently drop them from the panel while they kept counting towards `summary.expense`, leaving a breakdown whose rows no longer add up. When labels are in play we keep the top-level rollup.

### A note on the trigger

The sibling screens (`CashflowAnalyticsController`, `DashboardAnalyticsController`) get their drill parent from an explicit `parent` query param, because they have a real drill-in navigation. The transactions drawer has no such affordance and reuses the normal filter UI, so the drill is inferred from filter state instead. Predictable in practice — *"I filtered by Subscriptions, I see the Subscriptions split"* — but worth knowing it is a different contract from those two.

`rollUp()`'s private `displayNodeFor()` was solving the same "where does this category sit relative to the drill root" problem with its own implementation, so both now share `chainOffsetAfter()`. Behaviour unchanged, net fewer lines.

## Tests

Five new cases in `tests/Feature/TransactionAnalysisTest.php`:

- filtering by a parent returns its sub-categories with `distinct_category_count > 1`
- grandchildren nest under the sub-category rows when drilled
- spend booked on the drilled parent surfaces as its own "Direct" row
- several categories selected → unchanged top-level rollup
- a label filter alongside a category → unchanged top-level rollup, rows still sum to `summary.expense`

Full suite: 2779 passing. `pint`, `dry` and `crap --base=origin/main` all clean.

## QA

Verified in the browser against the demo account on a category with real spending across four sub-categories plus a grandchild and a direct-on-parent transaction:

- no filter → top-level rollup unchanged
- filtered by the parent → panel appears with 5 rows (4 sub-categories + `Directo`), summing to the parent total to the cent
- grandchild nests correctly under its sub-category when expanded
- category + label → falls back to the top-level rollup, label-matched transactions still accounted for
- two categories → top-level rollup, unchanged
- dark mode clean, no console errors

## Demo

<!-- PLACEHOLDER: drag the QA video here -->

https://github.com/user-attachments/assets/f035e91a-bfda-4a8e-a23c-d89579790972



