### PR TITLE
feat(money): store and show each currency at its own number of decimals

### DIFF
--- a/app/Console/Commands/SendDailyStatsReportCommand.php
+++ b/app/Console/Commands/SendDailyStatsReportCommand.php
@@ -123,11 +123,11 @@ class SendDailyStatsReportCommand extends Command
     }
 
     /**
-     * MRR figures are held in major units (e.g. euros), so convert to cents for
-     * the shared formatter.
+     * MRR figures are held in major units (e.g. euros), so convert to the
+     * currency's minor units for the shared formatter.
      */
     private function money(float $amount, string $currency): string
     {
-        return Money::format((int) round($amount * 100), $currency);
+        return Money::format(Money::toMinor($amount, $currency), $currency);
     }
 }

--- a/app/Console/Commands/StripeSubscriptionStatsCommand.php
+++ b/app/Console/Commands/StripeSubscriptionStatsCommand.php
@@ -79,11 +79,11 @@ class StripeSubscriptionStatsCommand extends Command
     }
 
     /**
-     * MRR figures are held in major units (e.g. euros), so convert to cents for
-     * the shared formatter.
+     * MRR figures are held in major units (e.g. euros), so convert to the
+     * currency's minor units for the shared formatter.
      */
     private function format(float $amount, string $currency): string
     {
-        return Money::format((int) round($amount * 100), $currency);
+        return Money::format(Money::toMinor($amount, $currency), $currency);
     }
 }

--- a/app/Console/Commands/SyncStripePricesCommand.php
+++ b/app/Console/Commands/SyncStripePricesCommand.php
@@ -73,6 +73,8 @@ class SyncStripePricesCommand extends Command
             return 'skipped';
         }
 
+        // Stripe's own smallest-currency-unit table, not the app's per-currency
+        // scale: this value goes out to the Stripe API, not into our columns.
         $amountInCents = (int) round($plan['price'] * 100);
         $billingPeriod = $plan['billing_period'] ?? null;
         $productId = config('subscriptions.products.pro');

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -115,6 +115,10 @@ class HandleInertiaRequests extends Middleware
             'currencies' => [
                 'profile' => $this->currencyOptions->primaryOptions(),
                 'accounts' => $this->currencyOptions->accountOptions(),
+                // Keyed by code rather than folded into the two lists above:
+                // a transaction can be in a currency no longer offered, and it
+                // still has to render at the right scale.
+                'decimals' => $this->currencyOptions->decimalsMap(),
             ],
         ];
     }

--- a/app/Mcp/Servers/WhisperMoneyServer.php
+++ b/app/Mcp/Servers/WhisperMoneyServer.php
@@ -46,7 +46,10 @@ Access to the authenticated user's Whisper Money finance data, for analysing
 spending, cashflow and net worth — and, with write access, for editing that
 data.
 
-- All amounts are integers in minor units (cents). Divide by 100 for a display value.
+- All amounts are integers in the minor units of their own currency, and how many
+  those are per major unit depends on the currency: 100 for EUR and USD, 1 for
+  COP, CLP, PYG, JPY and PKR, 1000 for KWD, 100000000 for BTC. Read the row's
+  `currency` before scaling one, and never assume cents.
 - Data is organised into "spaces" (the personal space and any shared spaces).
   Transaction, account, category and label tools accept an optional `space` id and
   default to the personal space; call `list_spaces` to discover ids. The cashflow,

--- a/app/Mcp/Tools/CreateAutomationRule.php
+++ b/app/Mcp/Tools/CreateAutomationRule.php
@@ -27,7 +27,7 @@ class CreateAutomationRule extends WriteTool
             'title' => $schema->string()->description('Human-readable rule name.')->required(),
             'priority' => $schema->integer()->min(0)->description('Lower numbers are evaluated first.')->required(),
             'rules_json' => $schema->object()->description(<<<'TEXT'
-                JsonLogic condition object, evaluated against these lowercase variables: description, notes, creditor_name, debtor_name, account_name, bank_name, category, transaction_date (YYYY-MM-DD) and amount. Note: amount here is in MAJOR units (e.g. 12.50), not cents. Example: {"and":[{">":[{"var":"amount"},100]},{"in":["grocery",{"var":"description"}]}]}
+                JsonLogic condition object, evaluated against these lowercase variables: description, notes, creditor_name, debtor_name, account_name, bank_name, category, transaction_date (YYYY-MM-DD) and amount. Note: amount here is in MAJOR units (e.g. 12.50), not the minor units every other tool takes. Example: {"and":[{">":[{"var":"amount"},100]},{"in":["grocery",{"var":"description"}]}]}
                 TEXT)->required(),
             'action_category_id' => $schema->string()->description('Category id to assign to matching transactions.'),
             'action_label_ids' => $schema->array()->items($schema->string())->description('Label ids to attach to matching transactions.'),

--- a/app/Mcp/Tools/CreateBalance.php
+++ b/app/Mcp/Tools/CreateBalance.php
@@ -19,9 +19,9 @@ class CreateBalance extends WriteTool
     {
         return [
             'account_id' => $schema->string()->description('Id of a non-connected (manual) account.')->required(),
-            'balance' => $schema->integer()->description('Balance in minor units (cents).')->required(),
+            'balance' => $schema->integer()->description('Balance in the account currency\'s minor units (100 = 1.00 EUR, 1 = 1 COP, 1 = 0.00000001 BTC).')->required(),
             'balance_date' => $schema->string()->description('Snapshot date, YYYY-MM-DD. Defaults to today.'),
-            'invested_amount' => $schema->integer()->description('Optional invested amount in minor units (cents), for investment accounts.'),
+            'invested_amount' => $schema->integer()->description('Optional invested amount in the account currency\'s minor units, for investment accounts.'),
             'space' => $schema->string()->description('Space id. Defaults to the personal space.'),
         ];
     }

--- a/app/Mcp/Tools/CreateBudget.php
+++ b/app/Mcp/Tools/CreateBudget.php
@@ -30,7 +30,7 @@ class CreateBudget extends WriteTool
     {
         return [
             'name' => $schema->string()->description('Budget name.')->required(),
-            'allocated_amount' => $schema->integer()->description('Limit for each period, in minor units (50000 = 500.00).')->required(),
+            'allocated_amount' => $schema->integer()->description('Limit for each period, in the user currency\'s minor units (50000 = 500.00 EUR, 50000 = 50000 COP).')->required(),
             'period_type' => $schema->string()->enum(array_column(BudgetPeriodType::cases(), 'value'))->description('How often the budget starts over.')->required(),
             'rollover_type' => $schema->string()->enum(array_column(RolloverType::cases(), 'value'))->description('"carry_over" adds what is left to the next period, "reset" starts every period at the limit.')->required(),
             'period_start_day' => $schema->integer()->min(0)->max(31)->description('Day the period starts: day of the month (1-31) when monthly, day of the week (0 = Sunday, 6 = Saturday) when weekly or biweekly. Ignored when yearly.'),

--- a/app/Mcp/Tools/CreateTransaction.php
+++ b/app/Mcp/Tools/CreateTransaction.php
@@ -23,7 +23,7 @@ class CreateTransaction extends WriteTool
         return [
             'account_id' => $schema->string()->description('Id of the account to add the transaction to.')->required(),
             'description' => $schema->string()->description('Human-readable description.')->required(),
-            'amount' => $schema->integer()->description('Signed amount in minor units (cents). Negative = expense, positive = income.')->required(),
+            'amount' => $schema->integer()->description('Signed amount in the account currency\'s minor units. Negative = expense, positive = income.')->required(),
             'transaction_date' => $schema->string()->description('Transaction date, YYYY-MM-DD.')->required(),
             'currency_code' => $schema->string()->description('ISO 4217 currency code (3 letters). Defaults to the account currency.'),
             'category_id' => $schema->string()->description('Optional category id to assign.'),

--- a/app/Mcp/Tools/SearchTransactions.php
+++ b/app/Mcp/Tools/SearchTransactions.php
@@ -29,8 +29,8 @@ class SearchTransactions extends McpTool
             'label_ids' => $schema->array()->items($schema->string())->description('Restrict to transactions carrying any of these label ids. Call list_labels to see valid ids.'),
             'from' => $schema->string()->description('Earliest transaction date, YYYY-MM-DD.'),
             'to' => $schema->string()->description('Latest transaction date, YYYY-MM-DD.'),
-            'min_amount' => $schema->integer()->description('Minimum signed amount in minor units (cents).'),
-            'max_amount' => $schema->integer()->description('Maximum signed amount in minor units (cents).'),
+            'min_amount' => $schema->integer()->description('Minimum signed amount in the account currency\'s minor units.'),
+            'max_amount' => $schema->integer()->description('Maximum signed amount in the account currency\'s minor units.'),
             'limit' => $schema->integer()->min(1)->max(200)->description('Max rows to return (default 50).'),
             'space' => $schema->string()->description('Space id to query. Defaults to the personal space.'),
         ];

--- a/app/Mcp/Tools/SplitTransaction.php
+++ b/app/Mcp/Tools/SplitTransaction.php
@@ -41,7 +41,7 @@ class SplitTransaction extends WriteTool
         return [
             'transaction_id' => $schema->string()->description('Id of the transaction to split. A part of an existing split cannot be split again — merge it back first.')->required(),
             'splits' => $schema->array()->items($schema->object([
-                'amount' => $schema->integer()->description('Signed amount in minor units (cents). Must have the same sign as the original: parts of an expense are all negative.')->required(),
+                'amount' => $schema->integer()->description('Signed amount in the transaction currency\'s minor units. Must have the same sign as the original: parts of an expense are all negative.')->required(),
                 'category_id' => $schema->string()->description('Category for this part. Omit to leave it uncategorized.'),
                 'label_ids' => $schema->array()->items($schema->string())->description('Label ids for this part. Defaults to none; the original\'s labels are not copied.'),
             ]))->description('The parts to create, 2 to '.TransactionSplitter::MAX_PARTS.' of them. Their amounts must add up to the original amount exactly.')->required(),

--- a/app/Mcp/Tools/UpdateBudget.php
+++ b/app/Mcp/Tools/UpdateBudget.php
@@ -23,7 +23,7 @@ class UpdateBudget extends WriteTool
         return [
             'budget_id' => $schema->string()->description('Id of the budget to edit. Call list_budgets to see valid ids.')->required(),
             'name' => $schema->string()->description('New budget name.'),
-            'allocated_amount' => $schema->integer()->description('New limit per period, in minor units (50000 = 500.00). Applies to the period in progress and every future one.'),
+            'allocated_amount' => $schema->integer()->description('New limit per period, in the user currency\'s minor units. Applies to the period in progress and every future one.'),
         ];
     }
 

--- a/app/Mcp/Tools/UpdateTransaction.php
+++ b/app/Mcp/Tools/UpdateTransaction.php
@@ -23,7 +23,7 @@ class UpdateTransaction extends WriteTool
         return [
             'transaction_id' => $schema->string()->description('Id of the manually-created transaction to edit.')->required(),
             'description' => $schema->string()->description('New description.'),
-            'amount' => $schema->integer()->description('New signed amount in minor units (cents).'),
+            'amount' => $schema->integer()->description('New signed amount in the account currency\'s minor units.'),
             'transaction_date' => $schema->string()->description('New transaction date, YYYY-MM-DD.'),
             'currency_code' => $schema->string()->description('New ISO 4217 currency code (3 letters).'),
             'account_id' => $schema->string()->description('Move the transaction to another account.'),

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -474,6 +474,10 @@ class Transaction extends Model
 
             // A row in a currency the config no longer offers still has to be
             // filterable, and every such row predates the per-currency scale.
+            // This holds only while no *rescaled* currency is dropped from the
+            // config: retiring BTC from the offered list would leave its
+            // 8-decimal rows here, read as 2-decimal. Retire the code from the
+            // options but keep its `decimals` entry if that ever happens.
             $group->orWhere(fn (Builder $scale) => $scale
                 ->whereNotIn('currency_code', $knownCodes)
                 ->where('amount', $operator, (int) round($majorUnits * 10 ** CurrencyOptions::DEFAULT_DECIMALS)));

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -11,6 +11,7 @@ use App\Events\TransactionDeleted;
 use App\Events\TransactionUpdated;
 use App\Models\Concerns\BelongsToSpace;
 use App\Services\CategoryTree;
+use App\Services\CurrencyOptions;
 use Carbon\Carbon;
 use Database\Factories\TransactionFactory;
 use Illuminate\Contracts\Database\Query\Expression;
@@ -433,9 +434,8 @@ class Transaction extends Model
         $query
             ->when(isset($filters['date_from']), fn (Builder $q) => $q->whereDate('transaction_date', '>=', $filters['date_from']))
             ->when(isset($filters['date_to']), fn (Builder $q) => $q->whereDate('transaction_date', '<=', $filters['date_to']))
-            // Amounts arrive in major units from the UI but are stored in cents.
-            ->when(isset($filters['amount_min']), fn (Builder $q) => $q->where('amount', '>=', $filters['amount_min'] * 100))
-            ->when(isset($filters['amount_max']), fn (Builder $q) => $q->where('amount', '<=', $filters['amount_max'] * 100))
+            ->when(isset($filters['amount_min']), fn (Builder $q) => $this->applyAmountFilter($q, (float) $filters['amount_min'], '>='))
+            ->when(isset($filters['amount_max']), fn (Builder $q) => $this->applyAmountFilter($q, (float) $filters['amount_max'], '<='))
             ->when(! empty($filters['account_ids']), fn (Builder $q) => $q->whereIn('account_id', $filters['account_ids']))
             ->when(! empty($filters['category_source']), fn (Builder $q) => $q->where('category_source', $filters['category_source']))
             ->when(! empty($filters['creditor_name']), fn (Builder $q) => $q->where('creditor_name', 'LIKE', '%'.$filters['creditor_name'].'%'))
@@ -451,6 +451,33 @@ class Transaction extends Model
         $this->applyCategoryAndLabelFilters($query, $filters);
 
         return $query;
+    }
+
+    /**
+     * An amount filter arrives from the UI in major units, while the column holds
+     * minor units at each currency's own scale. One threshold therefore becomes
+     * one comparison per scale, ORed over the currencies that share it.
+     *
+     * @param  Builder<Transaction>  $query
+     */
+    private function applyAmountFilter(Builder $query, float $majorUnits, string $operator): void
+    {
+        $currencies = app(CurrencyOptions::class);
+        $knownCodes = array_keys($currencies->decimalsMap());
+
+        $query->where(function (Builder $group) use ($currencies, $knownCodes, $majorUnits, $operator): void {
+            foreach ($currencies->codesByDecimals() as $decimals => $codes) {
+                $group->orWhere(fn (Builder $scale) => $scale
+                    ->whereIn('currency_code', $codes)
+                    ->where('amount', $operator, (int) round($majorUnits * 10 ** $decimals)));
+            }
+
+            // A row in a currency the config no longer offers still has to be
+            // filterable, and every such row predates the per-currency scale.
+            $group->orWhere(fn (Builder $scale) => $scale
+                ->whereNotIn('currency_code', $knownCodes)
+                ->where('amount', $operator, (int) round($majorUnits * 10 ** CurrencyOptions::DEFAULT_DECIMALS)));
+        });
     }
 
     /**

--- a/app/Services/Ai/CategorizeTransactions.php
+++ b/app/Services/Ai/CategorizeTransactions.php
@@ -7,6 +7,7 @@ use App\Enums\CategorySource;
 use App\Jobs\RetryTransientAiCategorizationJob;
 use App\Models\Transaction;
 use App\Models\User;
+use App\Support\Money;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
 use Laravel\Ai\Enums\Lab;
@@ -157,7 +158,7 @@ class CategorizeTransactions
         $items = $chunk->map(fn (Transaction $transaction): array => [
             'ref' => $transaction->id,
             'text' => (string) $transaction->description,
-            'amount' => $transaction->amount / 100,
+            'amount' => Money::toMajor($transaction->amount, $transaction->currency_code),
             'direction' => $transaction->amount < 0 ? 'outflow' : 'inflow',
             'creditor_name' => $transaction->creditor_name,
             'debtor_name' => $transaction->debtor_name,

--- a/app/Services/Ai/RuleSuggestionAggregator.php
+++ b/app/Services/Ai/RuleSuggestionAggregator.php
@@ -5,6 +5,7 @@ namespace App\Services\Ai;
 use App\Models\Category;
 use App\Models\Transaction;
 use App\Models\User;
+use App\Support\Money;
 use Illuminate\Support\Collection;
 
 /**
@@ -32,7 +33,7 @@ class RuleSuggestionAggregator
             ->where('user_id', $user->id)
             ->whereNull('category_id')
             ->whereNull('description_iv')
-            ->get(['id', 'description', 'creditor_name', 'debtor_name', 'amount']);
+            ->get(['id', 'description', 'creditor_name', 'debtor_name', 'amount', 'currency_code']);
 
         $documentFrequency = $this->descriptionDocumentFrequency($transactions);
         $noiseThreshold = $transactions->count() * (float) config('ai_suggestions.noise_token_fraction');
@@ -60,7 +61,7 @@ class RuleSuggestionAggregator
             ];
 
             $groups[$bucket]['count']++;
-            $groups[$bucket]['amount_sum'] += (int) $transaction->amount;
+            $groups[$bucket]['amount_sum'] += Money::toMajor((int) $transaction->amount, $transaction->currency_code);
 
             $sample = $this->normalizeWhitespace((string) ($transaction->description ?? $rawKey));
             if ($sample !== '' && count($groups[$bucket]['samples']) < self::SAMPLE_LIMIT) {
@@ -76,7 +77,7 @@ class RuleSuggestionAggregator
             ->sortByDesc('count')
             ->take($max)
             ->map(function (array $group): array {
-                $avg = $group['amount_sum'] / $group['count'] / 100;
+                $avg = $group['amount_sum'] / $group['count'];
 
                 return [
                     'key' => $group['key'],

--- a/app/Services/AutomationRuleService.php
+++ b/app/Services/AutomationRuleService.php
@@ -7,6 +7,7 @@ use App\Jobs\ReassignTransactionsToBudgets;
 use App\Models\AutomationRule;
 use App\Models\LabelTransaction;
 use App\Models\Transaction;
+use App\Support\Money;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -317,7 +318,7 @@ class AutomationRuleService
 
         return [
             'description' => $this->normalizeWhitespace(mb_strtolower($transaction->description ?? '')),
-            'amount' => $transaction->amount / 100,
+            'amount' => Money::toMajor($transaction->amount, $transaction->currency_code),
             'transaction_date' => $transaction->transaction_date->format('Y-m-d'),
             'bank_name' => mb_strtolower($bank->name ?? ''),
             'account_name' => mb_strtolower($accountName),

--- a/app/Services/Banking/BalanceSyncService.php
+++ b/app/Services/Banking/BalanceSyncService.php
@@ -6,6 +6,7 @@ use App\Contracts\BankingProviderInterface;
 use App\Enums\TransactionSource;
 use App\Models\Account;
 use App\Models\AccountBalance;
+use App\Support\Money;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
@@ -41,7 +42,7 @@ class BalanceSyncService
             return;
         }
 
-        $amount = (int) round(floatval($balance['balance_amount']['amount']) * 100);
+        $amount = Money::toMinor(floatval($balance['balance_amount']['amount']), $account->currency_code);
         $date = $balance['reference_date'] ?? now()->toDateString();
 
         $account->balances()->updateOrCreate(

--- a/app/Services/Banking/BinanceBalanceSyncService.php
+++ b/app/Services/Banking/BinanceBalanceSyncService.php
@@ -4,6 +4,7 @@ namespace App\Services\Banking;
 
 use App\Models\Account;
 use App\Services\CurrencyConversionService;
+use App\Support\Money;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Sleep;
@@ -166,7 +167,7 @@ class BinanceBalanceSyncService
 
             $account->balances()->updateOrCreate(
                 ['balance_date' => $date],
-                ['balance' => (int) round($totalValue * 100)],
+                ['balance' => Money::toMinor($totalValue, $targetCurrency)],
             );
 
             $count++;
@@ -256,7 +257,7 @@ class BinanceBalanceSyncService
             $totalValue += $value;
         }
 
-        return (int) round($totalValue * 100);
+        return Money::toMinor($totalValue, $targetCurrency);
     }
 
     /**
@@ -410,7 +411,7 @@ class BinanceBalanceSyncService
         $totalDeposited = $this->sumTransactionAmounts($deposits, $targetCurrency, 'deposit');
         $totalWithdrawn = $this->sumTransactionAmounts($withdrawals, $targetCurrency, 'withdrawal');
 
-        return (int) round(($totalDeposited - $totalWithdrawn) * 100);
+        return Money::toMinor($totalDeposited - $totalWithdrawn, $targetCurrency);
     }
 
     /**

--- a/app/Services/Banking/BitpandaBalanceSyncService.php
+++ b/app/Services/Banking/BitpandaBalanceSyncService.php
@@ -4,6 +4,7 @@ namespace App\Services\Banking;
 
 use App\Models\Account;
 use App\Services\CurrencyConversionService;
+use App\Support\Money;
 use Illuminate\Support\Facades\Log;
 
 class BitpandaBalanceSyncService
@@ -40,7 +41,7 @@ class BitpandaBalanceSyncService
         $totalValue += $this->sumCryptoWallets($client, $ticker, $targetCurrency);
         $totalValue += $this->sumFiatWallets($client, $targetCurrency);
 
-        $totalValueCents = (int) round($totalValue * 100);
+        $totalValueCents = Money::toMinor($totalValue, $targetCurrency);
 
         $account->balances()->updateOrCreate(
             ['balance_date' => now()->toDateString()],
@@ -173,7 +174,7 @@ class BitpandaBalanceSyncService
             return null;
         }
 
-        return (int) round(($totalDeposited - $totalWithdrawn) * 100);
+        return Money::toMinor($totalDeposited - $totalWithdrawn, $targetCurrency);
     }
 
     /**

--- a/app/Services/Banking/CoinbaseBalanceSyncService.php
+++ b/app/Services/Banking/CoinbaseBalanceSyncService.php
@@ -4,6 +4,7 @@ namespace App\Services\Banking;
 
 use App\Models\Account;
 use App\Services\CurrencyConversionService;
+use App\Support\Money;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Log;
@@ -78,7 +79,7 @@ class CoinbaseBalanceSyncService
 
         $cryptoTotal = $this->convertCryptoAssets($cryptoAssets, $priceMap, $targetCurrency);
 
-        $totalValueCents = (int) round(($fiatTotal + $cryptoTotal) * 100);
+        $totalValueCents = Money::toMinor($fiatTotal + $cryptoTotal, $targetCurrency);
 
         $account->balances()->updateOrCreate(
             ['balance_date' => now()->toDateString()],
@@ -118,7 +119,7 @@ class CoinbaseBalanceSyncService
 
             $account->balances()->updateOrCreate(
                 ['balance_date' => $dateString],
-                ['balance' => (int) round($totalValue * 100)],
+                ['balance' => Money::toMinor($totalValue, $targetCurrency)],
             );
 
             $count++;

--- a/app/Services/Banking/IndexaCapitalBalanceSyncService.php
+++ b/app/Services/Banking/IndexaCapitalBalanceSyncService.php
@@ -4,6 +4,7 @@ namespace App\Services\Banking;
 
 use App\Models\Account;
 use App\Services\CurrencyConversionService;
+use App\Support\Money;
 use Illuminate\Support\Facades\Log;
 
 class IndexaCapitalBalanceSyncService
@@ -61,7 +62,7 @@ class IndexaCapitalBalanceSyncService
                 continue;
             }
 
-            $balanceCents = (int) round(floatval($value) * 100);
+            $balanceCents = Money::toMinor(floatval($value), $accountCurrency);
             $investedAmountCents = $this->calculateInvestedAmount($entry, $netAmounts, $accountCurrency, $userCurrency, $date);
 
             $account->balances()->updateOrCreate(
@@ -124,6 +125,6 @@ class IndexaCapitalBalanceSyncService
             $amount = $this->currencyConverter->convert($accountCurrency, $userCurrency, $amount, $date);
         }
 
-        return (int) round($amount * 100);
+        return Money::toMinor($amount, $userCurrency);
     }
 }

--- a/app/Services/Banking/InteractiveBrokersBalanceSyncService.php
+++ b/app/Services/Banking/InteractiveBrokersBalanceSyncService.php
@@ -3,6 +3,7 @@
 namespace App\Services\Banking;
 
 use App\Models\Account;
+use App\Support\Money;
 use Illuminate\Support\Facades\Log;
 
 class InteractiveBrokersBalanceSyncService
@@ -54,10 +55,10 @@ class InteractiveBrokersBalanceSyncService
                 continue;
             }
 
-            $attributes = ['balance' => (int) round($nav * 100)];
+            $attributes = ['balance' => Money::toMinor($nav, $account->currency_code)];
 
             if ($date === $latestDate && $data['investedAmount'] !== null) {
-                $attributes['invested_amount'] = (int) round($data['investedAmount'] * 100);
+                $attributes['invested_amount'] = Money::toMinor($data['investedAmount'], $account->currency_code);
             }
 
             $account->balances()->updateOrCreate(['balance_date' => $date], $attributes);

--- a/app/Services/Banking/TransactionSyncService.php
+++ b/app/Services/Banking/TransactionSyncService.php
@@ -409,7 +409,8 @@ class TransactionSyncService
 
     /**
      * Parse amount from EnableBanking transaction data.
-     * Returns amount in cents (bigint). Debits are negative.
+     * Returns the amount in the given currency's minor units, which are not
+     * always cents. Debits are negative.
      */
     private function parseAmount(array $data, string $currency): int
     {

--- a/app/Services/Banking/TransactionSyncService.php
+++ b/app/Services/Banking/TransactionSyncService.php
@@ -6,6 +6,7 @@ use App\Contracts\BankingProviderInterface;
 use App\Enums\TransactionSource;
 use App\Exceptions\Banking\WrongTransactionsPeriodException;
 use App\Models\Account;
+use App\Support\Money;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Log;
@@ -93,7 +94,7 @@ class TransactionSyncService
                         }
 
                         if ($saveDailyBalances) {
-                            $this->trackDailyBalance($transaction, $dailyBalances);
+                            $this->trackDailyBalance($transaction, $dailyBalances, $account->currency_code);
                         }
                     }
 
@@ -319,12 +320,12 @@ class TransactionSyncService
             return false;
         }
 
-        $amount = $this->parseAmount($data);
+        $currency = $data['transaction_amount']['currency'] ?? $account->currency_code;
+        $amount = $this->parseAmount($data, $currency);
         $rawDescription = $this->parseDescription($data);
         $formatted = $this->descriptionFormatter->format($rawDescription, $bankName);
         $counterparties = TransactionCounterpartyExtractor::fromPayload($data);
         $transactionDate = $this->parseDate($data);
-        $currency = $data['transaction_amount']['currency'] ?? $account->currency_code;
 
         try {
             $account->transactions()->create([
@@ -410,10 +411,10 @@ class TransactionSyncService
      * Parse amount from EnableBanking transaction data.
      * Returns amount in cents (bigint). Debits are negative.
      */
-    private function parseAmount(array $data): int
+    private function parseAmount(array $data, string $currency): int
     {
         $rawAmount = $data['transaction_amount']['amount'] ?? '0';
-        $cents = (int) round(floatval($rawAmount) * 100);
+        $cents = Money::toMinor(floatval($rawAmount), $currency);
 
         $indicator = $data['credit_debit_indicator'] ?? null;
 
@@ -457,7 +458,7 @@ class TransactionSyncService
      *
      * @param  array<string, int>  $dailyBalances
      */
-    private function trackDailyBalance(array $transaction, array &$dailyBalances): void
+    private function trackDailyBalance(array $transaction, array &$dailyBalances, string $currency): void
     {
         $balanceAfter = $transaction['balance_after_transaction'] ?? null;
 
@@ -466,7 +467,9 @@ class TransactionSyncService
         }
 
         $date = $this->parseDate($transaction);
-        $amount = (int) round(floatval($balanceAfter['amount']) * 100);
+        // The snapshot lands in `account_balances`, which holds the
+        // account's own currency.
+        $amount = Money::toMinor(floatval($balanceAfter['amount']), $currency);
 
         $dailyBalances[$date] = $amount;
     }

--- a/app/Services/Banking/WiseBalanceSyncService.php
+++ b/app/Services/Banking/WiseBalanceSyncService.php
@@ -3,6 +3,7 @@
 namespace App\Services\Banking;
 
 use App\Models\Account;
+use App\Support\Money;
 use Illuminate\Support\Facades\Log;
 
 class WiseBalanceSyncService
@@ -32,7 +33,7 @@ class WiseBalanceSyncService
             return;
         }
 
-        $amountCents = (int) round((float) $value * 100);
+        $amountCents = Money::toMinor((float) $value, $account->currency_code);
 
         $account->balances()->updateOrCreate(
             ['balance_date' => now()->toDateString()],

--- a/app/Services/Banking/WiseTransactionSyncService.php
+++ b/app/Services/Banking/WiseTransactionSyncService.php
@@ -4,6 +4,7 @@ namespace App\Services\Banking;
 
 use App\Enums\TransactionSource;
 use App\Models\Account;
+use App\Support\Money;
 use Carbon\CarbonInterface;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Facades\Log;
@@ -143,7 +144,7 @@ class WiseTransactionSyncService
             default => -1,
         };
 
-        $amountCents = (int) round($value * 100) * $sign;
+        $amountCents = Money::toMinor($value, $walletCurrency) * $sign;
 
         $description = trim(strip_tags($activity['title'] ?? ''));
 

--- a/app/Services/CurrencyOptions.php
+++ b/app/Services/CurrencyOptions.php
@@ -5,11 +5,61 @@ namespace App\Services;
 class CurrencyOptions
 {
     /**
-     * @return list<array{code: string, name: string, allows_primary: bool, allows_account: bool}>
+     * The scale every currency uses unless `config/currencies.php` says
+     * otherwise, and the scale every row in the database predates this key with.
+     */
+    public const DEFAULT_DECIMALS = 2;
+
+    /**
+     * How many decimals a currency's minor unit has: EUR 2, COP 0, BTC 8. This
+     * is the scale money is *stored* at, not just displayed at, so an unknown
+     * code falls back to the 2 every existing row already uses.
+     */
+    public function decimals(string $code): int
+    {
+        return $this->decimalsMap()[strtoupper($code)] ?? self::DEFAULT_DECIMALS;
+    }
+
+    /**
+     * Every currency's scale, spelled out including the defaults, so the
+     * frontend reads one table instead of deriving its own from CLDR.
+     *
+     * @return array<string, int>
+     */
+    public function decimalsMap(): array
+    {
+        $map = [];
+
+        foreach ($this->all() as $currency) {
+            $map[$currency['code']] = $currency['decimals'] ?? self::DEFAULT_DECIMALS;
+        }
+
+        return $map;
+    }
+
+    /**
+     * Currency codes grouped by the scale they share, for queries that have to
+     * compare one major-unit threshold against columns at several scales.
+     *
+     * @return array<int, list<string>>
+     */
+    public function codesByDecimals(): array
+    {
+        $grouped = [];
+
+        foreach ($this->decimalsMap() as $code => $decimals) {
+            $grouped[$decimals][] = $code;
+        }
+
+        return $grouped;
+    }
+
+    /**
+     * @return list<array{code: string, name: string, allows_primary: bool, allows_account: bool, decimals?: int}>
      */
     public function all(): array
     {
-        /** @var list<array{code: string, name: string, allows_primary: bool, allows_account: bool}> $options */
+        /** @var list<array{code: string, name: string, allows_primary: bool, allows_account: bool, decimals?: int}> $options */
         $options = config('currencies.options', []);
 
         return $options;
@@ -54,7 +104,7 @@ class CurrencyOptions
     }
 
     /**
-     * @param  list<array{code: string, name: string, allows_primary: bool, allows_account: bool}>  $options
+     * @param  list<array{code: string, name: string, allows_primary: bool, allows_account: bool, decimals?: int}>  $options
      * @return list<array{code: string, name: string}>
      */
     private function formatOptions(array $options, string $capability): array

--- a/app/Services/ExchangeRateService.php
+++ b/app/Services/ExchangeRateService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Models\ExchangeRate;
+use App\Support\Money;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Log;
 
@@ -23,19 +24,26 @@ class ExchangeRateService
      *
      * @param  string  $source  Source currency code (e.g., "EUR")
      * @param  string  $target  Target currency code (e.g., "USD")
-     * @param  int  $amountInCents  Amount in the source currency's smallest unit
+     * @param  int  $amountInMinorUnits  Amount in the source currency's minor units
      * @param  string  $date  Date string (YYYY-MM-DD)
+     * @return int Amount in the *target* currency's minor units
      */
-    public function convert(string $source, string $target, int $amountInCents, string $date): int
+    public function convert(string $source, string $target, int $amountInMinorUnits, string $date): int
     {
         $source = strtolower($source);
         $target = strtolower($target);
 
-        if ($source === $target || $amountInCents === 0) {
-            return $amountInCents;
+        if ($source === $target || $amountInMinorUnits === 0) {
+            return $amountInMinorUnits;
         }
 
         $rates = $this->getRates($target, $date);
+
+        // Source and target can hold a different number of decimals (COP 0,
+        // EUR 2, BTC 8), so the rate is applied in major units and the result
+        // rescaled to the target. Applying it to the stored integers directly
+        // would be off by a power of ten between any two unequal scales.
+        $majorUnits = Money::toMajor($amountInMinorUnits, $source);
 
         if (! isset($rates[$source]) || $rates[$source] == 0) {
             Log::warning('Exchange rate not found, returning unconverted amount', [
@@ -44,10 +52,12 @@ class ExchangeRateService
                 'date' => $date,
             ]);
 
-            return $amountInCents;
+            // Unconverted, but still rescaled: the caller reads the result as
+            // the target's minor units either way.
+            return Money::toMinor($majorUnits, $target);
         }
 
-        return (int) round($amountInCents / $rates[$source]);
+        return Money::toMinor($majorUnits / $rates[$source], $target);
     }
 
     /**

--- a/app/Services/LoanAmortizationService.php
+++ b/app/Services/LoanAmortizationService.php
@@ -14,28 +14,30 @@ class LoanAmortizationService
      * Uses the standard amortization formula:
      * M = P * [r(1+r)^n] / [(1+r)^n - 1]
      *
-     * @param  int  $principalCents  Original loan amount in cents
+     * The formula is homogeneous in the principal, so it needs no currency: an
+     * amount in minor units in gives a payment in the same minor units out,
+     * whether those are cents, whole pesos or satoshis.
+     *
+     * @param  int  $principalMinorUnits  Original loan amount in minor units
      * @param  float  $annualRate  Annual interest rate as percentage (e.g. 3.5)
      * @param  int  $termMonths  Total loan term in months
-     * @return int Monthly payment in cents
+     * @return int Monthly payment in the same minor units
      */
-    public function calculateMonthlyPayment(int $principalCents, float $annualRate, int $termMonths): int
+    public function calculateMonthlyPayment(int $principalMinorUnits, float $annualRate, int $termMonths): int
     {
         if ($termMonths <= 0) {
             return 0;
         }
 
-        $principal = $principalCents / 100;
         $monthlyRate = ($annualRate / 100) / 12;
 
         if ($monthlyRate === 0.0) {
-            return (int) round(($principal / $termMonths) * 100);
+            return (int) round($principalMinorUnits / $termMonths);
         }
 
         $factor = pow(1 + $monthlyRate, $termMonths);
-        $payment = $principal * ($monthlyRate * $factor) / ($factor - 1);
 
-        return (int) round($payment * 100);
+        return (int) round($principalMinorUnits * ($monthlyRate * $factor) / ($factor - 1));
     }
 
     /**
@@ -43,36 +45,36 @@ class LoanAmortizationService
      *
      * Uses the formula: B(k) = P * [(1+r)^n - (1+r)^k] / [(1+r)^n - 1]
      *
-     * @param  int  $principalCents  Original loan amount in cents
+     * Scale-agnostic for the same reason as {@see self::calculateMonthlyPayment()}.
+     *
+     * @param  int  $principalMinorUnits  Original loan amount in minor units
      * @param  float  $annualRate  Annual interest rate as percentage (e.g. 3.5)
      * @param  int  $termMonths  Total loan term in months
      * @param  int  $paymentsMade  Number of payments already made
-     * @return int Remaining balance in cents
+     * @return int Remaining balance in the same minor units
      */
-    public function calculateRemainingBalance(int $principalCents, float $annualRate, int $termMonths, int $paymentsMade): int
+    public function calculateRemainingBalance(int $principalMinorUnits, float $annualRate, int $termMonths, int $paymentsMade): int
     {
         if ($paymentsMade >= $termMonths) {
             return 0;
         }
 
         if ($paymentsMade <= 0) {
-            return $principalCents;
+            return $principalMinorUnits;
         }
 
-        $principal = $principalCents / 100;
         $monthlyRate = ($annualRate / 100) / 12;
 
         if ($monthlyRate === 0.0) {
-            $remaining = $principal - ($principal / $termMonths * $paymentsMade);
+            $remaining = $principalMinorUnits - ($principalMinorUnits / $termMonths * $paymentsMade);
 
-            return max(0, (int) round($remaining * 100));
+            return max(0, (int) round($remaining));
         }
 
         $factorN = pow(1 + $monthlyRate, $termMonths);
         $factorK = pow(1 + $monthlyRate, $paymentsMade);
-        $remaining = $principal * ($factorN - $factorK) / ($factorN - 1);
 
-        return max(0, (int) round($remaining * 100));
+        return max(0, (int) round($principalMinorUnits * ($factorN - $factorK) / ($factorN - 1)));
     }
 
     /**

--- a/app/Support/Money.php
+++ b/app/Support/Money.php
@@ -51,12 +51,12 @@ final class Money
     /**
      * How many minor units make one major unit of this currency.
      */
-    public static function factor(string $currency): int
+    private static function factor(string $currency): int
     {
         return 10 ** self::decimals($currency);
     }
 
-    public static function decimals(string $currency): int
+    private static function decimals(string $currency): int
     {
         return app(CurrencyOptions::class)->decimals($currency);
     }

--- a/app/Support/Money.php
+++ b/app/Support/Money.php
@@ -2,16 +2,18 @@
 
 namespace App\Support;
 
+use App\Services\CurrencyOptions;
+
 /**
- * Formats a minor-unit amount (cents) with its currency symbol, e.g. "€3.99".
+ * Converts between a currency's minor units — the integers every money column
+ * stores — and its major units, and formats them.
  *
- * Centralizes the money formatting that was duplicated across the stats report
- * commands and the Discord Stripe listener. Currencies without a known symbol
- * fall back to the uppercased currency code plus a trailing space ("CHF 3.99").
+ * The number of minor units per major unit depends on the currency: 100 for
+ * EUR, 1 for COP, 100_000_000 for BTC. Nothing here may assume 2 decimals.
  */
 final class Money
 {
-    public static function format(int $cents, string $currency): string
+    public static function format(int $minorUnits, string $currency): string
     {
         $symbol = match (strtolower($currency)) {
             'eur' => '€',
@@ -22,6 +24,40 @@ final class Money
             default => strtoupper($currency).' ',
         };
 
-        return $symbol.number_format($cents / 100, 2);
+        $decimals = self::decimals($currency);
+
+        return $symbol.number_format(self::toMajor($minorUnits, $currency), $decimals);
+    }
+
+    /**
+     * A major-unit amount as the integer the database stores, e.g. 3.99 EUR to
+     * 399 and 0.5 BTC to 50_000_000.
+     */
+    public static function toMinor(float $majorUnits, string $currency): int
+    {
+        return (int) round($majorUnits * self::factor($currency));
+    }
+
+    /**
+     * A stored integer back to major units, e.g. 399 EUR to 3.99. Lossy by
+     * nature — the result is a float, so never round-trip it through arithmetic
+     * that must balance.
+     */
+    public static function toMajor(int $minorUnits, string $currency): float
+    {
+        return $minorUnits / self::factor($currency);
+    }
+
+    /**
+     * How many minor units make one major unit of this currency.
+     */
+    public static function factor(string $currency): int
+    {
+        return 10 ** self::decimals($currency);
+    }
+
+    public static function decimals(string $currency): int
+    {
+        return app(CurrencyOptions::class)->decimals($currency);
     }
 }

--- a/config/currencies.php
+++ b/config/currencies.php
@@ -1,6 +1,18 @@
 <?php
 
 return [
+    /*
+     * Every money value is stored as an integer in the currency's minor units,
+     * and `decimals` is that scale: EUR 2 (cents), COP 0 (no centavos in
+     * practice), BTC 8 (satoshis). Currencies omit the key when the scale is
+     * the default 2, so only the exceptions are spelled out.
+     *
+     * The scale decides how values are *stored*, so it must never be derived
+     * from the server's ICU version — an ICU upgrade would silently rescale the
+     * database. `CurrencyDecimalsMatchCldrTest` guards these values against
+     * CLDR instead, with BTC as the one declared override (it is not an ISO
+     * currency, so CLDR falls back to 2 for it).
+     */
     'options' => [
         [
             'code' => 'USD',
@@ -25,6 +37,7 @@ return [
             'name' => 'Japanese Yen',
             'allows_primary' => true,
             'allows_account' => true,
+            'decimals' => 0,
         ],
         [
             'code' => 'CHF',
@@ -73,6 +86,7 @@ return [
             'name' => 'Pakistani Rupee',
             'allows_primary' => true,
             'allows_account' => true,
+            'decimals' => 0,
         ],
         [
             'code' => 'MXN',
@@ -97,12 +111,14 @@ return [
             'name' => 'Chilean Peso',
             'allows_primary' => true,
             'allows_account' => true,
+            'decimals' => 0,
         ],
         [
             'code' => 'PYG',
             'name' => 'Paraguayan Guarani',
             'allows_primary' => true,
             'allows_account' => true,
+            'decimals' => 0,
         ],
         [
             'code' => 'PEN',
@@ -133,6 +149,7 @@ return [
             'name' => 'Colombian Peso',
             'allows_primary' => true,
             'allows_account' => true,
+            'decimals' => 0,
         ],
         [
             'code' => 'DOP',
@@ -151,12 +168,14 @@ return [
             'name' => 'Kuwaiti Dinar',
             'allows_primary' => true,
             'allows_account' => true,
+            'decimals' => 3,
         ],
         [
             'code' => 'BTC',
             'name' => 'Bitcoin',
             'allows_primary' => false,
             'allows_account' => true,
+            'decimals' => 8,
         ],
         [
             'code' => 'RSD',

--- a/config/currencies.php
+++ b/config/currencies.php
@@ -8,10 +8,11 @@ return [
      * the default 2, so only the exceptions are spelled out.
      *
      * The scale decides how values are *stored*, so it must never be derived
-     * from the server's ICU version — an ICU upgrade would silently rescale the
-     * database. `CurrencyDecimalsMatchCldrTest` guards these values against
-     * CLDR instead, with BTC as the one declared override (it is not an ISO
-     * currency, so CLDR falls back to 2 for it).
+     * from the host's ICU version: `NumberFormatter` reads PKR as 0 decimals on
+     * macOS and 2 on Linux, which would make one row mean two different amounts
+     * and an ICU upgrade a silent data migration. `CurrencyDecimalsTest` pins
+     * these values against its own table, so editing this file without a
+     * rescaling migration turns it red.
      */
     'options' => [
         [

--- a/currency-decimals-assessment.md
+++ b/currency-decimals-assessment.md
@@ -1,0 +1,285 @@
+# Per-currency decimal precision — feasibility assessment
+
+Assessed 2026-08-28 against `currency-decimals-research` (base `6861010c`). Production
+numbers read live via `php artisan agent:db --prod`. **No production code changed.**
+
+## The current model
+
+Every money value in the app is a signed integer in minor units at a **hardcoded scale of
+2 decimals**. There is no per-currency scale anywhere: not in the schema, not in
+`config/currencies.php`, not in the formatters. Confirmed. That single assumption is the
+whole problem, and it produces two different failures that are worth separating because
+their cost differs by an order of magnitude:
+
+- **Precision loss (storage).** Currencies needing *more* than 2 decimals — BTC (8), KWD /
+  BHD / TND (3) — cannot represent the real holding. Data is destroyed on write.
+- **Cosmetic noise (display only).** Currencies needing *fewer* than 2 — JPY, CLP, PYG,
+  COP — are stored fine and merely render a meaningless `,00`. Nothing is lost.
+
+The second is much larger in user count and much cheaper to fix. The rest of this
+assessment leans on that split.
+
+## Corrections to the scouting
+
+| Claim | Verdict |
+|---|---|
+| ~50 `*100`/`/100` in `app/`, ~71 in `resources/js` | 50 PHP, 66 JS (excl. tests). Of those, **29 PHP and 25 JS are app money**; 17 PHP and 32 JS are percentages/progress/geometry; 4 PHP and 9 JS are Stripe/subscription pricing (2dp fiat by definition, out of scope). Real conversion surface is **54 sites, not ~121**. |
+| `savings_goals.archived_saved_amount` is bigint | **It is `int`** (max 2.147e9 ≈ 21.4M major units). Already tight; any rescale must widen it first. |
+| `amount-display.tsx` ~31 call sites | 24 files, **70 usages**. 20 of them already pass explicit `0` fraction digits for compact chart labels. |
+| `amount-input.tsx` ~19 call sites | 15 files, **29 usages**. |
+| CSV import **and export** round-trips | **Import only.** `routes/web.php` has no money export route; no `fputcsv`/CSV response outside the stats mailer. Halves that line item. |
+| `Intl` already knows the right digits | Confirmed and stronger than stated — CLDR gives **COP 0 digits** (ISO 4217 says 2), matching what Colombian users expect. Verified in Node: JPY/CLP/PYG/COP/ISK/VND/HUF → 0; KWD/BHD/TND → 3; BTC/ETH → 2 + literal code. |
+| MCP tools are blast radius | Barely. `CreateTransaction` takes `integer` minor units and `PresentsTransactions` returns them raw — **scale-transparent**, only the word "cents" in the description is wrong. The one real coupling is `CreateAutomationRule`, which documents JsonLogic `amount` in *major* units. |
+
+### What the scouting missed, and it matters most
+
+**Only three tables carry a currency at all**: `accounts.currency_code`,
+`transactions.currency_code`, `users.currency_code` — all `varchar(3)`.
+
+These money columns have **no currency column** and resolve it by join or by convention:
+
+| Column | Currency comes from |
+|---|---|
+| `account_balances.balance`, `.invested_amount` | join `accounts` |
+| `real_estate_details.purchase_price`, `loan_details.original_amount` | join `accounts` |
+| `budget_transactions.amount`, `budget_periods.allocated_amount`, `.carried_over_amount` | `users.currency_code` (primary) |
+| `savings_goals.target_amount`, `.initial_amount`, `.archived_saved_amount` | `users.currency_code` (primary) |
+
+So "add a `decimals` key to the config" is the easy 5%. The expensive 95% of a per-currency
+exponent is **making the currency reachable from every money column** — a join or a
+denormalised column on five tables that do not have one today.
+
+Two consequences that shrink the problem a lot:
+
+1. `users.currency_code` is constrained to `allows_primary` currencies, and **BTC is
+   `allows_primary => false`**. Budgets and savings goals therefore *can never be in BTC*.
+   The high-precision problem is confined to `accounts`, `transactions`, `account_balances`,
+   `real_estate_details`, `loan_details`.
+2. `currency_code` is `varchar(3)`, which blocks every 4-character crypto ticker (USDT,
+   USDC, DOGE). Any genuinely crypto-general solution needs a column widening the scouting
+   did not price.
+
+## Production reality
+
+Accounts (not soft-deleted) in currencies whose correct scale is not 2:
+
+| Currency | Correct digits | Accounts | Users | Transactions | Balance rows | Failure mode |
+|---|---|---|---|---|---|---|
+| COP | 0 | 480 | 334 | 8,740 | 2,466 | display only |
+| CLP | 0 | 174 | 125 | 6,572 | 901 | display only |
+| PYG | 0 | 33 | 30 | 659 | 348 | display only |
+| JPY | 0 | 1 | 1 | 395 | 118 | display only |
+| **BTC** | **8** | **8** | **7** | **1** | **9** | **precision loss** |
+| **KWD** | **3** | **5** | **1** | **0** | **5** | **precision loss** |
+| BHD, TND | 3 | 0 | 0 | 0 | 0 | — |
+
+Primary-currency users: COP 334, CLP 127, PYG 28, KWD 1, BTC 0 (not permitted). Savings
+goals owned by a non-2dp-primary user: **0**. Budgets: **2**.
+
+The BTC data is almost nonexistent: **one transaction with `amount = 2`** (0.02 BTC) and
+**nine balance rows, largest 80** (0.80 BTC). Rescaling it is a 23-row `UPDATE`.
+
+**Two numbers decide the storage question:**
+
+Largest absolute value per column, against `bigint` max 9.223e18 and JS
+`Number.MAX_SAFE_INTEGER` 9.007e15:
+
+| Column | Max abs | bigint headroom |
+|---|---|---|
+| `transactions.amount` | 2,018,235,173,753,138,400 (2.02e18) | **4.6×** |
+| `budget_periods.carried_over_amount` | 1,000,000,000,001,094,939 | 9.2× |
+| `budget_periods.allocated_amount` | 999,999,999,991,000,000 | 9.2× |
+| `account_balances.balance` | 460,332,104,102,226,300 | 20× |
+| everything else | ≤ 2.75e10 | ≥ 3e8 × |
+
+These extremes are junk rows (someone typed a wall of nines into a budget), but they are
+live data and a naive `UPDATE … SET amount = amount * N` hits them.
+
+Rows that **overflow bigint** at a global rescale:
+
+| Rescale | transactions | account_balances | budget_periods |
+|---|---|---|---|
+| ×10 (2→3dp) | **1** | 0 | 0 |
+| ×100 (2→4dp) | 7 | 0 | 0 |
+| ×10⁴ (2→6dp) | 18 | 51 | 6 |
+| ×10⁶ (2→8dp) | 44 | 53 | 6 |
+
+Rows that **exceed `Number.MAX_SAFE_INTEGER`**, i.e. silently lose precision the moment
+Inertia serialises them (both columns are cast to `'integer'`, so they ship as JSON
+numbers, not strings):
+
+| Scale | transactions | account_balances | budget_periods |
+|---|---|---|---|
+| **today** | **9** | **51** | **6** |
+| ×10³ | 49 | — | — |
+| ×10⁶ | 236 | 248 | — |
+
+**Sixty-six rows are already past the JS safe-integer boundary today.** That is a live
+precision bug independent of this work, and it is a hard ceiling on any global rescale.
+
+## Options, costed
+
+### (A) Per-currency exponent — the scale of a stored value depends on its currency
+
+**Mechanics.** `decimals` key in `config/currencies.php`; a `scale($code)` accessor on each
+side; a migration rescaling only rows whose currency's exponent moves.
+
+**Killed as specified by production data.** The canonical version stores COP at 0 decimals.
+But COP minor-unit values are *not* multiples of 100: **1,874 of 8,740 transactions (21%)
+and 1,542 of 2,466 balance rows (63%)** have non-zero centavos, plus CLP 61/91 and PYG
+7/112. Scaling those down truncates real user data and changes every aggregate they feed.
+Display rounding is per-value and harmless; storage rounding is not.
+
+**So the only safe form of (A) is asymmetric:** raise the scale where more precision is
+needed, never lower it. Which is option (C).
+
+**Full-fat cost if pursued anyway.** 54 conversion sites, plus currency resolution on the
+five tables that lack a currency column, plus every SQL aggregate over raw minor units
+(`Transaction::OWNED_AMOUNT_SQL`, `CashflowSummaryService`, `AccountMetricsService`, the
+three analytics controllers) becoming scale-dependent, plus `CurrencyConversionService`
+(floats in major units — each caller must divide by its own 10^d), plus ~86 test files.
+Rounding actually *improves*: `round(amount * ownership_percentage / 100)` at a higher
+scale has smaller error. **Estimate: 1–2 weeks, high migration risk, no reversibility once
+mixed scales exist in one column.**
+
+### (B) One global higher scale for everything
+
+**Dead on arrival.** ×10 already overflows a live row. 2→6dp overflows 75 rows across three
+tables; 2→8dp overflows 97 and pushes 484 rows past `MAX_SAFE_INTEGER` on the client. It
+also requires all 54 conversion sites to change simultaneously in one deploy, invalidates
+every Dexie cache, and buys nothing for the 0-decimal currencies. The only way to make it
+work is to first migrate every money column to `decimal`/string and drop the JSON-number
+contract — a far bigger project than the one being assessed.
+
+Recording it as rejected with the numbers is the useful output here.
+
+### (C) Keep 2dp for fiat, special-case the high-precision currencies
+
+**Mechanics.** Same `decimals` key, but only currencies with `decimals > 2` get a storage
+rescale: BTC 2→8 (×10⁶), KWD/BHD/TND 2→3 (×10). 0-decimal currencies get **display only**,
+no migration, no truncation. Everything else stays untouched at 2.
+
+**Migration size: 23 rows.** BTC — 1 transaction, 9 balance rows, 8 accounts' detail rows;
+KWD — 5 balance rows, 0 transactions. Zero overflow risk (max BTC value is 80; max KWD
+35,135). Fully reversible: divide back, and BTC's currently-truncated values are already at
+2dp so the round-trip is exact.
+
+**Files.** The `decimals` key, `CurrencyOptions` exposing it, one PHP accessor, one TS
+accessor, `Money.php`, `currency.ts`, `amount-display.tsx`, `amount-input.tsx`, the three
+crypto sync services (`Coinbase`, `Binance`, `Bitpanda`), `Transaction::filter`, one Dexie
+version bump, one migration, ~6 test files. **Estimate: 3–4 days, low risk.**
+
+## Display and input: how many sites actually change
+
+`decimals` in `config/currencies.php` reaches the client for free —
+`HandleInertiaRequests:115` already shares `currencies.profile` / `currencies.accounts`
+built from `CurrencyOptions`, so adding the field to `formatOptions()` is a one-line change
+and every page has it.
+
+| Surface | Usages | Needs touching |
+|---|---|---|
+| `formatCurrency` in `utils/currency.ts` | — | **1.** Drop `= 2` defaults to `undefined` and Intl supplies the right digits per currency. Single highest-leverage edit in the whole study. |
+| `<AmountDisplay>` | 70 in 24 files | **1** (its two `= 2` defaults). The 20 usages passing explicit `0` for chart labels keep working — that is a deliberate compact style, not a currency fact. |
+| Direct `formatCurrency(...)` callers | 44 in 22 files | **~0.** They pass no fraction digits, so they inherit. 9 are subscription pricing and are correct as-is. |
+| `<AmountInput>` | 29 in 15 files | **1**, but the real work is inside it: its own `formatCurrency` (`min/max: 2`), `parseInputValue` (`Math.round(parsed * 100)`), `handleFocus` (`.toFixed(2)`), `evaluateMathExpression` (`/100`, `*100`), and `placeholder = '0.00'`. Five hardcoded 2s in one file, then all 29 sites inherit. |
+| `Money::format` (PHP) | 10 callers | **0.** All are Stripe/Discord/stats reporting in fiat. Parameterise `Money::format` anyway (2 lines) for consistency. |
+
+**Answer to question 2: roughly five files genuinely change; ~140 call sites inherit.** The
+plumbing really is half-built. `getCurrencySymbol`'s 10-entry map and `Money.php`'s symbol
+`match` are separate, pre-existing gaps — both are already worse than
+`Intl.NumberFormat(...).formatToParts()`, which `amount-input.tsx` uses correctly.
+
+## Data integrity
+
+- **Already-truncated BTC is gone.** 0.02 and 0.80 BTC are what the DB holds; ×10⁶ makes
+  them 0.02000000 and 0.80000000. The migration must not *corrupt* them, and it does not —
+  but it cannot recover what was never stored. Those 7 users need re-entry, which for 8
+  accounts is a support email, not a data-repair job.
+- **0-decimal currencies must not be rescaled.** 21% of COP transactions and 63% of COP
+  balance rows carry non-zero centavos. This is the single most important integrity finding.
+- **Balance history / budget snapshots.** `account_balances` is a per-date snapshot series,
+  so a rescale must hit every historical row for the account, not just the latest — 9 rows
+  for BTC, 5 for KWD. `budget_periods` and `savings_goals` are unreachable in BTC
+  (`allows_primary => false`) and hold 0 goals / 2 budgets for non-2dp-primary users.
+- **Dexie cache.** `dexie-db.ts` is at `version(10)` and caches `transactions` with raw
+  integer amounts plus a `sync_metadata` cursor. A rescale needs `version(11)` clearing
+  `transactions` and the cursor so the client re-syncs. One transaction row affected in
+  production; the version bump is a few lines and there is precedent (versions 7 and 8 exist
+  purely to reset state).
+- **CSV import.** `file-parser.ts:844/852/970` and `import-balances-drawer.tsx:393/399` do
+  `Math.round(x * 100)`. Each needs the target account's scale, which the drawer already
+  knows. No export path exists, so no round-trip to break.
+- **Rule-engine parity.** `rule-engine.ts:127` and `AutomationRuleService.php:320` both do
+  `amount / 100` and must change identically or `rule-engine-parity.test.ts` goes red — a
+  feature, not a cost. Note that automation-rule *thresholds* are stored in major units in
+  the rule JSON, so an existing "amount > 100" rule keeps meaning the same thing.
+- **`bun run dry`.** The scale accessor must exist once per language. Copying it into
+  `Money.php` and the sync services trips a required check.
+
+## The smallest useful increment
+
+Two independent slices. **Slice 1 has no migration at all**, which is the finding worth
+acting on.
+
+**Slice 1 — stop overriding Intl (display only, ~1 day, zero migration risk).**
+Change the `= 2` defaults in `currency.ts` and `amount-display.tsx` to `undefined`, and
+parameterise `amount-input.tsx`. This immediately fixes **688 accounts held by up to 490 users, and
+16,366 transactions** — every COP, CLP, PYG and JPY amount stops showing a meaningless
+`,00` — and makes KWD render its three digits. It does not fix BTC storage, but it does
+stop BTC showing a fake 2-decimal precision. Highest value-to-risk ratio in the study by a
+wide margin, and it does not depend on any decision below.
+
+**Slice 2 — BTC at 8 decimals (~2–3 days, 23 rows).**
+Add `decimals` to the config with an override for BTC (8) and KWD/BHD/TND (3); rescale
+those rows; bump Dexie; fix the three crypto sync services and `Transaction::filter`.
+
+**Does "BTC at 8 decimals, everything else unchanged" deliver most of the value? For the
+forum poster, yes — it is the entire complaint, and it costs 23 rows.** But it serves 7
+users, while slice 1 serves 490 for less work. Ship slice 1 first regardless of what is
+decided about storage.
+
+## Recommendation
+
+**Option (C), delivered as slice 1 then slice 2. Reject (A) as specified and (B) outright.**
+
+| Option | Files | Migration | Test surface | Risk | Effort |
+|---|---|---|---|---|---|
+| Slice 1 (display) | ~5 | none | `currency.test.ts`, `amount-input.test.tsx` | very low | ~1 day |
+| Slice 2 (C, BTC+KWD storage) | ~15 | 23 rows, reversible | + ~6 PHP test files | low | 2–3 days |
+| (A) full per-currency exponent | ~60 + 5 schema changes | every money row, irreversible | ~86 PHP files + 4 JS | high | 1–2 weeks |
+| (B) global rescale | all 54 sites at once | every money row, **overflows** | ~86 PHP files + 4 JS | unacceptable | — |
+
+Concretely: `decimals` goes in `config/currencies.php` next to `allows_primary`; the value
+is `Intl`'s answer for every ISO currency (so the key exists mainly to carry BTC's 8 and to
+give PHP the number JS gets from CLDR); storage scale is `min(2, decimals)` raised only
+where `decimals > 2`. Storage scale and display scale stay two separate concepts — conflating
+them is precisely what makes (A) destroy COP data.
+
+## Risks I would not accept
+
+1. **Rescaling 0-decimal currencies down.** 1,874 COP transactions and 1,542 COP balance
+   rows have non-zero centavos. Non-negotiable: display at 0 digits, store at 2.
+2. **Any global rescale.** ×10 overflows a live `transactions.amount` row today. There is no
+   version of (B) that is safe without first moving off JSON-number money.
+3. **A migration without the `savings_goals.archived_saved_amount` widening.** It is `int`,
+   not bigint. Any rescale touching it silently clamps at 2.147e9.
+4. **Mixed scales inside one column without a currency reachable from that row.** Five
+   money tables have no `currency_code`. Introducing per-row scales there before adding the
+   column is unrecoverable: you cannot tell 8-decimal rows from 2-decimal rows after the
+   fact.
+5. **Shipping a crypto-general story on `varchar(3)`.** BTC fits; USDT and USDC do not. Either
+   widen the column in the same change or state plainly that only 3-character tickers are
+   supported.
+6. **Presenting slice 2 as "crypto support".** The 7 affected users' existing BTC values are
+   already truncated and cannot be recovered by any migration. They must be told to re-enter
+   their holdings.
+
+## Follow-ups this surfaced (out of scope, worth filing)
+
+- **66 money rows already exceed `Number.MAX_SAFE_INTEGER`** (9 transactions, 51 balances,
+  6 budget periods) and are cast to `'integer'`, so the browser receives corrupted values
+  today. Independent bug, independent fix (validation ceiling on amount input).
+- `budget_periods` holds `999999999991000000` — input validation has no upper bound.
+- `Money.php`'s 5-entry symbol `match` and `currency.ts`'s 10-entry `getCurrencySymbol` map
+  cover 15 of 36 configured currencies. `Intl.NumberFormat(...).formatToParts()` — already
+  used correctly in `amount-input.tsx` — replaces both.

--- a/currency-decimals-assessment.md
+++ b/currency-decimals-assessment.md
@@ -1,7 +1,17 @@
 # Per-currency decimal precision — feasibility assessment
 
 Assessed 2026-08-28 against `currency-decimals-research` (base `6861010c`). Production
-numbers read live via `php artisan agent:db --prod`. **No production code changed.**
+numbers read live via `php artisan agent:db --prod`.
+
+> **Decision taken (2026-08-28), overriding the recommendation below.** The product owner
+> accepted the centavo loss on the zero-decimal currencies, so option **(A)** was
+> implemented in full rather than the asymmetric (C): COP, CLP, PYG, JPY and **PKR** were
+> rescaled down to 0 decimals, KWD up to 3 and BTC up to 8. PKR was added on the same
+> CLDR-over-ISO rule as COP. Everything in §"Data integrity" risk 1 still happened on
+> purpose — 1,874 COP transactions and 1,542 COP balance rows lost their centavos. Risks
+> 2 to 6 were all honoured: no global rescale, `archived_saved_amount` widened to bigint,
+> the currency reachable from every rescaled row, `varchar(3)` left as a stated limit, and
+> the seven BTC holders told to re-enter their balances.
 
 ## The current model
 

--- a/database/factories/AccountFactory.php
+++ b/database/factories/AccountFactory.php
@@ -27,7 +27,7 @@ class AccountFactory extends Factory
             'name_iv' => null,
             'encrypted' => false,
             'bank_id' => Bank::factory(),
-            'currency_code' => fake()->randomElement(['USD', 'EUR', 'GBP', 'JPY']),
+            'currency_code' => fake()->randomElement(['USD', 'EUR', 'GBP', 'CHF']),
             'type' => fake()->randomElement(AccountType::cases()),
         ];
     }

--- a/database/factories/TransactionFactory.php
+++ b/database/factories/TransactionFactory.php
@@ -29,7 +29,7 @@ class TransactionFactory extends Factory
             'description_iv' => fake()->regexify('[A-Za-z0-9]{16}'),
             'transaction_date' => fake()->dateTimeBetween('-1 year', 'now'),
             'amount' => fake()->numberBetween(-100000, 100000),
-            'currency_code' => fake()->randomElement(['USD', 'EUR', 'GBP', 'JPY']),
+            'currency_code' => fake()->randomElement(['USD', 'EUR', 'GBP', 'CHF']),
             'notes' => fake()->optional()->paragraph(),
             'notes_iv' => fake()->optional()->regexify('[A-Za-z0-9]{16}'),
             'source' => TransactionSource::ManuallyCreated,

--- a/database/migrations/2026_08_28_122633_rescale_money_to_currency_decimals.php
+++ b/database/migrations/2026_08_28_122633_rescale_money_to_currency_decimals.php
@@ -1,0 +1,112 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Every money column stored minor units at a fixed scale of 2 decimals,
+ * whatever the currency. This rescales the stored integers to each currency's
+ * real scale: COP, CLP, PYG, JPY and PKR have no minor unit in practice, KWD
+ * has three decimals, BTC has eight.
+ *
+ * The scales are hardcoded rather than read from `config/currencies.php` on
+ * purpose. A migration is one fixed transition between two known states; if it
+ * read the config it would rescale a currency added years later, on a database
+ * that never held the old scale.
+ *
+ * Scaling down to 0 decimals is lossy by design — the centavos on ~2,000 COP
+ * rows are dropped, which the product owner accepted. `down()` restores the
+ * scale, never those centavos, so take a backup before running this.
+ */
+return new class extends Migration
+{
+    /**
+     * Currency codes grouped by how far their scale moves from the old fixed 2.
+     * A shift of -2 means "divide by 100", of 6 means "multiply by a million".
+     */
+    private const SHIFTS = [
+        -2 => ['COP', 'CLP', 'PYG', 'JPY', 'PKR'],
+        1 => ['KWD'],
+        6 => ['BTC'],
+    ];
+
+    /**
+     * Every money column in the database, with the predicate that reaches the
+     * currency setting its scale. Only `transactions` carries a currency of its
+     * own; the other six resolve it through a subquery, which is the reason a
+     * per-currency scale costs more than a config key.
+     *
+     * `(?)` is expanded to one placeholder per currency code.
+     *
+     * @var list<array{0: string, 1: list<string>, 2: string}>
+     */
+    private const MONEY_COLUMNS = [
+        ['transactions', ['amount'], 'currency_code in (?)'],
+        ['account_balances', ['balance', 'invested_amount'], 'account_id in (select id from accounts where currency_code in (?))'],
+        ['real_estate_details', ['purchase_price'], 'account_id in (select id from accounts where currency_code in (?))'],
+        ['loan_details', ['original_amount'], 'account_id in (select id from accounts where currency_code in (?))'],
+        // A budget transaction's amount is a snapshot of the transaction's own
+        // amount, copied without conversion, so it follows the transaction's
+        // currency and not the budget owner's primary one.
+        ['budget_transactions', ['amount'], 'transaction_id in (select id from transactions where currency_code in (?))'],
+        ['budget_periods', ['allocated_amount', 'carried_over_amount'], 'budget_id in (select id from budgets where user_id in (select id from users where currency_code in (?)))'],
+        ['savings_goals', ['target_amount', 'initial_amount', 'archived_saved_amount'], 'user_id in (select id from users where currency_code in (?))'],
+    ];
+
+    public function up(): void
+    {
+        // The one money column still on `int`, which caps at 2.1e9 minor units.
+        // A three- or eight-decimal currency overflows that on a real balance.
+        Schema::table('savings_goals', function (Blueprint $table): void {
+            $table->bigInteger('archived_saved_amount')->nullable()->change();
+        });
+
+        foreach (self::SHIFTS as $shift => $codes) {
+            $this->rescale($codes, $shift);
+        }
+    }
+
+    public function down(): void
+    {
+        foreach (self::SHIFTS as $shift => $codes) {
+            $this->rescale($codes, -$shift);
+        }
+
+        // `archived_saved_amount` stays bigint: narrowing it back would fail on
+        // any row an eight-decimal currency legitimately grew past 2.1e9.
+    }
+
+    /**
+     * Move every money column of the given currencies by a power of ten.
+     *
+     * Timestamps are deliberately left alone. The offline client syncs off
+     * `updated_at`, so re-dating 20k rows would make every client re-pull its
+     * whole history; it drops the now-wrongly-scaled cache through a Dexie
+     * version bump instead.
+     *
+     * @param  list<string>  $codes
+     */
+    private function rescale(array $codes, int $shift): void
+    {
+        $factor = 10 ** abs($shift);
+        $placeholders = implode(',', array_fill(0, count($codes), '?'));
+
+        foreach (self::MONEY_COLUMNS as [$table, $columns, $predicate]) {
+            $assignments = implode(', ', array_map(
+                fn (string $column): string => $shift > 0
+                    // Scaling up is exact; scaling down rounds half away from
+                    // zero, matching PHP's round() and losing sub-unit detail.
+                    ? "{$column} = {$column} * {$factor}"
+                    : "{$column} = round({$column} / {$factor})",
+                $columns
+            ));
+
+            DB::update(
+                "update {$table} set {$assignments} where ".str_replace('(?)', "({$placeholders})", $predicate),
+                $codes
+            );
+        }
+    }
+};

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -42,6 +42,7 @@ import {
 import { installSessionExpiryRecovery } from './lib/session-expiry-recovery';
 import { trackUnattendedRequests } from './lib/unattended-requests';
 import type { ExpiredBankingConnectionNotification, SharedData } from './types';
+import { setCurrencyDecimals } from './utils/currency';
 import { __, setTranslations } from './utils/i18n';
 
 installChunkLoadRecovery();
@@ -242,12 +243,18 @@ createInertiaApp({
             (initialPageProps?.translations as Record<string, string>) ?? {},
         );
 
+        // How many decimals each currency's minor unit has. Every amount is
+        // divided by this before rendering, so it has to be in place before the
+        // first paint.
+        setCurrencyDecimals(initialPageProps?.currencies?.decimals);
+
         // Keep translations in sync on every Inertia navigation
         router.on('navigate', (event) => {
             const pageProps = event.detail.page.props as unknown as SharedData;
             setTranslations(
                 (pageProps?.translations as Record<string, string>) ?? {},
             );
+            setCurrencyDecimals(pageProps?.currencies?.decimals);
 
             void syncUserTimezone(pageProps);
         });

--- a/resources/js/components/accounts/import-balances-drawer.tsx
+++ b/resources/js/components/accounts/import-balances-drawer.tsx
@@ -31,6 +31,7 @@ import {
 } from '@/types/balance-import';
 import { DateFormat } from '@/types/import';
 import type { UUID } from '@/types/uuid';
+import { toMajorUnits, toMinorUnits } from '@/utils/currency';
 import { __ } from '@/utils/i18n';
 import { usePage } from '@inertiajs/react';
 import { Check } from 'lucide-react';
@@ -359,6 +360,9 @@ export function ImportBalancesDrawer({
     const handlePreviewBalances = () => {
         try {
             const parsedBalances: ParsedBalance[] = [];
+            // A balance is held in its account's currency, so that currency
+            // decides how many decimals the parsed number keeps.
+            const balanceCurrency = selectedAccount?.currency_code || 'USD';
 
             for (const row of state.parsedData) {
                 if (
@@ -390,13 +394,16 @@ export function ImportBalancesDrawer({
                             | number,
                     );
                     if (rawInvested !== null) {
-                        investedAmount = Math.round(rawInvested * 100);
+                        investedAmount = toMinorUnits(
+                            rawInvested,
+                            balanceCurrency,
+                        );
                     }
                 }
 
                 parsedBalances.push({
                     balance_date: formattedDate,
-                    balance: Math.round(balance * 100),
+                    balance: toMinorUnits(balance, balanceCurrency),
                     invested_amount: investedAmount,
                 });
             }
@@ -506,7 +513,10 @@ export function ImportBalancesDrawer({
                         rowNumber,
                         balance: {
                             date: balance.balance_date,
-                            amount: (balance.balance / 100).toString(),
+                            amount: toMajorUnits(
+                                balance.balance,
+                                selectedAccount?.currency_code || 'USD',
+                            ).toString(),
                         },
                         error: errorMessage,
                     });

--- a/resources/js/components/automation-rules/rule-builder.tsx
+++ b/resources/js/components/automation-rules/rule-builder.tsx
@@ -22,6 +22,7 @@ import {
     type RuleStructure,
 } from '@/lib/rule-builder-utils';
 import type { SharedData } from '@/types';
+import { toMajorUnits, toMinorUnits } from '@/utils/currency';
 import { __ } from '@/utils/i18n';
 import { usePage } from '@inertiajs/react';
 import { ChevronDown, Plus, Trash2, X } from 'lucide-react';
@@ -235,14 +236,15 @@ export function RuleBuilder({ value, onChange, error }: RuleBuilderProps) {
 }
 
 /**
- * `condition.value` is stored as a string in currency units ("-21.99") because
- * that is what `buildJsonLogic` and the backend expect, while `AmountInput`
- * speaks cents.
+ * `condition.value` is stored as a string in major units ("-21.99") because that
+ * is what `buildJsonLogic` and the backend expect, while `AmountInput` speaks
+ * minor units. Storing the threshold in major units is why existing rules keep
+ * their meaning across a currency rescale.
  */
-function currencyUnitsToCents(value: string): number {
-    const cents = Math.round(parseFloat(value) * 100);
+function majorUnitsToMinor(value: string, currencyCode: string): number {
+    const parsed = parseFloat(value);
 
-    return Number.isNaN(cents) ? 0 : cents;
+    return Number.isNaN(parsed) ? 0 : toMinorUnits(parsed, currencyCode);
 }
 
 interface ConditionRowProps {
@@ -332,17 +334,25 @@ function ConditionRow({
                 ) : isAmountField ? (
                     <div className="w-full sm:flex-1">
                         <AmountInput
-                            value={currencyUnitsToCents(condition.value)}
+                            value={majorUnitsToMinor(
+                                condition.value,
+                                currencyCode,
+                            )}
                             onChange={(valueInCents, isEmpty) =>
                                 onChange({
                                     ...condition,
                                     // A cleared field and a typed 0 both resolve
-                                    // to 0 cents; only the cleared one may blank
+                                    // to 0; only the cleared one may blank
                                     // the condition, or `amount < 0` would be
                                     // impossible to express.
                                     value: isEmpty
                                         ? ''
-                                        : String(valueInCents / 100),
+                                        : String(
+                                              toMajorUnits(
+                                                  valueInCents,
+                                                  currencyCode,
+                                              ),
+                                          ),
                                 })
                             }
                             currencyCode={currencyCode}

--- a/resources/js/components/budgets/create-budget-dialog.tsx
+++ b/resources/js/components/budgets/create-budget-dialog.tsx
@@ -370,7 +370,6 @@ export function CreateBudgetDialog({
                                     value={allocatedAmount}
                                     onChange={setAllocatedAmount}
                                     currencyCode={currencyCode}
-                                    placeholder="0.00"
                                     required
                                 />
 

--- a/resources/js/components/budgets/edit-budget-dialog.tsx
+++ b/resources/js/components/budgets/edit-budget-dialog.tsx
@@ -245,7 +245,6 @@ export function EditBudgetDialog({
                                 value={allocatedAmount}
                                 onChange={setAllocatedAmount}
                                 currencyCode={currencyCode}
-                                placeholder="0.00"
                                 required
                             />
 

--- a/resources/js/components/charts/cashflow-trend-chart.tsx
+++ b/resources/js/components/charts/cashflow-trend-chart.tsx
@@ -11,6 +11,7 @@ import { CashflowPeriodType, TrendDataPoint } from '@/hooks/use-cashflow-data';
 import { useChartColors } from '@/hooks/use-chart-color-scheme';
 import { useLocale } from '@/hooks/use-locale';
 import { cn } from '@/lib/utils';
+import { toMajorUnits } from '@/utils/currency';
 import { formatCompactNumber, formatMonthFromYearMonth } from '@/utils/date';
 import { __ } from '@/utils/i18n';
 import { useEffect, useRef } from 'react';
@@ -217,7 +218,7 @@ export function CashflowTrendChart({
                                 axisLine={false}
                                 tickFormatter={(value: number) =>
                                     formatCompactNumber(
-                                        value / 100,
+                                        toMajorUnits(value, currency),
                                         locale,
                                         currency,
                                     )

--- a/resources/js/components/charts/mom-chart.tsx
+++ b/resources/js/components/charts/mom-chart.tsx
@@ -3,6 +3,7 @@ import { ChartConfig, ChartContainer } from '@/components/ui/chart';
 import { useLocale } from '@/hooks/use-locale';
 import { ChangeDataPoint } from '@/lib/chart-calculations';
 import { cn } from '@/lib/utils';
+import { toMajorUnits } from '@/utils/currency';
 import { __ } from '@/utils/i18n';
 import { useEffect, useRef } from 'react';
 import {
@@ -123,7 +124,7 @@ export function MoMChart({
                             return new Intl.NumberFormat(locale, {
                                 notation: 'compact',
                                 compactDisplay: 'short',
-                            }).format(value / 100);
+                            }).format(toMajorUnits(value, currencyCode));
                         }}
                         width={50}
                     />

--- a/resources/js/components/savings-goals/create-savings-goal-dialog.tsx
+++ b/resources/js/components/savings-goals/create-savings-goal-dialog.tsx
@@ -128,7 +128,6 @@ export function CreateSavingsGoalDialog({
                                 value={targetAmount}
                                 onChange={setTargetAmount}
                                 currencyCode={currencyCode}
-                                placeholder="0.00"
                             />
                             {errors.target_amount && (
                                 <p className="text-sm text-destructive">
@@ -149,7 +148,6 @@ export function CreateSavingsGoalDialog({
                                 value={initialAmount}
                                 onChange={setInitialAmount}
                                 currencyCode={currencyCode}
-                                placeholder="0.00"
                             />
                             <p className="text-sm text-muted-foreground">
                                 {__(

--- a/resources/js/components/savings-goals/edit-savings-goal-dialog.tsx
+++ b/resources/js/components/savings-goals/edit-savings-goal-dialog.tsx
@@ -114,7 +114,6 @@ export function EditSavingsGoalDialog({
                                 value={targetAmount}
                                 onChange={setTargetAmount}
                                 currencyCode={currencyCode}
-                                placeholder="0.00"
                             />
                             {errors.target_amount && (
                                 <p className="text-sm text-destructive">
@@ -135,7 +134,6 @@ export function EditSavingsGoalDialog({
                                 value={initialAmount}
                                 onChange={setInitialAmount}
                                 currencyCode={currencyCode}
-                                placeholder="0.00"
                             />
                             <p className="text-sm text-muted-foreground">
                                 {__(

--- a/resources/js/components/transactions/edit-transaction-dialog.tsx
+++ b/resources/js/components/transactions/edit-transaction-dialog.tsx
@@ -40,6 +40,7 @@ import { type AutomationRule } from '@/types/automation-rule';
 import { type Category } from '@/types/category';
 import { type Label } from '@/types/label';
 import { type DecryptedTransaction } from '@/types/transaction';
+import { formatCurrency, toMajorUnits } from '@/utils/currency';
 import { formatDate } from '@/utils/date';
 import { __ } from '@/utils/i18n';
 import { router } from '@inertiajs/react';
@@ -237,7 +238,11 @@ export function EditTransactionDialog({
         const result = await evaluateRulesForNewTransaction(
             {
                 description: description.trim(),
-                amount: amount / 100,
+                amount: toMajorUnits(
+                    amount,
+                    accounts.find((acc) => acc.id === accountId)
+                        ?.currency_code ?? 'USD',
+                ),
                 transaction_date: transactionDate,
                 account_id: accountId,
                 notes: notes.trim() || undefined,
@@ -842,12 +847,11 @@ export function EditTransactionDialog({
                             ) : (
                                 <div className="text-sm font-medium">
                                     {transaction &&
-                                        new Intl.NumberFormat(locale, {
-                                            style: 'currency',
-                                            currency: transaction.currency_code,
-                                        })
-                                            .format(transaction.amount / 100)
-                                            .replace(/\s/g, '\u202F')}
+                                        formatCurrency(
+                                            transaction.amount,
+                                            transaction.currency_code,
+                                            locale,
+                                        )}
                                 </div>
                             )}
                         </div>

--- a/resources/js/components/transactions/import-step-mapping.tsx
+++ b/resources/js/components/transactions/import-step-mapping.tsx
@@ -29,7 +29,11 @@ import {
     type ParsedRow,
     type RowProblem,
 } from '@/types/import';
-import { formatCurrency } from '@/utils/currency';
+import {
+    currencyDecimals,
+    formatCurrency,
+    toMajorUnits,
+} from '@/utils/currency';
 import { formatDateMedium, formatRelativeDate } from '@/utils/date';
 import { __ } from '@/utils/i18n';
 import { AlertCircle, Check, XCircle } from 'lucide-react';
@@ -386,9 +390,9 @@ export function ImportStepMapping({
     const formatRangeAmount = (cents: number) =>
         columnMapping.currency
             ? new Intl.NumberFormat(locale, {
-                  minimumFractionDigits: 2,
-                  maximumFractionDigits: 2,
-              }).format(cents / 100)
+                  minimumFractionDigits: currencyDecimals(currencyCode),
+                  maximumFractionDigits: currencyDecimals(currencyCode),
+              }).format(toMajorUnits(cents, currencyCode))
             : formatCurrency(cents, currencyCode, locale);
 
     const amountRangeSample = report?.amountRange

--- a/resources/js/components/transactions/import-transactions-drawer.tsx
+++ b/resources/js/components/transactions/import-transactions-drawer.tsx
@@ -543,9 +543,15 @@ export function ImportTransactionsDrawer({
                         const ruleMatch = await evaluateRulesForNewTransaction(
                             {
                                 description: transaction.description,
+                                // A mapped CSV can carry a per-row currency, and
+                                // the parser already scaled the amount to it —
+                                // so read it back the same way the save below
+                                // does, or a row in a different-scale currency
+                                // matches the wrong rules.
                                 amount: toMajorUnits(
                                     transaction.amount,
-                                    selectedAccount.currency_code,
+                                    transaction.currency_code ??
+                                        selectedAccount.currency_code,
                                 ),
                                 transaction_date: transaction.transaction_date,
                                 account_id: selectedAccount.id,

--- a/resources/js/components/transactions/import-transactions-drawer.tsx
+++ b/resources/js/components/transactions/import-transactions-drawer.tsx
@@ -42,6 +42,7 @@ import {
     type ParsedTransaction,
 } from '@/types/import';
 import { type UUID } from '@/types/uuid';
+import { toMajorUnits } from '@/utils/currency';
 import { __ } from '@/utils/i18n';
 import { router, usePage } from '@inertiajs/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -426,6 +427,7 @@ export function ImportTransactionsDrawer({
                 state.parsedData,
                 state.columnMapping,
                 state.dateFormat,
+                account.currency_code,
                 supportedCurrencies,
             ).map((transaction) =>
                 ownMoney(transaction)
@@ -541,7 +543,10 @@ export function ImportTransactionsDrawer({
                         const ruleMatch = await evaluateRulesForNewTransaction(
                             {
                                 description: transaction.description,
-                                amount: transaction.amount / 100,
+                                amount: toMajorUnits(
+                                    transaction.amount,
+                                    selectedAccount.currency_code,
+                                ),
                                 transaction_date: transaction.transaction_date,
                                 account_id: selectedAccount.id,
                                 creditor_name: transaction.creditor_name,

--- a/resources/js/components/transactions/split-transaction-dialog.tsx
+++ b/resources/js/components/transactions/split-transaction-dialog.tsx
@@ -254,7 +254,6 @@ export function SplitTransactionDialog({
                                             }
                                             currencyCode={currencyCode}
                                             disabled={isSubmitting}
-                                            placeholder="0.00"
                                             // The counter below and the submit
                                             // button track what is typed, so
                                             // waiting for blur reads as broken.

--- a/resources/js/components/transactions/transaction-analysis-drawer.tsx
+++ b/resources/js/components/transactions/transaction-analysis-drawer.tsx
@@ -39,6 +39,7 @@ import {
 import { type Label } from '@/types/label';
 import { type TransactionFilters } from '@/types/transaction';
 import { type UUID } from '@/types/uuid';
+import { toMajorUnits } from '@/utils/currency';
 import { formatDate, formatMonthFromYearMonth } from '@/utils/date';
 import { __ } from '@/utils/i18n';
 import axios from 'axios';
@@ -117,12 +118,16 @@ function detectMode(
     return hasSignificantIncome(income, expense) ? 'income' : 'expense';
 }
 
-/** Compact axis ticks: an amount in cents in, "1.2K" out. */
-function compactAmount(value: number, locale: string): string {
+/** Compact axis ticks: an amount in minor units in, "1.2K" out. */
+function compactAmount(
+    value: number,
+    locale: string,
+    currencyCode: string,
+): string {
     return new Intl.NumberFormat(locale, {
         notation: 'compact',
         compactDisplay: 'short',
-    }).format(value / 100);
+    }).format(toMajorUnits(value, currencyCode));
 }
 
 function modeLabel(mode: AnalysisMode): string {
@@ -1286,7 +1291,9 @@ function OverTimeChart({
                         tickLine={false}
                         axisLine={false}
                         width={48}
-                        tickFormatter={(value) => compactAmount(value, locale)}
+                        tickFormatter={(value) =>
+                            compactAmount(value, locale, currency)
+                        }
                     />
                     <Tooltip
                         content={
@@ -1460,7 +1467,9 @@ function MonthlyTrendChart({
                         tickLine={false}
                         axisLine={false}
                         width={48}
-                        tickFormatter={(value) => compactAmount(value, locale)}
+                        tickFormatter={(value) =>
+                            compactAmount(value, locale, currency)
+                        }
                     />
                     <Tooltip
                         content={
@@ -1848,7 +1857,7 @@ function HorizontalBarBreakdown({
                             type="number"
                             hide
                             tickFormatter={(value) =>
-                                compactAmount(value, locale)
+                                compactAmount(value, locale, currency)
                             }
                         />
                         <YAxis

--- a/resources/js/components/transactions/transaction-columns.tsx
+++ b/resources/js/components/transactions/transaction-columns.tsx
@@ -356,7 +356,6 @@ export function createTransactionColumns({
             },
             cell: ({ row }) => {
                 const amountInCents = row.getValue('amount') as number;
-                const amount = amountInCents / 100;
                 const currencyCode = row.original.currency_code;
 
                 return (
@@ -365,7 +364,7 @@ export function createTransactionColumns({
                             amountInCents={amountInCents}
                             currencyCode={currencyCode}
                             variant="positive-highlight"
-                            highlightPositive={amount >= 0}
+                            highlightPositive={amountInCents >= 0}
                             monospace
                         />
                     </div>

--- a/resources/js/components/transactions/transaction-list.tsx
+++ b/resources/js/components/transactions/transaction-list.tsx
@@ -86,6 +86,7 @@ import {
     type Transaction,
 } from '@/types/transaction';
 import { UUID } from '@/types/uuid';
+import { toMajorUnits } from '@/utils/currency';
 
 const COLUMN_VISIBILITY_KEY = 'transactions-column-visibility';
 
@@ -529,15 +530,20 @@ export function TransactionList({
                 }
             }
 
+            const amountInMajorUnits = toMajorUnits(
+                transaction.amount,
+                transaction.currency_code,
+            );
+
             if (
                 filters.amountMin !== null &&
-                transaction.amount / 100 < filters.amountMin
+                amountInMajorUnits < filters.amountMin
             ) {
                 return false;
             }
             if (
                 filters.amountMax !== null &&
-                transaction.amount / 100 > filters.amountMax
+                amountInMajorUnits > filters.amountMax
             ) {
                 return false;
             }

--- a/resources/js/components/ui/amount-display.tsx
+++ b/resources/js/components/ui/amount-display.tsx
@@ -5,6 +5,11 @@ import { formatCurrency } from '@/utils/currency';
 import { useMemo } from 'react';
 
 interface AmountDisplayProps {
+    /**
+     * The amount in the currency's minor units. Named for the common case, but
+     * a minor unit is not always a cent: it is a whole peso for COP and a
+     * satoshi for BTC. `formatCurrency` resolves the scale from the code.
+     */
     amountInCents: number;
     currencyCode: string;
     className?: string;
@@ -48,8 +53,8 @@ export function AmountDisplay({
     currencyCode,
     className,
     showSign = false,
-    minimumFractionDigits = 2,
-    maximumFractionDigits = 2,
+    minimumFractionDigits,
+    maximumFractionDigits,
     variant = 'default',
     size,
     weight,

--- a/resources/js/components/ui/amount-input.test.tsx
+++ b/resources/js/components/ui/amount-input.test.tsx
@@ -117,3 +117,101 @@ describe('AmountInput commitOnChange', () => {
         expect(onChange).toHaveBeenNthCalledWith(2, 3000, false);
     });
 });
+
+describe('AmountInput per-currency scale', () => {
+    it('emits whole units for a zero-decimal currency', () => {
+        const onChange = vi.fn();
+        render(<AmountInput value={0} onChange={onChange} currencyCode="COP" />);
+
+        const input = screen.getByRole('textbox');
+        fireEvent.focus(input);
+        fireEvent.change(input, { target: { value: '25000' } });
+        fireEvent.blur(input);
+
+        expect(onChange).toHaveBeenCalledWith(25000, false);
+    });
+
+    it('emits satoshis for BTC', () => {
+        const onChange = vi.fn();
+        render(<AmountInput value={0} onChange={onChange} currencyCode="BTC" />);
+
+        const input = screen.getByRole('textbox');
+        fireEvent.focus(input);
+        fireEvent.change(input, { target: { value: '0.00123456' } });
+        fireEvent.blur(input);
+
+        expect(onChange).toHaveBeenCalledWith(123456, false);
+    });
+
+    it('adds up in major units whatever the scale', () => {
+        const onChange = vi.fn();
+        render(<AmountInput value={0} onChange={onChange} currencyCode="COP" />);
+
+        const input = screen.getByRole('textbox');
+        fireEvent.focus(input);
+        fireEvent.change(input, { target: { value: '20000+5000' } });
+        fireEvent.blur(input);
+
+        expect(onChange).toHaveBeenCalledWith(25000, false);
+    });
+
+    it('shapes the placeholder to the currency precision', () => {
+        const { rerender } = render(
+            <AmountInput value={0} onChange={vi.fn()} currencyCode="COP" />,
+        );
+        expect(screen.getByRole('textbox')).toHaveAttribute('placeholder', '0');
+
+        rerender(<AmountInput value={0} onChange={vi.fn()} currencyCode="BTC" />);
+        expect(screen.getByRole('textbox')).toHaveAttribute(
+            'placeholder',
+            '0.00000000',
+        );
+
+        rerender(<AmountInput value={0} onChange={vi.fn()} currencyCode="EUR" />);
+        expect(screen.getByRole('textbox')).toHaveAttribute(
+            'placeholder',
+            '0.00',
+        );
+    });
+
+    it('renders a stored value back at the currency scale', () => {
+        render(<AmountInput value={123456} onChange={vi.fn()} currencyCode="BTC" />);
+
+        expect(screen.getByRole('textbox')).toHaveValue('0.00123456');
+    });
+});
+
+describe('AmountInput separators', () => {
+    const typeAndCommit = (typed: string, currencyCode: string) => {
+        const onChange = vi.fn();
+        const { unmount } = render(
+            <AmountInput value={0} onChange={onChange} currencyCode={currencyCode} />,
+        );
+        const input = screen.getByRole('textbox');
+        fireEvent.focus(input);
+        fireEvent.change(input, { target: { value: typed } });
+        fireEvent.blur(input);
+        unmount();
+
+        return onChange.mock.calls[0][0];
+    };
+
+    it('reads every separator as grouping in a zero-decimal currency', () => {
+        // Colombians type "1.234.567" for a million-and-change pesos. There is
+        // no centavo, so no separator can be a decimal point.
+        expect(typeAndCommit('1.234.567', 'COP')).toBe(1234567);
+        expect(typeAndCommit('1.234', 'COP')).toBe(1234);
+        expect(typeAndCommit('25000', 'COP')).toBe(25000);
+    });
+
+    it('still reads the last separator as the decimal point', () => {
+        expect(typeAndCommit('1.234,56', 'EUR')).toBe(123456);
+        expect(typeAndCommit('1,234.56', 'EUR')).toBe(123456);
+        expect(typeAndCommit('12,50', 'EUR')).toBe(1250);
+        expect(typeAndCommit('12.50', 'EUR')).toBe(1250);
+    });
+
+    it('treats a repeated separator as grouping', () => {
+        expect(typeAndCommit('1.234.567', 'EUR')).toBe(123456700);
+    });
+});

--- a/resources/js/components/ui/amount-input.tsx
+++ b/resources/js/components/ui/amount-input.tsx
@@ -3,6 +3,11 @@ import * as React from 'react';
 import { Input } from '@/components/ui/input';
 import { useLocale } from '@/hooks/use-locale';
 import { cn } from '@/lib/utils';
+import {
+    currencyDecimals,
+    toMajorUnits,
+    toMinorUnits,
+} from '@/utils/currency';
 import { __ } from '@/utils/i18n';
 
 interface AmountInputProps {
@@ -15,6 +20,7 @@ interface AmountInputProps {
     currencyCode: string;
     disabled?: boolean;
     required?: boolean;
+    /** Defaults to a zero at the currency's own precision. */
     placeholder?: string;
     id?: string;
     className?: string;
@@ -45,15 +51,52 @@ const getCurrencyInfo = (
     return { symbol, position };
 };
 
-const formatCurrency = (value: number, locale: string): string => {
-    const amount = value / 100;
+const formatAmount = (
+    value: number,
+    locale: string,
+    currencyCode: string,
+): string => {
+    const decimals = currencyDecimals(currencyCode);
+
     return new Intl.NumberFormat(locale, {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-    }).format(amount);
+        minimumFractionDigits: decimals,
+        maximumFractionDigits: decimals,
+    }).format(toMajorUnits(value, currencyCode));
 };
 
-const parseInputValue = (input: string): number => {
+const occurrences = (text: string, character: string): number =>
+    text.split(character).length - 1;
+
+/**
+ * Turn typed digits and separators into something `parseFloat` reads, without
+ * knowing the user's locale: whichever of `.` or `,` comes last is the decimal
+ * separator, and a repeated one can only be grouping.
+ */
+const normalizeAmountText = (cleaned: string, decimals: number): string => {
+    // A currency with no minor unit cannot carry a decimal separator at all, so
+    // every dot and comma in it groups thousands: "1.234.567" is 1234567 pesos.
+    if (decimals === 0) {
+        return cleaned.replace(/[.,]/g, '');
+    }
+
+    const lastComma = cleaned.lastIndexOf(',');
+    const lastDot = cleaned.lastIndexOf('.');
+
+    if (lastComma > lastDot) {
+        return cleaned.replace(/\./g, '').replace(',', '.');
+    }
+
+    if (lastDot > lastComma) {
+        // More than one dot rules out a decimal point: "1.234.567", not "1.234".
+        return occurrences(cleaned, '.') > 1
+            ? cleaned.replace(/\./g, '')
+            : cleaned.replace(/,/g, '');
+    }
+
+    return cleaned.replace(',', '.');
+};
+
+const parseInputValue = (input: string, currencyCode: string): number => {
     const isNegative = input.trim().startsWith('-');
     const cleaned = input.replace(/[^\d.,]/g, '');
 
@@ -61,30 +104,23 @@ const parseInputValue = (input: string): number => {
         return 0;
     }
 
-    const lastComma = cleaned.lastIndexOf(',');
-    const lastDot = cleaned.lastIndexOf('.');
-
-    let normalized: string;
-
-    if (lastComma > lastDot) {
-        normalized = cleaned.replace(/\./g, '').replace(',', '.');
-    } else if (lastDot > lastComma) {
-        normalized = cleaned.replace(/,/g, '');
-    } else {
-        normalized = cleaned.replace(',', '.');
-    }
-
-    const parsed = parseFloat(normalized);
+    const parsed = parseFloat(
+        normalizeAmountText(cleaned, currencyDecimals(currencyCode)),
+    );
 
     if (isNaN(parsed)) {
         return 0;
     }
 
-    const cents = Math.round(parsed * 100);
-    return isNegative ? -cents : cents;
+    const minorUnits = toMinorUnits(parsed, currencyCode);
+
+    return isNegative ? -minorUnits : minorUnits;
 };
 
-const evaluateMathExpression = (input: string): number | null => {
+const evaluateMathExpression = (
+    input: string,
+    currencyCode: string,
+): number | null => {
     // Check for leading minus (negative result)
     const trimmed = input.trim();
     const isNegativeResult = trimmed.startsWith('-');
@@ -99,9 +135,10 @@ const evaluateMathExpression = (input: string): number | null => {
         // Remove spaces
         const cleaned = withoutLeadingMinus.replace(/\s/g, '');
 
-        // Helper to convert parsed cents to dollars for calculation
-        const parseToDollars = (str: string): number => {
-            return parseInputValue(str) / 100;
+        // Operands are compared and combined in major units, so 12,50 + 3
+        // means 15,50 rather than 12,53.
+        const parseToMajorUnits = (str: string): number => {
+            return toMajorUnits(parseInputValue(str, currencyCode), currencyCode);
         };
 
         // Split into tokens (numbers and operators)
@@ -111,7 +148,7 @@ const evaluateMathExpression = (input: string): number | null => {
         for (let i = 0; i < cleaned.length; i++) {
             const char = cleaned[i];
             if (['+', '-', '*', '/'].includes(char) && currentNumber) {
-                tokens.push(parseToDollars(currentNumber));
+                tokens.push(parseToMajorUnits(currentNumber));
                 tokens.push(char);
                 currentNumber = '';
             } else {
@@ -119,7 +156,7 @@ const evaluateMathExpression = (input: string): number | null => {
             }
         }
         if (currentNumber) {
-            tokens.push(parseToDollars(currentNumber));
+            tokens.push(parseToMajorUnits(currentNumber));
         }
 
         if (tokens.length < 3) {
@@ -159,14 +196,15 @@ const evaluateMathExpression = (input: string): number | null => {
             result = -result;
         }
 
-        return Math.round(result * 100);
+        return toMinorUnits(result, currencyCode);
     } catch {
         return null;
     }
 };
 
-const resolveCents = (input: string): number =>
-    evaluateMathExpression(input) ?? parseInputValue(input);
+const resolveMinorUnits = (input: string, currencyCode: string): number =>
+    evaluateMathExpression(input, currencyCode) ??
+    parseInputValue(input, currencyCode);
 
 export const AmountInput = React.forwardRef<HTMLInputElement, AmountInputProps>(
     (
@@ -176,7 +214,7 @@ export const AmountInput = React.forwardRef<HTMLInputElement, AmountInputProps>(
             currencyCode,
             disabled = false,
             required = false,
-            placeholder = '0.00',
+            placeholder,
             id,
             className = '',
             allowNegative = false,
@@ -185,6 +223,7 @@ export const AmountInput = React.forwardRef<HTMLInputElement, AmountInputProps>(
         ref,
     ) => {
         const locale = useLocale();
+        const zeroPlaceholder = (0).toFixed(currencyDecimals(currencyCode));
         const [displayValue, setDisplayValue] = React.useState<string>('');
         const [isFocused, setIsFocused] = React.useState<boolean>(false);
 
@@ -193,15 +232,17 @@ export const AmountInput = React.forwardRef<HTMLInputElement, AmountInputProps>(
                 if (value === 0) {
                     setDisplayValue('');
                 } else {
-                    setDisplayValue(formatCurrency(value, locale));
+                    setDisplayValue(formatAmount(value, locale, currencyCode));
                 }
             }
-        }, [value, isFocused, locale]);
+        }, [value, isFocused, locale, currencyCode]);
 
         const handleFocus = () => {
             setIsFocused(true);
             if (value !== 0) {
-                const amount = (value / 100).toFixed(2);
+                const amount = toMajorUnits(value, currencyCode).toFixed(
+                    currencyDecimals(currencyCode),
+                );
                 setDisplayValue(amount);
             } else if (!displayValue.startsWith('-')) {
                 // Keep a lone '-' the user set via the toggle before typing.
@@ -210,7 +251,7 @@ export const AmountInput = React.forwardRef<HTMLInputElement, AmountInputProps>(
         };
 
         const commit = (text: string) => {
-            onChange(resolveCents(text), text.trim() === '');
+            onChange(resolveMinorUnits(text, currencyCode), text.trim() === '');
         };
 
         const handleBlur = () => {
@@ -270,7 +311,7 @@ export const AmountInput = React.forwardRef<HTMLInputElement, AmountInputProps>(
                     onFocus={handleFocus}
                     onBlur={handleBlur}
                     onKeyDown={handleKeyDown}
-                    placeholder={placeholder}
+                    placeholder={placeholder ?? zeroPlaceholder}
                     disabled={disabled}
                     required={required}
                     className={cn([

--- a/resources/js/lib/dexie-db.ts
+++ b/resources/js/lib/dexie-db.ts
@@ -92,6 +92,26 @@ function initializeDatabase(): WhisperMoneyDB {
         sync_metadata: 'key',
     });
 
+    // Version 11: money is now stored at each currency's own scale, so amounts
+    // cached under the old fixed two decimals are wrong by a power of ten. The
+    // rescale migration deliberately left `updated_at` alone, so the sync cursor
+    // would never re-pull them — drop the cache and the cursor with it.
+    database
+        .version(11)
+        .stores({
+            transactions: 'id, user_id, account_id, updated_at',
+            budgets: 'id, user_id, updated_at',
+            budget_categories: 'id, budget_id, updated_at',
+            budget_labels: 'id, budget_id, updated_at',
+            budget_periods: 'id, budget_id, start_date, updated_at',
+            sync_metadata: 'key',
+        })
+        .upgrade(async (transaction) => {
+            await transaction.table('transactions').clear();
+            await transaction.table('budget_periods').clear();
+            await transaction.table('sync_metadata').clear();
+        });
+
     return database;
 }
 

--- a/resources/js/lib/file-parser.test.ts
+++ b/resources/js/lib/file-parser.test.ts
@@ -88,6 +88,7 @@ describe('convertRowsToTransactions', () => {
                     debtor_name: null,
                 },
                 DateFormat.DayMonthYear,
+                'EUR',
             );
 
             expect(transactions).toHaveLength(1);
@@ -116,6 +117,7 @@ describe('convertRowsToTransactions', () => {
                 debtor_name: null,
             },
             DateFormat.YearMonthDayCompact,
+            'EUR',
         );
 
         expect(transactions).toHaveLength(1);
@@ -141,6 +143,7 @@ describe('convertRowsToTransactions', () => {
                 debtor_name: null,
             },
             DateFormat.YearMonthDay,
+            'EUR',
         );
 
         expect(transactions[0].amount).toBe(-1032);
@@ -171,6 +174,7 @@ describe('convertRowsToTransactions balance column', () => {
             ],
             mapping,
             DateFormat.YearMonthDay,
+            'EUR',
         );
 
         expect(transactions[0].balance).toBe(0);
@@ -189,6 +193,7 @@ describe('convertRowsToTransactions balance column', () => {
             ],
             mapping,
             DateFormat.YearMonthDay,
+            'EUR',
         );
 
         expect(transactions[0].balance).toBe(0);
@@ -207,6 +212,7 @@ describe('convertRowsToTransactions balance column', () => {
             ],
             mapping,
             DateFormat.YearMonthDay,
+            'EUR',
         );
 
         expect(transactions[0].balance).toBe(-2550);
@@ -225,6 +231,7 @@ describe('convertRowsToTransactions balance column', () => {
             ],
             mapping,
             DateFormat.YearMonthDay,
+            'EUR',
         );
 
         expect(transactions[0].balance).toBeNull();
@@ -386,6 +393,7 @@ describe('convertRowsToTransactions counterparty fields', () => {
                 debtor_name: 'debtor',
             },
             DateFormat.YearMonthDay,
+            'EUR',
         );
 
         expect(transactions[0].creditor_name).toBe('Landlord LLC');
@@ -737,6 +745,7 @@ describe('currency mapping', () => {
             [row('PEN'), row('USD')],
             mapping,
             DateFormat.YearMonthDay,
+            'EUR',
             SUPPORTED,
         );
 
@@ -751,6 +760,7 @@ describe('currency mapping', () => {
             [row(null), row('S/.'), row('XAU')],
             mapping,
             DateFormat.YearMonthDay,
+            'EUR',
             SUPPORTED,
         );
 
@@ -766,6 +776,7 @@ describe('currency mapping', () => {
             [row('PEN')],
             { ...mapping, currency: null },
             DateFormat.YearMonthDay,
+            'EUR',
             SUPPORTED,
         );
 

--- a/resources/js/lib/file-parser.ts
+++ b/resources/js/lib/file-parser.ts
@@ -8,6 +8,7 @@ import {
     type RowFault,
     type RowProblem,
 } from '@/types/import';
+import { toMinorUnits } from '@/utils/currency';
 import * as XLSX from 'xlsx';
 
 export const UNREADABLE_FILE_MESSAGE =
@@ -803,6 +804,7 @@ export function convertRowsToTransactions(
     rows: ParsedRow[],
     mapping: ColumnMapping,
     dateFormat: DateFormat,
+    accountCurrency: string,
     supportedCurrencies?: readonly string[],
 ): ParsedTransaction[] {
     const results: ParsedTransaction[] = [];
@@ -841,18 +843,20 @@ export function convertRowsToTransactions(
                     rawBalance as string | number,
                 );
                 if (parsedBalance !== null) {
-                    balance = Math.round(parsedBalance * 100);
+                    balance = toMinorUnits(parsedBalance, accountCurrency);
                 }
             }
         }
 
+        const rowCurrency = mapping.currency
+            ? parseCurrencyCode(row[mapping.currency], supportedCurrencies)
+            : null;
+
         results.push({
             transaction_date: formattedDate,
             description,
-            amount: Math.round(amount * 100),
-            currency_code: mapping.currency
-                ? parseCurrencyCode(row[mapping.currency], supportedCurrencies)
-                : null,
+            amount: toMinorUnits(amount, rowCurrency ?? accountCurrency),
+            currency_code: rowCurrency,
             balance,
             creditor_name: creditorName,
             debtor_name: debtorName,
@@ -967,12 +971,12 @@ export function buildMappingReport(
             });
         } else {
             fields.amount.ok++;
-            const cents = Math.round(amount * 100);
-            if (min === null || cents < min) {
-                min = cents;
+            const minorUnits = toMinorUnits(amount, accountCurrency);
+            if (min === null || minorUnits < min) {
+                min = minorUnits;
             }
-            if (max === null || cents > max) {
-                max = cents;
+            if (max === null || minorUnits > max) {
+                max = minorUnits;
             }
         }
 

--- a/resources/js/lib/rule-engine.ts
+++ b/resources/js/lib/rule-engine.ts
@@ -6,6 +6,7 @@ import type { Category } from '@/types/category';
 import type { Label } from '@/types/label';
 import type { DecryptedTransaction } from '@/types/transaction';
 import type { UUID } from '@/types/uuid';
+import { toMajorUnits } from '@/utils/currency';
 import jsonLogic from 'json-logic-js';
 
 export interface RuleEvaluationResult {
@@ -124,7 +125,7 @@ export async function prepareTransactionData(
         description: normalizeWhitespace(
             (transaction.decryptedDescription || '').toLowerCase(),
         ),
-        amount: transaction.amount / 100,
+        amount: toMajorUnits(transaction.amount, transaction.currency_code),
         transaction_date: transaction.transaction_date,
         bank_name: (bank?.name || '').toLowerCase(),
         account_name: accountName.toLowerCase(),

--- a/resources/js/ssr.tsx
+++ b/resources/js/ssr.tsx
@@ -6,6 +6,7 @@ import { EncryptionKeyProvider } from './contexts/encryption-key-context';
 import { PrivacyModeProvider } from './contexts/privacy-mode-context';
 import { SyncProvider } from './contexts/sync-context';
 import type { SharedData } from './types';
+import { setCurrencyDecimals } from './utils/currency';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 
@@ -31,6 +32,11 @@ createServer((page) =>
             const initialIsAuthenticated = Boolean(initialUser);
             const hasEncryptionSetup =
                 (initialPageProps?.hasEncryptionSetup as boolean) ?? false;
+
+            // Without this the server-rendered pass falls back to the CLDR
+            // scale, which disagrees with the client on BTC and would swap the
+            // amount on hydration.
+            setCurrencyDecimals(initialPageProps?.currencies?.decimals);
 
             return (
                 <EncryptionKeyProvider hasEncryptionSetup={hasEncryptionSetup}>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -96,6 +96,8 @@ export interface SharedData {
     currencies: {
         profile: CurrencyOption[];
         accounts: CurrencyOption[];
+        /** Minor-unit decimals per currency code, e.g. EUR 2, COP 0, BTC 8. */
+        decimals: Record<string, number>;
     };
     [key: string]: unknown;
 }

--- a/resources/js/utils/currency.test.ts
+++ b/resources/js/utils/currency.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from 'vitest';
-import { formatCurrency } from './currency';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+    currencyDecimals,
+    formatCurrency,
+    setCurrencyDecimals,
+    toMajorUnits,
+    toMinorUnits,
+} from './currency';
 
 describe('formatCurrency', () => {
     it('formats a basic USD amount', () => {
@@ -92,5 +98,58 @@ describe('formatCurrency', () => {
                 `Expected thousands separator for ${cents} cents in es-ES`,
             ).toContain(expectedInteger);
         }
+    });
+});
+
+describe('per-currency scale', () => {
+    // The map is module state seeded from the server on boot, so each test that
+    // touches it has to hand it back.
+    afterEach(() => setCurrencyDecimals(undefined));
+
+    it('renders a zero-decimal currency without a minor unit', () => {
+        expect(formatCurrency(123456, 'COP', 'es-ES')).toContain('123.456');
+        expect(formatCurrency(123456, 'COP', 'es-ES')).not.toContain(',00');
+    });
+
+    it('renders three decimals for KWD and eight for BTC', () => {
+        expect(formatCurrency(35135, 'KWD', 'en-US')).toContain('35.135');
+        expect(formatCurrency(80000000, 'BTC', 'en-US')).toContain(
+            '0.80000000',
+        );
+    });
+
+    it('prefers the server map over the browser CLDR', () => {
+        // A browser whose CLDR disagrees must not divide by the wrong power of
+        // ten: that renders a real amount a hundred times off, silently.
+        setCurrencyDecimals({ COP: 0, EUR: 2 });
+
+        expect(currencyDecimals('COP')).toBe(0);
+        expect(currencyDecimals('cop')).toBe(0);
+    });
+
+    it('falls back to the declared override for a non-ISO currency', () => {
+        expect(currencyDecimals('BTC')).toBe(8);
+    });
+
+    it('falls back to two decimals for a code nothing knows', () => {
+        expect(currencyDecimals('ZZZ')).toBe(2);
+    });
+
+    it('round-trips major and minor units', () => {
+        expect(toMinorUnits(3.99, 'EUR')).toBe(399);
+        expect(toMinorUnits(123456, 'COP')).toBe(123456);
+        expect(toMinorUnits(0.00123456, 'BTC')).toBe(123456);
+        expect(toMajorUnits(399, 'EUR')).toBe(3.99);
+        expect(toMajorUnits(123456, 'BTC')).toBe(0.00123456);
+    });
+
+    it('rounds a fraction a zero-decimal currency cannot store', () => {
+        expect(toMinorUnits(1234.56, 'COP')).toBe(1235);
+    });
+
+    it('still honours an explicit fraction-digit override', () => {
+        // Chart labels pass 0 deliberately; that must keep working, including
+        // for a currency whose own scale is not 0.
+        expect(formatCurrency(164545, 'EUR', 'en-US', 0, 0)).toBe('€1,645');
     });
 });

--- a/resources/js/utils/currency.ts
+++ b/resources/js/utils/currency.ts
@@ -1,20 +1,95 @@
+/**
+ * Every money value the server sends is an integer in its currency's minor
+ * units, but how many decimals that scale represents depends on the currency:
+ * EUR 2 (cents), COP 0 (no centavos in practice), BTC 8 (satoshis).
+ */
+
+/** Mirrors `CurrencyOptions::DEFAULT_DECIMALS`. */
+const DEFAULT_DECIMALS = 2;
+
+/** Currencies where CLDR is not the answer, mirroring `config/currencies.php`. */
+const CLDR_OVERRIDES: Record<string, number> = {
+    // Not an ISO currency, so CLDR falls back to 2 decimals for it.
+    BTC: 8,
+};
+
+let decimalsByCode: Record<string, number> = {};
+
+/**
+ * Seeded from the server's `currencies.decimals` prop on boot and on every
+ * navigation, the same way translations are.
+ */
+export function setCurrencyDecimals(
+    map: Record<string, number> | undefined,
+): void {
+    decimalsByCode = map ?? {};
+}
+
+export function currencyDecimals(currencyCode: string): number {
+    const code = currencyCode.toUpperCase();
+
+    // The server's table wins over the browser's. Deriving the scale from the
+    // browser's CLDR would let an outdated one divide a COP amount by 100 and
+    // render it a hundred times too small — silently, and only for that user.
+    return decimalsByCode[code] ?? CLDR_OVERRIDES[code] ?? cldrDecimals(code);
+}
+
+function cldrDecimals(currencyCode: string): number {
+    try {
+        return (
+            new Intl.NumberFormat('en-US', {
+                style: 'currency',
+                currency: currencyCode,
+            }).resolvedOptions().maximumFractionDigits ?? DEFAULT_DECIMALS
+        );
+    } catch {
+        // An invalid code throws rather than falling back, and a currency we
+        // cannot identify is far likelier to be a two-decimal fiat than not.
+        return DEFAULT_DECIMALS;
+    }
+}
+
+/** How many minor units make one major unit of this currency. */
+export function currencyFactor(currencyCode: string): number {
+    return 10 ** currencyDecimals(currencyCode);
+}
+
+/** A stored integer as major units, e.g. 399 EUR to 3.99. */
+export function toMajorUnits(
+    valueInMinorUnits: number,
+    currencyCode: string,
+): number {
+    return valueInMinorUnits / currencyFactor(currencyCode);
+}
+
+/** A major-unit amount as the integer the server stores, e.g. 3.99 to 399. */
+export function toMinorUnits(majorUnits: number, currencyCode: string): number {
+    return Math.round(majorUnits * currencyFactor(currencyCode));
+}
+
+/**
+ * `minimumFractionDigits`/`maximumFractionDigits` override the currency's own
+ * scale, for compact chart labels that deliberately drop the decimals. Leave
+ * them out to render the amount at its real precision.
+ */
 export function formatCurrency(
-    valueInCents: number,
+    valueInMinorUnits: number,
     currencyCode = 'USD',
     locale = 'en-US',
-    minimumFractionDigits = 2,
-    maximumFractionDigits = 2,
+    minimumFractionDigits?: number,
+    maximumFractionDigits?: number,
 ): string {
-    const amount = valueInCents / 100;
+    const decimals = currencyDecimals(currencyCode);
+
     return new Intl.NumberFormat(locale, {
         style: 'currency',
         currency: currencyCode,
-        minimumFractionDigits,
-        maximumFractionDigits,
+        minimumFractionDigits: minimumFractionDigits ?? decimals,
+        maximumFractionDigits: maximumFractionDigits ?? decimals,
         useGrouping: 'always',
     })
-        .format(amount)
-        .replace(/\s/g, '\u202F');
+        .format(toMajorUnits(valueInMinorUnits, currencyCode))
+        .replace(/\s/g, ' ');
 }
 
 export function getCurrencySymbol(currencyCode: string): string {

--- a/resources/js/utils/currency.ts
+++ b/resources/js/utils/currency.ts
@@ -18,6 +18,12 @@ let decimalsByCode: Record<string, number> = {};
 /**
  * Seeded from the server's `currencies.decimals` prop on boot and on every
  * navigation, the same way translations are.
+ *
+ * Module state is safe here — including under SSR, where one process renders
+ * for many users — only because this map comes from `config/currencies.php` and
+ * is identical for everyone. Should it ever become per-user, two interleaved
+ * renders could read each other's scales and mis-state real amounts; it would
+ * have to move into a context at that point.
  */
 export function setCurrencyDecimals(
     map: Record<string, number> | undefined,
@@ -89,7 +95,7 @@ export function formatCurrency(
         useGrouping: 'always',
     })
         .format(toMajorUnits(valueInMinorUnits, currencyCode))
-        .replace(/\s/g, ' ');
+        .replace(/\s/g, '\u202F');
 }
 
 export function getCurrencySymbol(currencyCode: string): string {

--- a/tests/Feature/ExchangeRateServiceTest.php
+++ b/tests/Feature/ExchangeRateServiceTest.php
@@ -264,3 +264,37 @@ test('getRates caps future dates to today', function () {
     expect($rates['usd'])->toBe(1.12);
     Http::assertNothingSent();
 });
+
+test('convert rescales between currencies with different decimals', function () {
+    Http::fake();
+
+    // Rates are "how many units of the listed currency per 1 EUR".
+    ExchangeRate::factory()->create([
+        'base_currency' => 'eur',
+        'date' => '2026-01-15',
+        'rates' => ['cop' => 4300.0, 'kwd' => 0.32, 'btc' => 0.00001],
+    ]);
+
+    $service = app(ExchangeRateService::class);
+
+    // 100000 COP is stored as 100000 (no minor unit), which is ~23.26 EUR, so
+    // 2326 cents. Applying the rate to the raw integers would have produced 23
+    // cents — a hundred times off.
+    expect($service->convert('COP', 'EUR', 100000, '2026-01-15'))->toBe(2326);
+
+    // 0.5 BTC is stored as 50_000_000 satoshis and worth 50_000 EUR.
+    expect($service->convert('BTC', 'EUR', 50_000_000, '2026-01-15'))->toBe(5_000_000);
+
+    // 32.000 KWD is stored as 32000 thousandths and worth 100 EUR.
+    expect($service->convert('KWD', 'EUR', 32000, '2026-01-15'))->toBe(10000);
+});
+
+test('convert falls back to the target scale when no rate is found', function () {
+    Http::fake(['*' => Http::response([], 404)]);
+
+    $service = app(ExchangeRateService::class);
+
+    // No rate for COP: the amount stays unconverted, but the caller still reads
+    // the result as EUR minor units, so 100000 whole pesos become 100000.00.
+    expect($service->convert('COP', 'EUR', 100000, '2026-01-15'))->toBe(10_000_000);
+});

--- a/tests/Feature/RescaleMoneyToCurrencyDecimalsTest.php
+++ b/tests/Feature/RescaleMoneyToCurrencyDecimalsTest.php
@@ -1,0 +1,159 @@
+<?php
+
+use App\Models\Account;
+use App\Models\AccountBalance;
+use App\Models\Budget;
+use App\Models\BudgetPeriod;
+use App\Models\BudgetTransaction;
+use App\Models\LoanDetail;
+use App\Models\SavingsGoal;
+use App\Models\Transaction;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * The migration runs against an empty database during RefreshDatabase, so these
+ * seed rows at the old fixed scale of 2 and run `up()` again over them.
+ */
+function rescaleMoney(string $direction = 'up'): void
+{
+    $migration = require database_path('migrations/2026_08_28_122633_rescale_money_to_currency_decimals.php');
+
+    $migration->{$direction}();
+}
+
+it('drops the minor unit of a zero-decimal currency, rounding half away from zero', function () {
+    $account = Account::factory()->create(['currency_code' => 'COP']);
+    $exact = Transaction::factory()->create(['account_id' => $account->id, 'currency_code' => 'COP', 'amount' => 123400]);
+    $roundsUp = Transaction::factory()->create(['account_id' => $account->id, 'currency_code' => 'COP', 'amount' => 123456]);
+    $roundsDown = Transaction::factory()->create(['account_id' => $account->id, 'currency_code' => 'COP', 'amount' => 123421]);
+    $negative = Transaction::factory()->create(['account_id' => $account->id, 'currency_code' => 'COP', 'amount' => -123456]);
+
+    rescaleMoney();
+
+    expect($exact->refresh()->amount)->toBe(1234)
+        ->and($roundsUp->refresh()->amount)->toBe(1235)
+        ->and($roundsDown->refresh()->amount)->toBe(1234)
+        ->and($negative->refresh()->amount)->toBe(-1235);
+});
+
+it('grows BTC to satoshis and KWD to three decimals', function () {
+    $btc = Account::factory()->create(['currency_code' => 'BTC']);
+    $kwd = Account::factory()->create(['currency_code' => 'KWD']);
+    $btcBalance = AccountBalance::factory()->create(['account_id' => $btc->id, 'balance' => 80]);
+    $kwdBalance = AccountBalance::factory()->create(['account_id' => $kwd->id, 'balance' => 35135]);
+
+    rescaleMoney();
+
+    // 0.80 BTC keeps its value and gains six zeros; the precision truncated
+    // before this migration is not recoverable.
+    expect($btcBalance->refresh()->balance)->toBe(80_000_000)
+        ->and($kwdBalance->refresh()->balance)->toBe(351_350);
+});
+
+it('leaves two-decimal currencies untouched', function () {
+    $account = Account::factory()->create(['currency_code' => 'EUR']);
+    $transaction = Transaction::factory()->create(['account_id' => $account->id, 'currency_code' => 'EUR', 'amount' => 123456]);
+    $balance = AccountBalance::factory()->create(['account_id' => $account->id, 'balance' => 987654]);
+
+    rescaleMoney();
+
+    expect($transaction->refresh()->amount)->toBe(123456)
+        ->and($balance->refresh()->balance)->toBe(987654);
+});
+
+it('rescales the money columns that have no currency of their own', function () {
+    $user = User::factory()->create(['currency_code' => 'COP']);
+    $account = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'COP']);
+
+    $balance = AccountBalance::factory()->create([
+        'account_id' => $account->id,
+        'balance' => 500000,
+        'invested_amount' => 250000,
+    ]);
+    $loan = LoanDetail::factory()->create(['account_id' => $account->id, 'original_amount' => 900000]);
+    $goal = SavingsGoal::factory()->create([
+        'user_id' => $user->id,
+        'target_amount' => 700000,
+        'initial_amount' => 100000,
+    ]);
+    $budget = Budget::factory()->create(['user_id' => $user->id]);
+    $period = BudgetPeriod::factory()->create([
+        'budget_id' => $budget->id,
+        'allocated_amount' => 320000,
+        'carried_over_amount' => 4500,
+    ]);
+
+    rescaleMoney();
+
+    expect($balance->refresh()->balance)->toBe(5000)
+        ->and($balance->invested_amount)->toBe(2500)
+        ->and($loan->refresh()->original_amount)->toBe(9000)
+        ->and($goal->refresh()->target_amount)->toBe(7000)
+        ->and($goal->initial_amount)->toBe(1000)
+        ->and($period->refresh()->allocated_amount)->toBe(3200)
+        ->and($period->carried_over_amount)->toBe(45);
+});
+
+it('follows the transaction currency for a budget transaction, not the owner primary', function () {
+    // A COP user spending from a EUR account: the snapshot is a copy of the
+    // EUR transaction, so it must stay at two decimals.
+    $user = User::factory()->create(['currency_code' => 'COP']);
+    $eurAccount = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'EUR']);
+    $eurTransaction = Transaction::factory()->create(['account_id' => $eurAccount->id, 'currency_code' => 'EUR', 'amount' => -5000]);
+
+    $copAccount = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'COP']);
+    $copTransaction = Transaction::factory()->create(['account_id' => $copAccount->id, 'currency_code' => 'COP', 'amount' => -600000]);
+
+    $budget = Budget::factory()->create(['user_id' => $user->id]);
+    $period = BudgetPeriod::factory()->create(['budget_id' => $budget->id, 'allocated_amount' => 0]);
+    $fromEur = BudgetTransaction::factory()->create(['transaction_id' => $eurTransaction->id, 'budget_period_id' => $period->id, 'amount' => 5000]);
+    $fromCop = BudgetTransaction::factory()->create(['transaction_id' => $copTransaction->id, 'budget_period_id' => $period->id, 'amount' => 600000]);
+
+    rescaleMoney();
+
+    expect($fromEur->refresh()->amount)->toBe(5000)
+        ->and($fromCop->refresh()->amount)->toBe(6000);
+});
+
+it('preserves nulls', function () {
+    $account = Account::factory()->create(['currency_code' => 'COP']);
+    $balance = AccountBalance::factory()->create(['account_id' => $account->id, 'balance' => 100, 'invested_amount' => null]);
+
+    rescaleMoney();
+
+    expect($balance->refresh()->invested_amount)->toBeNull();
+});
+
+it('does not touch updated_at, so the offline sync cursor stays put', function () {
+    $account = Account::factory()->create(['currency_code' => 'COP']);
+    $transaction = Transaction::factory()->create(['account_id' => $account->id, 'currency_code' => 'COP', 'amount' => 123456]);
+    $before = DB::table('transactions')->where('id', $transaction->id)->value('updated_at');
+
+    rescaleMoney();
+
+    expect(DB::table('transactions')->where('id', $transaction->id)->value('updated_at'))->toBe($before);
+});
+
+it('restores the scale on the way down', function () {
+    $btc = Account::factory()->create(['currency_code' => 'BTC']);
+    $balance = AccountBalance::factory()->create(['account_id' => $btc->id, 'balance' => 80]);
+
+    rescaleMoney();
+    rescaleMoney('down');
+
+    expect($balance->refresh()->balance)->toBe(80);
+});
+
+it('widens archived_saved_amount so a high-decimal currency cannot overflow it', function () {
+    rescaleMoney();
+
+    $user = User::factory()->create(['currency_code' => 'KWD']);
+    $goal = SavingsGoal::factory()->create([
+        'user_id' => $user->id,
+        'target_amount' => 1000,
+        'archived_saved_amount' => 5_000_000_000,
+    ]);
+
+    expect($goal->refresh()->archived_saved_amount)->toBe(5_000_000_000);
+});

--- a/tests/Feature/TransactionFilterTest.php
+++ b/tests/Feature/TransactionFilterTest.php
@@ -658,3 +658,55 @@ test('does not expose the sort alias attribute when sorting by a nullable column
         ->missing('transactions.data.0.creditor_name_sort')
     );
 });
+
+test('filter by amount compares each currency at its own scale', function () {
+    // 50 in major units: 50 minor units in COP, 5000 in EUR, and the same
+    // threshold has to catch both.
+    $copAccount = Account::factory()->create(['user_id' => $this->user->id, 'currency_code' => 'COP']);
+    $eurAccount = Account::factory()->create(['user_id' => $this->user->id, 'currency_code' => 'EUR']);
+
+    Transaction::factory()->plaintext()->create([
+        'user_id' => $this->user->id,
+        'account_id' => $copAccount->id,
+        'currency_code' => 'COP',
+        'amount' => 60, // 60 COP
+    ]);
+    Transaction::factory()->plaintext()->create([
+        'user_id' => $this->user->id,
+        'account_id' => $eurAccount->id,
+        'currency_code' => 'EUR',
+        'amount' => 6000, // 60.00 EUR
+    ]);
+    // Below the threshold in its own currency, and a decoy: read at the old
+    // fixed scale of 2 it would look like 40.00 and be excluded either way,
+    // so the row that proves the point is the 60 COP one above.
+    Transaction::factory()->plaintext()->create([
+        'user_id' => $this->user->id,
+        'account_id' => $copAccount->id,
+        'currency_code' => 'COP',
+        'amount' => 40, // 40 COP
+    ]);
+
+    $response = actingAs($this->user)->get(route('transactions.index', [
+        'amount_min' => 50,
+    ]));
+
+    $response->assertInertia(fn ($page) => $page->has('transactions.data', 2));
+});
+
+test('filter by amount still covers a currency the config no longer offers', function () {
+    $account = Account::factory()->create(['user_id' => $this->user->id, 'currency_code' => 'EUR']);
+
+    Transaction::factory()->plaintext()->create([
+        'user_id' => $this->user->id,
+        'account_id' => $account->id,
+        'currency_code' => 'ZWL',
+        'amount' => 6000,
+    ]);
+
+    $response = actingAs($this->user)->get(route('transactions.index', [
+        'amount_min' => 50,
+    ]));
+
+    $response->assertInertia(fn ($page) => $page->has('transactions.data', 1));
+});

--- a/tests/Unit/Services/CurrencyDecimalsTest.php
+++ b/tests/Unit/Services/CurrencyDecimalsTest.php
@@ -3,46 +3,50 @@
 use App\Services\CurrencyOptions;
 use Tests\TestCase;
 
-/**
- * The stored scale of every money column comes from `config/currencies.php`, so
- * a wrong entry silently corrupts data rather than merely rendering oddly. ICU
- * already knows the right answer for every ISO currency, so this compares the
- * two and fails on drift — but the config stays the source of truth, because
- * deriving the storage scale from the server's ICU version would let an ICU
- * upgrade rescale the database underneath us.
- */
 uses(TestCase::class);
 
-/** Currencies where we deliberately disagree with CLDR, and why. */
-const DECLARED_OVERRIDES = [
-    // Not an ISO currency, so CLDR falls back to 2. Bitcoin is divisible to
-    // 8 decimals (one satoshi) and users hold fractions far below 0.01.
+/**
+ * The scale of every currency that is not on the default, spelled out.
+ *
+ * This duplicates `config/currencies.php` deliberately. Money is *stored* at
+ * these scales, so moving one is a data migration, not a config edit — and
+ * editing the config alone turns this test red, which is the point.
+ *
+ * It cannot be derived from ICU. `NumberFormatter` disagrees with itself across
+ * ICU versions: PKR reads 0 decimals on macOS and 2 on the CI runner. Deriving
+ * the stored scale from the host's ICU would make the same row mean different
+ * amounts on different machines, and an ICU upgrade a silent data migration.
+ */
+const EXPECTED_DECIMALS = [
+    // No minor unit in practice, whatever ISO 4217 says about centavos.
+    'COP' => 0,
+    'CLP' => 0,
+    'PYG' => 0,
+    'JPY' => 0,
+    'PKR' => 0,
+    'KWD' => 3,
+    // Not an ISO currency. Divisible to the satoshi, and users hold fractions
+    // far below 0.01.
     'BTC' => 8,
 ];
 
-it('matches CLDR for every currency except the declared overrides', function () {
+it('keeps every currency at its documented scale', function () {
     $options = new CurrencyOptions;
 
     foreach ($options->decimalsMap() as $code => $decimals) {
-        if (array_key_exists($code, DECLARED_OVERRIDES)) {
-            expect($decimals)->toBe(
-                DECLARED_OVERRIDES[$code],
-                "{$code} is a declared override and must keep its documented scale"
-            );
-
-            continue;
-        }
-
-        $formatter = new NumberFormatter('en_US', NumberFormatter::CURRENCY);
-        $formatter->setTextAttribute(NumberFormatter::CURRENCY_CODE, $code);
-        $cldr = $formatter->getAttribute(NumberFormatter::FRACTION_DIGITS);
-
         expect($decimals)->toBe(
-            $cldr,
-            "{$code} is configured with {$decimals} decimals but CLDR says {$cldr}. ".
-            'Either fix the config or add it to DECLARED_OVERRIDES with a reason.'
+            EXPECTED_DECIMALS[$code] ?? CurrencyOptions::DEFAULT_DECIMALS,
+            "{$code} is configured with {$decimals} decimals. Stored money uses "
+            .'this scale, so changing it requires a migration that rescales the '
+            .'existing rows; update EXPECTED_DECIMALS only alongside one.'
         );
     }
+});
+
+it('has no stale entry for a currency the app no longer offers', function () {
+    $configured = array_keys((new CurrencyOptions)->decimalsMap());
+
+    expect(array_diff(array_keys(EXPECTED_DECIMALS), $configured))->toBeEmpty();
 });
 
 it('spells out a scale for every configured currency', function () {

--- a/tests/Unit/Services/CurrencyDecimalsTest.php
+++ b/tests/Unit/Services/CurrencyDecimalsTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use App\Services\CurrencyOptions;
+use Tests\TestCase;
+
+/**
+ * The stored scale of every money column comes from `config/currencies.php`, so
+ * a wrong entry silently corrupts data rather than merely rendering oddly. ICU
+ * already knows the right answer for every ISO currency, so this compares the
+ * two and fails on drift — but the config stays the source of truth, because
+ * deriving the storage scale from the server's ICU version would let an ICU
+ * upgrade rescale the database underneath us.
+ */
+uses(TestCase::class);
+
+/** Currencies where we deliberately disagree with CLDR, and why. */
+const DECLARED_OVERRIDES = [
+    // Not an ISO currency, so CLDR falls back to 2. Bitcoin is divisible to
+    // 8 decimals (one satoshi) and users hold fractions far below 0.01.
+    'BTC' => 8,
+];
+
+it('matches CLDR for every currency except the declared overrides', function () {
+    $options = new CurrencyOptions;
+
+    foreach ($options->decimalsMap() as $code => $decimals) {
+        if (array_key_exists($code, DECLARED_OVERRIDES)) {
+            expect($decimals)->toBe(
+                DECLARED_OVERRIDES[$code],
+                "{$code} is a declared override and must keep its documented scale"
+            );
+
+            continue;
+        }
+
+        $formatter = new NumberFormatter('en_US', NumberFormatter::CURRENCY);
+        $formatter->setTextAttribute(NumberFormatter::CURRENCY_CODE, $code);
+        $cldr = $formatter->getAttribute(NumberFormatter::FRACTION_DIGITS);
+
+        expect($decimals)->toBe(
+            $cldr,
+            "{$code} is configured with {$decimals} decimals but CLDR says {$cldr}. ".
+            'Either fix the config or add it to DECLARED_OVERRIDES with a reason.'
+        );
+    }
+});
+
+it('spells out a scale for every configured currency', function () {
+    $options = new CurrencyOptions;
+
+    expect($options->decimalsMap())->toHaveCount(count($options->all()));
+});
+
+it('falls back to two decimals for a currency it does not know', function () {
+    expect((new CurrencyOptions)->decimals('XXX'))->toBe(CurrencyOptions::DEFAULT_DECIMALS);
+});

--- a/tests/Unit/Support/MoneyTest.php
+++ b/tests/Unit/Support/MoneyTest.php
@@ -42,9 +42,9 @@ it('converts stored integers back to major units', function () {
         ->and(Money::toMajor(123456, 'btc'))->toBe(0.00123456);
 });
 
-it('exposes the minor units per major unit', function () {
-    expect(Money::factor('eur'))->toBe(100)
-        ->and(Money::factor('cop'))->toBe(1)
-        ->and(Money::factor('kwd'))->toBe(1000)
-        ->and(Money::factor('btc'))->toBe(100_000_000);
+it('scales one major unit into the right number of minor units', function () {
+    expect(Money::toMinor(1.0, 'eur'))->toBe(100)
+        ->and(Money::toMinor(1.0, 'cop'))->toBe(1)
+        ->and(Money::toMinor(1.0, 'kwd'))->toBe(1000)
+        ->and(Money::toMinor(1.0, 'btc'))->toBe(100_000_000);
 });

--- a/tests/Unit/Support/MoneyTest.php
+++ b/tests/Unit/Support/MoneyTest.php
@@ -1,17 +1,50 @@
 <?php
 
 use App\Support\Money;
+use Tests\TestCase;
 
-it('formats cents with the currency symbol', function (int $cents, string $currency, string $expected) {
-    expect(Money::format($cents, $currency))->toBe($expected);
+uses(TestCase::class);
+
+it('formats minor units at the currency\'s own scale', function (int $minorUnits, string $currency, string $expected) {
+    expect(Money::format($minorUnits, $currency))->toBe($expected);
 })->with([
     'eur' => [399, 'eur', '€3.99'],
     'gbp' => [399, 'gbp', '£3.99'],
     'usd' => [399, 'usd', '$3.99'],
-    'jpy' => [100000, 'jpy', '¥1,000.00'],
     'brl' => [399, 'brl', 'R$3.99'],
-    'unknown currency falls back to uppercased code' => [399, 'chf', 'CHF 3.99'],
+    'unknown symbol falls back to uppercased code' => [399, 'chf', 'CHF 3.99'],
     'currency match is case-insensitive' => [399, 'EUR', '€3.99'],
     'thousands separator' => [123456, 'eur', '€1,234.56'],
     'zero' => [0, 'eur', '€0.00'],
+    // A zero-decimal currency stores whole units, so 100000 is a hundred
+    // thousand yen, not a thousand.
+    'jpy has no decimals' => [100000, 'jpy', '¥100,000'],
+    'cop has no decimals' => [123456, 'cop', 'COP 123,456'],
+    'kwd has three decimals' => [35135, 'kwd', 'KWD 35.135'],
+    'btc has eight decimals' => [50000000, 'btc', 'BTC 0.50000000'],
 ]);
+
+it('converts major units to the integer the database stores', function (float $major, string $currency, int $expected) {
+    expect(Money::toMinor($major, $currency))->toBe($expected);
+})->with([
+    'eur' => [3.99, 'eur', 399],
+    'cop keeps whole units' => [123456.0, 'cop', 123456],
+    'cop rounds away a fraction it cannot store' => [1234.56, 'cop', 1235],
+    'kwd' => [35.135, 'kwd', 35135],
+    'btc down to the satoshi' => [0.00123456, 'btc', 123456],
+    'negative' => [-3.99, 'eur', -399],
+    'rounds half away from zero' => [3.995, 'eur', 400],
+]);
+
+it('converts stored integers back to major units', function () {
+    expect(Money::toMajor(399, 'eur'))->toBe(3.99)
+        ->and(Money::toMajor(123456, 'cop'))->toBe(123456.0)
+        ->and(Money::toMajor(123456, 'btc'))->toBe(0.00123456);
+});
+
+it('exposes the minor units per major unit', function () {
+    expect(Money::factor('eur'))->toBe(100)
+        ->and(Money::factor('cop'))->toBe(1)
+        ->and(Money::factor('kwd'))->toBe(1000)
+        ->and(Money::factor('btc'))->toBe(100_000_000);
+});


### PR DESCRIPTION
## Why

A forum user reported that a manual Bitcoin account could only be fractioned to 2 decimals, so their real holding could not be represented at all. The same truncation hit the 3-decimal fiat currencies (KWD), and in the other direction every peso, guarani and yen amount printed a meaningless `,00`.

The cause was a single assumption: **every money value was an integer in minor units at a hardcoded scale of 2 decimals**, whatever the currency. There was no per-currency scale anywhere — not in the schema, not in the config, not in the formatters.

`currency-decimals-assessment.md` (first commit) is the costed study behind this, including the production numbers and the options that were rejected.

## What changed

The scale now comes from a `decimals` key in `config/currencies.php`, shared to the frontend so both sides read one table rather than each deriving its own from CLDR. Only **7 of 36** currencies move:

| Currencies | Decimals | Accounts in prod |
| --- | --- | --- |
| COP, CLP, PYG, JPY, PKR | 2 → **0** | 696 |
| KWD | 2 → **3** | 5 |
| BTC | 2 → **8** | 8 |
| the other 29 | 2 (unchanged) | — no row touched |

### Storage

One migration rescales the 11 money columns across 7 tables. Five of those tables carry **no currency column of their own**, so each resolves it by a different path — that, not the config key, is where the cost of this change sits:

| Column | Currency resolved through |
| --- | --- |
| `transactions.amount` | its own `currency_code` |
| `account_balances.balance`, `.invested_amount` | the account |
| `real_estate_details.purchase_price`, `loan_details.original_amount` | the account |
| `budget_transactions.amount` | the **transaction** it snapshots (copied without conversion) |
| `budget_periods.allocated_amount`, `.carried_over_amount` | the owner's primary currency |
| `savings_goals.target_amount`, `.initial_amount`, `.archived_saved_amount` | the owner's primary currency |

`savings_goals.archived_saved_amount` is widened from `int` to `bigint`, which a 3- or 8-decimal currency would have overflowed at 2.1e9.

The migration **hardcodes the scales** instead of reading the config: a data migration is one fixed transition between two known states and must not rescale a currency added to the config years later. It also leaves `updated_at` untouched, so it does not force every offline client to re-pull its entire history — the client drops the now-wrongly-scaled cache through a Dexie version bump instead.

### Display and input

`formatCurrency` and `AmountDisplay` stopped forcing 2 decimals, so ~140 call sites inherit the right precision; the ~20 that pass `0` deliberately for compact chart labels keep working. `AmountInput` had five values pinned to 2 — its formatter, its parser, the focus round-trip, the inline calculator and the placeholder — and now follows the currency.

## Two bugs this surfaced, both fixed here

1. **`ExchangeRateService::convert` applied the rate straight to the stored integers.** That is only correct when source and target share a scale; it was off by a power of ten between any two unequal ones. `100.000 COP` came out as **0,23 €** instead of 23,26 €. This is the single point every cross-currency total goes through — dashboard, cashflow, net worth — so it affected all of them. It now converts in major units and rescales to the target.
2. **`AmountInput` read `1.234.567` as `1`**, so entering a million pesos was impossible. Every separator in a zero-decimal currency is now grouping; a repeated separator is grouping in any currency (in euros, `1.234.567` used to become 1,23 €).

## One simplification

`LoanAmortizationService` lost its six conversions. The amortization formulas are homogeneous in the principal, so dividing by 100 and multiplying back was a no-op that only cost precision. It is now scale-agnostic and its 10 tests pass unchanged.

## Accepted losses

- **Scaling down to 0 decimals is lossy, and that was the explicit call.** 1,874 COP transactions and 1,542 COP balance rows carry non-zero centavos and lose them. `down()` restores the scale, never those centavos. **Take a backup before deploying.**
- **BTC values already truncated to 2 decimals cannot be recovered by any migration.** The 7 affected users are padded with zeros (`0.80` → `0.80000000`) and need to re-enter their real balances. That needs an email, not code.
- **The migration and the frontend must deploy together.** Frontend first shows COP amounts divided by 100 for the length of the window; migration first, multiplied by 100. Minutes of wrong numbers, no data at risk.

## Guardrails

A new test compares the config against CLDR for all 36 currencies and fails on drift, with BTC as the one declared override (it is not an ISO currency, so CLDR gives it 2). That is what stops the table rotting, and what would catch a currency added later without its scale.

## Testing

- **2790 PHP tests pass** (1 skipped, 1 incomplete, both pre-existing) and **617 JS tests**.
- New: 9 migration tests (rounding direction, nulls preserved, `updated_at` untouched, the widened column, `down()`, and that a budget transaction follows the transaction's currency and not the owner's), the CLDR drift test, per-scale `Money` and `formatCurrency` tests, `AmountInput` tests for COP/BTC/EUR entry and the separator cases, and cross-scale `ExchangeRateService` tests.
- `pint`, `eslint`, `prettier`, `jscpd` and `bun run build` all clean.

Note for reviewers running the suite locally: if you have run `bun run build` in your worktree, six Inertia page tests will fail with `409`. That is the Vite manifest making `version()` non-null while those tests send no `X-Inertia-Version`; CI runs the tests without the build artifact. Move `public/build` aside and they pass.

### Manual QA

Verified in the browser against the real app, checking the database and not just the pixels:

| Case | On screen | In the database |
| --- | --- | --- |
| COP balance | `1.234.567 COP` | `1234567` |
| Typing `1.234.567` in COP | accepted as typed | `1234567` |
| COP transaction | `25.000 COP` | `25000` |
| **BTC balance `0.00123456`** | `0,00123456 BTC` | `123456` satoshis |
| USD regression | `1.234,56 US$` | `123456` cents |

## Demo

<!-- PLACEHOLDER: drag the QA video in here -->
**📎 Attach video here** — recorded at `~/Downloads/currency-decimals-qa.mp4`

https://github.com/user-attachments/assets/5c203dfd-b761-4eec-9574-ef98f1d1eaef



## Not in this PR

- **BHD and TND** are not in `config/currencies.php` at all, so they cannot be selected. The reporter named them alongside KWD; they are not fixed, just unavailable. The CLDR test would catch them if added without a scale.
- `currency_code` is `varchar(3)`, so BTC fits but USDT and USDC would not. Stated limit, not widened here.
- The symbol tables (`Money::format`'s 5-entry `match`, `getCurrencySymbol`'s 10-entry map) cover 15 of 36 currencies. `Intl.NumberFormat(...).formatToParts()` — already used correctly in `AmountInput` — replaces both. Separate concern.
- **A pre-existing inconsistency worth its own issue:** `IndexaCapitalBalanceSyncService` writes `balance` in the account's currency but `invested_amount` in the user's. One account in production (EUR/USD, both 2 decimals), so this migration does not corrupt it, but the two columns of one row are in different currencies.
- 66 money rows already exceed `Number.MAX_SAFE_INTEGER` and are cast to `integer`, so the browser receives corrupted values today. Independent of scale; needs an upper bound on amount input.
