### PR TITLE
fix(accounts): stop account cards overflowing narrow phones

### DIFF
--- a/resources/js/components/accounts/account-list-card.tsx
+++ b/resources/js/components/accounts/account-list-card.tsx
@@ -103,7 +103,10 @@ export function AccountListCard({
             <Card className="w-full">
                 <CardContent className="p-6">
                     <div className="flex flex-col gap-4">
-                        <div className="flex items-center justify-between">
+                        {/* Stacks on phones like the loaded card does, so the
+                            fixed-width bars cannot push the card past the
+                            viewport while the metrics are still deferred. */}
+                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                             <div className="flex items-center gap-3">
                                 <div className="h-10 w-10 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700" />
                                 <div className="flex flex-col gap-2">
@@ -111,7 +114,7 @@ export function AccountListCard({
                                     <div className="h-6 w-40 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
                                 </div>
                             </div>
-                            <div className="flex flex-col items-end gap-2">
+                            <div className="flex flex-col items-start gap-2 sm:items-end">
                                 <div className="h-8 w-32 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
                                 <div className="h-4 w-24 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
                             </div>
@@ -430,7 +433,7 @@ export function AccountListCard({
                             </LineChart>
                         </ResponsiveContainer>
                     </div>
-                    <div className="flex items-center gap-2">
+                    <div className="flex flex-wrap items-center gap-2">
                         <div className="relative size-5 shrink-0 text-muted-foreground">
                             <AccountTypeIcon
                                 type={account.type}

--- a/tests/Browser/AccountsPageMobileWidthTest.php
+++ b/tests/Browser/AccountsPageMobileWidthTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use App\Enums\AccountType;
+use App\Models\Account;
+use App\Models\AccountBalance;
+use App\Models\RealEstateDetail;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+
+it('does not scroll horizontally on a small phone', function () {
+    $user = User::factory()->onboarded()->create();
+
+    // Real estate accounts carry the longest action label ("Update market
+    // value"), so their card is the first one to outgrow a phone viewport.
+    $account = Account::factory()->create([
+        'user_id' => $user->id,
+        'bank_id' => null,
+        'name' => 'Beach Condo',
+        'type' => AccountType::RealEstate,
+        'currency_code' => 'EUR',
+    ]);
+
+    RealEstateDetail::factory()->create([
+        'account_id' => $account->id,
+        'linked_loan_account_id' => null,
+    ]);
+
+    AccountBalance::factory()->create([
+        'account_id' => $account->id,
+        'balance_date' => '2024-01-01',
+        'balance' => 30000000,
+    ]);
+
+    actingAs($user);
+
+    // 320px wide: the narrowest phone the app has to fit, and the width where
+    // every translation has to fit rather than get lucky.
+    $page = visit('/accounts')
+        ->on()
+        ->iPhoneSE()
+        ->navigate('/accounts', ['waitUntil' => 'domcontentloaded']);
+
+    // accountMetrics is a deferred prop, so the cards render as skeletons
+    // first, and that state has its own width to get wrong. Waiting and
+    // measuring in one evaluation keeps the metrics from landing in between.
+    // The overflow shows up on the page's scroll container, not the document.
+    $skeletonOverflow = (int) $page->script(<<<'JS'
+        (async () => {
+            const deadline = Date.now() + 3000;
+            while (!document.querySelector('.animate-pulse') && Date.now() < deadline) {
+                await new Promise((resolve) => setTimeout(resolve, 10));
+            }
+
+            const main = document.querySelector('[data-slot="sidebar-inset"]');
+
+            return main.scrollWidth - main.clientWidth;
+        })()
+    JS);
+
+    expect($skeletonOverflow)->toBeLessThanOrEqual(0);
+
+    $page->waitForText('Update market value');
+
+    $loadedOverflow = (int) $page->script(<<<'JS'
+        (() => {
+            const main = document.querySelector('[data-slot="sidebar-inset"]');
+
+            return main.scrollWidth - main.clientWidth;
+        })()
+    JS);
+
+    expect($loadedOverflow)->toBeLessThanOrEqual(0);
+
+    $page->assertNoJavascriptErrors();
+});


### PR DESCRIPTION
## Problem

On a narrow phone the Accounts page scrolled sideways: the account card grew
wider than the viewport and `Details →` was cut off at the right edge.

Two independent causes, both in `AccountListCard`:

1. **Loaded card.** The bottom action row (`type icon` + `Update balance` +
   `Details →`) is a non-wrapping flex row, so its min-content width sets the
   card's min-content width. At 320px that is 32px more than the card has, and
   the grid item grows past the page.
2. **Loading skeleton.** `accountMetrics` is a deferred prop, so every visit
   renders skeletons first. Its header was a fixed-width `justify-between` row
   (`w-40` + `w-32` bars), 94px too wide at 320px — the page could be scrolled
   sideways on every load, before any data arrived.

## Fix

CSS only, no behaviour change:

- The action row wraps (`flex-wrap`), so `Details →` drops to a second line,
  still right-aligned, when the labels no longer fit on one.
- The skeleton header stacks on phones and only becomes a `justify-between`
  row from `sm:` up — the same responsive shape the loaded card already uses.

Nothing changes at `sm:` and above, so tablet and desktop are untouched.

## Test

`tests/Browser/AccountsPageMobileWidthTest.php` asserts that the page's scroll
container has no horizontal overflow at **320px**, in both the skeleton and the
loaded state. It uses a real estate account because `Update market value` is the
longest action label, so the assertion does not depend on a translation
happening to be short. Verified to fail on each cause independently and pass
with both fixed:

| state | before | after |
| --- | --- | --- |
| skeleton | 94px overflow | 0 |
| loaded card | 32px overflow | 0 |

Also ran `AccountsPageTest`, `RealEstateAccountTest` and `PageWidthTest` — green.

## Demo

<!-- PLACEHOLDER: drag the QA video here -->

## Note

Not fixed here: at 320px a French real estate account (`Mettre à jour la valeur
marchande`) is still ~7px wider than the row it sits in, even alone on its own
line. Making the label itself shrinkable needs `whitespace-normal` plus a
variable-height button, which looks worse than the 7px it saves.
