### PR TITLE
fix(banking): let the callback carrying a valid code win the iOS authorization race

### DIFF
--- a/app/Http/Controllers/OpenBanking/AuthorizationController.php
+++ b/app/Http/Controllers/OpenBanking/AuthorizationController.php
@@ -14,6 +14,7 @@ use App\Jobs\SyncBankingConnectionJob;
 use App\Models\BankingConnection;
 use App\Models\User;
 use App\Services\AccountUserCurrencyService;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -165,6 +166,15 @@ class AuthorizationController extends Controller
      * back to the system browser (Safari), where the app session does not exist, so
      * the connection is resolved from the signed state token EnableBanking echoes
      * back rather than from the logged-in session.
+     *
+     * That split is also a race: the return URL is back inside the PWA scope, so
+     * iOS may deliver it to the app, to Safari, or to both. The context that did
+     * not run the SCA reports `access_denied` seconds after the flow starts and
+     * soft-deletes the connection the other one is still authorizing. So the
+     * callback carrying a code the provider accepts wins whatever the arrival
+     * order: a code EnableBanking honours is proof the user did authorize, and
+     * nothing weaker resurrects a row. Completion burns the state token, which
+     * is what keeps a finished connection out of a second callback's reach.
      */
     public function callback(Request $request, BankingProviderInterface $provider, AccountUserCurrencyService $accountUserCurrencyService): RedirectResponse|Response
     {
@@ -205,6 +215,12 @@ class AuthorizationController extends Controller
 
         if (! $connection) {
             return $this->finishWithError($user, 'No pending connection found.');
+        }
+
+        // Undo the cancellation an orphaned context sent while the user was
+        // still at their bank. See the race in this method's docblock.
+        if ($connection->trashed()) {
+            $connection->restore();
         }
 
         $isReconnect = $connection->accounts()->exists();
@@ -297,6 +313,15 @@ class AuthorizationController extends Controller
      *
      * A pending connection that already has accounts is a reconnect, so it is kept
      * and marked as failing. A brand new one has nothing worth keeping.
+     *
+     * Only the connection the state token names is touched. The old fallback -
+     * the user's latest pending connection - deleted whatever it happened to
+     * find: in production an error belonging to a 10:57 attempt deleted the
+     * connection started at 09:41. An error we cannot attribute is still shown
+     * to the user, but it takes no row down with it.
+     *
+     * The state token deliberately survives an error, so the winner of the race
+     * in callback() can still claim this attempt.
      */
     private function handleAuthorizationError(Request $request, User $user, ?BankingConnection $connection): RedirectResponse|Response
     {
@@ -307,29 +332,23 @@ class AuthorizationController extends Controller
             is_string($errorDescription) ? $errorDescription : null,
         );
 
-        $pendingConnection = $connection ?? $user->bankingConnections()
-            ->where('status', BankingConnectionStatus::Pending)
-            ->latest()
-            ->first();
-
         // The bank is logged because these failures are bank-specific, and the
         // connection row is about to be deleted on one of the branches below.
         Log::warning('EnableBanking authorization error', [
             'error' => $errorCode,
             'description' => $errorDescription,
-            'aspsp_name' => $pendingConnection?->aspsp_name,
-            'connection_id' => $pendingConnection?->id,
+            'aspsp_name' => $connection?->aspsp_name,
+            'connection_id' => $connection?->id,
         ]);
 
-        if ($pendingConnection) {
-            if ($pendingConnection->accounts()->exists()) {
-                $pendingConnection->update([
+        if ($connection) {
+            if ($connection->accounts()->exists()) {
+                $connection->update([
                     'status' => BankingConnectionStatus::Error,
                     'error_message' => $errorMessage,
-                    'state_token' => null,
                 ]);
             } else {
-                $pendingConnection->delete();
+                $connection->delete();
             }
         }
 
@@ -380,7 +399,11 @@ class AuthorizationController extends Controller
             return null;
         }
 
+        // Trashed rows count: a cancelled attempt is exactly what the winner of
+        // the race in callback() has to land on. `state_token` is unique, so a
+        // trashed row still holds the index and this stays single-valued.
         return BankingConnection::query()
+            ->withoutGlobalScope(SoftDeletingScope::class)
             ->where('state_token', $stateToken)
             ->first();
     }

--- a/tests/Browser/OnboardingFlowTest.php
+++ b/tests/Browser/OnboardingFlowTest.php
@@ -245,11 +245,14 @@ it('returns to the accounts step when bank authorization fails during onboarding
         'user_id' => $user->id,
         'aspsp_name' => 'Failing Bank',
         'aspsp_country' => 'ES',
+        'state_token' => 'onboarding-failure-token',
     ]);
 
     $this->actingAs($user);
 
-    $page = visit('/open-banking/callback?error=access_denied&error_description=Authentication+failed');
+    // The state token is what attributes the failure to this attempt: an error
+    // the callback cannot resolve deletes nothing.
+    $page = visit('/open-banking/callback?error=access_denied&error_description=Authentication+failed&state=onboarding-failure-token');
 
     $page->wait(1)
         ->assertPathIs('/onboarding')

--- a/tests/Feature/OpenBanking/AuthorizationControllerTest.php
+++ b/tests/Feature/OpenBanking/AuthorizationControllerTest.php
@@ -135,10 +135,11 @@ test('callback with error redirects with error message and deletes pending conne
     $user = User::factory()->onboarded()->create();
     $connection = BankingConnection::factory()->pending()->create([
         'user_id' => $user->id,
+        'state_token' => 'state-token-denied',
     ]);
 
     $response = $this->actingAs($user)
-        ->get('/open-banking/callback?error=access_denied&error_description=User+denied+access');
+        ->get('/open-banking/callback?error=access_denied&error_description=User+denied+access&state=state-token-denied');
 
     $response->assertRedirect(route('settings.connections.index'));
     $response->assertSessionHas('error', 'User denied access');
@@ -152,10 +153,11 @@ test('callback with error during onboarding redirects to the accounts step', fun
     Account::factory()->create(['user_id' => $user->id]);
     $connection = BankingConnection::factory()->pending()->create([
         'user_id' => $user->id,
+        'state_token' => 'state-token-onboarding-denied',
     ]);
 
     $response = $this->actingAs($user)
-        ->get('/open-banking/callback?error=access_denied&error_description=User+denied+access');
+        ->get('/open-banking/callback?error=access_denied&error_description=User+denied+access&state=state-token-onboarding-denied');
 
     $response->assertRedirect(route('onboarding', ['step' => 'create-account']));
     $response->assertSessionHas('error', 'User denied access');
@@ -170,6 +172,7 @@ test('callback with error during reconnect preserves existing connection', funct
         'user_id' => $user->id,
         'aspsp_name' => 'ING',
         'aspsp_country' => 'ES',
+        'state_token' => 'state-token-reconnect-denied',
     ]);
 
     Account::factory()->create([
@@ -178,7 +181,7 @@ test('callback with error during reconnect preserves existing connection', funct
     ]);
 
     $response = $this->actingAs($user)
-        ->get('/open-banking/callback?error=access_denied&error_description=User+denied+access');
+        ->get('/open-banking/callback?error=access_denied&error_description=User+denied+access&state=state-token-reconnect-denied');
 
     $response->assertRedirect(route('settings.connections.index'));
     $response->assertSessionHas('error', 'User denied access');
@@ -203,9 +206,10 @@ test('callback with error and no description falls back to a generic message', f
     $user = User::factory()->onboarded()->create();
     $connection = BankingConnection::factory()->pending()->create([
         'user_id' => $user->id,
+        'state_token' => 'state-token-no-description',
     ]);
 
-    $response = $this->actingAs($user)->get('/open-banking/callback?error=access_denied');
+    $response = $this->actingAs($user)->get('/open-banking/callback?error=access_denied&state=state-token-no-description');
 
     $response->assertRedirect(route('settings.connections.index'));
     $response->assertSessionHas('error', 'Authorization was denied or cancelled.');
@@ -215,9 +219,12 @@ test('callback with error and no description falls back to a generic message', f
 
 test('callback does not blame the user when the bank fails the authorization', function (string $errorCode) {
     $user = User::factory()->onboarded()->create();
-    $connection = BankingConnection::factory()->pending()->create(['user_id' => $user->id]);
+    $connection = BankingConnection::factory()->pending()->create([
+        'user_id' => $user->id,
+        'state_token' => "state-token-{$errorCode}",
+    ]);
 
-    $response = $this->actingAs($user)->get("/open-banking/callback?error={$errorCode}");
+    $response = $this->actingAs($user)->get("/open-banking/callback?error={$errorCode}&state=state-token-{$errorCode}");
 
     $response->assertRedirect(route('settings.connections.index'));
     $response->assertSessionHas('error', 'We could not complete the connection with your bank. Please try again later.');
@@ -240,13 +247,16 @@ test('callback ignores the provider description unless the user denied the conse
 
 test('callback stores the bank failure on a reconnect instead of blaming the user', function () {
     $user = User::factory()->onboarded()->create();
-    $connection = BankingConnection::factory()->pending()->create(['user_id' => $user->id]);
+    $connection = BankingConnection::factory()->pending()->create([
+        'user_id' => $user->id,
+        'state_token' => 'state-token-reconnect-failure',
+    ]);
     Account::factory()->create([
         'user_id' => $user->id,
         'banking_connection_id' => $connection->id,
     ]);
 
-    $response = $this->actingAs($user)->get('/open-banking/callback?error=server_error');
+    $response = $this->actingAs($user)->get('/open-banking/callback?error=server_error&state=state-token-reconnect-failure');
 
     $response->assertSessionHas('error', 'We could not complete the connection with your bank. Please try again later.');
 
@@ -262,9 +272,10 @@ test('callback logs the bank behind an authorization error', function () {
     $connection = BankingConnection::factory()->pending()->create([
         'user_id' => $user->id,
         'aspsp_name' => 'Banco Mediolanum',
+        'state_token' => 'state-token-logged',
     ]);
 
-    $this->actingAs($user)->get('/open-banking/callback?error=server_error');
+    $this->actingAs($user)->get('/open-banking/callback?error=server_error&state=state-token-logged');
 
     Log::shouldHaveReceived('warning')
         ->once()
@@ -1088,6 +1099,167 @@ test('callback renders the completion page on error without an authenticated ses
     );
 
     expect($connection->fresh()->trashed())->toBeTrue();
+});
+
+// The iOS/PWA split-context race: the bank redirect leaves the installed app for
+// Safari, and only one of the two contexts gets the return. The orphan cancels the
+// authorization the other one is still completing.
+
+test('a valid code restores the connection a cancelled callback deleted', function () {
+    Queue::fake();
+
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->pending()->create([
+        'user_id' => $user->id,
+        'aspsp_name' => 'CaixaBank',
+        'aspsp_country' => 'ES',
+        'state_token' => 'state-token-race',
+    ]);
+
+    $accounts = [
+        [
+            'uid' => 'ext-account-1',
+            'currency' => 'EUR',
+            'name' => 'My Checking Account',
+            'account_id' => ['iban' => 'ES1234567890123456789012'],
+        ],
+    ];
+
+    $mockProvider = Mockery::mock(BankingProviderInterface::class);
+    $mockProvider->shouldReceive('createSession')
+        ->with('test-code')
+        ->once()
+        ->andReturn([
+            'session_id' => 'session-race',
+            'accounts' => $accounts,
+            'aspsp' => ['name' => 'CaixaBank', 'country' => 'ES'],
+            'access' => ['valid_until' => now()->addDays(90)->toIso8601String()],
+        ]);
+
+    $this->app->instance(BankingProviderInterface::class, $mockProvider);
+
+    // The orphaned context aborts the flow seconds after it started.
+    $this->get('/open-banking/callback?error=access_denied&error_description=Cancelled+by+user&state=state-token-race');
+
+    expect($connection->fresh()->trashed())->toBeTrue();
+
+    // The context the user actually authorized in comes back with the code.
+    $this->actingAs($user)
+        ->get('/open-banking/callback?code=test-code&state=state-token-race')
+        ->assertRedirect(route('open-banking.map-accounts', $connection));
+
+    $connection->refresh();
+    expect($connection->trashed())->toBeFalse();
+    expect($connection->status)->toBe(BankingConnectionStatus::AwaitingMapping);
+    expect($connection->session_id)->toBe('session-race');
+    expect($connection->pending_accounts_data)->toEqual($accounts);
+    expect($connection->state_token)->toBeNull();
+});
+
+test('a valid code completes a reconnect a cancelled callback marked as failed', function () {
+    Queue::fake();
+
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->pending()->create([
+        'user_id' => $user->id,
+        'aspsp_name' => 'CaixaBank',
+        'aspsp_country' => 'ES',
+        'state_token' => 'state-token-race-reconnect',
+    ]);
+
+    Account::factory()->create([
+        'user_id' => $user->id,
+        'banking_connection_id' => $connection->id,
+        'external_account_id' => 'old-ext-account-1',
+        'iban' => 'ES1234567890123456789012',
+    ]);
+
+    $mockProvider = Mockery::mock(BankingProviderInterface::class);
+    $mockProvider->shouldReceive('createSession')
+        ->with('test-code')
+        ->once()
+        ->andReturn([
+            'session_id' => 'session-race-reconnect',
+            'accounts' => [
+                [
+                    'uid' => 'new-ext-account-1',
+                    'currency' => 'EUR',
+                    'name' => 'My Checking Account',
+                    'account_id' => ['iban' => 'ES1234567890123456789012'],
+                ],
+            ],
+            'aspsp' => ['name' => 'CaixaBank', 'country' => 'ES'],
+            'access' => ['valid_until' => now()->addDays(90)->toIso8601String()],
+        ]);
+
+    $this->app->instance(BankingProviderInterface::class, $mockProvider);
+
+    $this->get('/open-banking/callback?error=access_denied&error_description=Cancelled+by+user&state=state-token-race-reconnect');
+
+    expect($connection->fresh()->status)->toBe(BankingConnectionStatus::Error);
+
+    $this->actingAs($user)
+        ->get('/open-banking/callback?code=test-code&state=state-token-race-reconnect')
+        ->assertRedirect(route('settings.connections.index'));
+
+    $connection->refresh();
+    expect($connection->status)->toBe(BankingConnectionStatus::Active);
+    expect($connection->session_id)->toBe('session-race-reconnect');
+    expect($connection->error_message)->toBeNull();
+    expect($connection->state_token)->toBeNull();
+    expect($connection->accounts()->first()->external_account_id)->toBe('new-ext-account-1');
+});
+
+test('a code the provider rejects leaves a deleted connection deleted', function () {
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->pending()->create([
+        'user_id' => $user->id,
+        'aspsp_name' => 'CaixaBank',
+        'aspsp_country' => 'ES',
+        'state_token' => 'state-token-race-rejected',
+    ]);
+
+    $mockProvider = Mockery::mock(BankingProviderInterface::class);
+    $mockProvider->shouldReceive('createSession')
+        ->with('stale-code')
+        ->once()
+        ->andThrow(new RuntimeException('Invalid authorization code'));
+
+    $this->app->instance(BankingProviderInterface::class, $mockProvider);
+
+    $this->get('/open-banking/callback?error=access_denied&error_description=Cancelled+by+user&state=state-token-race-rejected');
+
+    $response = $this->actingAs($user)
+        ->get('/open-banking/callback?code=stale-code&state=state-token-race-rejected');
+
+    $response->assertSessionHas('error', 'Failed to connect to your bank. Please try again.');
+
+    // Only a session the provider issued resurrects a connection, so this one
+    // stays trashed and keeps counting as a failed authorization.
+    $connection->refresh();
+    expect($connection->trashed())->toBeTrue();
+    expect($connection->status)->toBe(BankingConnectionStatus::Pending);
+    expect($connection->state_token)->toBeNull();
+});
+
+test('an error with no resolvable state token deletes nothing', function () {
+    $user = User::factory()->onboarded()->create();
+    $unrelated = BankingConnection::factory()->pending()->create([
+        'user_id' => $user->id,
+        'aspsp_name' => 'CaixaBank',
+        'aspsp_country' => 'ES',
+        'state_token' => 'state-token-unrelated',
+    ]);
+
+    $response = $this->actingAs($user)
+        ->get('/open-banking/callback?error=access_denied&error_description=Cancelled+by+user');
+
+    $response->assertRedirect(route('settings.connections.index'));
+    $response->assertSessionHas('error', 'Cancelled by user');
+
+    // The old fallback deleted the latest pending connection, which in production
+    // was an attempt started an hour and a quarter earlier.
+    expect($unrelated->fresh()->trashed())->toBeFalse();
 });
 
 test('reconnect hands back the full scheduled retry budget', function () {


### PR DESCRIPTION
On iOS, a paying CaixaBank user failed to connect their bank 8 times in a row on
2026-08-28 while everyone else connected fine. They authorized correctly every
time; we threw the authorization away.

## The race

The PWA manifest is `"display": "standalone"` with `"scope": "/"`. iOS has no
Custom Tabs, so `leavePage()`'s navigation to `tilisy.enablebanking.com` is
out-of-scope and WebKit opens it in **Safari** — a separate process with its own
cookie jar. The return URL `/open-banking/callback` is back **inside** the scope,
so iOS may hand it to the installed PWA or leave it in Safari. Whichever context
does not get it becomes an orphan that aborts the authorization.

Every failed attempt produced **two** callbacks:

```
15:45:34  connection created (state token S)
15:45:55  callback #1: ?error=access_denied&error_description=Cancelled+by+user   → row soft-deleted
15:46:11  callback #2: ?error=invalid_request (aspsp_name null in the log = no pending row left)
```

Same shape at 15:51:39/15:51:55/15:52:19 and 15:54:15/15:54:36/15:54:52. The first
callback lands **7–27 s** after the flow starts, far too fast for a real SCA — the
one attempt that succeeded (20:22:21 → accounts created 20:23:30) took **69 s**,
which is what a CaixaBank SCA actually costs. PostHog confirms the split contexts:
four interleaved `$session_id` values inside those 10 minutes, plus two fresh
anonymous `distinct_id`s that each had to hit `/login` again.

The orphan's `access_denied` **soft-deletes the connection row the good callback
then needs**. When the real return arrives with a valid `code`,
`resolveConnectionFromState()` can no longer see the row (the SoftDeletes global
scope hides it), `findPendingConnectionForSession()` finds nothing either, and the
user is told *"No pending connection found."* after authorizing at their bank.

This is not CaixaBank-specific and not user-specific. Any split browser context
triggers it.

## The fix

Server-side only: the callback carrying a valid `code` wins, whatever the arrival
order.

- `resolveConnectionFromState()` drops the SoftDeletes scope, so it can still find
  a row an orphaned context deleted. `state_token` is `unique()`, so a trashed row
  still occupies the index and this stays single-valued.
- When the callback carries a `code` and `createSession($code)` succeeds, the
  connection is `restore()`d before being completed. **Only** a successful
  exchange restores it — Enable Banking validates the code, and that is what
  proves the user really did authorize. A failed exchange keeps today's behaviour:
  burn the state token, stay deleted.
- `handleAuthorizationError()` stops guessing. It used to fall back to
  `->where('status', Pending)->latest()->first()` and delete whatever that
  returned. Production proof that this is wrong: at **10:57:14 it deleted the
  connection created at 09:41:53** — an hour and a quarter earlier — because of an
  error belonging to the 10:57 attempt. With no resolvable state it now deletes
  nothing, and still reports the error to the user.
- The error path no longer nulls `state_token`, so a good code arriving later can
  still claim the attempt. Completing a connection is what burns the token
  (`completeFirstConnection` / `completeReconnect`), so a finished connection can
  never be re-resolved — unchanged.

## Interaction with the bank health report

`QueriesBankFailures::failedAuthorizations()` treats **a soft-deleted row still in
`pending` status** as the fingerprint of a failed authorization, and that feeds
`banking:health --email` (scheduled daily at 09:30) and
`NotifyBankConnectFailureCommand`.

The fingerprint is intact: a genuine error still deletes while pending. What
changes is that an attempt later proven successful drops out of the report — it is
restored (`deleted_at` cleared) and moved off `Pending` in the same request. That
is correct: it was never a bank failure. A code the provider rejects leaves the
row trashed and `pending`, so real failures still surface.

## Tests

`tests/Feature/OpenBanking/AuthorizationControllerTest.php`, extended in place.

New:
- the production sequence end to end — `?error=access_denied` deletes the row,
  then a second callback with the same state token and a valid code restores it
  and completes it with its accounts;
- the same for a reconnect (a connection that already has accounts);
- a second callback whose session exchange fails leaves the connection deleted and
  does not resurrect it;
- an error callback with no resolvable state token deletes nothing (an unrelated
  pending connection survives) and still shows the user the error.

The existing error tests still assert the delete-on-error path; they now pass the
state token the callback really carries, which is what makes the connection
resolvable.

## Out of scope

- The PWA manifest (`display` / `scope`). Changing it affects the whole app and is
  a separate decision.
- `resources/js/lib/leave-page.ts` and the rest of the frontend.
- The `access_denied` copy, which is also wrong ("Cancelled by user",
  untranslated, shown to a user who cancelled nothing).

Known residual, same root cause, opposite order: if the good callback lands
*first* and the orphan's error arrives after, the error is unattributable (the
token is burned by then) so no row is touched — but an authenticated orphan still
flashes an error to a user whose connection just succeeded. Telling that apart
from a genuinely unknown state would mean guessing, which is exactly what this PR
removes, so it is left for a follow-up.
