### PR TITLE
refactor(cashflow): simplify the sankey breakdown into one shared pipeline

### DIFF
--- a/app/Http/Controllers/Api/CashflowAnalyticsController.php
+++ b/app/Http/Controllers/Api/CashflowAnalyticsController.php
@@ -200,13 +200,13 @@ class CashflowAnalyticsController extends Controller
             fn (Transaction $transaction): bool => $this->isTransferOnCashflowSide($transaction, $type),
         );
 
-        $categorized = collect($this->tree->rollUp(
+        $rolledUp = $this->tree->rollUp(
             $regularCategories->concat($transferCategories)->values()->all(),
             $userId,
             $drillParentId,
-        ));
+        );
 
-        return $this->appendUncategorized($categorized, $transactions, $userCurrency, $type, $drillParentId);
+        return collect($this->appendUncategorized($rolledUp, $transactions, $userCurrency, $type, $drillParentId));
     }
 
     private function getMonthlyTrendTotals(string $userId, string $userCurrency, Carbon $from, Carbon $to): Collection
@@ -272,13 +272,13 @@ class CashflowAnalyticsController extends Controller
             fn (Transaction $transaction): bool => $transaction->categoryType() === $type,
         );
 
-        return $this->appendUncategorized(
-            collect($this->tree->rollUp($categorized->values()->all(), $userId, $drillParentId)),
+        return collect($this->appendUncategorized(
+            $this->tree->rollUp($categorized->values()->all(), $userId, $drillParentId),
             $transactions,
             $userCurrency,
             $type,
             $drillParentId,
-        );
+        ));
     }
 
     /**
@@ -363,11 +363,11 @@ class CashflowAnalyticsController extends Controller
      * Appends the transactions with no category as a single synthetic row. Only
      * at the top level: a drilled-down parent has no uncategorized children.
      *
-     * @param  Collection<int, array<string, mixed>>  $categorized
+     * @param  array<int, array{category_id: ?string, category: Category|null, amount: int, has_children: bool, is_direct: bool}>  $rolledUp
      * @param  Collection<int, Transaction>  $transactions
-     * @return Collection<int, array<string, mixed>>
+     * @return array<int, array{category_id: ?string, category: Category|null, amount: int, has_children: bool, is_direct: bool}>
      */
-    private function appendUncategorized(Collection $categorized, Collection $transactions, string $userCurrency, CategoryType $type, ?string $drillParentId): Collection
+    private function appendUncategorized(array $rolledUp, Collection $transactions, string $userCurrency, CategoryType $type, ?string $drillParentId): array
     {
         $uncategorized = $transactions
             ->filter(fn (Transaction $transaction): bool => $transaction->category_id === null
@@ -375,7 +375,7 @@ class CashflowAnalyticsController extends Controller
             ->sum(fn (Transaction $transaction): int => $this->convertTransactionAmount($transaction, $userCurrency));
 
         if ($drillParentId === null && $uncategorized != 0) {
-            $categorized->push([
+            $rolledUp[] = [
                 'category_id' => null,
                 'category' => (new Category)->forceFill([
                     'id' => null,
@@ -387,10 +387,10 @@ class CashflowAnalyticsController extends Controller
                 'amount' => abs($uncategorized),
                 'has_children' => false,
                 'is_direct' => false,
-            ]);
+            ];
         }
 
-        return $categorized;
+        return $rolledUp;
     }
 
     private function categoryCashflowDirection(Transaction $transaction): ?CategoryCashflowDirection

--- a/app/Http/Controllers/Api/CashflowAnalyticsController.php
+++ b/app/Http/Controllers/Api/CashflowAnalyticsController.php
@@ -183,69 +183,22 @@ class CashflowAnalyticsController extends Controller
 
     private function getSankeyBreakdown(string $userId, string $userCurrency, Carbon $from, Carbon $to, string $operator, ?string $drillParentId = null): Collection
     {
-        $isIncome = $operator === '>';
-        $type = $isIncome ? CategoryType::Income : CategoryType::Expense;
-        $transactions = Transaction::query()
-            ->where('transactions.user_id', $userId)
-            ->whereBetween('transactions.transaction_date', [$from, $to])
-            ->countingTowardsTotals()
-            ->with(['account', 'category'])
-            ->get();
+        $type = $operator === '>' ? CategoryType::Income : CategoryType::Expense;
+        $transactions = $this->transactionsForPeriod($userId, $userCurrency, $from, $to);
 
-        $this->preloadExchangeRates($transactions, $userCurrency);
+        $regularCategories = $this->netAmountsByCategory(
+            $transactions,
+            $userCurrency,
+            $type,
+            fn (Transaction $transaction): bool => $this->belongsToCashflowSide($transaction, $type),
+        );
 
-        $regularCategories = $transactions
-            ->filter(function (Transaction $transaction) use ($type): bool {
-                $categoryType = $transaction->categoryType();
-
-                return $transaction->category_id !== null
-                    && ($categoryType === $type
-                        || ($type === CategoryType::Expense
-                            && in_array($categoryType, [CategoryType::Savings, CategoryType::Investment], true)));
-            })
-            ->groupBy('category_id')
-            ->map(function (Collection $transactions) use ($userCurrency): array {
-                $totalAmount = $transactions->sum(fn (Transaction $transaction): int => $this->convertTransactionAmount($transaction, $userCurrency));
-
-                return [
-                    'category_id' => $transactions->first()->category_id,
-                    'category' => $transactions->first()->category,
-                    'amount' => abs($totalAmount),
-                    'total_amount' => $totalAmount,
-                ];
-            })
-            ->filter(fn (array $item): bool => $this->categoryNetAmountMatchesSide($item['total_amount'], $type))
-            ->map(fn (array $item): array => [
-                'category_id' => $item['category_id'],
-                'category' => $item['category'],
-                'amount' => $item['amount'],
-            ]);
-
-        $transferCategories = $transactions
-            ->filter(function (Transaction $transaction) use ($isIncome): bool {
-                return $transaction->category_id !== null
-                    && $transaction->categoryType() === CategoryType::Transfer
-                    && $this->categoryCashflowDirection($transaction) === ($isIncome
-                        ? CategoryCashflowDirection::Inflow
-                        : CategoryCashflowDirection::Outflow);
-            })
-            ->groupBy('category_id')
-            ->map(function (Collection $transactions) use ($userCurrency): array {
-                $totalAmount = $transactions->sum(fn (Transaction $transaction): int => $this->convertTransactionAmount($transaction, $userCurrency));
-
-                return [
-                    'category_id' => $transactions->first()->category_id,
-                    'category' => $transactions->first()->category,
-                    'amount' => abs($totalAmount),
-                    'total_amount' => $totalAmount,
-                ];
-            })
-            ->filter(fn (array $item): bool => $isIncome ? $item['total_amount'] > 0 : $item['total_amount'] < 0)
-            ->map(fn (array $item): array => [
-                'category_id' => $item['category_id'],
-                'category' => $item['category'],
-                'amount' => $item['amount'],
-            ]);
+        $transferCategories = $this->netAmountsByCategory(
+            $transactions,
+            $userCurrency,
+            $type,
+            fn (Transaction $transaction): bool => $this->isTransferOnCashflowSide($transaction, $type),
+        );
 
         $categorized = collect($this->tree->rollUp(
             $regularCategories->concat($transferCategories)->values()->all(),
@@ -253,42 +206,12 @@ class CashflowAnalyticsController extends Controller
             $drillParentId,
         ));
 
-        $uncategorized = $transactions
-            ->filter(function (Transaction $transaction) use ($operator): bool {
-                return $transaction->category_id === null
-                    && $this->matchesSign($transaction->amount, $operator);
-            })
-            ->sum(fn (Transaction $transaction): int => $this->convertTransactionAmount($transaction, $userCurrency));
-
-        if ($drillParentId === null && $uncategorized != 0) {
-            $categorized->push([
-                'category_id' => null,
-                'category' => (new Category)->forceFill([
-                    'id' => null,
-                    'name' => $isIncome ? __('Unknown Income') : __('Unknown Expense'),
-                    'type' => $isIncome ? CategoryType::Income : CategoryType::Expense,
-                    'color' => 'gray',
-                    'icon' => 'HelpCircle',
-                ]),
-                'amount' => abs($uncategorized),
-                'has_children' => false,
-                'is_direct' => false,
-            ]);
-        }
-
-        return $categorized;
+        return $this->appendUncategorized($categorized, $transactions, $userCurrency, $type, $drillParentId);
     }
 
     private function getMonthlyTrendTotals(string $userId, string $userCurrency, Carbon $from, Carbon $to): Collection
     {
-        $transactions = Transaction::query()
-            ->where('transactions.user_id', $userId)
-            ->whereBetween('transactions.transaction_date', [$from, $to])
-            ->countingTowardsTotals()
-            ->with(['account', 'category'])
-            ->get();
-
-        $this->preloadExchangeRates($transactions, $userCurrency);
+        $transactions = $this->transactionsForPeriod($userId, $userCurrency, $from, $to);
 
         return $transactions
             ->groupBy(fn (Transaction $transaction): string => $transaction->transaction_date->format('Y-m'))
@@ -310,7 +233,7 @@ class CashflowAnalyticsController extends Controller
 
                     $amount = $categoryTransactions->sum(fn (Transaction $transaction): int => $this->convertTransactionAmount($transaction, $userCurrency));
 
-                    if ($this->categoryNetAmountMatchesSide($amount, $type)) {
+                    if ($this->amountMatchesSide($amount, $type)) {
                         if ($type === CategoryType::Income) {
                             $income += $amount;
                         } else {
@@ -340,6 +263,32 @@ class CashflowAnalyticsController extends Controller
 
     private function getCategoryBreakdown(string $userId, string $userCurrency, Carbon $from, Carbon $to, CategoryType $type, ?string $drillParentId = null): Collection
     {
+        $transactions = $this->transactionsForPeriod($userId, $userCurrency, $from, $to);
+
+        $categorized = $this->netAmountsByCategory(
+            $transactions,
+            $userCurrency,
+            $type,
+            fn (Transaction $transaction): bool => $transaction->categoryType() === $type,
+        );
+
+        return $this->appendUncategorized(
+            collect($this->tree->rollUp($categorized->values()->all(), $userId, $drillParentId)),
+            $transactions,
+            $userCurrency,
+            $type,
+            $drillParentId,
+        );
+    }
+
+    /**
+     * Every transaction in the window, with the exchange rates its conversion
+     * needs already primed so the callers never hit the rate service per row.
+     *
+     * @return Collection<int, Transaction>
+     */
+    private function transactionsForPeriod(string $userId, string $userCurrency, Carbon $from, Carbon $to): Collection
+    {
         $transactions = Transaction::query()
             ->where('transactions.user_id', $userId)
             ->whereBetween('transactions.transaction_date', [$from, $to])
@@ -349,36 +298,82 @@ class CashflowAnalyticsController extends Controller
 
         $this->preloadExchangeRates($transactions, $userCurrency);
 
-        $categorized = $transactions
-            ->filter(fn (Transaction $transaction): bool => $transaction->categoryType() === $type)
+        return $transactions;
+    }
+
+    /**
+     * Nets the transactions $belongsToSide selects into one row per category,
+     * dropping the categories whose net lands on the opposite side of $type.
+     *
+     * @param  Collection<int, Transaction>  $transactions
+     * @param  callable(Transaction): bool  $belongsToSide
+     * @return Collection<string, array{category_id: string, category: Category, amount: int}>
+     */
+    private function netAmountsByCategory(Collection $transactions, string $userCurrency, CategoryType $type, callable $belongsToSide): Collection
+    {
+        return $transactions
+            ->filter($belongsToSide)
             ->groupBy('category_id')
-            ->map(function (Collection $transactions) use ($userCurrency): array {
-                $totalAmount = $transactions->sum(fn (Transaction $transaction): int => $this->convertTransactionAmount($transaction, $userCurrency));
+            ->map(function (Collection $categoryTransactions) use ($userCurrency): array {
+                $totalAmount = $categoryTransactions->sum(fn (Transaction $transaction): int => $this->convertTransactionAmount($transaction, $userCurrency));
 
                 return [
-                    'category_id' => $transactions->first()->category_id,
-                    'category' => $transactions->first()->category,
+                    'category_id' => $categoryTransactions->first()->category_id,
+                    'category' => $categoryTransactions->first()->category,
                     'amount' => abs($totalAmount),
                     'total_amount' => $totalAmount,
                 ];
             })
-            ->filter(fn (array $item): bool => $this->categoryNetAmountMatchesSide($item['total_amount'], $type))
+            ->filter(fn (array $item): bool => $this->amountMatchesSide($item['total_amount'], $type))
             ->map(fn (array $item): array => [
                 'category_id' => $item['category_id'],
                 'category' => $item['category'],
                 'amount' => $item['amount'],
             ]);
+    }
 
-        $categorized = collect($this->tree->rollUp($categorized->values()->all(), $userId, $drillParentId));
+    /**
+     * Savings and investment categories are money leaving the cashflow, so they
+     * sit on the expense side next to the plain expense categories.
+     */
+    private function belongsToCashflowSide(Transaction $transaction, CategoryType $type): bool
+    {
+        $categoryType = $transaction->categoryType();
 
+        return $transaction->category_id !== null
+            && ($categoryType === $type
+                || ($type === CategoryType::Expense
+                    && in_array($categoryType, [CategoryType::Savings, CategoryType::Investment], true)));
+    }
+
+    /**
+     * A transfer category lands on whichever side its configured direction
+     * points at, regardless of the sign of its individual transactions.
+     */
+    private function isTransferOnCashflowSide(Transaction $transaction, CategoryType $type): bool
+    {
+        return $transaction->category_id !== null
+            && $transaction->categoryType() === CategoryType::Transfer
+            && $this->categoryCashflowDirection($transaction) === ($type === CategoryType::Income
+                ? CategoryCashflowDirection::Inflow
+                : CategoryCashflowDirection::Outflow);
+    }
+
+    /**
+     * Appends the transactions with no category as a single synthetic row. Only
+     * at the top level: a drilled-down parent has no uncategorized children.
+     *
+     * @param  Collection<int, array<string, mixed>>  $categorized
+     * @param  Collection<int, Transaction>  $transactions
+     * @return Collection<int, array<string, mixed>>
+     */
+    private function appendUncategorized(Collection $categorized, Collection $transactions, string $userCurrency, CategoryType $type, ?string $drillParentId): Collection
+    {
         $uncategorized = $transactions
-            ->filter(function (Transaction $transaction) use ($type): bool {
-                return $transaction->category_id === null
-                    && $this->matchesSign($transaction->amount, $type === CategoryType::Income ? '>' : '<');
-            })
+            ->filter(fn (Transaction $transaction): bool => $transaction->category_id === null
+                && $this->amountMatchesSide($transaction->amount, $type))
             ->sum(fn (Transaction $transaction): int => $this->convertTransactionAmount($transaction, $userCurrency));
 
-        // Add uncategorized as a special category if there are any
         if ($drillParentId === null && $uncategorized != 0) {
             $categorized->push([
                 'category_id' => null,
@@ -409,12 +404,7 @@ class CashflowAnalyticsController extends Controller
         return is_string($direction) ? CategoryCashflowDirection::tryFrom($direction) : null;
     }
 
-    private function matchesSign(int $amount, string $operator): bool
-    {
-        return $operator === '>' ? $amount > 0 : $amount < 0;
-    }
-
-    private function categoryNetAmountMatchesSide(int $amount, CategoryType $type): bool
+    private function amountMatchesSide(int $amount, CategoryType $type): bool
     {
         return $type === CategoryType::Income ? $amount > 0 : $amount < 0;
     }


### PR DESCRIPTION
## Why

`php artisan crap` was failing on a single method:

```
| Cplx | Method                                                     |
| 14   | CashflowAnalyticsController::getSankeyBreakdown            |
```

The threshold is 10. The complexity and the duplication in this file were the
same problem: the same ~22-line collection pipeline

```
->filter(<predicate>)->groupBy('category_id')->map(<net + shape>)
->filter(<side check>)->map(<strip total_amount>)
```

appeared **three times** — twice inside `getSankeyBreakdown()` and once in
`getCategoryBreakdown()` — with its predicates inlined as closures. The
complexity counter attributes closures nested in a body to the enclosing
method, so extracting the pipeline alone would not have moved the number; the
boolean logic had to leave the method too.

## Numbers

|  | Before | After |
| --- | --- | --- |
| `getSankeyBreakdown` cyclomatic complexity | **14** | **2** |
| jscpd PHP duplication (`bun run dry`) | **5.08%** (2475 lines, 202 clones) | **4.98%** (2424 lines, 198 clones) |

No method touched by this diff is above 10 — the highest is
`getMonthlyTrendTotals` at 8, unchanged. `.crap-ignore.json` and the
`.jscpd.json` threshold are untouched.

## What changed

Five new private methods, all under the threshold:

- `transactionsForPeriod()` — the query plus `preloadExchangeRates()`, which
  was written out identically in all three methods. `->countingTowardsTotals()`
  is preserved.
- `netAmountsByCategory()` — the shared pipeline, taking the side to keep and a
  predicate for which transactions belong to it.
- `belongsToCashflowSide()` — the regular-category predicate (savings and
  investment still fold into the expense side).
- `isTransferOnCashflowSide()` — the transfer predicate (a transfer category
  follows its configured `cashflow_direction`).
- `appendUncategorized()` — the uncategorized total and the synthetic
  "Unknown Income" / "Unknown Expense" row, which was duplicated between
  `getSankeyBreakdown()` and `getCategoryBreakdown()`.

`matchesSign(int, string $operator)` and
`categoryNetAmountMatchesSide(int, CategoryType)` were the same predicate under
two names — `'>'` ↔ `Income`, `'<'` ↔ `Expense` — so they collapse into a
single `amountMatchesSide(int, CategoryType)`.

`getCategoryBreakdown()` now reads as the same four steps as
`getSankeyBreakdown()`: fetch → net by category → roll up → append
uncategorized.

`appendUncategorized()` deliberately takes and returns the plain array that
`rollUp()` already produces rather than a `Collection`: `Collection`'s `TValue`
template is invariant, so handing a `Collection` of a concrete array shape to a
parameter declaring that same shape is a PHPStan error. Appending to the array
and letting the two callers wrap it in `collect()` sidesteps that and drops a
`collect()` from each call site. `push()` on a collected list and `$array[] =`
both append under the next integer key, so the result is the same ordered list.

## Zero behaviour change

This is a pure refactor. Same queries, same ordering, same response shapes.

Beyond the existing suite, I verified it directly: I stood the `origin/main`
controller up beside the new one under a second set of routes and compared the
**raw response bodies** across 8 endpoint/parameter combinations (`sankey`,
`trend`, `breakdown`; both sides; with and without a drill-down parent) against
a fixture covering income, expenses, savings, investment, inflow/outflow/hidden
transfers, nested categories, a refund flipping a category's net onto the other
side, uncategorized on both signs, a USD account needing conversion, and an
archived account that must stop counting. All 8 came back byte-for-byte
identical — re-run after the `appendUncategorized()` signature change above, so
the claim covers the final state of the branch.

To confirm that check had teeth, I swapped `regular->concat(transfer)` for
`transfer->concat(regular)` — a pure ordering change — and it failed as
expected. The scratch files were removed before committing.

## Verification

- `php artisan test --exclude-testsuite=Browser --compact` → 2783 passed, 1 skipped, 1 incomplete
- `vendor/bin/phpstan analyse` → 0 errors
- `php artisan crap --base=origin/main --no-coverage` → 9 methods analyzed, none above 10
- `bun run dry` → PHP duplication down from 5.08% to 4.98%
- `vendor/bin/pint --test`, `bun run format:check`, `bunx eslint .` → clean