### PR TITLE
fix(import): [WM-4C8E] keep the amount sign and stop date columns being mapped as amounts

### DIFF
--- a/resources/js/lib/file-parser.test.ts
+++ b/resources/js/lib/file-parser.test.ts
@@ -10,6 +10,7 @@ import {
     detectDateFormat,
     getLatestTransactionDate,
     getLocaleDateFormat,
+    parseAmount,
     parseDate,
     parseFile,
 } from './file-parser';
@@ -98,6 +99,29 @@ describe('convertRowsToTransactions', () => {
 
         expect(transactions).toHaveLength(1);
         expect(transactions[0].transaction_date).toBe('2024-12-31');
+    });
+
+    it('stores an amount with a trailing sign as an expense', () => {
+        const transactions = convertRowsToTransactions(
+            [
+                {
+                    date: '2026-05-04',
+                    description: 'Card purchase',
+                    amount: '10,32-',
+                },
+            ],
+            {
+                transaction_date: 'date',
+                description: 'description',
+                amount: 'amount',
+                balance: null,
+                creditor_name: null,
+                debtor_name: null,
+            },
+            DateFormat.YearMonthDay,
+        );
+
+        expect(transactions[0].amount).toBe(-1032);
     });
 });
 
@@ -192,6 +216,104 @@ describe('autoDetectColumns', () => {
 
         expect(mapping.creditor_name).toBe('Creditor Name');
         expect(mapping.debtor_name).toBe('Debtor Name');
+    });
+
+    it('maps an English header set', () => {
+        const mapping = autoDetectColumns([
+            'Transaction Date',
+            'Description',
+            'Amount',
+        ]);
+
+        expect(mapping.transaction_date).toBe('Transaction Date');
+        expect(mapping.description).toBe('Description');
+        expect(mapping.amount).toBe('Amount');
+    });
+
+    it('maps a Spanish header set', () => {
+        const mapping = autoDetectColumns(['Fecha', 'Concepto', 'Importe']);
+
+        expect(mapping.transaction_date).toBe('Fecha');
+        expect(mapping.description).toBe('Concepto');
+        expect(mapping.amount).toBe('Importe');
+    });
+
+    it('prefers Importe over a date column matching "valor"', () => {
+        const mapping = autoDetectColumns([
+            'Fecha operación',
+            'Fecha valor',
+            'Concepto',
+            'Importe',
+            'Saldo',
+        ]);
+
+        expect(mapping.transaction_date).toBe('Fecha operación');
+        expect(mapping.description).toBe('Concepto');
+        expect(mapping.amount).toBe('Importe');
+        expect(mapping.balance).toBe('Saldo');
+    });
+
+    it('does not claim the date column as the amount column', () => {
+        const mapping = autoDetectColumns([
+            'Fecha valor',
+            'Concepto',
+            'Importe',
+        ]);
+
+        expect(mapping.transaction_date).toBe('Fecha valor');
+        expect(mapping.amount).toBe('Importe');
+    });
+
+    it('keeps Valor as the amount column when it is the only match', () => {
+        const mapping = autoDetectColumns(['Data', 'Descrição', 'Valor']);
+
+        expect(mapping.description).toBe('Descrição');
+        expect(mapping.amount).toBe('Valor');
+    });
+});
+
+describe('parseAmount', () => {
+    it('keeps the sign for the layouts that already worked', () => {
+        expect(parseAmount('-50,32')).toBe(-50.32);
+        expect(parseAmount('-50,32 €')).toBe(-50.32);
+        expect(parseAmount('(50,32)')).toBe(-50.32);
+        expect(parseAmount('- 50,32')).toBe(-50.32);
+        expect(parseAmount('-1.234,56')).toBe(-1234.56);
+    });
+
+    it('detects a sign written after the currency symbol or code', () => {
+        expect(parseAmount('€ -50,32')).toBe(-50.32);
+        expect(parseAmount('EUR -50,32')).toBe(-50.32);
+    });
+
+    it('detects a trailing sign', () => {
+        expect(parseAmount('50,32-')).toBe(-50.32);
+        expect(parseAmount('1.234,56-')).toBe(-1234.56);
+    });
+
+    it('detects the unicode minus sign and the en dash', () => {
+        expect(parseAmount('\u221250,32')).toBe(-50.32);
+        expect(parseAmount('\u2013 50,32')).toBe(-50.32);
+    });
+
+    it('detects a sign wrapped in quotes', () => {
+        expect(parseAmount('"-50,32"')).toBe(-50.32);
+    });
+
+    it('does not read hyphens between digits as a negative sign', () => {
+        expect(parseAmount('31-07-2026')).toBe(31072026);
+        expect(parseAmount('2026-07-31')).toBe(20260731);
+        expect(parseAmount('50,32')).toBe(50.32);
+    });
+
+    it('leaves numeric cells untouched', () => {
+        expect(parseAmount(-50.32)).toBe(-50.32);
+        expect(parseAmount(50.32)).toBe(50.32);
+    });
+
+    it('returns null when there is no number to parse', () => {
+        expect(parseAmount('')).toBeNull();
+        expect(parseAmount('-')).toBeNull();
     });
 });
 

--- a/resources/js/lib/file-parser.test.ts
+++ b/resources/js/lib/file-parser.test.ts
@@ -264,6 +264,26 @@ describe('autoDetectColumns', () => {
         expect(mapping.amount).toBe('Importe');
     });
 
+    it('leaves the amount unmapped rather than taking a losing date column', () => {
+        const mapping = autoDetectColumns([
+            'Fecha operación',
+            'Fecha valor',
+            'Concepto',
+            'Saldo',
+        ]);
+
+        expect(mapping.transaction_date).toBe('Fecha operación');
+        expect(mapping.balance).toBe('Saldo');
+        expect(mapping.amount).toBeNull();
+    });
+
+    it('reads "Saldo total" as a balance rather than an amount', () => {
+        const mapping = autoDetectColumns(['Fecha', 'Concepto', 'Saldo total']);
+
+        expect(mapping.balance).toBe('Saldo total');
+        expect(mapping.amount).toBeNull();
+    });
+
     it('keeps Valor as the amount column when it is the only match', () => {
         const mapping = autoDetectColumns(['Data', 'Descrição', 'Valor']);
 

--- a/resources/js/lib/file-parser.ts
+++ b/resources/js/lib/file-parser.ts
@@ -368,53 +368,52 @@ export function autoDetectColumns(headers: string[]): ColumnMapping {
         'deudor',
     ];
 
-    for (let i = 0; i < lowerHeaders.length; i++) {
-        const header = lowerHeaders[i];
-        const originalHeader = headers[i];
+    const claimedIndexes = new Set<number>();
 
-        if (!header || typeof header !== 'string') {
-            continue;
+    // Each header can only be claimed by a single field, and the field takes
+    // the header with the longest matching pattern instead of the leftmost one.
+    // "Fecha valor" matches both the date patterns and the amount pattern
+    // 'valor', but it is a date column, so "Importe" stays free to become the
+    // amount column.
+    const claimBestHeader = (patterns: string[]): string | null => {
+        let bestIndex = -1;
+        let bestMatchLength = 0;
+
+        for (let i = 0; i < lowerHeaders.length; i++) {
+            const header = lowerHeaders[i];
+
+            if (!header || claimedIndexes.has(i)) {
+                continue;
+            }
+
+            const matchLength = Math.max(
+                0,
+                ...patterns
+                    .filter((pattern) => header.includes(pattern))
+                    .map((pattern) => pattern.length),
+            );
+
+            if (matchLength > bestMatchLength) {
+                bestIndex = i;
+                bestMatchLength = matchLength;
+            }
         }
 
-        if (
-            !mapping.transaction_date &&
-            datePatterns.some((p) => header.includes(p))
-        ) {
-            mapping.transaction_date = originalHeader;
+        if (bestIndex === -1) {
+            return null;
         }
 
-        if (
-            !mapping.description &&
-            descriptionPatterns.some((p) => header.includes(p))
-        ) {
-            mapping.description = originalHeader;
-        }
+        claimedIndexes.add(bestIndex);
 
-        if (!mapping.amount && amountPatterns.some((p) => header.includes(p))) {
-            mapping.amount = originalHeader;
-        }
+        return headers[bestIndex];
+    };
 
-        if (
-            !mapping.balance &&
-            balancePatterns.some((p) => header.includes(p))
-        ) {
-            mapping.balance = originalHeader;
-        }
-
-        if (
-            !mapping.creditor_name &&
-            creditorPatterns.some((p) => header.includes(p))
-        ) {
-            mapping.creditor_name = originalHeader;
-        }
-
-        if (
-            !mapping.debtor_name &&
-            debtorPatterns.some((p) => header.includes(p))
-        ) {
-            mapping.debtor_name = originalHeader;
-        }
-    }
+    mapping.transaction_date = claimBestHeader(datePatterns);
+    mapping.description = claimBestHeader(descriptionPatterns);
+    mapping.amount = claimBestHeader(amountPatterns);
+    mapping.balance = claimBestHeader(balancePatterns);
+    mapping.creditor_name = claimBestHeader(creditorPatterns);
+    mapping.debtor_name = claimBestHeader(debtorPatterns);
 
     return mapping;
 }
@@ -526,7 +525,14 @@ export function parseAmount(amountStr: string | number): number | null {
 
     let str = String(amountStr).trim();
 
-    const isNegative = /^-/.test(str) || /^\(.*\)$/.test(str);
+    // A sign only counts at either edge: leading it may sit behind a currency
+    // symbol or code ("€ -50,32"), trailing it must follow the digits
+    // ("50,32-"). Hyphens between digits are date separators ("31-07-2026")
+    // and a trailing "1'234.-" means zero cents, not a negative sign.
+    const isNegative =
+        /^\D*[-\u2212\u2013]/.test(str) ||
+        /\d\s*[-\u2212\u2013]\D*$/.test(str) ||
+        /^\(.*\)$/.test(str);
 
     const dotPos = str.lastIndexOf('.');
     const commaPos = str.lastIndexOf(',');

--- a/resources/js/lib/file-parser.ts
+++ b/resources/js/lib/file-parser.ts
@@ -368,52 +368,68 @@ export function autoDetectColumns(headers: string[]): ColumnMapping {
         'deudor',
     ];
 
-    const claimedIndexes = new Set<number>();
+    // Each header is claimed by a single field: the one whose longest pattern
+    // matches it, and on a tie the field listed first below. Amount is last
+    // because its patterns are the most generic: 'valor' is the real amount
+    // header in Portuguese exports, but in "Fecha valor" it is a date column
+    // and must not end up holding a date rendered as a number.
+    const fieldPatterns = [
+        ['transaction_date', datePatterns],
+        ['description', descriptionPatterns],
+        ['balance', balancePatterns],
+        ['creditor_name', creditorPatterns],
+        ['debtor_name', debtorPatterns],
+        ['amount', amountPatterns],
+    ] as const;
 
-    // Each header can only be claimed by a single field, and the field takes
-    // the header with the longest matching pattern instead of the leftmost one.
-    // "Fecha valor" matches both the date patterns and the amount pattern
-    // 'valor', but it is a date column, so "Importe" stays free to become the
-    // amount column.
-    const claimBestHeader = (patterns: string[]): string | null => {
-        let bestIndex = -1;
-        let bestMatchLength = 0;
-
-        for (let i = 0; i < lowerHeaders.length; i++) {
-            const header = lowerHeaders[i];
-
-            if (!header || claimedIndexes.has(i)) {
-                continue;
-            }
-
-            const matchLength = Math.max(
-                0,
-                ...patterns
-                    .filter((pattern) => header.includes(pattern))
-                    .map((pattern) => pattern.length),
-            );
-
-            if (matchLength > bestMatchLength) {
-                bestIndex = i;
-                bestMatchLength = matchLength;
-            }
-        }
-
-        if (bestIndex === -1) {
-            return null;
-        }
-
-        claimedIndexes.add(bestIndex);
-
-        return headers[bestIndex];
+    const longestMatch = (
+        patterns: readonly string[],
+        header: string,
+    ): number => {
+        return Math.max(
+            0,
+            ...patterns
+                .filter((pattern) => header.includes(pattern))
+                .map((pattern) => pattern.length),
+        );
     };
 
-    mapping.transaction_date = claimBestHeader(datePatterns);
-    mapping.description = claimBestHeader(descriptionPatterns);
-    mapping.amount = claimBestHeader(amountPatterns);
-    mapping.balance = claimBestHeader(balancePatterns);
-    mapping.creditor_name = claimBestHeader(creditorPatterns);
-    mapping.debtor_name = claimBestHeader(debtorPatterns);
+    const claims: Record<string, { header: string; length: number }> = {};
+
+    lowerHeaders.forEach((header, index) => {
+        let claimedField: { field: string; length: number } | null = null;
+
+        for (const [field, patterns] of fieldPatterns) {
+            const length = longestMatch(patterns, header);
+
+            if (
+                length > 0 &&
+                (claimedField === null || length > claimedField.length)
+            ) {
+                claimedField = { field, length };
+            }
+        }
+
+        if (claimedField === null) {
+            return;
+        }
+
+        const current = claims[claimedField.field];
+
+        if (current === undefined || claimedField.length > current.length) {
+            claims[claimedField.field] = {
+                header: headers[index],
+                length: claimedField.length,
+            };
+        }
+    });
+
+    mapping.transaction_date = claims.transaction_date?.header ?? null;
+    mapping.description = claims.description?.header ?? null;
+    mapping.amount = claims.amount?.header ?? null;
+    mapping.balance = claims.balance?.header ?? null;
+    mapping.creditor_name = claims.creditor_name?.header ?? null;
+    mapping.debtor_name = claims.debtor_name?.header ?? null;
 
     return mapping;
 }


### PR DESCRIPTION
Two bugs in the client-side CSV/Excel importer (`resources/js/lib/file-parser.ts`), both confirmed against real statement files.

## Bug 1 — a date column could be auto-mapped as the amount column

`autoDetectColumns` walked the headers left to right and took the first substring match per field:

```ts
if (!mapping.amount && amountPatterns.some((p) => header.includes(p))) {
    mapping.amount = originalHeader;
}
```

`amountPatterns` contains `'valor'`, so `"fecha valor".includes('valor')` is true and **"Fecha valor" was mapped as the amount column** at index 1, while the real `Importe` at index 3 was never reached. The same header also matches `datePatterns`, so one column ended up claimed by two fields. The imported amount was then the date rendered as a number (`31/07/2026` → `31072026`), which wrecks every total the account feeds.

`'valor'` is **kept** in `amountPatterns` on purpose: `Valor` on its own is the real amount column in Portuguese and Brazilian exports, so deleting the pattern would just move the bug to another set of banks.

Instead the resolution changed. Every header is claimed by exactly one field: the field whose **longest** pattern matches it, instead of the leftmost match by column position. On a tie the field declared first wins, and `amount` is declared **last** because its patterns are the most generic — a header that any other field recognises just as well is not the amount column.

That ordering matters: with `Fecha operación | Fecha valor | Concepto | Saldo` (a statement whose amount column is named something not in the pattern list at all), `'fecha'` and `'valor'` both match 5 characters, so "Fecha valor" goes to the date field, loses the date slot to "Fecha operación", and is left unmapped instead of falling through to `amount`. The importer then shows the amount column as unmapped and the user picks it, rather than silently importing dates as money. The same ordering keeps a header like `Saldo total` on the balance side.

| headers | amount | date |
| --- | --- | --- |
| `Fecha operación, Fecha valor, Concepto, Importe, Saldo` | `Importe` | `Fecha operación` |
| `Data, Descrição, Valor` | `Valor` | — |
| `Fecha, Concepto, Importe` | `Importe` | `Fecha` |
| `Transaction Date, Description, Amount` | `Amount` | `Transaction Date` |
| `Fecha valor, Concepto, Importe` | `Importe` | `Fecha valor` |

## Bug 2 — `parseAmount` dropped the negative sign

The sign was only recognised as the very first character:

```ts
const isNegative = /^-/.test(str) || /^\(.*\)$/.test(str);
```

and any minus that survived was then deleted by `str.replace(/[^\d]/g, '')`. So an expense imported as income. Behaviour of the current function vs. this branch:

| input | before | after |
| --- | --- | --- |
| `-50,32` | -50.32 | -50.32 |
| `-50,32 €` | -50.32 | -50.32 |
| `(50,32)` | -50.32 | -50.32 |
| `- 50,32` | -50.32 | -50.32 |
| `-1.234,56` | -1234.56 | -1234.56 |
| `€ -50,32` | **50.32** | -50.32 |
| `EUR -50,32` | **50.32** | -50.32 |
| `50,32-` | **50.32** | -50.32 |
| `1.234,56-` | **1234.56** | -1234.56 |
| `−50,32` (U+2212) | **50.32** | -50.32 |
| `– 50,32` (U+2013) | **50.32** | -50.32 |
| `"-50,32"` | **50.32** | -50.32 |

A sign now counts at either edge: leading it may sit behind a currency symbol or code, trailing it must follow the digits. Deliberately **not** treated as negative:

- hyphens between digits — a date landing in the amount cell (`31-07-2026`, `2026-07-31`) must not flip the row negative, which is exactly what bug 1 could produce;
- a trailing `.-` (`1'234.-`), which means zero cents, not a negative amount.

Still not detected, and left that way on purpose until a real export needs it: a trailing sign separated from the digits by a currency code (`50,32 EUR-`). The trailing form requires the sign to follow the digits, which is what keeps `1'234.-` positive.

The `typeof amountStr === 'number'` early return is untouched: native `.xls`/`.xlsx` cells arrive as numbers and already carry the correct sign. The fix lives inside `parseAmount` rather than at the transaction call site because the same function parses the balance column for the balance-import flows.

## Tests

`resources/js/lib/file-parser.test.ts` covers every row of both tables — the previously correct cases as regression guards, the previously wrong ones as the bug being fixed — plus an end-to-end `convertRowsToTransactions` case asserting a trailing-sign amount is stored as negative cents.
