### PR TITLE
fix(ui): reserve room for multi-character currency symbols in amount input

### DIFF
--- a/resources/js/components/ui/amount-input.test.tsx
+++ b/resources/js/components/ui/amount-input.test.tsx
@@ -215,3 +215,45 @@ describe('AmountInput separators', () => {
         expect(typeAndCommit('1.234.567', 'EUR')).toBe(123456700);
     });
 });
+
+describe('AmountInput currency symbol spacing', () => {
+    const reservedCharacters = (padding: string): number =>
+        Number(padding.match(/([\d.]+)ch/)?.[1] ?? 0);
+
+    it('reserves room for the whole symbol, not just one character', () => {
+        const { rerender } = render(
+            <AmountInput value={0} onChange={vi.fn()} currencyCode="EUR" />,
+        );
+        const euro = screen.getByRole('textbox').style.paddingLeft;
+
+        rerender(<AmountInput value={0} onChange={vi.fn()} currencyCode="BTC" />);
+        const bitcoin = screen.getByRole('textbox').style.paddingLeft;
+
+        expect(reservedCharacters(euro)).toBe(1);
+        expect(reservedCharacters(bitcoin)).toBeGreaterThan(
+            reservedCharacters(euro),
+        );
+    });
+
+    it('stacks the symbol room on top of the sign toggle room', () => {
+        const { rerender } = render(
+            <AmountInput value={0} onChange={vi.fn()} currencyCode="BTC" />,
+        );
+        const withoutToggle = screen.getByRole('textbox').style.paddingLeft;
+
+        rerender(
+            <AmountInput
+                value={0}
+                onChange={vi.fn()}
+                currencyCode="BTC"
+                allowNegative
+            />,
+        );
+        const withToggle = screen.getByRole('textbox').style.paddingLeft;
+
+        expect(withToggle).not.toBe(withoutToggle);
+        expect(reservedCharacters(withToggle)).toBe(
+            reservedCharacters(withoutToggle),
+        );
+    });
+});

--- a/resources/js/components/ui/amount-input.tsx
+++ b/resources/js/components/ui/amount-input.tsx
@@ -202,6 +202,9 @@ const evaluateMathExpression = (
     }
 };
 
+/** Breathing room between the symbol and the number it labels. */
+const SYMBOL_GAP = '0.75rem';
+
 const resolveMinorUnits = (input: string, currencyCode: string): number =>
     evaluateMathExpression(input, currencyCode) ??
     parseInputValue(input, currencyCode);
@@ -289,14 +292,20 @@ export const AmountInput = React.forwardRef<HTMLInputElement, AmountInputProps>(
 
         const { symbol: currencySymbol, position: symbolPosition } = getCurrencyInfo(currencyCode, locale);
 
+        // The symbol sits `symbolInset` in from the edge, so the input has to
+        // reserve that plus the symbol's own width. Deriving the width from the
+        // character count keeps a code like `BTC` or `CHF` off the number, which
+        // a padding hardcoded for a one-character `€` did not.
+        const symbolInset =
+            symbolPosition === 'prefix' && allowNegative ? '2.5rem' : '0.75rem';
+        const symbolRoom = `calc(${symbolInset} + ${currencySymbol.length}ch + ${SYMBOL_GAP})`;
+
         return (
             <div className="relative">
                 {symbolPosition === 'prefix' && (
                     <span
-                        className={cn([
-                            '-translate-y-1/2 absolute top-1/2 text-muted-foreground text-sm',
-                            allowNegative ? 'left-10' : 'left-3',
-                        ])}
+                        className="-translate-y-1/2 absolute top-1/2 text-muted-foreground text-sm"
+                        style={{ left: symbolInset }}
                     >
                         {currencySymbol}
                     </span>
@@ -316,17 +325,20 @@ export const AmountInput = React.forwardRef<HTMLInputElement, AmountInputProps>(
                     required={required}
                     className={cn([
                         'bg-background',
-                        symbolPosition === 'suffix' && 'pr-9',
-                        allowNegative
-                            ? symbolPosition === 'prefix'
-                                ? 'pl-14'
-                                : 'pl-11'
-                            : symbolPosition === 'prefix' && 'pl-9',
+                        allowNegative && symbolPosition === 'suffix' && 'pl-11',
                         className,
                     ])}
+                    style={
+                        symbolPosition === 'prefix'
+                            ? { paddingLeft: symbolRoom }
+                            : { paddingRight: symbolRoom }
+                    }
                 />
                 {symbolPosition === 'suffix' && (
-                    <span className="-translate-y-1/2 absolute top-1/2 right-3 text-muted-foreground text-sm">
+                    <span
+                        className="-translate-y-1/2 absolute top-1/2 text-muted-foreground text-sm"
+                        style={{ right: symbolInset }}
+                    >
                         {currencySymbol}
                     </span>
                 )}


### PR DESCRIPTION
## The bug

`AmountInput` renders the currency symbol as an absolutely-positioned prefix and
reserved room for it with **hardcoded** padding on the input: `pl-9`, `pl-14` for
the `allowNegative` variant, and `pr-9` on the suffix side. Those numbers assume a
one-character symbol like `€`.

`getCurrencyInfo()` derives the symbol from `Intl.NumberFormat(...).formatToParts()`
and already falls back to the raw currency code when CLDR has no glyph for it — which
is exactly the BTC case, since BTC is not an ISO currency (see `CLDR_OVERRIDES` in
`resources/js/utils/currency.ts`). So a three-character symbol is expected, not an
edge case, and it collided with the number:

**Before** — Update Balance on a BTC account, zero gap:

```
BTC0.04825488
```

## The fix

Derive the reserved space from the symbol's own character count instead of assuming
one glyph:

```ts
const symbolInset =
    symbolPosition === 'prefix' && allowNegative ? '2.5rem' : '0.75rem';
const symbolRoom = `calc(${symbolInset} + ${currencySymbol.length}ch + ${SYMBOL_GAP})`;
```

`symbolInset` now drives **both** the symbol span's position and the input's reserved
padding, so the two cannot drift apart the way `left-3`/`pl-9` could. The suffix side
gets the same treatment — it had the identical defect.

No refs, no layout effects, no new dependency, and the wrapper is untouched, so the
border and focus ring stay where they were. All 19 call sites and the public props are
unchanged.

## Measured result

Read off the live DOM (`paddingLeft` vs the symbol span's `offsetLeft + offsetWidth`):

| Case | Reserved padding | Symbol ends at | Gap |
| --- | --- | --- | --- |
| BTC, prefix | 49.2px | 37px | **12.2px** |
| EUR, prefix | 32.4px | 21px | **11.4px** |
| BTC + `allowNegative` | 77.2px | 65px | **12.2px** (toggle→symbol: 6.4px) |

## Worth a look before merging

Single-character symbols lose a little room: the old `pl-9` left a 15px gap after `€`,
the derived padding leaves 11.4px. That is because the two hardcoded values disagreed
with each other — `pl-9` implied a ~15px gap while `pl-14` implied ~7px — and one
derived gap cannot reproduce both. `0.75rem` sits between them and applies consistently
everywhere, which reads better than the old inconsistency, but €/$ is the
highest-traffic case so it deserves an eyeball on the screenshots below rather than a
number in a table.

## Tests

Two cases in `amount-input.test.tsx`, both failing before the fix
(`expected +0 to be 1`) and passing after: the input reserves more left padding for a
three-character `BTC` symbol than for `€`, and the symbol room stacks on top of the
sign-toggle room rather than replacing it.

## QA

Browser QA on the running app, logged in against seeded data, in the Update Balance
dialog for a BTC account and a EUR account, light and dark. Typed long values
(`21000000.87654321`, `-1234567.89`) with no overlap at any length, and confirmed each
save round-trips to the expected minor units in `account_balances`. The
`allowNegative` path — the tightest layout, toggle plus a three-character symbol — was
reached through the automation-rule builder's Amount condition, the only real call site
that uses it.

### Screenshots

> **Placeholder — drag the four screenshots in here.**

| | Light | Dark |
| --- | --- | --- |
| **BTC** | _paste `amount-input-btc-light.png`_ | _paste `amount-input-btc-dark.png`_ |
| **EUR** | _paste `amount-input-eur-light.png`_ | _paste `amount-input-eur-dark.png`_ |

### Demo

<img width="1265" height="940" alt="amount-input-eur-light" src="https://github.com/user-attachments/assets/82f229a4-1a11-42f5-8596-c5d4844a6efe" />
<img width="1265" height="940" alt="amount-input-btc-dark" src="https://github.com/user-attachments/assets/82b85216-ab87-4363-8430-5f0d3101bcb7" />
<img width="1265" height="940" alt="amount-input-btc-light" src="https://github.com/user-attachments/assets/ad55734f-f17b-43f1-8f4a-35d4ed81631d" />
<img width="1265" height="940" alt="amount-input-eur-dark" src="https://github.com/user-attachments/assets/dddf8594-ad6a-443e-99bf-6a172df5fc4f" />
