### PR TITLE
fix(open-banking): stop the bank authorization redirect dying on a dead port

### DIFF
--- a/app/Http/Controllers/OpenBanking/AuthorizationController.php
+++ b/app/Http/Controllers/OpenBanking/AuthorizationController.php
@@ -172,6 +172,14 @@ class AuthorizationController extends Controller
         $user = $connection ? $connection->user : auth()->user();
 
         if (! $user) {
+            // Silent until now, which made "the bank never came back" and "it
+            // came back and we dropped it" indistinguishable in the logs.
+            // Presence only: the state token and the code are credentials.
+            Log::warning('EnableBanking callback could not be attributed to a user', [
+                'has_state' => $request->has('state'),
+                'has_code' => $request->has('code'),
+            ]);
+
             return redirect()->route('login')
                 ->with('error', __('Please log back in to finish connecting your bank account.'));
         }

--- a/app/Services/Banking/EnableBankingProvider.php
+++ b/app/Services/Banking/EnableBankingProvider.php
@@ -85,7 +85,14 @@ class EnableBankingProvider implements BankingProviderInterface
         $data = $response->json();
 
         return [
-            'url' => $data['url'],
+            // EnableBanking answers with an http:// authorization URL, and port
+            // 80 on that host is a black hole - it never responds, so the
+            // browser navigation dies rather than failing fast. Its HSTS header
+            // is only served over HTTPS, so a browser that has never reached
+            // the host over TLS has nothing cached to upgrade with and follows
+            // the http:// URL literally. That is why the same user could fail
+            // ten times in a row while other users connected fine.
+            'url' => preg_replace('#^http://#i', 'https://', $data['url']),
             'authorization_id' => $data['authorization_id'],
         ];
     }

--- a/resources/js/components/onboarding/step-complete.test.tsx
+++ b/resources/js/components/onboarding/step-complete.test.tsx
@@ -12,6 +12,7 @@ type VisitCallbacks = {
     onError?: () => void;
     onFinish?: () => void;
     onNetworkError?: (error: Error) => void;
+    onSuccess?: () => void;
 };
 
 /**
@@ -45,6 +46,23 @@ const failures: Array<[string, (callbacks: VisitCallbacks) => void]> = [
 describe('StepComplete', () => {
     afterEach(() => {
         post.mockReset();
+    });
+
+    it('forgets the stored resume step once onboarding is done', async () => {
+        window.localStorage.setItem('onboarding-step', 'complete');
+
+        render(<StepComplete />);
+
+        fireEvent.click(screen.getByRole('button'));
+
+        await act(async () => {
+            const callbacks = post.mock.calls[0][2] as VisitCallbacks;
+            callbacks.onSuccess?.();
+            callbacks.onFinish?.();
+        });
+
+        // Left behind, it would drag a returning user back into onboarding.
+        expect(window.localStorage.getItem('onboarding-step')).toBeNull();
     });
 
     it.each(failures)(

--- a/resources/js/components/onboarding/step-complete.tsx
+++ b/resources/js/components/onboarding/step-complete.tsx
@@ -2,6 +2,7 @@ import { complete } from '@/actions/App/Http/Controllers/OnboardingController';
 import { StepButton } from '@/components/onboarding/step-button';
 import { StepList, StepRow } from '@/components/onboarding/step-list';
 import { StepScreen } from '@/components/onboarding/step-screen';
+import { clearStoredOnboardingStep } from '@/hooks/use-onboarding-state';
 import { __ } from '@/utils/i18n';
 import { router } from '@inertiajs/react';
 import { Check } from 'lucide-react';
@@ -17,6 +18,9 @@ export function StepComplete() {
             complete.url(),
             {},
             {
+                // Onboarding is over, so the locally stored resume step has to
+                // go with it or a later visit drags the user back in.
+                onSuccess: clearStoredOnboardingStep,
                 // `onError` only fires for a response Inertia could read, so a
                 // request that died on the network left the last step of
                 // onboarding behind a spinning, disabled button with no way out

--- a/resources/js/hooks/use-onboarding-state.test.tsx
+++ b/resources/js/hooks/use-onboarding-state.test.tsx
@@ -120,6 +120,58 @@ describe('useOnboardingState', () => {
         });
     });
 
+    describe('resuming after a redirect that lost the ?step= param', () => {
+        // iOS hands the user back to a bare /onboarding when a bank redirect
+        // dies, and the step only ever lived in the URL.
+        it('resumes from the stored step when nothing else says otherwise', () => {
+            window.localStorage.setItem('onboarding-step', 'create-account');
+
+            const { result } = renderHook(() => useOnboardingState());
+
+            expect(result.current.currentStep).toBe('create-account');
+        });
+
+        it('lets the server-resolved step win over the stored one', () => {
+            window.localStorage.setItem('onboarding-step', 'create-account');
+
+            const { result } = renderHook(() =>
+                useOnboardingState({ initialStep: 'smart-rules' }),
+            );
+
+            expect(result.current.currentStep).toBe('smart-rules');
+        });
+
+        it('falls back to welcome when the stored step is not a real step', () => {
+            window.localStorage.setItem('onboarding-step', 'not-a-step');
+
+            const { result } = renderHook(() => useOnboardingState());
+
+            expect(result.current.currentStep).toBe('welcome');
+        });
+
+        it('never resumes a free signup onto the AI step', () => {
+            window.localStorage.setItem('onboarding-step', 'ai-suggestions');
+
+            const { result } = renderHook(() =>
+                useOnboardingState({ skipAiSuggestions: true }),
+            );
+
+            expect(result.current.currentStep).toBe('welcome');
+        });
+
+        it('stores every step it moves to', () => {
+            const { result } = renderHook(() => useOnboardingState());
+
+            act(() => {
+                result.current.goToStep('syncing');
+            });
+
+            expect(window.localStorage.getItem('onboarding-step')).toBe(
+                'syncing',
+            );
+        });
+    });
+
     it('remembers connected account setup when a connected account appears later', () => {
         const { result, rerender } = renderHook(
             ({ hasConnectedAccount }: { hasConnectedAccount: boolean }) =>

--- a/resources/js/hooks/use-onboarding-state.test.tsx
+++ b/resources/js/hooks/use-onboarding-state.test.tsx
@@ -121,54 +121,91 @@ describe('useOnboardingState', () => {
     });
 
     describe('resuming after a redirect that lost the ?step= param', () => {
+        const store = (value: string) =>
+            window.localStorage.setItem('onboarding-step', value);
+
         // iOS hands the user back to a bare /onboarding when a bank redirect
         // dies, and the step only ever lived in the URL.
         it('resumes from the stored step when nothing else says otherwise', () => {
-            window.localStorage.setItem('onboarding-step', 'create-account');
+            store('user-1:create-account');
 
-            const { result } = renderHook(() => useOnboardingState());
+            const { result } = renderHook(() =>
+                useOnboardingState({ userId: 'user-1' }),
+            );
 
             expect(result.current.currentStep).toBe('create-account');
         });
 
         it('lets the server-resolved step win over the stored one', () => {
-            window.localStorage.setItem('onboarding-step', 'create-account');
+            store('user-1:create-account');
 
             const { result } = renderHook(() =>
-                useOnboardingState({ initialStep: 'smart-rules' }),
+                useOnboardingState({
+                    userId: 'user-1',
+                    initialStep: 'smart-rules',
+                }),
             );
 
             expect(result.current.currentStep).toBe('smart-rules');
         });
 
         it('falls back to welcome when the stored step is not a real step', () => {
-            window.localStorage.setItem('onboarding-step', 'not-a-step');
-
-            const { result } = renderHook(() => useOnboardingState());
-
-            expect(result.current.currentStep).toBe('welcome');
-        });
-
-        it('never resumes a free signup onto the AI step', () => {
-            window.localStorage.setItem('onboarding-step', 'ai-suggestions');
+            store('user-1:not-a-step');
 
             const { result } = renderHook(() =>
-                useOnboardingState({ skipAiSuggestions: true }),
+                useOnboardingState({ userId: 'user-1' }),
             );
 
             expect(result.current.currentStep).toBe('welcome');
         });
 
-        it('stores every step it moves to', () => {
-            const { result } = renderHook(() => useOnboardingState());
+        it('never resumes a free signup onto the AI step', () => {
+            store('user-1:ai-suggestions');
+
+            const { result } = renderHook(() =>
+                useOnboardingState({
+                    userId: 'user-1',
+                    skipAiSuggestions: true,
+                }),
+            );
+
+            expect(result.current.currentStep).toBe('welcome');
+        });
+
+        // Storage is per browser, not per account: the next signup on a shared
+        // machine would otherwise land mid-onboarding with nothing created.
+        it('ignores a step another account left behind', () => {
+            store('user-1:smart-rules');
+
+            const { result } = renderHook(() =>
+                useOnboardingState({ userId: 'user-2' }),
+            );
+
+            expect(result.current.currentStep).toBe('welcome');
+        });
+
+        it('stores every step it moves to against its owner', () => {
+            const { result } = renderHook(() =>
+                useOnboardingState({ userId: 'user-1' }),
+            );
 
             act(() => {
                 result.current.goToStep('syncing');
             });
 
             expect(window.localStorage.getItem('onboarding-step')).toBe(
-                'syncing',
+                'user-1:syncing',
             );
+        });
+
+        it('stores nothing when there is no user to store it against', () => {
+            const { result } = renderHook(() => useOnboardingState());
+
+            act(() => {
+                result.current.goToStep('syncing');
+            });
+
+            expect(window.localStorage.getItem('onboarding-step')).toBeNull();
         });
     });
 

--- a/resources/js/hooks/use-onboarding-state.ts
+++ b/resources/js/hooks/use-onboarding-state.ts
@@ -1,3 +1,8 @@
+import {
+    readStoredValue,
+    removeStoredValue,
+    writeStoredValue,
+} from '@/lib/safe-storage';
 import { type AccountType } from '@/types/account';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -14,6 +19,60 @@ export type OnboardingStep =
     | 'import-balances'
     | 'categorize-transactions'
     | 'complete';
+
+/**
+ * Every step onboarding may be resumed on, whether from ?step=, from the server
+ * prop or from the value stored below. Mirrors `OnboardingController::VALID_STEPS`.
+ */
+export const VALID_STEPS: OnboardingStep[] = [
+    'welcome',
+    'account-types',
+    'create-account',
+    'import-transactions',
+    'import-balances',
+    'category-types',
+    'customize-categories',
+    'smart-rules',
+    'syncing',
+    'ai-suggestions',
+    'categorize-transactions',
+    'complete',
+];
+
+/**
+ * The step is otherwise only ever persisted into ?step=, and a bank redirect
+ * that dies on iOS drops the user back on a bare /onboarding — which restarted
+ * them from 'welcome' having already created their accounts. localStorage
+ * survives that round trip; the URL does not.
+ */
+const STEP_STORAGE_KEY = 'onboarding-step';
+
+/**
+ * Forget the resume point. Called once onboarding is actually finished, so a
+ * returning user is not pulled back into it.
+ */
+export function clearStoredOnboardingStep(): void {
+    removeStoredValue(STEP_STORAGE_KEY);
+}
+
+/**
+ * The stored resume point, or undefined when there is none worth trusting. A
+ * stale or hand-edited key is validated like any deep link, so it cannot drop a
+ * free-plan user onto the AI step they never see.
+ */
+function readStoredStep(
+    skipAiSuggestions: boolean,
+): OnboardingStep | undefined {
+    const stored = readStoredValue(STEP_STORAGE_KEY) as OnboardingStep | null;
+
+    if (!stored || !VALID_STEPS.includes(stored)) {
+        return undefined;
+    }
+
+    return skipAiSuggestions && stored === 'ai-suggestions'
+        ? undefined
+        : stored;
+}
 
 // Primary steps shown in the progress indicator
 // import-transactions and import-balances are sub-steps that don't increment the counter
@@ -91,10 +150,11 @@ export function useOnboardingState(options: UseOnboardingStateOptions = {}) {
         [skipAiSuggestions],
     );
 
-    // Determine initial step based on existing state
+    // Determine initial step based on existing state. The server prop (already
+    // covering ?step=) wins; the stored step only answers a return with neither.
     const resolvedInitialStep = useMemo((): OnboardingStep => {
-        return initialStep ?? 'welcome';
-    }, [initialStep]);
+        return initialStep ?? readStoredStep(skipAiSuggestions) ?? 'welcome';
+    }, [initialStep, skipAiSuggestions]);
 
     const [currentStep, setCurrentStep] =
         useState<OnboardingStep>(resolvedInitialStep);
@@ -117,6 +177,7 @@ export function useOnboardingState(options: UseOnboardingStateOptions = {}) {
         if (typeof window === 'undefined') {
             return;
         }
+        writeStoredValue(STEP_STORAGE_KEY, currentStep);
         const url = new URL(window.location.href);
         if (url.searchParams.get('step') === currentStep) {
             return;

--- a/resources/js/hooks/use-onboarding-state.ts
+++ b/resources/js/hooks/use-onboarding-state.ts
@@ -24,7 +24,7 @@ export type OnboardingStep =
  * Every step onboarding may be resumed on, whether from ?step=, from the server
  * prop or from the value stored below. Mirrors `OnboardingController::VALID_STEPS`.
  */
-export const VALID_STEPS: OnboardingStep[] = [
+const VALID_STEPS: OnboardingStep[] = [
     'welcome',
     'account-types',
     'create-account',
@@ -40,10 +40,25 @@ export const VALID_STEPS: OnboardingStep[] = [
 ];
 
 /**
+ * The steps a signup may be resumed on. A free signup never sees the AI step, so
+ * no resume path - deep link, stored value or otherwise - may land them on it.
+ */
+export function validStepsFor(skipAiSuggestions: boolean): OnboardingStep[] {
+    return skipAiSuggestions
+        ? VALID_STEPS.filter((step) => step !== 'ai-suggestions')
+        : VALID_STEPS;
+}
+
+/**
  * The step is otherwise only ever persisted into ?step=, and a bank redirect
  * that dies on iOS drops the user back on a bare /onboarding — which restarted
  * them from 'welcome' having already created their accounts. localStorage
  * survives that round trip; the URL does not.
+ *
+ * The value carries the user it belongs to, because storage is per browser and
+ * not per account. Without that, the next person to sign up on a shared browser
+ * resumes into someone else's progress, having created none of the accounts the
+ * step they land on assumes.
  */
 const STEP_STORAGE_KEY = 'onboarding-step';
 
@@ -56,22 +71,23 @@ export function clearStoredOnboardingStep(): void {
 }
 
 /**
- * The stored resume point, or undefined when there is none worth trusting. A
- * stale or hand-edited key is validated like any deep link, so it cannot drop a
- * free-plan user onto the AI step they never see.
+ * The resume point stored for this user, or undefined when there is none worth
+ * trusting: another account's, or a stale or hand-edited step, which is
+ * validated like any deep link.
  */
 function readStoredStep(
+    userId: string | undefined,
     skipAiSuggestions: boolean,
 ): OnboardingStep | undefined {
-    const stored = readStoredValue(STEP_STORAGE_KEY) as OnboardingStep | null;
+    const [owner, stored] = (readStoredValue(STEP_STORAGE_KEY) ?? '').split(
+        ':',
+    );
 
-    if (!stored || !VALID_STEPS.includes(stored)) {
-        return undefined;
-    }
-
-    return skipAiSuggestions && stored === 'ai-suggestions'
-        ? undefined
-        : stored;
+    return userId !== undefined &&
+        owner === userId &&
+        validStepsFor(skipAiSuggestions).includes(stored as OnboardingStep)
+        ? (stored as OnboardingStep)
+        : undefined;
 }
 
 // Primary steps shown in the progress indicator
@@ -130,6 +146,8 @@ interface UseOnboardingStateOptions {
     initialStep?: OnboardingStep;
     hasConnectedAccount?: boolean;
     skipAiSuggestions?: boolean;
+    /** Owner of the stored resume point. Nothing is stored without it. */
+    userId?: string;
 }
 
 export function useOnboardingState(options: UseOnboardingStateOptions = {}) {
@@ -138,6 +156,7 @@ export function useOnboardingState(options: UseOnboardingStateOptions = {}) {
         initialStep,
         hasConnectedAccount = false,
         skipAiSuggestions = false,
+        userId,
     } = options;
 
     // Dropped from the array rather than short-circuited in the component, so
@@ -153,8 +172,12 @@ export function useOnboardingState(options: UseOnboardingStateOptions = {}) {
     // Determine initial step based on existing state. The server prop (already
     // covering ?step=) wins; the stored step only answers a return with neither.
     const resolvedInitialStep = useMemo((): OnboardingStep => {
-        return initialStep ?? readStoredStep(skipAiSuggestions) ?? 'welcome';
-    }, [initialStep, skipAiSuggestions]);
+        return (
+            initialStep ??
+            readStoredStep(userId, skipAiSuggestions) ??
+            'welcome'
+        );
+    }, [initialStep, skipAiSuggestions, userId]);
 
     const [currentStep, setCurrentStep] =
         useState<OnboardingStep>(resolvedInitialStep);
@@ -177,14 +200,16 @@ export function useOnboardingState(options: UseOnboardingStateOptions = {}) {
         if (typeof window === 'undefined') {
             return;
         }
-        writeStoredValue(STEP_STORAGE_KEY, currentStep);
+        if (userId !== undefined) {
+            writeStoredValue(STEP_STORAGE_KEY, `${userId}:${currentStep}`);
+        }
         const url = new URL(window.location.href);
         if (url.searchParams.get('step') === currentStep) {
             return;
         }
         url.searchParams.set('step', currentStep);
         window.history.replaceState(window.history.state, '', url.toString());
-    }, [currentStep]);
+    }, [currentStep, userId]);
 
     // Calculate step index for progress indicator
     // Sub-steps (import-transactions, import-balances) use the same index as 'create-account'

--- a/resources/js/lib/safe-storage.ts
+++ b/resources/js/lib/safe-storage.ts
@@ -46,3 +46,11 @@ export function writeStoredValue(key: string, value: string): void {
         // simply does not survive the session.
     }
 }
+
+export function removeStoredValue(key: string): void {
+    try {
+        getStorage('local')?.removeItem(key);
+    } catch {
+        // Same as above: nothing was persisted, so nothing needs clearing.
+    }
+}

--- a/resources/js/pages/onboarding/index.tsx
+++ b/resources/js/pages/onboarding/index.tsx
@@ -18,6 +18,7 @@ import {
     BACKABLE_STEPS,
     CreatedAccount,
     OnboardingStep,
+    VALID_STEPS,
     useOnboardingState,
 } from '@/hooks/use-onboarding-state';
 import OnboardingLayout from '@/layouts/onboarding-layout';
@@ -38,21 +39,6 @@ interface OnboardingProps {
     signupPlan?: SignupPlan | null;
 }
 
-const VALID_STEPS: OnboardingStep[] = [
-    'welcome',
-    'account-types',
-    'create-account',
-    'import-transactions',
-    'import-balances',
-    'category-types',
-    'customize-categories',
-    'smart-rules',
-    'syncing',
-    'ai-suggestions',
-    'categorize-transactions',
-    'complete',
-];
-
 export default function Onboarding({
     banks,
     accounts,
@@ -66,7 +52,8 @@ export default function Onboarding({
     const isFreePlan = signupPlan === 'free';
 
     // Prefer the server-validated step; fall back to ?step= from the URL so
-    // client-side deep links keep working.
+    // client-side deep links keep working. Neither is the hook's last resort:
+    // it falls back again to the step it stored locally.
     const initialStep = useMemo((): OnboardingStep | undefined => {
         const validSteps = isFreePlan
             ? VALID_STEPS.filter((step) => step !== 'ai-suggestions')

--- a/resources/js/pages/onboarding/index.tsx
+++ b/resources/js/pages/onboarding/index.tsx
@@ -18,16 +18,17 @@ import {
     BACKABLE_STEPS,
     CreatedAccount,
     OnboardingStep,
-    VALID_STEPS,
     useOnboardingState,
+    validStepsFor,
 } from '@/hooks/use-onboarding-state';
 import OnboardingLayout from '@/layouts/onboarding-layout';
+import { type SharedData } from '@/types';
 import { type Account, type Bank } from '@/types/account';
 import { type Category } from '@/types/category';
 import { type SignupPlan } from '@/types/pricing';
 import { type Transaction } from '@/types/transaction';
 import { __ } from '@/utils/i18n';
-import { Head, usePoll } from '@inertiajs/react';
+import { Head, usePage, usePoll } from '@inertiajs/react';
 import { useEffect, useMemo, useRef } from 'react';
 
 interface OnboardingProps {
@@ -48,6 +49,7 @@ export default function Onboarding({
     signupPlan = null,
 }: OnboardingProps) {
     const { sync } = useSyncContext();
+    const { auth } = usePage<SharedData>().props;
     const hasSyncedRef = useRef(false);
     const isFreePlan = signupPlan === 'free';
 
@@ -55,9 +57,7 @@ export default function Onboarding({
     // client-side deep links keep working. Neither is the hook's last resort:
     // it falls back again to the step it stored locally.
     const initialStep = useMemo((): OnboardingStep | undefined => {
-        const validSteps = isFreePlan
-            ? VALID_STEPS.filter((step) => step !== 'ai-suggestions')
-            : VALID_STEPS;
+        const validSteps = validStepsFor(isFreePlan);
 
         if (initialStepProp && validSteps.includes(initialStepProp)) {
             return initialStepProp;
@@ -101,6 +101,7 @@ export default function Onboarding({
         initialStep,
         hasConnectedAccount,
         skipAiSuggestions: isFreePlan,
+        userId: auth.user.id,
     });
 
     // While on the connections step, poll for connections finalized elsewhere

--- a/tests/Feature/OpenBanking/AuthorizationControllerTest.php
+++ b/tests/Feature/OpenBanking/AuthorizationControllerTest.php
@@ -1046,6 +1046,30 @@ test('callback without a session or a resolvable state redirects to login', func
     $response->assertRedirect(route('login'));
 });
 
+test('callback logs the callback it could not attribute to a user', function () {
+    Log::spy();
+
+    $this->get('/open-banking/callback?code=test-code&state=unknown-token');
+
+    // Presence only: both the state token and the code are credentials, and
+    // this branch is the one that made a dropped callback indistinguishable
+    // from a callback the bank never sent.
+    Log::shouldHaveReceived('warning')
+        ->once()
+        ->withArgs(fn (string $message, array $context) => $message === 'EnableBanking callback could not be attributed to a user'
+            && $context === ['has_state' => true, 'has_code' => true]);
+});
+
+test('callback records which parameters were missing when it cannot attribute the callback', function () {
+    Log::spy();
+
+    $this->get('/open-banking/callback');
+
+    Log::shouldHaveReceived('warning')
+        ->once()
+        ->withArgs(fn (string $message, array $context) => $context === ['has_state' => false, 'has_code' => false]);
+});
+
 test('callback renders the completion page on error without an authenticated session', function () {
     $user = User::factory()->onboarded()->create();
     $connection = BankingConnection::factory()->pending()->create([

--- a/tests/Feature/OpenBanking/EnableBankingProviderTest.php
+++ b/tests/Feature/OpenBanking/EnableBankingProviderTest.php
@@ -668,3 +668,38 @@ test('getInstitutions passes the provider beta flag through, defaulting to stabl
         // A connector the provider says nothing about is not a beta connector.
         ->and($institutions['CaixaBank']['beta'])->toBeFalse();
 });
+
+test('startAuthorization upgrades the authorization url the provider hands back to https', function () {
+    Http::fake([
+        'api.enablebanking.com/auth' => Http::response([
+            'url' => 'http://tilisy.enablebanking.com/ais/start?sessionid=auth-1',
+            'authorization_id' => 'auth-1',
+        ]),
+    ]);
+
+    $result = enableBankingProviderForTest()
+        ->startAuthorization('CaixaBank', 'ES', 'https://example.com/callback', 'state-1');
+
+    // Port 80 on that host never answers, so the browser navigation dies where
+    // the user cannot see it. The HSTS header that would upgrade the scheme is
+    // only served over HTTPS, so a browser reaching the host for the first time
+    // has nothing cached to upgrade with.
+    expect($result['url'])->toBe('https://tilisy.enablebanking.com/ais/start?sessionid=auth-1')
+        ->and($result['authorization_id'])->toBe('auth-1');
+});
+
+test('startAuthorization leaves an https authorization url untouched', function () {
+    Http::fake([
+        'api.enablebanking.com/auth' => Http::response([
+            // A query param carrying its own http:// url: a bare str_replace
+            // would corrupt it, so the rewrite is anchored to the scheme.
+            'url' => 'https://tilisy.enablebanking.com/ais/start?redirect=http://localhost/callback',
+            'authorization_id' => 'auth-2',
+        ]),
+    ]);
+
+    $result = enableBankingProviderForTest()
+        ->startAuthorization('CaixaBank', 'ES', 'https://example.com/callback', 'state-2');
+
+    expect($result['url'])->toBe('https://tilisy.enablebanking.com/ais/start?redirect=http://localhost/callback');
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,24 @@
 import '@testing-library/jest-dom/vitest';
+import { beforeEach } from 'vitest';
+
+/**
+ * jsdom exposes `window.localStorage` as a getter that hands back undefined, so
+ * every test sees what a browser with site data blocked sees. Give the suite a
+ * working in-memory Storage, emptied between tests; the tests that care about a
+ * hostile localStorage still replace it themselves (see lib/safe-storage.test.ts).
+ */
+const store = new Map<string, string>();
+
+Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+        getItem: (key: string) => store.get(key) ?? null,
+        setItem: (key: string, value: string) => void store.set(key, value),
+        removeItem: (key: string) => void store.delete(key),
+        clear: () => store.clear(),
+    },
+});
+
+beforeEach(() => {
+    store.clear();
+});


### PR DESCRIPTION
Three fixes that came out of investigating a paid user who tried to connect ING
ten times over six days and never once succeeded.

## Fix 1 — the authorization URL pointed at a dead port (the root cause)

`POST /auth` at EnableBanking answers with an **`http://`** authorization URL:

```
http://tilisy.enablebanking.com/ais/start?sessionid=<authorization_id>
```

We handed that straight to `window.location.href`. **Port 80 on that host is
firewalled and does not respond at all** — the navigation does not fail, it hangs
and dies. Verified with curl:

| Request | Result |
| --- | --- |
| `http://tilisy.enablebanking.com/ais/start?sessionid=test` | `code=000` — *Trying 35.214.250.233:80… Connection timed out after 8005 ms* |
| `https://tilisy.enablebanking.com/ais/start?sessionid=test` | `code=422` — host is fine, 422 only because the sessionid is bogus |
| `https://tilisy.enablebanking.com/` | `strict-transport-security: max-age=31536000; includeSubDomains` |

The HSTS header exists, but it is **only served over HTTPS**. A browser that has
never reached that host over TLS has no HSTS entry cached, so it follows the
`http://` URL literally into the black hole. Browsers that already had the entry
cached — or that upgrade `http://` on their own — connect fine.

That is the whole reason this looked unreproducible: it depends on the state of
the browser's HSTS cache, not on the bank, the account or the plan. It is also
why the same user failed in both Chrome iOS and Mobile Safari.

`EnableBankingProvider::startAuthorization()` now upgrades the scheme before the
URL leaves the provider, which covers both entry points
(`AuthorizationController::store()` and `::startReauthorization()`). Anchored
`preg_replace`, not `str_replace`, so an `http://` inside a query param survives —
there is a test for exactly that.

## Fix 2 — the callback could lose a connection with zero logs

When the state token did not resolve **and** there was no session (the iOS-PWA
case), `callback()` bailed out silently. During the investigation that made "the
callback never arrived" indistinguishable from "it arrived and we dropped it".

It now logs a warning first. Presence booleans only — the state token and the
authorization code are credentials and are never written:

```
EnableBanking callback could not be attributed to a user {"has_state":true,"has_code":true}
```

## Fix 3 — a failed bank redirect restarted onboarding from step 1

When the redirect above died, iOS returned the user to `/onboarding` **without the
`?step=`**. Confirmed in analytics — this exact sequence, three times in five
minutes:

```
12:50:44  $autocapture  /onboarding?step=create-account   ← clicked connect
12:50:45  $pageleave    /onboarding?step=create-account   ← navigation starts
12:54:03  $pageview     /onboarding                       ← 3m17s later, back
12:54:03  $set          /onboarding?step=welcome          ← and back at step 1
```

The step only ever lived in the URL, so a return without the query param fell
through to `welcome` — after the user had already created their accounts.

It is now also persisted client-side through the existing `safe-storage` helpers.
Precedence is **server prop → `?step=` → stored value → `welcome`**; the server
prop still wins. The stored value is validated against the same list as any deep
link, so a stale or hand-edited key cannot drop a free-plan user onto
`ai-suggestions`, and it is cleared once onboarding completes.

The stored value carries the user it belongs to (`<userId>:<step>`). Storage is
per browser, not per account: unscoped, the next person to sign up on a shared
machine would resume into the previous account's progress with none of the
accounts that step assumes.

## Incidental

`vitest.setup.ts` now installs a working in-memory `localStorage`. jsdom exposes
the global as a getter that hands back `undefined`, so until now the whole suite
ran as if the browser had site data blocked and nothing persisted could be tested
at all. All 601 frontend tests pass with it.

## Testing

- `EnableBankingProviderTest`: an `http://` url comes back as `https://`; an
  already-`https://` url with an `http://` query param is passed through untouched.
- `AuthorizationControllerTest`: the unattributable callback logs the warning, and
  logs which parameters were present.
- `use-onboarding-state.test.tsx`: the stored step resumes; the server prop beats
  it; an invalid step falls back to `welcome`; a free signup is never resumed onto
  `ai-suggestions`; another account's value is ignored; nothing is stored without
  a user.
- `step-complete.test.tsx`: the key is gone once onboarding completes.
- Manual QA in the browser against a real non-onboarded user: walked to
  `create-account`, confirmed `localStorage` held `<uuid>:create-account`, then hit
  a bare `/onboarding` and landed back on `create-account` instead of `welcome`.
  Also checked precedence and the cross-account case. The live callback endpoint
  was hit with a bogus code and state, and neither value appears anywhere in
  `laravel.log`.

## Demo

<!-- PLACEHOLDER: attach onboarding-step-resume-qa.mp4 here -->

https://github.com/user-attachments/assets/259f1411-a65d-47b3-82b5-0863b5186e24


