### PR TITLE
fix(transactions): stop the transaction modal scrolling sideways on long concepts

### DIFF
--- a/resources/js/components/transactions/edit-transaction-dialog.test.tsx
+++ b/resources/js/components/transactions/edit-transaction-dialog.test.tsx
@@ -156,6 +156,48 @@ describe('EditTransactionDialog', () => {
         expect(screen.getByText('Victor Falcon')).toBeInTheDocument();
     });
 
+    it('shows the whole concept in the header instead of truncating it', () => {
+        const longDescription =
+            'Adeudo de Comunidad de Propietarios y Verificacion Pago Mensual Extraordinario';
+
+        render(
+            <EditTransactionDialog
+                transaction={{
+                    id: 'tx-1',
+                    user_id: 'user-1',
+                    account_id: 'account-1',
+                    category_id: null,
+                    description: longDescription,
+                    description_iv: null,
+                    transaction_date: '2026-05-27',
+                    amount: -1200,
+                    currency_code: 'EUR',
+                    notes: null,
+                    notes_iv: null,
+                    source: 'imported',
+                    created_at: '2026-05-27T00:00:00Z',
+                    updated_at: '2026-05-27T00:00:00Z',
+                    decryptedDescription: longDescription,
+                    decryptedNotes: null,
+                    label_ids: [],
+                }}
+                categories={[]}
+                accounts={[]}
+                banks={[]}
+                labels={[]}
+                open
+                onOpenChange={vi.fn()}
+                onSuccess={vi.fn()}
+                mode="edit"
+            />,
+        );
+
+        const header = screen.getByTestId('transaction-header-description');
+
+        expect(header).toHaveTextContent(longDescription);
+        expect(header.className).not.toContain('truncate');
+    });
+
     const checkingAccount = {
         id: 'account-1',
         name: 'Checking',

--- a/resources/js/components/transactions/edit-transaction-dialog.tsx
+++ b/resources/js/components/transactions/edit-transaction-dialog.tsx
@@ -987,23 +987,30 @@ export function EditTransactionDialog({
                         ) : (
                             transaction && (
                                 <>
-                                    <div className="flex items-center gap-3">
-                                        {headerCategory ? (
-                                            <CategoryIcon
-                                                category={headerCategory}
-                                                className="p-2.5"
-                                                iconClassName="size-5 sm:size-5"
-                                            />
-                                        ) : (
-                                            <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800">
-                                                <HelpCircle className="size-4 text-zinc-500" />
-                                            </div>
-                                        )}
-                                        <div className="min-w-0 flex-1">
-                                            <div className="truncate font-medium">
-                                                {description}
-                                            </div>
-                                            <div className="text-sm text-muted-foreground">
+                                    <div className="space-y-2">
+                                        {/* The concept is the one thing that
+                                            identifies the transaction, so it
+                                            gets the full width and wraps -
+                                            bank descriptions are long and an
+                                            ellipsis hid the useful half. */}
+                                        <div
+                                            className="font-medium break-words"
+                                            data-testid="transaction-header-description"
+                                        >
+                                            {description}
+                                        </div>
+                                        <div className="flex items-center gap-2">
+                                            {headerCategory ? (
+                                                <CategoryIcon
+                                                    category={headerCategory}
+                                                    className="p-1.5"
+                                                />
+                                            ) : (
+                                                <div className="flex size-7 shrink-0 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800">
+                                                    <HelpCircle className="size-3.5 text-zinc-500" />
+                                                </div>
+                                            )}
+                                            <div className="min-w-0 flex-1 text-sm text-muted-foreground">
                                                 {formatTransactionDate(
                                                     transaction.transaction_date,
                                                     locale,
@@ -1012,9 +1019,9 @@ export function EditTransactionDialog({
                                                     ? ` · ${accountName}`
                                                     : ''}
                                             </div>
-                                        </div>
-                                        <div className="shrink-0 text-2xl font-semibold tabular-nums">
-                                            {formattedAmount}
+                                            <div className="shrink-0 text-2xl font-semibold tabular-nums">
+                                                {formattedAmount}
+                                            </div>
                                         </div>
                                     </div>
 

--- a/resources/js/components/ui/dialog.test.tsx
+++ b/resources/js/components/ui/dialog.test.tsx
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Dialog, DialogContent, DialogTitle } from './dialog';
+
+describe('DialogContent', () => {
+    it('pins its grid column so long content cannot widen the dialog', () => {
+        render(
+            <Dialog open>
+                <DialogContent>
+                    <DialogTitle>Edit</DialogTitle>
+                    <div className="whitespace-nowrap">
+                        A description far longer than any phone screen can fit
+                        without wrapping anywhere at all
+                    </div>
+                </DialogContent>
+            </Dialog>,
+        );
+
+        // The dialog is a grid, and an implicit `auto` column is sized by the
+        // min-content of its children - non-wrapping content then stretched the
+        // whole dialog past the viewport and gave it a horizontal scrollbar.
+        // `grid-cols-1` is `minmax(0, 1fr)`, which pins the track to the
+        // container. jsdom has no layout, so the class is what we can assert.
+        expect(
+            document.querySelector('[data-slot="dialog-content"]'),
+        ).toHaveClass('grid-cols-1');
+    });
+});

--- a/resources/js/components/ui/dialog.tsx
+++ b/resources/js/components/ui/dialog.tsx
@@ -62,7 +62,7 @@ function DialogContent({
             <DialogPrimitive.Content
                 data-slot="dialog-content"
                 className={cn(
-                    "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] z-50 grid w-full max-w-[calc(100%-1.5rem)] max-h-[95vh] translate-x-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 overflow-y-auto sm:max-w-lg",
+                    "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] z-50 grid grid-cols-1 w-full max-w-[calc(100%-1.5rem)] max-h-[95vh] translate-x-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 overflow-y-auto sm:max-w-lg",
                     hasKeyboard && "top-[10%] sm:top-[50%] sm:translate-y-[-50%]",
                     !hasKeyboard && "top-[50%] translate-y-[-50%]",
                     className


### PR DESCRIPTION
## Problem

When a transaction had a long concept, the view/edit transaction modal grew a **horizontal scrollbar** and every field inside it was pushed past the right edge — the date input, the category select, the details rows and even the Save button were all clipped.

## Cause

`DialogContent` is a CSS grid, and its implicit `auto` column is sized by the **min-content** of its children. The read-only header truncated the concept with `truncate`, which is `white-space: nowrap`, so that track was sized to the full width of the text rather than to the dialog. Since `DialogContent` also has `overflow-y-auto`, `overflow-x` computes to `auto` — hence the sideways scroll.

Measured in a browser repro at 390px wide: `scrollWidth` 708 vs `clientWidth` 364.

## Fix

1. `grid-cols-1` on `DialogContent` pins the track to `minmax(0, 1fr)`, so no child can widen a dialog again. This applies to every dialog in the app; nothing overrode `grid-cols-*` or relied on the old min-content sizing, and content that used to overflow now gets clamped instead — which is what was wanted everywhere.
2. The concept is what identifies a transaction, so cutting it with an ellipsis hid the half that mattered. It now takes the full width and wraps, with the category icon, `date · account` and the amount moved to a secondary row below it.

Same repro after the change: `scrollWidth` 364 = `clientWidth` 364.

## Tests

- `resources/js/components/ui/dialog.test.tsx` — new: guards the pinned grid column on `DialogContent`. jsdom has no layout engine, so the class is what can be asserted; the comment records why.
- `edit-transaction-dialog.test.tsx` — new case: the header renders the whole concept and no longer truncates it.
- `bun run test` → 100 files / 648 tests pass. `lint`, `format:check`, `dry` and `pint --test` clean.

## Demo

<!-- PLACEHOLDER: drag the QA video here -->

https://github.com/user-attachments/assets/c5520d50-3cb4-4b02-acd7-37480f856a20
