### PR TITLE
feat(currencies): [WM-6C69] add the Czech koruna (CZK)

### DIFF
--- a/config/currencies.php
+++ b/config/currencies.php
@@ -33,6 +33,12 @@ return [
             'allows_account' => true,
         ],
         [
+            'code' => 'CZK',
+            'name' => 'Czech Koruna',
+            'allows_primary' => true,
+            'allows_account' => true,
+        ],
+        [
             'code' => 'CAD',
             'name' => 'Canadian Dollar',
             'allows_primary' => true,

--- a/lang/es.json
+++ b/lang/es.json
@@ -1621,6 +1621,7 @@
     "Ghanaian Cedi": "Cedi ghanés",
     "Swedish Krona": "Corona sueca",
     "Danish Krone": "Corona danesa",
+    "Czech Koruna": "Corona checa",
     "Pakistani Rupee": "Rupia pakistaní",
     "Brazilian Real": "Real brasileño",
     "Dominican Peso": "Peso dominicano",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1530,6 +1530,7 @@
     "Ghanaian Cedi": "Cedi ghanéen",
     "Swedish Krona": "Couronne suédoise",
     "Danish Krone": "Couronne danoise",
+    "Czech Koruna": "Couronne tchèque",
     "Nigerian Naira": "Naira nigérian",
     "Pakistani Rupee": "Roupie pakistanaise",
     "Brazilian Real": "Réal brésilien",

--- a/tests/Feature/InertiaSharedDataTest.php
+++ b/tests/Feature/InertiaSharedDataTest.php
@@ -198,4 +198,6 @@ test('shared currency options split profile and account currencies', function ()
     expect(collect($props['currencies']['profile'])->pluck('code'))->toContain('ARS');
     expect(collect($props['currencies']['profile'])->pluck('code'))->not->toContain('BTC');
     expect(collect($props['currencies']['accounts'])->pluck('code'))->toContain('BTC');
+    expect(collect($props['currencies']['profile'])->pluck('code'))->toContain('CZK');
+    expect(collect($props['currencies']['accounts'])->pluck('code'))->toContain('CZK');
 });


### PR DESCRIPTION
The Czech koruna was missing from the currencies offered for a profile and for
an account, so it could not be picked during setup. This adds `CZK` to
`config/currencies.php` with `allows_primary` and `allows_account`, next to the
other European codes, plus the Spanish and French names that
`LocalizationTest` enforces.

Purely additive: `App\Services\CurrencyOptions` is the only consumer of
`currencies.options` and derives the primary/account lists from it, so no
registry, enum or frontend list needed a parallel change. The rate source
(@fawazahmed0/currency-api) already publishes `czk`, so conversion works as-is.

## Tests

`tests/Feature/InertiaSharedDataTest.php` now asserts CZK is offered both as a
profile currency and as an account currency.

## Deliberately not changed

- **No currency symbol.** `Money::format()` and `getCurrencySymbol()` both fall
  back to the code, exactly as they do for CHF, DKK and SEK. The main UI formats
  through `Intl.NumberFormat`, which renders `CZK 1,234.56` / `1 234,56 CZK`.
- **No bank or country catalogue change.** The provider returns 0 institutions
  for `CZ`, so Czech bank connections do not exist; the bank picker for manual
  accounts already lists Czech banks.

## Demo

<!-- PLACEHOLDER: attach czk-currency-qa.mp4 here -->

QA: logged in as a throwaway local user, switched the profile currency from USD
to CZK and confirmed it survived a reload, then created a manual `Savings`
account in CZK and confirmed the list shows it. No new console errors; the
throwaway user was deleted afterwards.
