### PR TITLE
docs: clarify that `agent:db --prod` is read-only by credentials

### DIFF
--- a/.agents/skills/querying-the-database/SKILL.md
+++ b/.agents/skills/querying-the-database/SKILL.md
@@ -29,6 +29,13 @@ php artisan agent:db "<query>"
 - `--prod` — run against the **production** database (the `prod` connection backed by
   `PROD_DB_URL`). Without this flag the query runs against the local DB.
 
+  `PROD_DB_URL` holds a MySQL user with **read-only grants**, so any write —
+  `INSERT`, `UPDATE`, `DELETE`, DDL — fails with an access-denied error from the
+  server. That is deliberate, and it is the only thing enforcing read-only: the
+  command itself hands the query straight to PDO. If a prod write fails, the
+  guardrail is working; run it against the local connection, or ship it as a
+  migration or a release command. Never work around it.
+
 ### Examples
 
 ```bash
@@ -45,7 +52,7 @@ php artisan agent:db --prod --format=table "select status, count(*) from subscri
 
 ## Guidelines
 
-- **Be careful with `--prod`**: this is live customer data. Only run prod queries the
+- **`--prod` is read-only by credentials, not by convention** (see above), but it is still live customer data. Only run prod queries the
   user explicitly asked for, keep them scoped (add `LIMIT`, filter by id), and never
   dump large or sensitive datasets unprompted. This app is privacy-first.
 - Use `--format=json` when you need to read the values to continue working; use

--- a/.ai/rules/agent-db.md
+++ b/.ai/rules/agent-db.md
@@ -1,0 +1,33 @@
+---
+paths:
+  - 'app/Console/Commands/AgentDatabaseCommand.php'
+---
+
+# agent:db
+
+## Read-only against prod is enforced by the credentials, not by this command
+`agent:db` hands the raw query argument straight to `DB::connection($connection)->select()`.
+`select()` executes whatever statement it is given — it does not restrict it to reads — so
+nothing in this command, and nothing in the `querying-the-database` skill, blocks a write.
+
+What blocks it is `PROD_DB_URL`: it points at a MySQL user with read-only grants, so an
+`INSERT`, `UPDATE`, `DELETE` or DDL against `--prod` fails with an access-denied error from
+the server. That is the whole guardrail, and it lives outside the codebase.
+
+Two things follow:
+
+- **A failing write against prod is the guardrail working.** Never fix it by widening that
+  user's grants or repointing `PROD_DB_URL` at an account with more rights. Run it against
+  the local connection, or ship it as a migration or a release command.
+- **Do not add a write path here** (a `--write` flag, a second prod connection, a
+  `DB::statement()` branch). The command is safe to hand to an agent only because the
+  credentials it uses cannot write.
+
+Adding a `SELECT`-only check in PHP would be redundant with the grants and easy to bypass by
+rewriting the query, which is why there isn't one.
+
+Confirm the grants are still read-only:
+
+```bash
+php artisan agent:db --prod --format=table "show grants for current_user"
+```

--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -4,6 +4,7 @@ Before planning or editing, find the row whose globs match the file's path and r
 
 | Applies to | Rule file |
 | --- | --- |
+| app/Console/Commands/AgentDatabaseCommand.php | .ai/rules/agent-db.md |
 | app/Jobs/** | .ai/rules/jobs.md |
 | app/Mcp/** | .ai/rules/mcp.md |
 | app/Services/Demo/**, app/Console/Commands/ResetDemoAccountCommand.php | .ai/rules/seeded-accounts.md |


### PR DESCRIPTION
## What

Documents where the read-only guarantee of `agent:db --prod` actually comes from, so no agent (or human) "fixes" a failing prod write by widening grants.

- New `.ai/rules/agent-db.md`, scoped to `app/Console/Commands/AgentDatabaseCommand.php`: the command passes the query straight to `DB::connection()->select()`, which does not restrict statements to reads. The guardrail is `PROD_DB_URL` pointing at a MySQL user with read-only grants — it lives outside the codebase. Rules out adding a `--write` flag or a `DB::statement()` branch, and notes why a `SELECT`-only check in PHP isn't there.
- Registers the rule in `.ai/rules/index.md`.
- Updates the `querying-the-database` skill with the same clarification, so a prod write failing reads as the guardrail working rather than a bug.

## Testing

Docs only — no code paths changed.