### PR TITLE
feat(dashboard): add a Top labels card for the last 30 days

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -6,6 +6,7 @@ use App\Models\Account;
 use App\Services\AccountMetricsService;
 use App\Services\CashflowSummaryService;
 use App\Services\CategorySpendingService;
+use App\Services\LabelSpendingService;
 use App\Services\PeriodComparator;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
@@ -17,6 +18,7 @@ class DashboardController extends Controller
     public function __construct(
         private AccountMetricsService $accountMetricsService,
         private CategorySpendingService $categorySpendingService,
+        private LabelSpendingService $labelSpendingService,
         private CashflowSummaryService $summaries,
     ) {}
 
@@ -26,6 +28,7 @@ class DashboardController extends Controller
             'showEncryptionPrompt' => session('show_encryption_prompt', false),
             'netWorthEvolution' => Inertia::defer(fn () => $this->getNetWorthEvolution($request), 'dashboard'),
             'topCategories' => Inertia::defer(fn () => $this->getTopCategories($request), 'dashboard'),
+            'topLabels' => Inertia::defer(fn () => $this->getTopLabels($request), 'dashboard'),
             'cashflowSummary' => Inertia::defer(fn () => $this->getCashflowSummary($request), 'dashboard'),
         ]);
     }
@@ -80,6 +83,16 @@ class DashboardController extends Controller
             })
             ->values()
             ->all();
+    }
+
+    private function getTopLabels(Request $request): array
+    {
+        $now = Carbon::now();
+
+        return $this->labelSpendingService->topForPeriod(
+            $request->user()->id,
+            new PeriodComparator($now->copy()->subDays(30), $now),
+        );
     }
 
     private function getCashflowSummary(Request $request): array

--- a/app/Services/LabelSpendingService.php
+++ b/app/Services/LabelSpendingService.php
@@ -59,7 +59,7 @@ class LabelSpendingService
      * A transaction counts towards every label attached to it, so the totals can
      * add up to more than the period's expenses.
      *
-     * @return Collection<string, array{id: string, name: string, color: string, amount: int}>
+     * @return Collection<string, array{id: string, name: string, color: string, amount: positive-int}>
      */
     private function forPeriod(string $userId, Carbon $from, Carbon $to): Collection
     {
@@ -83,14 +83,15 @@ class LabelSpendingService
             ->select('labels.id', 'labels.name', 'labels.color', DB::raw('sum('.Transaction::OWNED_AMOUNT_SQL.') as total_amount'))
             ->toBase()
             ->get()
-            ->map(fn ($row): array => [
-                'id' => $row->id,
-                'name' => $row->name,
-                'color' => $row->color,
-                'amount' => (int) -$row->total_amount,
+            ->mapWithKeys(fn ($row): array => [
+                (string) $row->id => [
+                    'id' => (string) $row->id,
+                    'name' => (string) $row->name,
+                    'color' => (string) $row->color,
+                    'amount' => (int) -$row->total_amount,
+                ],
             ])
-            ->filter(fn (array $label): bool => $label['amount'] > 0)
-            ->keyBy('id');
+            ->filter(fn (array $label): bool => $label['amount'] > 0);
     }
 
     /**

--- a/app/Services/LabelSpendingService.php
+++ b/app/Services/LabelSpendingService.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\CategoryType;
+use App\Enums\LabelSource;
+use App\Models\Transaction;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\JoinClause;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class LabelSpendingService
+{
+    private const LIMIT = 10;
+
+    /**
+     * The labels the user spent the most on during the period, biggest first,
+     * each with the same figure for the preceding period so the widget can show
+     * a trend. Empty when nothing labelled was spent — the dashboard then draws
+     * no card at all.
+     *
+     * @return list<array{id: string, name: string, color: string, amount: int, previous_amount: int, total_amount: int}>
+     */
+    public function topForPeriod(string $userId, PeriodComparator $period): array
+    {
+        $current = $this->forPeriod($userId, $period->from, $period->to);
+
+        if ($current->isEmpty()) {
+            return [];
+        }
+
+        $previousPeriod = $period->previous();
+        $previous = $this->forPeriod($userId, $previousPeriod->from, $previousPeriod->to);
+        $totalAmount = $current->sum('amount');
+
+        return $current
+            ->sortByDesc('amount')
+            ->take(self::LIMIT)
+            ->map(fn (array $label): array => [
+                ...$label,
+                'previous_amount' => $previous[$label['id']]['amount'] ?? 0,
+                'total_amount' => $totalAmount,
+            ])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Expense spending per label over a period, keyed by label id.
+     *
+     * Amounts are ownership-weighted and leave out what an archived account no
+     * longer contributes, matching {@see CategorySpendingService::forPeriod()};
+     * amounts are summed as they are stored, with no currency conversion, so
+     * both dashboard cards read the same money. Labels backing a savings goal
+     * are skipped: they track contributions, not spending.
+     *
+     * A transaction counts towards every label attached to it, so the totals can
+     * add up to more than the period's expenses.
+     *
+     * @return Collection<string, array{id: string, name: string, color: string, amount: int}>
+     */
+    private function forPeriod(string $userId, Carbon $from, Carbon $to): Collection
+    {
+        return Transaction::query()
+            ->where('transactions.user_id', $userId)
+            ->whereBetween('transactions.transaction_date', [$from, $to])
+            ->joinOwningAccount()
+            ->withoutArchivedAccountActivity()
+            ->join('label_transaction', 'label_transaction.transaction_id', '=', 'transactions.id')
+            ->join('labels', function (JoinClause $join): void {
+                $join->on('labels.id', '=', 'label_transaction.label_id')
+                    ->where('labels.source', '=', LabelSource::User)
+                    ->whereNull('labels.deleted_at');
+            })
+            ->leftJoin('categories', function (JoinClause $join): void {
+                $join->on('categories.id', '=', 'transactions.category_id')
+                    ->whereNull('categories.deleted_at');
+            })
+            ->where($this->expenseSide(...))
+            ->groupBy('labels.id', 'labels.name', 'labels.color')
+            ->select('labels.id', 'labels.name', 'labels.color', DB::raw('sum('.Transaction::OWNED_AMOUNT_SQL.') as total_amount'))
+            ->toBase()
+            ->get()
+            ->map(fn ($row): array => [
+                'id' => $row->id,
+                'name' => $row->name,
+                'color' => $row->color,
+                'amount' => (int) -$row->total_amount,
+            ])
+            ->filter(fn (array $label): bool => $label['amount'] > 0)
+            ->keyBy('id');
+    }
+
+    /**
+     * {@see Transaction::isExpenseSide()} expressed in SQL: an expense category,
+     * or money leaving with no category at all.
+     */
+    private function expenseSide(Builder $query): void
+    {
+        $query->where('categories.type', CategoryType::Expense)
+            ->orWhere(function (Builder $uncategorized): void {
+                $uncategorized->whereNull('transactions.category_id')
+                    ->where('transactions.amount', '<', 0);
+            });
+    }
+}

--- a/lang/es.json
+++ b/lang/es.json
@@ -1777,6 +1777,7 @@
     "Today": "Hoy",
     "Toggle theme": "Cambiar tema",
     "Top Spending Categories": "Principales Categorías de Gasto",
+    "Top labels": "Principales etiquetas",
     "Top spending categories": "Principales categorías de gasto",
     "Total": "Total",
     "Total money you put into this account. Used to calculate gains/losses.": "Dinero total que has puesto en esta cuenta. Usado para calcular ganancias/pérdidas.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1682,6 +1682,7 @@
     "Today": "Aujourd'hui",
     "Toggle theme": "changer de thème",
     "Top Spending Categories": "Principales catégories de dépenses",
+    "Top labels": "Principales étiquettes",
     "Top spending categories": "Principales catégories de dépenses",
     "Total": "Total",
     "Total money you put into this account. Used to calculate gains/losses.": "Argent total que vous avez mis sur ce compte. Utilisé pour calculer le profit/la perte.",

--- a/resources/js/components/cashflow/breakdown-card.tsx
+++ b/resources/js/components/cashflow/breakdown-card.tsx
@@ -2,6 +2,7 @@ import { index as transactionsIndex } from '@/actions/App/Http/Controllers/Trans
 import { CategoryAnalysisButton } from '@/components/categories/category-analysis-button';
 import {
     CategoryBreakdownRow,
+    trendFrom,
     type CategoryBreakdownAdapter,
 } from '@/components/shared/category-breakdown-list';
 import { AmountDisplay } from '@/components/ui/amount-display';
@@ -131,17 +132,7 @@ export function BreakdownCard({
                       },
                   }).url
                 : null,
-        getTrend: (item) =>
-            item.previous_amount > 0
-                ? {
-                      change:
-                          ((item.amount - item.previous_amount) /
-                              item.previous_amount) *
-                          100,
-                      previousAmount: item.previous_amount,
-                      currentAmount: item.amount,
-                  }
-                : null,
+        getTrend: (item) => trendFrom(item.amount, item.previous_amount),
         canExpand: (item) =>
             Boolean(
                 item.has_children &&

--- a/resources/js/components/dashboard/top-categories-card.tsx
+++ b/resources/js/components/dashboard/top-categories-card.tsx
@@ -2,6 +2,7 @@ import { index as transactionsIndex } from '@/actions/App/Http/Controllers/Trans
 import { CategoryAnalysisButton } from '@/components/categories/category-analysis-button';
 import {
     CategoryBreakdownRow,
+    trendFrom,
     type CategoryBreakdownAdapter,
 } from '@/components/shared/category-breakdown-list';
 import {
@@ -13,6 +14,7 @@ import {
 } from '@/components/ui/card';
 import { useChartColors } from '@/hooks/use-chart-color-scheme';
 import { useExpandableCategories } from '@/hooks/use-expandable-categories';
+import { useLast30Days } from '@/hooks/use-last-30-days';
 import { fetchJson } from '@/lib/fetch-json';
 import { cn } from '@/lib/utils';
 import { SharedData } from '@/types';
@@ -23,10 +25,9 @@ import {
 } from '@/types/category';
 import { __ } from '@/utils/i18n';
 import { usePage } from '@inertiajs/react';
-import { format, subDays } from 'date-fns';
 import * as Icons from 'lucide-react';
 import { LucideIcon } from 'lucide-react';
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 
 interface CategoryData {
     category: Category | null;
@@ -54,13 +55,7 @@ export function TopCategoriesCard({
     const { auth } = usePage<SharedData>().props;
     const { categoryBarColor } = useChartColors();
 
-    const { dateFrom, dateTo } = useMemo(() => {
-        const now = new Date();
-        return {
-            dateFrom: format(subDays(now, 30), 'yyyy-MM-dd'),
-            dateTo: format(now, 'yyyy-MM-dd'),
-        };
-    }, []);
+    const { dateFrom, dateTo } = useLast30Days();
 
     const fetchChildren = useCallback(
         async (categoryId: string): Promise<CategoryData[]> => {
@@ -124,17 +119,7 @@ export function TopCategoriesCard({
                     date_to: dateTo,
                 },
             }).url,
-        getTrend: (item) =>
-            item.previous_amount > 0
-                ? {
-                      change:
-                          ((item.amount - item.previous_amount) /
-                              item.previous_amount) *
-                          100,
-                      previousAmount: item.previous_amount,
-                      currentAmount: item.amount,
-                  }
-                : null,
+        getTrend: (item) => trendFrom(item.amount, item.previous_amount),
         canExpand: (item) =>
             Boolean(item.has_children && !item.is_direct && item.category),
     };

--- a/resources/js/components/dashboard/top-labels-card.tsx
+++ b/resources/js/components/dashboard/top-labels-card.tsx
@@ -1,0 +1,119 @@
+import { index as transactionsIndex } from '@/actions/App/Http/Controllers/TransactionController';
+import {
+    CategoryBreakdownRow,
+    type CategoryBreakdownAdapter,
+} from '@/components/shared/category-breakdown-list';
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+import { useChartColors } from '@/hooks/use-chart-color-scheme';
+import { cn } from '@/lib/utils';
+import { SharedData } from '@/types';
+import { type CategoryColor } from '@/types/category';
+import { getLabelColorClasses } from '@/types/label';
+import { __ } from '@/utils/i18n';
+import { usePage } from '@inertiajs/react';
+import { format, subDays } from 'date-fns';
+import { Tag } from 'lucide-react';
+import { useMemo } from 'react';
+
+export interface LabelSpending {
+    id: string;
+    name: string;
+    color: string;
+    amount: number;
+    previous_amount: number;
+    total_amount: number;
+}
+
+/**
+ * Spending per label over the last 30 days. Nothing labelled, no card: an empty
+ * one would take up a dashboard slot to say nothing, so it stays hidden until
+ * the user actually tags what they spend.
+ */
+export function TopLabelsCard({ labels }: { labels: LabelSpending[] }) {
+    const { auth } = usePage<SharedData>().props;
+    const { categoryBarColor } = useChartColors();
+
+    const { dateFrom, dateTo } = useMemo(() => {
+        const now = new Date();
+        return {
+            dateFrom: format(subDays(now, 30), 'yyyy-MM-dd'),
+            dateTo: format(now, 'yyyy-MM-dd'),
+        };
+    }, []);
+
+    if (labels.length === 0 || !auth?.user) {
+        return null;
+    }
+
+    const adapter: CategoryBreakdownAdapter<LabelSpending> = {
+        getId: (item) => item.id,
+        getKey: (item) => item.id,
+        getName: (item) => item.name,
+        getAmount: (item) => item.amount,
+        getPercentage: (item) =>
+            item.total_amount > 0 ? (item.amount / item.total_amount) * 100 : 0,
+        getBarColor: (item, index) =>
+            categoryBarColor(item.color as CategoryColor, index),
+        renderLeading: (item) => {
+            const color = getLabelColorClasses(item.color);
+
+            return (
+                <div
+                    className={cn([
+                        'flex size-6 shrink-0 items-center justify-center rounded-full',
+                        `${color.bg} ${color.text}`,
+                    ])}
+                >
+                    <Tag className="size-4" />
+                </div>
+            );
+        },
+        getHref: (item) =>
+            transactionsIndex({
+                query: {
+                    label_ids: item.id,
+                    date_from: dateFrom,
+                    date_to: dateTo,
+                },
+            }).url,
+        getTrend: (item) =>
+            item.previous_amount > 0
+                ? {
+                      change:
+                          ((item.amount - item.previous_amount) /
+                              item.previous_amount) *
+                          100,
+                      previousAmount: item.previous_amount,
+                      currentAmount: item.amount,
+                  }
+                : null,
+    };
+
+    return (
+        <Card className="w-full">
+            <CardHeader className="gap-2">
+                <CardTitle>{__('Top labels')}</CardTitle>
+                <CardDescription>{__('on the last 30 days')}</CardDescription>
+            </CardHeader>
+            <CardContent>
+                <div className="space-y-3">
+                    {labels.map((item, index) => (
+                        <CategoryBreakdownRow
+                            key={item.id}
+                            item={item}
+                            index={index}
+                            currencyCode={auth.user.currency_code}
+                            adapter={adapter}
+                        />
+                    ))}
+                </div>
+            </CardContent>
+        </Card>
+    );
+}

--- a/resources/js/components/dashboard/top-labels-card.tsx
+++ b/resources/js/components/dashboard/top-labels-card.tsx
@@ -1,6 +1,7 @@
 import { index as transactionsIndex } from '@/actions/App/Http/Controllers/TransactionController';
 import {
     CategoryBreakdownRow,
+    trendFrom,
     type CategoryBreakdownAdapter,
 } from '@/components/shared/category-breakdown-list';
 import {
@@ -11,15 +12,14 @@ import {
     CardTitle,
 } from '@/components/ui/card';
 import { useChartColors } from '@/hooks/use-chart-color-scheme';
+import { useLast30Days } from '@/hooks/use-last-30-days';
 import { cn } from '@/lib/utils';
 import { SharedData } from '@/types';
 import { type CategoryColor } from '@/types/category';
 import { getLabelColorClasses } from '@/types/label';
 import { __ } from '@/utils/i18n';
 import { usePage } from '@inertiajs/react';
-import { format, subDays } from 'date-fns';
 import { Tag } from 'lucide-react';
-import { useMemo } from 'react';
 
 export interface LabelSpending {
     id: string;
@@ -39,13 +39,7 @@ export function TopLabelsCard({ labels }: { labels: LabelSpending[] }) {
     const { auth } = usePage<SharedData>().props;
     const { categoryBarColor } = useChartColors();
 
-    const { dateFrom, dateTo } = useMemo(() => {
-        const now = new Date();
-        return {
-            dateFrom: format(subDays(now, 30), 'yyyy-MM-dd'),
-            dateTo: format(now, 'yyyy-MM-dd'),
-        };
-    }, []);
+    const { dateFrom, dateTo } = useLast30Days();
 
     if (labels.length === 0 || !auth?.user) {
         return null;
@@ -82,17 +76,7 @@ export function TopLabelsCard({ labels }: { labels: LabelSpending[] }) {
                     date_to: dateTo,
                 },
             }).url,
-        getTrend: (item) =>
-            item.previous_amount > 0
-                ? {
-                      change:
-                          ((item.amount - item.previous_amount) /
-                              item.previous_amount) *
-                          100,
-                      previousAmount: item.previous_amount,
-                      currentAmount: item.amount,
-                  }
-                : null,
+        getTrend: (item) => trendFrom(item.amount, item.previous_amount),
     };
 
     return (

--- a/resources/js/components/shared/category-breakdown-list.tsx
+++ b/resources/js/components/shared/category-breakdown-list.tsx
@@ -15,6 +15,25 @@ export interface BreakdownTrend {
 }
 
 /**
+ * The trend between a period and the one before it. Nothing to compare against
+ * means no trend: a first-time amount is not a rise from zero.
+ */
+export function trendFrom(
+    amount: number,
+    previousAmount: number,
+): BreakdownTrend | null {
+    if (previousAmount <= 0) {
+        return null;
+    }
+
+    return {
+        change: ((amount - previousAmount) / previousAmount) * 100,
+        previousAmount,
+        currentAmount: amount,
+    };
+}
+
+/**
  * Maps an arbitrary item to the fields a breakdown row renders. Each widget
  * (dashboard categories, cash-flow income/expenses, the analysis drawer's
  * categories, tags and accounts) supplies one of these so they can all share

--- a/resources/js/hooks/use-last-30-days.ts
+++ b/resources/js/hooks/use-last-30-days.ts
@@ -1,0 +1,17 @@
+import { format, subDays } from 'date-fns';
+import { useMemo } from 'react';
+
+/**
+ * The trailing 30-day window the dashboard spending cards report on, as
+ * `yyyy-MM-dd` bounds ready to hand to a transactions filter.
+ */
+export function useLast30Days(): { dateFrom: string; dateTo: string } {
+    return useMemo(() => {
+        const now = new Date();
+
+        return {
+            dateFrom: format(subDays(now, 30), 'yyyy-MM-dd'),
+            dateTo: format(now, 'yyyy-MM-dd'),
+        };
+    }, []);
+}

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -7,15 +7,19 @@ import { AccountsManagerDialog } from '@/components/dashboard/accounts-manager-d
 import { CashflowSummaryCard } from '@/components/dashboard/cashflow-summary-card';
 import { NetWorthChart as NetWorthChartComponent } from '@/components/dashboard/net-worth-chart';
 import { TopCategoriesCard } from '@/components/dashboard/top-categories-card';
+import {
+    TopLabelsCard,
+    type LabelSpending,
+} from '@/components/dashboard/top-labels-card';
 import HeadingSmall from '@/components/heading-small';
 import { IntegrationRequestsDrawer } from '@/components/integration-requests/integration-requests-drawer';
 import { Button } from '@/components/ui/button';
 import UnlockMessageDialog from '@/components/unlock-message-dialog';
 import { useEncryptionKey } from '@/contexts/encryption-key-context';
 import {
+    deriveAccountMetrics,
     type AccountWithMetrics,
     type NetWorthEvolutionData,
-    deriveAccountMetrics,
 } from '@/hooks/use-dashboard-data';
 import { useLocale } from '@/hooks/use-locale';
 import AppSidebarLayout from '@/layouts/app/app-sidebar-layout';
@@ -46,6 +50,7 @@ interface DashboardProps extends SharedData {
         has_children?: boolean;
         is_direct?: boolean;
     }>;
+    topLabels?: LabelSpending[];
     cashflowSummary?: {
         current: CashflowSummary;
         previous: CashflowSummary;
@@ -207,7 +212,12 @@ export default function Dashboard() {
 
     const refetch = useCallback(() => {
         router.reload({
-            only: ['netWorthEvolution', 'topCategories', 'cashflowSummary'],
+            only: [
+                'netWorthEvolution',
+                'topCategories',
+                'topLabels',
+                'cashflowSummary',
+            ],
         });
     }, []);
 
@@ -350,6 +360,13 @@ export default function Dashboard() {
                         }
                     >
                         <TopCategoriesCard categories={topCategories} />
+                    </Deferred>
+
+                    {/* No skeleton: most users have nothing labelled, and a
+                        placeholder for a card that then disappears reads as a
+                        glitch. */}
+                    <Deferred data="topLabels" fallback={null}>
+                        <TopLabelsCard labels={props.topLabels ?? []} />
                     </Deferred>
 
                     {props.features.cashflow && (

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -362,10 +362,11 @@ export default function Dashboard() {
                         <TopCategoriesCard categories={topCategories} />
                     </Deferred>
 
-                    {/* No skeleton: most users have nothing labelled, and a
-                        placeholder for a card that then disappears reads as a
-                        glitch. */}
-                    <Deferred data="topLabels" fallback={null}>
+                    {/* An empty fragment, not null: Deferred rejects a falsy
+                        fallback. Nothing is drawn on purpose — most users have
+                        nothing labelled, and a placeholder for a card that then
+                        disappears reads as a glitch. */}
+                    <Deferred data="topLabels" fallback={<></>}>
                         <TopLabelsCard labels={props.topLabels ?? []} />
                     </Deferred>
 

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -1,9 +1,11 @@
 <?php
 
 use App\Enums\CategoryType;
+use App\Enums\LabelSource;
 use App\Models\Account;
 use App\Models\AccountBalance;
 use App\Models\Category;
+use App\Models\Label;
 use App\Models\Transaction;
 use App\Models\User;
 
@@ -58,6 +60,85 @@ test('dashboard top categories roll child spending up into the parent', function
         ->assertJsonCount(1, 'props.topCategories')
         ->assertJsonPath('props.topCategories.0.category.id', $food->id)
         ->assertJsonPath('props.topCategories.0.amount', 3000);
+});
+
+function labelledTransaction(User $user, Label $label, array $attributes = []): Transaction
+{
+    $transaction = Transaction::factory()->create([
+        'user_id' => $user->id,
+        'category_id' => null,
+        'amount' => -1000,
+        'transaction_date' => now(),
+        ...$attributes,
+    ]);
+
+    $transaction->labels()->attach($label->id);
+
+    return $transaction;
+}
+
+function topLabels(User $user): array
+{
+    return test()->actingAs($user)->get(route('dashboard'), [
+        'X-Inertia' => 'true',
+        'X-Inertia-Partial-Component' => 'dashboard',
+        'X-Inertia-Partial-Data' => 'topLabels',
+    ])->assertOk()->json('props.topLabels');
+}
+
+test('dashboard top labels add up the expenses carrying each label', function () {
+    $user = User::factory()->onboarded()->create();
+    $trip = Label::factory()->create(['user_id' => $user->id, 'name' => 'Trip']);
+    $gifts = Label::factory()->create(['user_id' => $user->id, 'name' => 'Gifts']);
+    $food = Category::factory()->create(['user_id' => $user->id, 'type' => CategoryType::Expense]);
+
+    labelledTransaction($user, $trip, ['amount' => -1000, 'category_id' => $food->id]);
+    labelledTransaction($user, $trip, ['amount' => -2000]);
+    labelledTransaction($user, $gifts, ['amount' => -500, 'category_id' => $food->id]);
+
+    expect(topLabels($user))->toBe([
+        ['id' => $trip->id, 'name' => 'Trip', 'color' => $trip->color, 'amount' => 3000, 'previous_amount' => 0, 'total_amount' => 3500],
+        ['id' => $gifts->id, 'name' => 'Gifts', 'color' => $gifts->color, 'amount' => 500, 'previous_amount' => 0, 'total_amount' => 3500],
+    ]);
+});
+
+test('dashboard top labels compare against the preceding period', function () {
+    $user = User::factory()->onboarded()->create();
+    $trip = Label::factory()->create(['user_id' => $user->id]);
+
+    labelledTransaction($user, $trip, ['amount' => -1000]);
+    labelledTransaction($user, $trip, ['amount' => -400, 'transaction_date' => now()->subDays(45)]);
+
+    $labels = topLabels($user);
+
+    expect($labels)->toHaveCount(1)
+        ->and($labels[0]['amount'])->toBe(1000)
+        ->and($labels[0]['previous_amount'])->toBe(400);
+});
+
+test('dashboard top labels leave out savings goal labels and money coming in', function () {
+    $user = User::factory()->onboarded()->create();
+    $goalLabel = Label::factory()->create(['user_id' => $user->id, 'source' => LabelSource::SavingsGoal]);
+    $salary = Label::factory()->create(['user_id' => $user->id]);
+    $income = Category::factory()->create(['user_id' => $user->id, 'type' => CategoryType::Income]);
+
+    labelledTransaction($user, $goalLabel, ['amount' => -1000]);
+    labelledTransaction($user, $salary, ['amount' => 5000, 'category_id' => $income->id]);
+
+    expect(topLabels($user))->toBe([]);
+});
+
+test('dashboard top labels are empty when nothing is labelled', function () {
+    $user = User::factory()->onboarded()->create();
+
+    Transaction::factory()->create([
+        'user_id' => $user->id,
+        'category_id' => null,
+        'amount' => -1000,
+        'transaction_date' => now(),
+    ]);
+
+    expect(topLabels($user))->toBe([]);
 });
 
 test('an archived account keeps its history but stops counting from the day it was archived', function () {


### PR DESCRIPTION
## Why

The dashboard reports on categories but says nothing about labels, even though a
user who tags what they spend has already told us how they think about their
money. This adds a **Top labels** card below "Top spending categories": the
labels they spent the most on over the last 30 days, with a trend against the
preceding 30 days, and a row that links straight to those transactions.

When there is no labelled spending in the window the card is not rendered at
all — no empty state taking up a dashboard slot for a user who does not use
labels.

<img width="1046" height="313" alt="image" src="https://github.com/user-attachments/assets/c1a76f46-c9c8-4ca3-ad45-b4d6b680d2dc" />

## How

- **`app/Services/LabelSpendingService.php`** aggregates expense spending per
  label in SQL: ownership-weighted amounts (`Transaction::OWNED_AMOUNT_SQL`),
  archived-account activity excluded, soft-deleted labels and categories
  excluded, and `saving_goal` labels left out — those track contributions, not
  spending. Amounts are summed as stored, with no FX conversion, so the figures
  agree with the neighbouring categories card.
- **`DashboardController`** exposes it as a deferred `topLabels` prop, mirroring
  `topCategories`; the controller method stays three lines.
- **`TopLabelsCard`** reuses the shared `CategoryBreakdownRow`, so the row reads
  exactly like the categories one: coloured chip, name, trend, amount, bar. Rows
  link to `/transactions?label_ids=…&date_from=…&date_to=…`.
- Two blocks the spending cards had each copied — the trend maths and the
  trailing 30-day window — are now `trendFrom()` in
  `category-breakdown-list.tsx` and the `useLast30Days()` hook, used by the
  labels, categories and cash-flow cards alike.

## Tests

Four Pest tests in `tests/Feature/DashboardTest.php`, following the existing
partial-visit pattern: per-label aggregation, comparison against the preceding
period, exclusion of savings-goal labels and of money coming in, and the empty
payload when nothing is labelled.

Full suite: 2814 tests, 2813 passing (1 skipped, 1 incomplete). `pint --test`,
`format:check`, `lint`, `dry` (duplication down to 3.77%) and
`crap --base=origin/main` all pass.

## QA

Checked in the browser against a seeded account:

- The card renders below "Top spending categories" with rows sorted descending;
  the totals match the DB exactly (`Essential` 325252, `Recurring` 271972,
  `Review Later` 138627 cents) when the same SQL is run by hand.
- Clicking a row lands on the transactions list filtered by that label and the
  30-day range, and every listed transaction carries the label.
- Dark mode: chips resolve to their `dark:` variants and stay readable.
- 390px wide: no horizontal overflow.
- With `label_transaction` emptied, the card disappears and the categories card
  stays — no error, no empty state. Restored afterwards.

QA also caught a crash in the first pass: `<Deferred fallback={null}>` throws in
`@inertiajs/react` 3.6.1 (it rejects a falsy fallback), which took down the
whole dashboard, not just this card. Fixed in 0efe22f7 with an empty fragment.
