### PR TITLE
refactor(banking): extract the balance sync resume point

### DIFF
--- a/app/Services/Banking/BinanceBalanceSyncService.php
+++ b/app/Services/Banking/BinanceBalanceSyncService.php
@@ -3,6 +3,7 @@
 namespace App\Services\Banking;
 
 use App\Models\Account;
+use App\Services\Banking\Sync\BalanceSyncResumePoint;
 use App\Services\CurrencyConversionService;
 use App\Support\Money;
 use Carbon\Carbon;
@@ -116,11 +117,11 @@ class BinanceBalanceSyncService
         $targetCurrency = strtoupper($account->currency_code);
 
         $endDate = now()->subDay();
-        $startDate = $isFirstSync
-            ? now()->subDays(self::SNAPSHOT_MAX_DAYS)
-            : ($account->balances()->max('balance_date')
-                ? Carbon::parse($account->balances()->max('balance_date'))->addDay()
-                : now()->subDays(self::SNAPSHOT_MAX_DAYS));
+        $startDate = BalanceSyncResumePoint::startDate(
+            $account,
+            $isFirstSync,
+            now()->subDays(self::SNAPSHOT_MAX_DAYS),
+        );
 
         if ($startDate->greaterThanOrEqualTo($endDate)) {
             return false;

--- a/app/Services/Banking/IndexaCapitalBalanceSyncService.php
+++ b/app/Services/Banking/IndexaCapitalBalanceSyncService.php
@@ -3,6 +3,7 @@
 namespace App\Services\Banking;
 
 use App\Models\Account;
+use App\Services\Banking\Sync\BalanceSyncResumePoint;
 use App\Services\CurrencyConversionService;
 use App\Support\Money;
 use Illuminate\Support\Facades\Log;
@@ -35,15 +36,7 @@ class IndexaCapitalBalanceSyncService
             return;
         }
 
-        $sinceDate = null;
-
-        if (! $isFirstSync) {
-            $lastBalanceDate = $account->balances()->max('balance_date');
-
-            if ($lastBalanceDate) {
-                $sinceDate = $lastBalanceDate;
-            }
-        }
+        $sinceDate = BalanceSyncResumePoint::lastSyncedDate($account, $isFirstSync);
 
         $accountCurrency = strtoupper($account->currency_code);
         $userCurrency = strtoupper($account->user->currency_code);

--- a/app/Services/Banking/InteractiveBrokersBalanceSyncService.php
+++ b/app/Services/Banking/InteractiveBrokersBalanceSyncService.php
@@ -3,6 +3,7 @@
 namespace App\Services\Banking;
 
 use App\Models\Account;
+use App\Services\Banking\Sync\BalanceSyncResumePoint;
 use App\Support\Money;
 use Illuminate\Support\Facades\Log;
 
@@ -38,15 +39,7 @@ class InteractiveBrokersBalanceSyncService
         ksort($navByDate);
         $latestDate = array_key_last($navByDate);
 
-        $sinceDate = null;
-
-        if (! $isFirstSync) {
-            $lastBalanceDate = $account->balances()->max('balance_date');
-
-            if ($lastBalanceDate) {
-                $sinceDate = $lastBalanceDate;
-            }
-        }
+        $sinceDate = BalanceSyncResumePoint::lastSyncedDate($account, $isFirstSync);
 
         $count = 0;
 

--- a/app/Services/Banking/Sync/BalanceSyncResumePoint.php
+++ b/app/Services/Banking/Sync/BalanceSyncResumePoint.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Services\Banking\Sync;
+
+use App\Models\Account;
+use Carbon\Carbon;
+
+/**
+ * Where a balance sync picks up from.
+ *
+ * A first sync backfills all the history the provider offers; every later sync
+ * resumes at the last balance already recorded, so the same history is not
+ * re-walked on every run.
+ */
+class BalanceSyncResumePoint
+{
+    /**
+     * The last balance date already recorded, or null when there is nothing to
+     * resume from: a first sync, or an account with no balances yet.
+     *
+     * Callers filter provider rows with `$date < $lastSyncedDate`, so the
+     * boundary day itself is re-synced rather than skipped - it may still have
+     * been incomplete when it was first stored.
+     */
+    public static function lastSyncedDate(Account $account, bool $isFirstSync): ?string
+    {
+        if ($isFirstSync) {
+            return null;
+        }
+
+        $lastSyncedDate = $account->balances()->max('balance_date');
+
+        return $lastSyncedDate ? (string) $lastSyncedDate : null;
+    }
+
+    /**
+     * The first date a windowed history fetch should ask the provider for: the
+     * day after the last recorded balance, or $fallback when there is none.
+     *
+     * Unlike lastSyncedDate(), this moves past the boundary day: a fetch window
+     * is asked of the provider up front, so re-requesting a day already stored
+     * would only cost an API call.
+     */
+    public static function startDate(Account $account, bool $isFirstSync, Carbon $fallback): Carbon
+    {
+        $lastSyncedDate = self::lastSyncedDate($account, $isFirstSync);
+
+        return $lastSyncedDate ? Carbon::parse($lastSyncedDate)->addDay() : $fallback;
+    }
+}

--- a/tests/Feature/OpenBanking/BalanceSyncResumePointTest.php
+++ b/tests/Feature/OpenBanking/BalanceSyncResumePointTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use App\Models\Account;
+use App\Models\User;
+use App\Services\Banking\Sync\BalanceSyncResumePoint;
+
+beforeEach(function () {
+    $this->account = Account::factory()->connected()->create([
+        'user_id' => User::factory()->onboarded()->create()->id,
+    ]);
+});
+
+test('a first sync has nothing to resume from', function () {
+    $this->account->balances()->create(['balance_date' => '2026-01-10', 'balance' => 100]);
+
+    expect(BalanceSyncResumePoint::lastSyncedDate($this->account, isFirstSync: true))->toBeNull();
+});
+
+test('a later sync resumes at the last recorded balance date', function () {
+    $this->account->balances()->create(['balance_date' => '2026-01-08', 'balance' => 100]);
+    $this->account->balances()->create(['balance_date' => '2026-01-10', 'balance' => 200]);
+
+    expect(BalanceSyncResumePoint::lastSyncedDate($this->account, isFirstSync: false))->toBe('2026-01-10');
+});
+
+test('a later sync on an account with no balances has nothing to resume from', function () {
+    expect(BalanceSyncResumePoint::lastSyncedDate($this->account, isFirstSync: false))->toBeNull();
+});
+
+test('a windowed fetch starts the day after the last recorded balance', function () {
+    $this->account->balances()->create(['balance_date' => '2026-01-10', 'balance' => 100]);
+
+    $startDate = BalanceSyncResumePoint::startDate($this->account, isFirstSync: false, fallback: now()->subDays(180));
+
+    expect($startDate->toDateString())->toBe('2026-01-11');
+});
+
+test('a windowed fetch falls back when there is nothing to resume from', function () {
+    $fallback = now()->subDays(180);
+
+    expect(BalanceSyncResumePoint::startDate($this->account, isFirstSync: true, fallback: $fallback))->toBe($fallback)
+        ->and(BalanceSyncResumePoint::startDate($this->account, isFirstSync: false, fallback: $fallback))->toBe($fallback);
+});


### PR DESCRIPTION
## Why

Three bank balance sync methods sat at cyclomatic complexity **12** against the
repo's threshold of 10, so the `crap` job goes red the moment a PR touches any
line inside them (this surfaced in #889). The complexity is pre-existing and
unrelated to that PR, so it gets its own change here.

| Method | Before | After |
| --- | --- | --- |
| `BinanceBalanceSyncService::syncHistoricalBalances` | 12 | 10 |
| `IndexaCapitalBalanceSyncService::sync` | 12 | 10 |
| `InteractiveBrokersBalanceSyncService::sync` | 12 | 10 |

## What

All three methods answered the same question inline — *where do I resume syncing
from?* — and two of them answered it with a character-for-character identical
block:

```php
$sinceDate = null;

if (! $isFirstSync) {
    $lastBalanceDate = $account->balances()->max('balance_date');

    if ($lastBalanceDate) {
        $sinceDate = $lastBalanceDate;
    }
}
```

Binance solved the same problem with a nested ternary producing a `Carbon`.

That rule now lives in one place, `App\Services\Banking\Sync\BalanceSyncResumePoint`,
with two methods for the two shapes the callers need:

- `lastSyncedDate()` → `?string`, for Indexa Capital and Interactive Brokers, which
  filter provider rows with `$date < $sinceDate`.
- `startDate()` → `Carbon`, for Binance, which asks the provider for a date window
  up front.

The two have deliberately different boundary semantics (the string callers re-sync
the boundary day, the windowed caller starts the day after), which the docblocks
now spell out — previously that difference was only visible by reading all three
methods side by side.

## Incidental fix

Binance's nested ternary called `$account->balances()->max('balance_date')` **twice**
— once in the condition, once inside `Carbon::parse(...)` — firing two identical
queries on every resumed sync. The extraction makes it one. This is the only
behavioural difference in the PR and it is invisible to users.

## Behaviour

Unchanged, and proven rather than asserted. The three services' existing Feature
tests were untouched and stay green. On top of that, all three services were driven
through 9 scenarios (3 providers x first sync / resumed with balances / resumed with
no balances) with time frozen, dumping every `account_balances` row written, every
log record emitted, and every outbound provider request. The dump was captured
against `origin/main`'s version of the three files and against this branch:
`diff` is empty.

## Tests

`BalanceSyncResumePointTest` covers the extracted unit directly, including the
`isFirstSync: false` + no-balances-yet branch that no existing test reached.

## Checks

- `php artisan crap --base=origin/main --no-coverage` → none above complexity 10
- `php artisan test tests/Feature/OpenBanking` → 449 passed
- `bun run dry` → green, no new clones (3.95%, threshold 5.4%)
- `vendor/bin/phpstan` → 0 errors
- `vendor/bin/pint --test` → passed

`.crap-ignore.json` is untouched — this complexity was untidy, not warranted.
