### PR TITLE
fix(dashboard): [WM-60CF] stop counting archived accounts in period totals

### DIFF
--- a/app/Http/Controllers/Api/CashflowAnalyticsController.php
+++ b/app/Http/Controllers/Api/CashflowAnalyticsController.php
@@ -188,6 +188,7 @@ class CashflowAnalyticsController extends Controller
         $transactions = Transaction::query()
             ->where('transactions.user_id', $userId)
             ->whereBetween('transactions.transaction_date', [$from, $to])
+            ->countingTowardsTotals()
             ->with(['account', 'category'])
             ->get();
 
@@ -283,6 +284,7 @@ class CashflowAnalyticsController extends Controller
         $transactions = Transaction::query()
             ->where('transactions.user_id', $userId)
             ->whereBetween('transactions.transaction_date', [$from, $to])
+            ->countingTowardsTotals()
             ->with(['account', 'category'])
             ->get();
 
@@ -341,6 +343,7 @@ class CashflowAnalyticsController extends Controller
         $transactions = Transaction::query()
             ->where('transactions.user_id', $userId)
             ->whereBetween('transactions.transaction_date', [$from, $to])
+            ->countingTowardsTotals()
             ->with(['account', 'category'])
             ->get();
 

--- a/app/Http/Controllers/Api/CategoryMonthlyBreakdownController.php
+++ b/app/Http/Controllers/Api/CategoryMonthlyBreakdownController.php
@@ -59,9 +59,10 @@ class CategoryMonthlyBreakdownController extends Controller
         ));
 
         $transactions = Transaction::query()
-            ->where('user_id', $user->id)
-            ->whereIn('category_id', $subtreeIds)
-            ->where('transaction_date', '>=', $start->toDateString())
+            ->where('transactions.user_id', $user->id)
+            ->whereIn('transactions.category_id', $subtreeIds)
+            ->where('transactions.transaction_date', '>=', $start->toDateString())
+            ->countingTowardsTotals()
             ->with('account')
             ->get();
 

--- a/app/Http/Controllers/Api/DashboardAnalyticsController.php
+++ b/app/Http/Controllers/Api/DashboardAnalyticsController.php
@@ -275,6 +275,7 @@ class DashboardAnalyticsController extends Controller
             ->where('transactions.user_id', request()->user()->id)
             ->whereBetween('transactions.transaction_date', [$from, $to])
             ->joinOwningAccount()
+            ->withoutArchivedAccountActivity()
             ->join('categories', function ($join) use ($type) {
                 $join->on('transactions.category_id', '=', 'categories.id')
                     ->where('categories.type', '=', $type)

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -350,6 +350,12 @@ class Transaction extends Model
      * soft-delete scope, so the row set is exactly what it was before the
      * ownership weighting existed.
      *
+     * A query that adds up a period — spending, cash flow, a category total —
+     * also wants {@see self::scopeWithoutArchivedAccountActivity()}, or an
+     * archived account keeps feeding the figure. A running accumulation is the
+     * exception: SavingsGoal's tagged contributions deliberately count archived
+     * accounts, since money set aside stays set aside.
+     *
      * @param  Builder<Transaction>  $query
      * @return Builder<Transaction>
      */
@@ -361,11 +367,18 @@ class Transaction extends Model
     /**
      * Drop what an archived account should no longer contribute: a transaction
      * dated on or after the day the account was archived. Earlier ones keep
-     * counting, so archiving never moves the history retroactively — the same
-     * cutoff that freezes an archived account's balance.
+     * counting, so archiving never moves the history retroactively. This mirrors
+     * AccountMetricsService, which freezes an archived account's balance from the
+     * same day, and BudgetTransactionService, where an archived budget stops
+     * taking in new spending from its own archive date.
      *
      * Spelled out rather than via Account::scopeNotArchived, which would drop
      * the account's whole past too.
+     *
+     * The cutoff day is `archived_at` read in UTC, not in the user's timezone,
+     * matching how the balance side reads it. At a non-zero offset that can land
+     * a day either side of the user's own day; fixing it means fixing both paths
+     * together, or they would disagree about when an account stopped counting.
      *
      * Only valid on queries that ran {@see self::scopeJoinOwningAccount()}.
      *
@@ -374,12 +387,32 @@ class Transaction extends Model
      */
     public function scopeWithoutArchivedAccountActivity(Builder $query): Builder
     {
-        return $query->where(function (Builder $query): void {
+        return $query->where(function (Builder $group): void {
             // date() on archived_at: it carries a time of day, transaction_date
             // does not, so a raw comparison would let the archiving day through.
-            $query->whereNull('accounts.archived_at')
+            $group->whereNull('accounts.archived_at')
                 ->orWhereRaw('transactions.transaction_date < date(accounts.archived_at)');
         });
+    }
+
+    /**
+     * Only the rows a period total should count: the same cutoff as
+     * {@see self::scopeWithoutArchivedAccountActivity()}, packaged for the
+     * queries that hydrate models and add up in PHP rather than in SQL.
+     *
+     * It re-selects `transactions.*` because the join drags the account's own
+     * columns into the default `select *`, where `id`, `user_id` and
+     * `currency_code` would overwrite the transaction's own values.
+     *
+     * @param  Builder<Transaction>  $query
+     * @return Builder<Transaction>
+     */
+    public function scopeCountingTowardsTotals(Builder $query): Builder
+    {
+        return $query
+            ->joinOwningAccount()
+            ->withoutArchivedAccountActivity()
+            ->select('transactions.*');
     }
 
     /**

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -359,6 +359,30 @@ class Transaction extends Model
     }
 
     /**
+     * Drop what an archived account should no longer contribute: a transaction
+     * dated on or after the day the account was archived. Earlier ones keep
+     * counting, so archiving never moves the history retroactively — the same
+     * cutoff that freezes an archived account's balance.
+     *
+     * Spelled out rather than via Account::scopeNotArchived, which would drop
+     * the account's whole past too.
+     *
+     * Only valid on queries that ran {@see self::scopeJoinOwningAccount()}.
+     *
+     * @param  Builder<Transaction>  $query
+     * @return Builder<Transaction>
+     */
+    public function scopeWithoutArchivedAccountActivity(Builder $query): Builder
+    {
+        return $query->where(function (Builder $query): void {
+            // date() on archived_at: it carries a time of day, transaction_date
+            // does not, so a raw comparison would let the archiving day through.
+            $query->whereNull('accounts.archived_at')
+                ->orWhereRaw('transactions.transaction_date < date(accounts.archived_at)');
+        });
+    }
+
+    /**
      * {@see self::OWNED_AMOUNT_SQL} as an expression, for `sum()` and friends.
      */
     public static function ownedAmount(): Expression

--- a/app/Services/CashflowSummaryService.php
+++ b/app/Services/CashflowSummaryService.php
@@ -43,6 +43,7 @@ class CashflowSummaryService
         $transactions = Transaction::query()
             ->where('transactions.user_id', $userId)
             ->whereBetween('transactions.transaction_date', [$previousPeriod->from, $period->to])
+            ->countingTowardsTotals()
             ->with(['account', 'category'])
             ->get();
 

--- a/app/Services/CategorySpendingService.php
+++ b/app/Services/CategorySpendingService.php
@@ -18,7 +18,9 @@ class CategorySpendingService
      * Without a drill target, child category amounts fold into their root
      * ancestor so only parents are listed. With one, the parent's children
      * become the rows (plus a direct node for transactions sitting on the
-     * parent itself). Soft-deleted categories are excluded.
+     * parent itself). Soft-deleted categories are excluded, as is what an
+     * archived account no longer contributes
+     * ({@see Transaction::scopeWithoutArchivedAccountActivity()}).
      */
     public function forPeriod(string $userId, Carbon $from, Carbon $to, ?string $drillParentId = null): Collection
     {
@@ -26,6 +28,7 @@ class CategorySpendingService
             ->where('transactions.user_id', $userId)
             ->whereBetween('transactions.transaction_date', [$from, $to])
             ->joinOwningAccount()
+            ->withoutArchivedAccountActivity()
             ->join('categories', function ($join) {
                 $join->on('transactions.category_id', '=', 'categories.id')
                     ->where('categories.type', '=', CategoryType::Expense)

--- a/lang/es.json
+++ b/lang/es.json
@@ -742,7 +742,7 @@
     "Archiving :name puts it away without deleting anything:": "Archivar :name la guarda sin borrar nada:",
     "It will be disconnected from the bank: no new transactions or balances will come in. Unarchiving brings the account back, not the connection \u2014 you would have to connect the bank again.": "Se desconectar\u00e1 del banco: no entrar\u00e1n nuevas transacciones ni balances. Al desarchivarla recuperas la cuenta, no la conexi\u00f3n \u2014 tendr\u00edas que volver a conectar el banco.",
     "It disappears from the dashboard and from the accounts page.": "Desaparece del panel y de la p\u00e1gina de cuentas.",
-    "It stops counting towards your net worth from today. The months before today keep the figures they already have.": "Deja de contar en tu patrimonio a partir de hoy. Los meses anteriores mantienen las cifras que ya ten\u00edan.",
+    "It stops counting towards your net worth, your spending and your category totals from today. The months before today keep the figures they already have.": "Deja de contar en tu patrimonio, en tus gastos y en tus totales por categor\u00eda a partir de hoy. Los meses anteriores mantienen las cifras que ya ten\u00edan.",
     "You will not be able to pick it for new transactions, but the ones it already has stay in your history and stay editable.": "No podr\u00e1s elegirla para nuevas transacciones, pero las que ya tiene siguen en tu historial y siguen siendo editables.",
     "You can bring it back any time from the Bank accounts settings.": "Puedes recuperarla cuando quieras desde la configuraci\u00f3n de Cuentas bancarias.",
     "Archived": "Archivada",

--- a/resources/js/components/accounts/archive-account-dialog.test.tsx
+++ b/resources/js/components/accounts/archive-account-dialog.test.tsx
@@ -45,7 +45,7 @@ describe('ArchiveAccountDialog', () => {
         ).toBeInTheDocument();
         expect(
             screen.getByText(
-                /stops counting towards your net worth from today/,
+                /stops counting towards your net worth, your spending and your category totals from today/,
             ),
         ).toBeInTheDocument();
         expect(

--- a/resources/js/components/accounts/archive-account-dialog.tsx
+++ b/resources/js/components/accounts/archive-account-dialog.tsx
@@ -61,7 +61,7 @@ export function ArchiveAccountDialog({
                     </li>
                     <li>
                         {__(
-                            'It stops counting towards your net worth from today. The months before today keep the figures they already have.',
+                            'It stops counting towards your net worth, your spending and your category totals from today. The months before today keep the figures they already have.',
                         )}
                     </li>
                     <li>

--- a/tests/Feature/CashflowAnalyticsTest.php
+++ b/tests/Feature/CashflowAnalyticsTest.php
@@ -1480,3 +1480,37 @@ test('drilling into a parent splits it into children plus a direct node', functi
     expect($directNode['category_id'])->toBe($parent->id)
         ->and($directNode['amount'])->toBe(10000);
 });
+
+test('archived accounts stop feeding the cashflow figures from the day they were archived', function () {
+    $expenseCategory = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'type' => CategoryType::Expense,
+        'name' => 'Groceries',
+    ]);
+
+    accountsAcrossArchiveCutoff($this->user, $expenseCategory);
+
+    $period = [
+        'from' => '2026-05-01',
+        'to' => '2026-05-31',
+    ];
+
+    // The dashboard widget and the cashflow screen read the same summary, so
+    // both stop counting the archived account from its archive day.
+    $this->getJson('/api/cashflow/summary?'.http_build_query($period))
+        ->assertOk()
+        ->assertJsonPath('current.expense', 8000);
+
+    $this->getJson('/api/cashflow/trend?'.http_build_query(['months' => 1, 'to' => '2026-05-31']))
+        ->assertOk()
+        ->assertJsonPath('data.0.expense', 8000);
+
+    $this->getJson('/api/cashflow/sankey?'.http_build_query($period))
+        ->assertOk()
+        ->assertJsonPath('total_expense', 8000);
+
+    $this->getJson('/api/cashflow/breakdown?'.http_build_query([...$period, 'type' => 'expense']))
+        ->assertOk()
+        ->assertJsonPath('total', 8000)
+        ->assertJsonPath('data.0.amount', 8000);
+});

--- a/tests/Feature/CategoryMonthlyBreakdownTest.php
+++ b/tests/Feature/CategoryMonthlyBreakdownTest.php
@@ -198,3 +198,20 @@ test('foreign-currency transactions are converted to the user currency', functio
     // 1000 EUR cents / 0.5 = 2000 USD cents.
     expect($response->json('months.11.'.$category->id))->toBe(2000);
 });
+
+test('the monthly chart stops counting an archived account from the day it was archived', function () {
+    $category = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'type' => CategoryType::Expense,
+        'name' => 'Groceries',
+    ]);
+
+    accountsAcrossArchiveCutoff($this->user, $category);
+
+    $response = monthlyBreakdown($category)->assertOk();
+
+    // The May bar reads the live account's 70 plus the 10 the archived account
+    // spent before it was archived, not the 30 it spent from that day on.
+    expect($response->json('months.10.key'))->toBe('2026-05');
+    expect($response->json('months.10.'.$category->id))->toBe(8000);
+});

--- a/tests/Feature/DashboardAnalyticsTest.php
+++ b/tests/Feature/DashboardAnalyticsTest.php
@@ -1658,3 +1658,94 @@ test('real estate balance evolution appends projected mortgage balance from link
         expect($mortgages[$i])->toBeLessThan($mortgages[$i - 1]);
     }
 });
+
+test('archived accounts stop feeding dashboard totals from the day they were archived', function () {
+    $expense = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'type' => CategoryType::Expense,
+        'name' => 'Groceries',
+    ]);
+    $income = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'type' => CategoryType::Income,
+        'name' => 'Salary',
+    ]);
+
+    // Archived mid-month, with a time of day, so the cutoff cannot lean on the
+    // archiving moment being midnight.
+    $archived = Account::factory()->create([
+        'user_id' => $this->user->id,
+        'archived_at' => '2026-05-15 10:30:00',
+    ]);
+    $active = Account::factory()->create([
+        'user_id' => $this->user->id,
+        'archived_at' => null,
+    ]);
+
+    // Before archiving: still counts, the history must not move.
+    Transaction::factory()->create([
+        'user_id' => $this->user->id,
+        'account_id' => $archived->id,
+        'category_id' => $expense->id,
+        'amount' => -1000,
+        'transaction_date' => '2026-05-14',
+    ]);
+    // On the archiving day: excluded.
+    Transaction::factory()->create([
+        'user_id' => $this->user->id,
+        'account_id' => $archived->id,
+        'category_id' => $expense->id,
+        'amount' => -2000,
+        'transaction_date' => '2026-05-15',
+    ]);
+    // After archiving: excluded, expense and income alike.
+    Transaction::factory()->create([
+        'user_id' => $this->user->id,
+        'account_id' => $archived->id,
+        'category_id' => $expense->id,
+        'amount' => -4000,
+        'transaction_date' => '2026-05-16',
+    ]);
+    Transaction::factory()->create([
+        'user_id' => $this->user->id,
+        'account_id' => $archived->id,
+        'category_id' => $income->id,
+        'amount' => 9000,
+        'transaction_date' => '2026-05-16',
+    ]);
+    // A live account is untouched by any of this.
+    Transaction::factory()->create([
+        'user_id' => $this->user->id,
+        'account_id' => $active->id,
+        'category_id' => $expense->id,
+        'amount' => -8000,
+        'transaction_date' => '2026-05-16',
+    ]);
+    Transaction::factory()->create([
+        'user_id' => $this->user->id,
+        'account_id' => $active->id,
+        'category_id' => $income->id,
+        'amount' => 3000,
+        'transaction_date' => '2026-05-16',
+    ]);
+
+    $period = [
+        'from' => '2026-05-01',
+        'to' => '2026-05-31',
+    ];
+
+    // 1000 (before archiving) + 8000 (live account), never the 2000 or the 4000.
+    $this->getJson('/api/dashboard/monthly-spending?'.http_build_query($period))
+        ->assertOk()
+        ->assertJsonPath('current', 9000);
+
+    $this->getJson('/api/dashboard/cash-flow?'.http_build_query($period))
+        ->assertOk()
+        ->assertJsonPath('current.expense', 9000)
+        ->assertJsonPath('current.income', 3000);
+
+    $this->getJson('/api/dashboard/top-categories?'.http_build_query($period))
+        ->assertOk()
+        ->assertJsonPath('0.category.name', 'Groceries')
+        ->assertJsonPath('0.amount', 9000);
+});

--- a/tests/Feature/DashboardAnalyticsTest.php
+++ b/tests/Feature/DashboardAnalyticsTest.php
@@ -1671,60 +1671,22 @@ test('archived accounts stop feeding dashboard totals from the day they were arc
         'name' => 'Salary',
     ]);
 
-    // Archived mid-month, with a time of day, so the cutoff cannot lean on the
-    // archiving moment being midnight.
-    $archived = Account::factory()->create([
-        'user_id' => $this->user->id,
-        'archived_at' => '2026-05-15 10:30:00',
-    ]);
-    $active = Account::factory()->create([
-        'user_id' => $this->user->id,
-        'archived_at' => null,
-    ]);
+    ['archived' => $archived, 'active' => $active] = accountsAcrossArchiveCutoff($this->user, $expense);
 
-    // Before archiving: still counts, the history must not move.
-    Transaction::factory()->create([
-        'user_id' => $this->user->id,
-        'account_id' => $archived->id,
-        'category_id' => $expense->id,
-        'amount' => -1000,
-        'transaction_date' => '2026-05-14',
-    ]);
-    // On the archiving day: excluded.
-    Transaction::factory()->create([
-        'user_id' => $this->user->id,
-        'account_id' => $archived->id,
-        'category_id' => $expense->id,
-        'amount' => -2000,
-        'transaction_date' => '2026-05-15',
-    ]);
-    // After archiving: excluded, expense and income alike.
-    Transaction::factory()->create([
-        'user_id' => $this->user->id,
-        'account_id' => $archived->id,
-        'category_id' => $expense->id,
-        'amount' => -4000,
-        'transaction_date' => '2026-05-16',
-    ]);
+    // Income after the cutoff is dropped too, not just spending.
     Transaction::factory()->create([
         'user_id' => $this->user->id,
         'account_id' => $archived->id,
         'category_id' => $income->id,
+        'currency_code' => $this->user->currency_code,
         'amount' => 9000,
         'transaction_date' => '2026-05-16',
     ]);
-    // A live account is untouched by any of this.
-    Transaction::factory()->create([
-        'user_id' => $this->user->id,
-        'account_id' => $active->id,
-        'category_id' => $expense->id,
-        'amount' => -8000,
-        'transaction_date' => '2026-05-16',
-    ]);
     Transaction::factory()->create([
         'user_id' => $this->user->id,
         'account_id' => $active->id,
         'category_id' => $income->id,
+        'currency_code' => $this->user->currency_code,
         'amount' => 3000,
         'transaction_date' => '2026-05-16',
     ]);
@@ -1734,18 +1696,60 @@ test('archived accounts stop feeding dashboard totals from the day they were arc
         'to' => '2026-05-31',
     ];
 
-    // 1000 (before archiving) + 8000 (live account), never the 2000 or the 4000.
     $this->getJson('/api/dashboard/monthly-spending?'.http_build_query($period))
         ->assertOk()
-        ->assertJsonPath('current', 9000);
+        ->assertJsonPath('current', 8000);
 
     $this->getJson('/api/dashboard/cash-flow?'.http_build_query($period))
         ->assertOk()
-        ->assertJsonPath('current.expense', 9000)
+        ->assertJsonPath('current.expense', 8000)
         ->assertJsonPath('current.income', 3000);
 
     $this->getJson('/api/dashboard/top-categories?'.http_build_query($period))
         ->assertOk()
         ->assertJsonPath('0.category.name', 'Groceries')
-        ->assertJsonPath('0.amount', 9000);
+        ->assertJsonPath('0.amount', 8000);
+});
+
+test('drilling into a parent category keeps archived account activity out of the children', function () {
+    $food = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'type' => CategoryType::Expense,
+        'name' => 'Food',
+    ]);
+    $groceries = Category::factory()->childOf($food)->create([
+        'user_id' => $this->user->id,
+        'name' => 'Groceries',
+    ]);
+
+    accountsAcrossArchiveCutoff($this->user, $groceries);
+
+    $this->getJson('/api/dashboard/top-categories?'.http_build_query([
+        'from' => '2026-05-01',
+        'to' => '2026-05-31',
+        'parent' => $food->id,
+    ]))
+        ->assertOk()
+        ->assertJsonPath('0.category.name', 'Groceries')
+        ->assertJsonPath('0.amount', 8000);
+});
+
+test('unarchiving an account puts its transactions back into the totals', function () {
+    $expense = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'type' => CategoryType::Expense,
+    ]);
+
+    ['archived' => $archived] = accountsAcrossArchiveCutoff($this->user, $expense);
+
+    // Accounts can come back, unlike budgets and savings goals, and nothing was
+    // snapshotted while it was away: the whole 7000 counts again.
+    $archived->update(['archived_at' => null]);
+
+    $this->getJson('/api/dashboard/monthly-spending?'.http_build_query([
+        'from' => '2026-05-01',
+        'to' => '2026-05-31',
+    ]))
+        ->assertOk()
+        ->assertJsonPath('current', 14000);
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -372,6 +372,52 @@ function finalAttemptJobFor(BankingConnection $connection): SyncBankingConnectio
 }
 
 /**
+ * Two accounts either side of the archive cutoff, for the surfaces that must
+ * stop counting an archived account from the day it was archived.
+ *
+ * One account is archived mid-May at 10:30 — a time of day, so a cutoff that
+ * compares the raw timestamp instead of the day is caught — and the other stays
+ * live. Both get the same three expenses: the day before the archive date, the
+ * day of, and the day after. So of the archived account's 7000 only the first
+ * 1000 may ever count, while the live account keeps all 7000, for 8000 in total
+ * over May 2026.
+ *
+ * Currencies are pinned to the user's so no exchange rate is involved.
+ *
+ * @return array{archived: Account, active: Account}
+ */
+function accountsAcrossArchiveCutoff(User $user, Category $category): array
+{
+    $accounts = [
+        'archived' => Account::factory()->create([
+            'user_id' => $user->id,
+            'currency_code' => $user->currency_code,
+            'archived_at' => '2026-05-15 10:30:00',
+        ]),
+        'active' => Account::factory()->create([
+            'user_id' => $user->id,
+            'currency_code' => $user->currency_code,
+            'archived_at' => null,
+        ]),
+    ];
+
+    foreach ($accounts as $account) {
+        foreach (['2026-05-14' => -1000, '2026-05-15' => -2000, '2026-05-16' => -4000] as $date => $amount) {
+            Transaction::factory()->create([
+                'user_id' => $user->id,
+                'account_id' => $account->id,
+                'category_id' => $category->id,
+                'currency_code' => $user->currency_code,
+                'amount' => $amount,
+                'transaction_date' => $date,
+            ]);
+        }
+    }
+
+    return $accounts;
+}
+
+/**
  * Fake the external currency-rate provider (the jsdelivr CDN and its pages.dev
  * fallback) that CurrencyConversionService and ExchangeRateService fetch from,
  * returning a deterministic 1:1 rate for every currency. Tests that trigger a


### PR DESCRIPTION
Transactions from archived accounts still counted in dashboard spending and
cash flow totals. Archiving an account changed the accounts page and the account
pickers, but left every figure that adds up a period exactly as it was.

## Demo

<!-- PLACEHOLDER: drag the QA recording in here -->

A recorded QA pass on a seeded account: the dashboard before archiving, the
archive dialog and its new copy, the totals after archiving, the untouched
earlier month, the cashflow page and the category chart, and the figures coming
back after unarchiving.

## The cutoff

An archived account stops counting **from the day it was archived**:

| Transaction date | Counts? |
| --- | --- |
| before `accounts.archived_at` | yes, unchanged |
| on `accounts.archived_at` | no |
| after `accounts.archived_at` | no |

A full retroactive exclusion was considered and rejected: the history must not
move. Archiving an account in August should not rewrite what June's spending
was. This is the rule `BudgetTransactionService` already uses for an archived
budget, and the cutoff `AccountMetricsService` already uses to freeze an
archived account's balance.

## The change

`Transaction::scopeJoinOwningAccount()` was a bare join with no archived filter.
Rather than repeat the date predicate at each call site, the rule lives in one
scope next to it:

```php
Transaction::query()
    ->joinOwningAccount()
    ->withoutArchivedAccountActivity()   // SQL aggregates
```

and a second scope packages the same predicate for the queries that hydrate
models and add up in PHP, where the join would otherwise let the account's `id`,
`user_id` and `currency_code` overwrite the transaction's own:

```php
Transaction::query()
    ->countingTowardsTotals()            // join + cutoff + select('transactions.*')
```

Applied to every query that totals a period:

| Surface | Query |
| --- | --- |
| Dashboard top-categories card, `/api/dashboard/top-categories`, `spending_by_category` MCP tool | `CategorySpendingService::forPeriod()` |
| Dashboard cashflow card, `/api/cashflow/summary` | `CashflowSummaryService::forComparedPeriods()` |
| Cashflow page sankey, trend and breakdown | `CashflowAnalyticsController` ×3 |
| Category monthly breakdown chart | `CategoryMonthlyBreakdownController` |
| `/api/dashboard/monthly-spending`, `/api/dashboard/cash-flow` | `DashboardAnalyticsController::sumByCategoryType()` |

The second commit is why the list is this long. Fixing only
`DashboardAnalyticsController` — where the bug looks like it lives — fixes two
endpoints no client calls: the dashboard's own spending and cash flow figures
come from `CashflowSummaryService` through `DashboardController`. It would also
have left the dashboard contradicting itself, with a top-categories card that
excluded the archived account sitting directly above a cashflow card that still
included it.

`date()` wraps `archived_at` in the comparison because it is a timestamp while
`transaction_date` is a plain date — without it, an account archived at 10:30
would still count that whole day's spending.

`scopeJoinOwningAccount()`'s docblock now points at the cutoff, so the next
period aggregate written against it doesn't reintroduce the bug.

## Deliberately left alone

- **`SavingsGoal::taggedContributions()`**, the third caller of
  `joinOwningAccount()`. A goal's saved amount is a running total of money set
  aside, not a figure for a period. Money that funded a goal from an account
  later archived is still set aside, so cutting those contributions off would
  drop the goal's progress for no reason a user could explain.
- **Net worth, balance evolution, `BalanceLookup`, `AccountMetricsService`.**
  Archived accounts belong in the balance history by design —
  `Account::scopeNotArchived()` says so in its own docblock, which is why this is
  a date cutoff on transactions rather than that scope.
- **The transactions ledger and the transaction analysis view.** A ledger should
  list what happened. So a total can now be smaller than the rows a user reaches
  by clicking into it. That is the intended shape of "stops counting", but it is
  the most likely thing to be reported as a bug, so it is worth knowing about.
- **How archiving works**, the accounts page and the account pickers, which
  already filter archived accounts out.

## Known limits

- **The cutoff day is `archived_at` read in UTC, not in the user's timezone.**
  At a non-zero offset that can land a day either side of the user's own day — a
  UTC+2 user archiving at 00:30 loses that day's earlier spending. The balance
  side reads it the same way, so this matches rather than contradicts the
  existing behaviour; fixing it means fixing both paths together or they would
  disagree about when an account stopped counting. Called out in the scope's
  docblock, and worth a follow-up.
- **Budgets still count spending from archived accounts.** Same class, different
  page and a different mental model, not touched here.
- **One distorted month-over-month arrow.** In the period containing the
  archiving, a category dominated by the archived account compares a partly
  counted current period against a fully counted previous one. Unavoidable
  consequence of a non-retroactive cutoff, and it affects one period only.
- `php artisan crap` flags `CashflowAnalyticsController::getSankeyBreakdown()` at
  complexity 14. That is pre-existing; the diff adds one method call to it, which
  is enough to pull it into the "methods this PR touched" set. Not a required
  check, and not something to fix by splitting the method.

## Copy

The archive dialog said the account "stops counting towards your net worth from
today". It now says net worth, spending and category totals, since that is what
actually happens.

## Tests

Behaviour is pinned on all four surfaces, off one shared fixture in
`tests/Pest.php` (an account archived mid-month at 10:30 — a time of day, so a
cutoff that compares the raw timestamp instead of the day is caught — alongside a
live account with the same three expenses):

- `DashboardAnalyticsTest` — all three dashboard endpoints; the day before the
  archive date still counts, the day of and the day after do not, income as well
  as expense; the `?parent=` drill keeps the archived activity out of the
  children; unarchiving puts the full amount back.
- `CashflowAnalyticsTest` — summary, trend, sankey and breakdown.
- `CategoryMonthlyBreakdownTest` — the archiving month's bar.

Each was verified red before the corresponding fix (the totals came back as
14000 instead of 8000) and green after.
