### PR TITLE
docs(accounts): explain the account ownership share field

### DIFF
--- a/resources/docs/documentation/20-your-data/10-accounts-en.md
+++ b/resources/docs/documentation/20-your-data/10-accounts-en.md
@@ -187,12 +187,37 @@ removes it from that one view; the account stays selectable everywhere else.
 
 ## Shared accounts
 
-An account can record the share of it that is yours. A joint account held 50/50
-contributes half of every amount to your own figures, while the account still
-shows the real balance.
+An account can record the share of it that is yours. Use it for accounts you
+genuinely co-own, such as a shared household account or a property owned with
+someone else.
 
-Use it for accounts you genuinely co-own, such as a shared household account or
-a property owned with someone else.
+Open **Edit account** and fill in **My share of this account (%)**. The share
+goes from 1 to 100, and 100 means the whole account is yours. Leaving the field
+empty keeps the share the account already has.
+
+From then on, income and expenses only count towards your own figures by that
+percentage. On an account held 50/50, a shared grocery bill counts as half of
+what the bank charged in:
+
+- Cashflow
+- Budgets
+- Label spending
+
+The account itself is left alone. It keeps showing the real balance and the real
+amount of every transaction, because that is what actually moved. Inside a
+budget, entries coming from an account with a share below 100% are marked, so you
+can tell which ones only count in part.
+
+The balance stays whole by default, so all of it counts towards net worth. When
+the share is below 100%, a checkbox appears under the field: **Apply it to the
+balance too, so only my share counts towards net worth**. Tick it for something
+like a flat you own half of, where only half the value is really yours.
+
+Changing the share later also rewrites what the account has already spent in
+your budgets, past periods included. Budgets store what each transaction
+contributed at the moment it was assigned, so they are recalculated for the new
+share. Cashflow and net worth are worked out as you read them, so they pick up
+the new share on their own.
 
 ## FAQ
 
@@ -213,3 +238,10 @@ The important number for property is its estimated value today. That value can c
 ### Should I create one account or combine several?
 
 Create separate accounts when the money is stored separately in real life. Reports are clearer that way.
+
+### Why did my past budgets change after I edited the share of an account?
+
+Budgets record what each transaction contributed at the moment it was assigned,
+so changing the share rewrites that contribution in every period, closed ones
+included. It keeps a 50/50 account looking the same in January as it does
+today.

--- a/resources/docs/documentation/20-your-data/10-accounts-es.md
+++ b/resources/docs/documentation/20-your-data/10-accounts-es.md
@@ -188,12 +188,37 @@ de esa vista; la cuenta sigue siendo seleccionable en todo lo demás.
 
 ## Cuentas compartidas
 
-Una cuenta puede registrar qué parte de ella es tuya. Una cuenta conjunta al
-50/50 aporta la mitad de cada importe a tus propias cifras, mientras la cuenta
-sigue mostrando el saldo real.
+Una cuenta puede registrar qué parte de ella es tuya. Úsalo para cuentas que de
+verdad compartes, como una cuenta doméstica común o un inmueble en copropiedad.
 
-Úsalo para cuentas que de verdad compartes, como una cuenta doméstica común o un
-inmueble en copropiedad.
+Abre **Editar cuenta** y rellena **Mi parte de esta cuenta (%)**. La parte va de
+1 a 100, y 100 significa que la cuenta es entera tuya. Si dejas el campo vacío,
+se mantiene la parte que la cuenta ya tenía.
+
+A partir de ahí, los ingresos y gastos solo cuentan en tus propias cifras en ese
+porcentaje. En una cuenta al 50/50, una compra del súper compartida cuenta como
+la mitad de lo que cobró el banco en:
+
+- Flujo de efectivo
+- Presupuestos
+- Gasto por etiqueta
+
+La cuenta en sí no cambia. Sigue mostrando el saldo real y el importe real de
+cada transacción, porque eso es lo que se movió de verdad. Dentro de un
+presupuesto, las transacciones que vienen de una cuenta con una parte inferior
+al 100 % aparecen marcadas, así ves cuáles cuentan solo en parte.
+
+El saldo se deja entero por defecto, así que cuenta completo en el patrimonio
+neto. Cuando la parte es inferior al 100 %, aparece una casilla debajo del campo:
+**Aplicarlo también al saldo, para que solo mi parte cuente en el patrimonio
+neto**. Márcala para algo como un piso del que tienes la mitad, donde solo la
+mitad del valor es realmente tuya.
+
+Cambiar la parte más adelante también reescribe lo que la cuenta ya ha gastado
+en tus presupuestos, incluidos los periodos pasados. Los presupuestos guardan lo
+que aportó cada transacción en el momento en que se asignó, así que se
+recalculan con la parte nueva. El flujo de efectivo y el patrimonio neto se
+calculan al leerlos, así que recogen la parte nueva por su cuenta.
 
 ## Preguntas frecuentes
 
@@ -214,3 +239,9 @@ El número importante de una propiedad es su valor estimado actual. Ese valor pu
 ### ¿Debería crear una cuenta o combinar varias?
 
 Crea cuentas separadas cuando el dinero esté separado en la vida real. Los informes serán más claros.
+
+### ¿Por qué han cambiado mis presupuestos pasados al editar la parte de una cuenta?
+
+Los presupuestos registran lo que aportó cada transacción en el momento en que se
+asignó, así que cambiar la parte reescribe esa aportación en todos los periodos,
+incluidos los cerrados. Así una cuenta al 50/50 se ve igual en enero que hoy.


### PR DESCRIPTION
## What

The **Shared accounts** section of the accounts documentation only said that an account can record the share of it that is yours. It never said where to set it, what the share actually changes, or that editing it rewrites budgets that are already closed — which is the one side effect that surprises people.

This expands that section in both languages and adds one FAQ entry per language.

## What the docs now cover

- **Where the field is** — Edit account → *My share of this account (%)*, the 1–100 range, and that leaving it empty keeps the current share.
- **What the share weights** — income and expenses only count towards your own figures by that percentage, in cashflow, budgets and label spending.
- **What it does not touch** — the account keeps showing its real balance and the real amount of every transaction, and budget entries from a shared account are marked so you can tell which ones count in part.
- **Net worth** — the balance stays whole by default; only the separate *Apply it to the balance too* checkbox (which appears when the share drops below 100%) carries the share into net worth.
- **The retroactive rewrite** — budgets store what each transaction contributed at assignment time, so changing the share rewrites past periods, while cashflow and net worth are computed at read time and pick it up on their own.

Every claim was verified against the implementation: `Account::shareOfAmount()`, `Transaction::OWNED_AMOUNT_SQL`, `BalanceLookup` (gated on `ownership_applies_to_balance`), `LabelSpendingService`, and the `updated` hook in `Account::booted()` that calls `BudgetTransactionService::reweighAccountSnapshots()`.

## Notes

- Docs only — no code, no dependencies, no new diagrams or images.
- EN and ES are structurally identical; the quoted UI labels match the component strings and `lang/es.json` verbatim in both languages.
- Kept the docs' own vocabulary ("label", matching the dedicated Labels page) rather than the one-off *Spending by tag* panel title used in the transaction analysis drawer.

## Testing

- `php artisan test tests/Feature/DocumentationTest.php tests/Feature/DocumentationImagesTest.php tests/Feature/DocumentationTreeTest.php` → 43 passed, 855 assertions.
- `bun run format` → clean, no reformatting.
- Browser QA on the running app in both languages: rendering, TOC entries and anchor jumps, dark mode, 390×844 mobile viewport (no horizontal overflow), and the `/documentation/accounts.md` raw endpoint. No console errors.

## Demo

https://github.com/user-attachments/assets/b9e122ea-ab8b-4659-9db4-2e70b725eca3

