### PR TITLE
feat(transactions): put add transaction in the mobile action bar

### DIFF
--- a/resources/js/components/transactions/transaction-actions-menu.test.tsx
+++ b/resources/js/components/transactions/transaction-actions-menu.test.tsx
@@ -1,15 +1,20 @@
-import { type TransactionFilters } from '@/types/transaction';
-import { fireEvent, render, screen } from '@testing-library/react';
+import {
+    type DecryptedTransaction,
+    type TransactionFilters,
+} from '@/types/transaction';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import type React from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TransactionActionsMenu } from './transaction-actions-menu';
 
 vi.mock('@/actions/App/Http/Controllers/TransactionController', () => ({
     categorize: { url: () => '/transactions/categorize' },
 }));
 
+let isMobile = false;
+
 vi.mock('@/hooks/use-mobile', () => ({
-    useIsMobile: () => false,
+    useIsMobile: () => isMobile,
 }));
 
 vi.mock('@/hooks/use-re-evaluate-all-transactions', () => ({
@@ -17,8 +22,8 @@ vi.mock('@/hooks/use-re-evaluate-all-transactions', () => ({
 }));
 
 vi.mock('@inertiajs/react', () => ({
-    Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
-        <a href={href}>{children}</a>
+    Link: ({ children, ...props }: React.ComponentProps<'a'>) => (
+        <a {...props}>{children}</a>
     ),
 }));
 
@@ -44,18 +49,44 @@ const emptyFilters: TransactionFilters = {
     searchText: '',
 };
 
-function renderMenu(filters: TransactionFilters) {
+function renderMenu(
+    filters: TransactionFilters,
+    transactions: DecryptedTransaction[] = [],
+) {
     return render(
         <TransactionActionsMenu
             categories={[]}
             accounts={[]}
             banks={[]}
             onAddTransaction={vi.fn()}
-            transactions={[]}
+            transactions={transactions}
             filters={filters}
         />,
     );
 }
+
+function uncategorized(id: string): DecryptedTransaction {
+    return { id, category_id: null } as DecryptedTransaction;
+}
+
+function openMoreActionsMenu() {
+    fireEvent.pointerDown(screen.getByLabelText('More actions'), {
+        button: 0,
+        ctrlKey: false,
+    });
+
+    return screen.findByRole('menu');
+}
+
+function actionBarLabels(container: HTMLElement) {
+    return [...container.querySelectorAll('button, a')].map(
+        (element) => element.getAttribute('aria-label') ?? element.textContent,
+    );
+}
+
+beforeEach(() => {
+    isMobile = false;
+});
 
 describe('TransactionActionsMenu analysis button', () => {
     it('is disabled when no filter is applied', () => {
@@ -75,5 +106,70 @@ describe('TransactionActionsMenu analysis button', () => {
 
         fireEvent.click(button);
         expect(screen.getByTestId('analysis-drawer')).toBeInTheDocument();
+    });
+});
+
+describe('TransactionActionsMenu action bar layout', () => {
+    it('shows analysis, add transaction and categorize in that order on desktop', () => {
+        const { container } = renderMenu(emptyFilters, [uncategorized('t-1')]);
+
+        expect(actionBarLabels(container)).toEqual([
+            'Analysis',
+            'Add transaction',
+            'Categorize1',
+            'More actions',
+        ]);
+    });
+
+    it('keeps the same order when every transaction is categorized', () => {
+        const { container } = renderMenu(emptyFilters);
+
+        expect(actionBarLabels(container)).toEqual([
+            'Analysis',
+            'Add transaction',
+            'Categorize',
+            'More actions',
+        ]);
+    });
+
+    it('keeps add transaction in the bar and moves categorize to the dropdown on mobile', async () => {
+        isMobile = true;
+        const { container } = renderMenu(emptyFilters, [
+            uncategorized('t-1'),
+            uncategorized('t-2'),
+        ]);
+
+        expect(actionBarLabels(container)).toEqual([
+            'Analysis',
+            'Add transaction',
+            'More actions',
+        ]);
+
+        const menu = await openMoreActionsMenu();
+        expect(
+            [...menu.querySelectorAll('[role="menuitem"]')].map(
+                (item) => item.textContent,
+            ),
+        ).toEqual([
+            'Categorize2',
+            'Import Transactions',
+            'Update categories automatically',
+        ]);
+        expect(
+            within(menu).getByText('Categorize').closest('a'),
+        ).toHaveAttribute('href', '/transactions/categorize');
+    });
+
+    it('disables the categorize dropdown item when nothing is uncategorized', async () => {
+        isMobile = true;
+        renderMenu(emptyFilters);
+
+        const menu = await openMoreActionsMenu();
+        const categorizeItem = within(menu)
+            .getByText('Categorize')
+            .closest('[role="menuitem"]')!;
+
+        expect(categorizeItem).toHaveAttribute('data-disabled');
+        expect(categorizeItem.closest('a')).toBeNull();
     });
 });

--- a/resources/js/components/transactions/transaction-actions-menu.tsx
+++ b/resources/js/components/transactions/transaction-actions-menu.tsx
@@ -30,10 +30,11 @@ import {
     BarChart3,
     ChevronDown,
     Plus,
+    Tags,
     Upload,
     WandSparkles,
 } from 'lucide-react';
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { ImportTransactionsDrawer } from './import-transactions-drawer';
 import { TransactionAnalysisDrawer } from './transaction-analysis-drawer';
 
@@ -101,94 +102,73 @@ export function TransactionActionsMenu({
         (t) => !t.category_id,
     ).length;
 
+    const hasUncategorized = uncategorizedCount > 0;
+
+    const categorizeLabel = (
+        <>
+            {__('Categorize')}
+            {hasUncategorized && (
+                <span className="ml-1 rounded-full bg-amber-100 px-1.5 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+                    {uncategorizedCount}
+                </span>
+            )}
+        </>
+    );
+
+    const withCategorizeLink = (content: ReactNode) =>
+        hasUncategorized ? (
+            <Link href={categorize.url()}>{content}</Link>
+        ) : (
+            content
+        );
+
     return (
         <>
             <ButtonGroup>
-                {isMobile ? (
-                    <TooltipProvider>
-                        <Tooltip
-                            open={!canAnalyze && analysisHintOpen}
-                            onOpenChange={setAnalysisHintOpen}
-                        >
-                            <TooltipTrigger asChild>
-                                <Button
-                                    variant="outline"
-                                    className={
-                                        !canAnalyze
-                                            ? 'cursor-not-allowed opacity-50'
-                                            : ''
-                                    }
-                                    aria-disabled={!canAnalyze}
-                                    onClick={handleAnalysisClick}
-                                >
-                                    <BarChart3 className="h-5 w-5" />
-                                    {__('Analysis')}
-                                </Button>
-                            </TooltipTrigger>
-                            {!canAnalyze && (
-                                <TooltipContent>
-                                    {__('Apply a filter to enable this button')}
-                                </TooltipContent>
-                            )}
-                        </Tooltip>
-                    </TooltipProvider>
-                ) : (
-                    <TooltipProvider>
-                        <Tooltip>
-                            <TooltipTrigger asChild>
-                                <Button
-                                    variant="outline"
-                                    className={
-                                        !canAnalyze
-                                            ? 'cursor-not-allowed opacity-50'
-                                            : ''
-                                    }
-                                    aria-disabled={!canAnalyze}
-                                    onClick={handleAnalysisClick}
-                                >
-                                    <BarChart3 className="h-5 w-5" />
-                                    {__('Analysis')}
-                                </Button>
-                            </TooltipTrigger>
-                            {!canAnalyze && (
-                                <TooltipContent>
-                                    {__('Apply a filter to enable this button')}
-                                </TooltipContent>
-                            )}
-                        </Tooltip>
-                    </TooltipProvider>
-                )}
+                <TooltipProvider>
+                    <Tooltip
+                        open={!canAnalyze && analysisHintOpen}
+                        onOpenChange={setAnalysisHintOpen}
+                    >
+                        <TooltipTrigger asChild>
+                            <Button
+                                variant="outline"
+                                className={
+                                    !canAnalyze
+                                        ? 'cursor-not-allowed opacity-50'
+                                        : ''
+                                }
+                                aria-disabled={!canAnalyze}
+                                onClick={handleAnalysisClick}
+                            >
+                                <BarChart3 className="h-5 w-5" />
+                                {__('Analysis')}
+                            </Button>
+                        </TooltipTrigger>
+                        {!canAnalyze && (
+                            <TooltipContent>
+                                {__('Apply a filter to enable this button')}
+                            </TooltipContent>
+                        )}
+                    </Tooltip>
+                </TooltipProvider>
 
                 <TooltipProvider>
                     <Tooltip>
                         <TooltipTrigger asChild>
                             <Button
                                 variant="outline"
-                                className={
-                                    uncategorizedCount === 0
-                                        ? 'cursor-not-allowed opacity-50'
-                                        : ''
-                                }
-                                disabled={uncategorizedCount === 0}
-                                asChild={uncategorizedCount > 0}
+                                onClick={handleAddTransaction}
+                                aria-label={__('Add transaction')}
                             >
-                                {uncategorizedCount > 0 ? (
-                                    <Link href={categorize.url()}>
-                                        {__('Categorize')}
-
-                                        <span className="ml-1 rounded-full bg-amber-100 px-1.5 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
-                                            {uncategorizedCount}
-                                        </span>
-                                    </Link>
-                                ) : (
-                                    <>{__('Categorize')}</>
-                                )}
+                                <Plus className="h-5 w-5" />
+                                <span className="hidden sm:inline">
+                                    {__('Transaction')}
+                                </span>
                             </Button>
                         </TooltipTrigger>
                         <TooltipContent>
-                            {uncategorizedCount === 0
-                                ? 'All transactions are categorized'
-                                : `Categorize ${uncategorizedCount} transactions`}
+                            {__('Create a new transaction')}
                         </TooltipContent>
                     </Tooltip>
                 </TooltipProvider>
@@ -199,17 +179,21 @@ export function TransactionActionsMenu({
                             <TooltipTrigger asChild>
                                 <Button
                                     variant="outline"
-                                    onClick={handleAddTransaction}
-                                    aria-label={__('Add transaction')}
+                                    className={
+                                        hasUncategorized
+                                            ? ''
+                                            : 'cursor-not-allowed opacity-50'
+                                    }
+                                    disabled={!hasUncategorized}
+                                    asChild={hasUncategorized}
                                 >
-                                    <Plus className="h-5 w-5" />
-                                    <span className="hidden sm:inline">
-                                        {__('Transaction')}
-                                    </span>
+                                    {withCategorizeLink(categorizeLabel)}
                                 </Button>
                             </TooltipTrigger>
                             <TooltipContent>
-                                {__('Create a new transaction')}
+                                {hasUncategorized
+                                    ? `Categorize ${uncategorizedCount} transactions`
+                                    : 'All transactions are categorized'}
                             </TooltipContent>
                         </Tooltip>
                     </TooltipProvider>
@@ -236,9 +220,16 @@ export function TransactionActionsMenu({
                     </TooltipProvider>
                     <DropdownMenuContent align="end">
                         {isMobile && (
-                            <DropdownMenuItem onClick={handleAddTransaction}>
-                                <Plus className="mr-2 h-4 w-4" />
-                                {__('Add transaction')}
+                            <DropdownMenuItem
+                                disabled={!hasUncategorized}
+                                asChild={hasUncategorized}
+                            >
+                                {withCategorizeLink(
+                                    <>
+                                        <Tags className="mr-2 h-4 w-4" />
+                                        {categorizeLabel}
+                                    </>,
+                                )}
                             </DropdownMenuItem>
                         )}
                         <DropdownMenuItem onClick={handleOpenImportDrawer}>

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -19,6 +19,15 @@ Object.defineProperty(window, 'localStorage', {
     },
 });
 
+/**
+ * jsdom ships no `PointerEvent`, so `fireEvent.pointerDown` falls back to a plain
+ * `Event` and Radix triggers (dropdowns, selects) never open. `MouseEvent` already
+ * carries the `button` / `ctrlKey` fields they check.
+ */
+if (!('PointerEvent' in window)) {
+    window.PointerEvent = MouseEvent as unknown as typeof window.PointerEvent;
+}
+
 beforeEach(() => {
     store.clear();
 });


### PR DESCRIPTION
## What

Reworks the order of the transactions page header action bar, and changes which
actions are visible on mobile.

**Desktop** — `Add transaction` now sits between Analysis and Categorize.
Categorize stays visible, with its amber count badge:

```
[ Analysis ] [ + Transaction ] [ Categorize N ] [ v ]
```

**Mobile** — `Add transaction` is now visible directly in the bar (it used to be
hidden below 768px and only reachable inside the chevron dropdown), and
Categorize moves into the dropdown (it used to be always visible):

```
[ Analysis ] [ + ] [ v ]
                    v = Categorize (N)
                        Import Transactions
                        Update categories automatically
```

## Why this order

Analysis and `+` hold the same position at both sizes, so the two actions people
reach for most don't move as the viewport changes, and Categorize is the one that
drops into the dropdown when space runs out. Adding a transaction on a phone now
takes one tap instead of two.

## Notes

- Everything is in `transaction-actions-menu.tsx`, the one part of the
  transactions page that is **not** duplicated across the two tables, so a single
  edit covers both call sites. Their props are unchanged, so neither call site is
  touched.
- The Categorize dropdown item keeps the amber count badge, is disabled when the
  count is zero, and navigates through Inertia (`<Link>` + `asChild`), never a raw
  `<a>`.
- The `+` button shows only the Plus icon below `sm` and keeps its
  `aria-label="Add transaction"`, so it stays accessible with no visible text.

### The two Analysis tooltip branches, collapsed

The Analysis button was rendered twice through `isMobile ? … : …`, and the two
branches were identical apart from the controlled `open` / `onOpenChange` props on
the mobile one — a jscpd clone waiting to trip the required `dry` check. They are
now one block that passes those props unconditionally.

Passing them *conditionally* (`open={isMobile ? … : undefined}`) was the obvious
move and is wrong: it flips the tooltip between controlled and uncontrolled on
every crossing of the 768px breakpoint, which React warns about in the console.
Browser QA caught that on the first pass. Unconditional is also behaviourally
identical to the old desktop branch, because the `TooltipContent` only renders
when the button is disabled — verified in the browser, see below.

### Not fixed here

The two Categorize tooltip strings (`'All transactions are categorized'` /
`` `Categorize ${n} transactions` ``) are not wrapped in `__()`. That predates this
PR — the block is only relocated — and fixing it means adding keys to three locale
catalogs for something unrelated to the reorder.

## Tests

`transaction-actions-menu.test.tsx` grows from 2 to 6 cases; the `useIsMobile` mock
is now switchable so both viewports are covered. The new cases assert the full
left-to-right order of the bar at each size, the dropdown's item order on mobile,
the `/transactions/categorize` href, the badge count, and the disabled
non-navigable item at zero.

`vitest.setup.ts` gains a `PointerEvent` shim: jsdom ships none, so
`fireEvent.pointerDown` degrades to a plain `Event` and Radix triggers never open.

## QA

Browser-tested on the running app at 1440x900, 375x812 and 700x900.

- Desktop: order confirmed; dropdown holds only Import and Update categories.
- Mobile: `+` in the bar opens the add-transaction dialog; Categorize is gone from
  the bar and is the first dropdown item, in the right order.
- The disabled Categorize item at zero does not navigate and the URL never changes.
- After the tooltip fix: desktop hover opens and closes the hint, the mobile tap
  toggles it open and closed, and resizing across 768px logs no console warning.

Two things the browser could not cover, both because the demo account has zero
uncategorized transactions: the amber badge's own appearance (including dark mode)
and a live navigation to `/transactions/categorize`. Both are covered by the unit
tests, and the badge keeps its existing `dark:` variants.

## Demo

https://github.com/user-attachments/assets/5048530b-a781-4af8-998a-d386dc7d86e3


