### PR TITLE
fix(ai): treat a provider connection failure as transient

### DIFF
--- a/app/Services/Ai/CategorizeTransactions.php
+++ b/app/Services/Ai/CategorizeTransactions.php
@@ -8,6 +8,7 @@ use App\Jobs\RetryTransientAiCategorizationJob;
 use App\Models\Transaction;
 use App\Models\User;
 use App\Support\Money;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
 use Laravel\Ai\Enums\Lab;
@@ -108,6 +109,10 @@ class CategorizeTransactions
      * the chunks that succeeded; a transient provider failure additionally
      * schedules a deferred retry of the user's still-pending transactions.
      *
+     * Transient covers both the provider answering badly (overload, rate limit)
+     * and it not answering at all (DNS, connect timeout): neither is a bug, and
+     * both leave the chunk's transactions uncategorized until the retry runs.
+     *
      * @param  Collection<int, Transaction>  $transactions
      * @return list<array<string, mixed>>
      */
@@ -121,7 +126,7 @@ class CategorizeTransactions
                 foreach ($this->resolveChunkWithRetry($chunk, $catalog) as $result) {
                     $results[] = $result;
                 }
-            } catch (FailoverableException $exception) {
+            } catch (ConnectionException|FailoverableException $exception) {
                 Log::warning('AI categorization chunk dropped: provider transient failure.', [
                     'exception' => $exception->getMessage(),
                 ]);

--- a/app/Services/Ai/CategorizeTransactions.php
+++ b/app/Services/Ai/CategorizeTransactions.php
@@ -112,6 +112,9 @@ class CategorizeTransactions
      * Transient covers both the provider answering badly (overload, rate limit)
      * and it not answering at all (DNS, connect timeout): neither is a bug, and
      * both leave the chunk's transactions uncategorized until the retry runs.
+     * The trade-off is that a provider which stays unreachable never reaches
+     * Sentry either — the warning below is the only trace, and the deferred
+     * retry gets one attempt (see {@see RetryTransientAiCategorizationJob}).
      *
      * @param  Collection<int, Transaction>  $transactions
      * @return list<array<string, mixed>>

--- a/app/Services/Ai/LaravelAiRuleSuggestionGenerator.php
+++ b/app/Services/Ai/LaravelAiRuleSuggestionGenerator.php
@@ -4,6 +4,7 @@ namespace App\Services\Ai;
 
 use App\Ai\Agents\RuleSuggestionAgent;
 use App\Services\Ai\Contracts\RuleSuggestionGenerator;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Log;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Exceptions\FailoverableException;
@@ -29,9 +30,10 @@ class LaravelAiRuleSuggestionGenerator implements RuleSuggestionGenerator
                 foreach ($this->generateBatchWithRetry($batch, $categoryOptions) as $suggestion) {
                     $suggestions[] = $suggestion;
                 }
-            } catch (FailoverableException $exception) {
-                // An overloaded or rate-limited provider is an expected transient
-                // condition, not a bug (PHP-LARAVEL-44). Count it as a failure so
+            } catch (ConnectionException|FailoverableException $exception) {
+                // A provider that is overloaded, rate-limiting us or simply not
+                // reachable is an expected transient condition, not a bug
+                // (PHP-LARAVEL-44, PHP-LARAVEL-5K). Count it as a failure so
                 // an all-transient run still surfaces, but don't report the
                 // per-batch noise — a genuine total failure is still reported once
                 // by the run-level handler. Mirrors CategorizeTransactions.

--- a/app/Services/Ai/ReportSummarizer.php
+++ b/app/Services/Ai/ReportSummarizer.php
@@ -3,6 +3,7 @@
 namespace App\Services\Ai;
 
 use App\Ai\Agents\ReportSummaryAgent;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
@@ -56,9 +57,10 @@ class ReportSummarizer
                 model: (string) config('ai_reports.model'),
                 timeout: (int) config('ai_reports.timeout'),
             );
-        } catch (FailoverableException $exception) {
-            // An overloaded or rate-limited provider is an expected transient
-            // condition, not a bug, so it stays out of the error reports.
+        } catch (ConnectionException|FailoverableException $exception) {
+            // A provider that is overloaded, rate-limiting us or simply not
+            // reachable is an expected transient condition, not a bug, so it
+            // stays out of the error reports.
             Log::warning('Report AI summary skipped: provider transient failure.', [
                 'report' => $reportKey,
                 'exception' => $exception->getMessage(),

--- a/tests/Feature/Ai/CategorizeTransactionsTest.php
+++ b/tests/Feature/Ai/CategorizeTransactionsTest.php
@@ -10,10 +10,8 @@ use App\Models\Transaction;
 use App\Models\User;
 use App\Services\Ai\CategorizeTransactions;
 use App\Services\Ai\CategoryCatalog;
-use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Exceptions;
 use Illuminate\Support\Facades\Queue;
-use Laravel\Ai\Exceptions\ProviderOverloadedException;
 
 function leafIndex(CategoryCatalog $catalog, string $categoryId): int
 {
@@ -137,7 +135,7 @@ it('never sends client-side encrypted transactions to the model', function () {
         ->and($encrypted->category_id)->toBeNull();
 });
 
-it('drops the chunk, skips reporting and schedules a retry when the provider is transiently overloaded', function () {
+it('drops the chunk, skips reporting and schedules a retry on a transient provider failure', function (Closure $makeFailure) {
     $user = User::factory()->create();
     groceries($user);
     $transaction = uncategorized($user);
@@ -145,7 +143,7 @@ it('drops the chunk, skips reporting and schedules a retry when the provider is 
     Exceptions::fake();
     Queue::fake();
 
-    TransactionCategorizationAgent::fake(fn () => throw ProviderOverloadedException::forProvider('gemini'));
+    TransactionCategorizationAgent::fake(fn () => throw $makeFailure());
 
     $outcomes = app(CategorizeTransactions::class)->forTransactions($user, collect([$transaction]));
 
@@ -159,33 +157,7 @@ it('drops the chunk, skips reporting and schedules a retry when the provider is 
         RetryTransientAiCategorizationJob::class,
         fn (RetryTransientAiCategorizationJob $job): bool => $job->user->is($user),
     );
-});
-
-it('drops the chunk, skips reporting and schedules a retry when the provider cannot be reached', function () {
-    $user = User::factory()->create();
-    groceries($user);
-    $transaction = uncategorized($user);
-
-    Exceptions::fake();
-    Queue::fake();
-
-    TransactionCategorizationAgent::fake(fn () => throw new ConnectionException(
-        'cURL error 6: Could not resolve host: generativelanguage.googleapis.com',
-    ));
-
-    $outcomes = app(CategorizeTransactions::class)->forTransactions($user, collect([$transaction]));
-
-    $transaction->refresh();
-
-    expect($outcomes)->toBe([])
-        ->and($transaction->category_id)->toBeNull();
-
-    Exceptions::assertNothingReported();
-    Queue::assertPushed(
-        RetryTransientAiCategorizationJob::class,
-        fn (RetryTransientAiCategorizationJob $job): bool => $job->user->is($user),
-    );
-});
+})->with('transient provider failures');
 
 it('reports unexpected failures and does not schedule a retry so real bugs are not swallowed', function () {
     $user = User::factory()->create();

--- a/tests/Feature/Ai/CategorizeTransactionsTest.php
+++ b/tests/Feature/Ai/CategorizeTransactionsTest.php
@@ -10,6 +10,7 @@ use App\Models\Transaction;
 use App\Models\User;
 use App\Services\Ai\CategorizeTransactions;
 use App\Services\Ai\CategoryCatalog;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Exceptions;
 use Illuminate\Support\Facades\Queue;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
@@ -145,6 +146,32 @@ it('drops the chunk, skips reporting and schedules a retry when the provider is 
     Queue::fake();
 
     TransactionCategorizationAgent::fake(fn () => throw ProviderOverloadedException::forProvider('gemini'));
+
+    $outcomes = app(CategorizeTransactions::class)->forTransactions($user, collect([$transaction]));
+
+    $transaction->refresh();
+
+    expect($outcomes)->toBe([])
+        ->and($transaction->category_id)->toBeNull();
+
+    Exceptions::assertNothingReported();
+    Queue::assertPushed(
+        RetryTransientAiCategorizationJob::class,
+        fn (RetryTransientAiCategorizationJob $job): bool => $job->user->is($user),
+    );
+});
+
+it('drops the chunk, skips reporting and schedules a retry when the provider cannot be reached', function () {
+    $user = User::factory()->create();
+    groceries($user);
+    $transaction = uncategorized($user);
+
+    Exceptions::fake();
+    Queue::fake();
+
+    TransactionCategorizationAgent::fake(fn () => throw new ConnectionException(
+        'cURL error 6: Could not resolve host: generativelanguage.googleapis.com',
+    ));
 
     $outcomes = app(CategorizeTransactions::class)->forTransactions($user, collect([$transaction]));
 

--- a/tests/Feature/Ai/ReportSummarizerTest.php
+++ b/tests/Feature/Ai/ReportSummarizerTest.php
@@ -5,7 +5,6 @@ use App\Services\Ai\ReportSummarizer;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Exceptions;
 use Illuminate\Support\Facades\Log;
-use Laravel\Ai\Exceptions\ProviderOverloadedException;
 
 function summarize(bool $remember = true): ?string
 {
@@ -91,10 +90,10 @@ it('returns null and reports the failure when the provider fails', function () {
     Exceptions::assertReported(fn (RuntimeException $exception): bool => $exception->getMessage() === 'provider down');
 });
 
-it('logs a transient provider failure without reporting it', function () {
+it('logs a transient provider failure without reporting it', function (Closure $makeFailure) {
     Exceptions::fake();
     Log::spy();
-    ReportSummaryAgent::fake(fn () => throw ProviderOverloadedException::forProvider('gemini'));
+    ReportSummaryAgent::fake(fn () => throw $makeFailure());
 
     expect(summarize())->toBeNull();
 
@@ -102,4 +101,4 @@ it('logs a transient provider failure without reporting it', function () {
     Log::shouldHaveReceived('warning')
         ->withArgs(fn (string $message): bool => str_contains($message, 'provider transient failure'))
         ->once();
-});
+})->with('transient provider failures');

--- a/tests/Feature/Ai/RuleSuggestionGeneratorTest.php
+++ b/tests/Feature/Ai/RuleSuggestionGeneratorTest.php
@@ -3,7 +3,6 @@
 use App\Ai\Agents\RuleSuggestionAgent;
 use App\Services\Ai\LaravelAiRuleSuggestionGenerator;
 use Illuminate\Support\Facades\Exceptions;
-use Laravel\Ai\Exceptions\ProviderOverloadedException;
 
 it('returns the structured suggestions produced by the model', function () {
     RuleSuggestionAgent::fake([
@@ -139,14 +138,14 @@ it('keeps successful batches when one batch fails after retry', function () {
         ->and($suggestions[0]['match_token'])->toBe('okkey');
 });
 
-it('does not report an expected transient provider overload', function () {
+it('does not report an expected transient provider failure', function (Closure $makeFailure) {
     config()->set('ai_suggestions.group_batch_size', 1);
 
     Exceptions::fake();
 
-    RuleSuggestionAgent::fake(function (string $prompt) {
+    RuleSuggestionAgent::fake(function (string $prompt) use ($makeFailure) {
         if (str_contains($prompt, 'boomtoken')) {
-            throw ProviderOverloadedException::forProvider('gemini');
+            throw $makeFailure();
         }
 
         return ['suggestions' => [genSuggestion('okkey')]];
@@ -163,7 +162,7 @@ it('does not report an expected transient provider overload', function () {
         ->and($suggestions[0]['match_token'])->toBe('okkey');
 
     Exceptions::assertNothingReported();
-});
+})->with('transient provider failures');
 
 it('reports an unexpected batch failure', function () {
     config()->set('ai_suggestions.group_batch_size', 1);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -17,9 +17,11 @@ use App\Services\Banking\Sync\BankingConnectionSyncerFactory;
 use App\Services\Banking\TransactionSyncService;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
 use Stripe\Collection as StripeCollection;
 use Stripe\Service\SubscriptionService;
 use Stripe\StripeClient;
@@ -42,6 +44,25 @@ pest()->extend(TestCase::class)
     ->in('Feature', 'Browser', 'Performance');
 
 pest()->browser()->timeout(15000);
+
+/*
+|--------------------------------------------------------------------------
+| Transient AI provider failures
+|--------------------------------------------------------------------------
+|
+| The two ways an AI provider fails with nobody having a bug to fix: it answers
+| badly (overloaded, rate-limiting us) or it does not answer at all (DNS, connect
+| timeout). Every service that prompts a provider has to treat the two the same
+| way, so they assert against one shared list rather than each keeping its own.
+|
+*/
+
+dataset('transient provider failures', [
+    'provider overloaded' => fn (): Throwable => ProviderOverloadedException::forProvider('gemini'),
+    'provider unreachable' => fn (): Throwable => new ConnectionException(
+        'cURL error 6: Could not resolve host: generativelanguage.googleapis.com',
+    ),
+]);
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
Fixes PHP-LARAVEL-5K.

## The bug

A DNS failure reaching Gemini (`cURL error 6: Could not resolve host: generativelanguage.googleapis.com`) surfaced in production from `CategorizeTransactions::resolveChunk`, inside the queued `CategorizeTransactionWithAi` listener.

`CategorizeTransactions::resolve()` sorts provider failures into two arms:

| arm | what it does |
| --- | --- |
| `FailoverableException` | logs a warning, dispatches `RetryTransientAiCategorizationJob` |
| `Throwable` | `report()`s it, schedules nothing |

`Illuminate\Http\Client\ConnectionException` does not implement `FailoverableException`, so it landed in the second arm. Two consequences, and the first is the one users feel:

- **The transactions were abandoned.** The deferred retry is only dispatched from the transient arm, so nothing ever came back for that chunk. Those transactions stay uncategorized permanently — a bank sync during any DNS blip silently loses AI categorization for everything it imported.
- Every blip opened a Sentry issue, burying the failures that are actually ours.

## The fix

A provider that cannot be reached is the same class of problem as one that answers 503: expected, temporary, already handled. `ConnectionException` now joins `FailoverableException` in the transient arm, so it logs a warning and schedules the retry.

Verified end to end: `RetryTransientAiCategorizationJob` → `AiCategorizer::backfill` selects via `Transaction::scopePendingAiCategorization` (`category_id IS NULL AND description_iv IS NULL`), which has no dependency on the AI having touched the row — so a transaction the DNS failure skipped does qualify for the retry sweep.

The same classification is applied to `LaravelAiRuleSuggestionGenerator` and `ReportSummarizer`, which split failures identically — the former's comment literally says *"Mirrors CategorizeTransactions"*. Neither loses work today, but without this the same blip reopens as a fresh Sentry fingerprint the moment it lands on a rule-suggestion or report-summary run instead.

## One trade-off worth your call

Silencing the report also silences a provider that is unreachable *permanently* — a wrong base URL for a self-hosted provider, an egress rule blocking `generativelanguage.googleapis.com`. `enable_logs` is off, so `Log::warning` only reaches Sentry as a breadcrumb on someone else's event, and `RetryTransientAiCategorizationJob` is `ShouldBeUnique` with `tries = 1`, so there is exactly one deferred attempt and then silence.

This is the same bargain already struck for rate limits and 503s, so I kept it rather than bolt on a counter, and documented where the catch is. If you'd rather have a signal, the natural shape is reporting once after N consecutive connection failures in a window — happy to add it.

## Tests

The connection-failure case was a line-for-line copy of the provider-overload test beside it, so the two transient cases now come from a shared `transient provider failures` dataset in `tests/Pest.php` and the body is written once. jscpd would not have caught that duplication — it only scans `app` and `resources/js`.

Each of the three sites was confirmed red before the fix (`The following exceptions were reported: Illuminate\Http\Client\ConnectionException`) and green after.

`tests/Feature/Ai` 144 passed · Unit suite 156 passed · `pint --test` · `crap --base=origin/main` · `bun run dry` all clean.
