### PR TITLE
fix(open-banking): localize the country selector

### DIFF
--- a/app/Support/Marketing/MarketingContent.php
+++ b/app/Support/Marketing/MarketingContent.php
@@ -40,7 +40,7 @@ final class MarketingContent
 
     /**
      * Countries the bank connect flow offers, with the name to print in each
-     * language. The codes mirror CONNECT_COUNTRIES in the frontend connect
+     * language. The codes mirror CONNECT_COUNTRY_CODES in the frontend connect
      * flow; a test fails if the two lists stop agreeing.
      */
     public const COUNTRIES = [

--- a/resources/js/components/open-banking/connect-account-dialog.test.tsx
+++ b/resources/js/components/open-banking/connect-account-dialog.test.tsx
@@ -10,7 +10,7 @@ globalThis.ResizeObserver ??= class {
 };
 
 vi.mock('@inertiajs/react', () => ({
-    usePage: () => ({ props: { features: {} } }),
+    usePage: () => ({ props: { features: {}, locale: 'es' } }),
 }));
 
 vi.mock('@/utils/i18n', () => ({
@@ -115,6 +115,17 @@ async function reachBankStep(
 describe('ConnectAccountDialog', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+    });
+
+    it('names the countries in the active locale', () => {
+        render(<ConnectAccountDialog open onOpenChange={vi.fn()} />);
+
+        expect(
+            screen.getByRole('option', { name: 'España' }),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByRole('option', { name: 'Spain' }),
+        ).not.toBeInTheDocument();
     });
 
     it('shows Interactive Brokers as a connectable provider', async () => {

--- a/resources/js/components/open-banking/connect-account-dialog.tsx
+++ b/resources/js/components/open-banking/connect-account-dialog.tsx
@@ -23,7 +23,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
-import { CONNECT_COUNTRIES, useConnectFlow } from '@/hooks/use-connect-flow';
+import { useConnectCountries, useConnectFlow } from '@/hooks/use-connect-flow';
 import { ProviderCredentialFields } from '@/lib/connect-providers';
 import type { BankingConnection } from '@/types/banking';
 import { __ } from '@/utils/i18n';
@@ -65,6 +65,8 @@ export function ConnectAccountDialog({
         handleAuthorize,
         reset,
     } = useConnectFlow(connections);
+
+    const countries = useConnectCountries();
 
     const [integrationDrawerOpen, setIntegrationDrawerOpen] = useState(false);
 
@@ -113,12 +115,12 @@ export function ConnectAccountDialog({
                                         />
                                     </SelectTrigger>
                                     <SelectContent>
-                                        {CONNECT_COUNTRIES.map((c) => (
+                                        {countries.map((c) => (
                                             <SelectItem
                                                 key={c.code}
                                                 value={c.code}
                                             >
-                                                {__(c.name)}
+                                                {c.name}
                                             </SelectItem>
                                         ))}
                                     </SelectContent>

--- a/resources/js/components/open-banking/connect-account-inline.tsx
+++ b/resources/js/components/open-banking/connect-account-inline.tsx
@@ -25,7 +25,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
-import { CONNECT_COUNTRIES, useConnectFlow } from '@/hooks/use-connect-flow';
+import { useConnectCountries, useConnectFlow } from '@/hooks/use-connect-flow';
 import { useWebHaptics } from '@/hooks/use-web-haptics';
 import { ProviderCredentialFields } from '@/lib/connect-providers';
 import { cn } from '@/lib/utils';
@@ -69,6 +69,8 @@ export function ConnectAccountInline({
         clearBankSelection,
     } = useConnectFlow(connections);
 
+    const countries = useConnectCountries();
+
     const { trigger } = useWebHaptics();
 
     const handleBack = useCallback(() => {
@@ -104,9 +106,9 @@ export function ConnectAccountInline({
                             <SelectValue placeholder={__('Select country')} />
                         </SelectTrigger>
                         <SelectContent>
-                            {CONNECT_COUNTRIES.map((c) => (
+                            {countries.map((c) => (
                                 <SelectItem key={c.code} value={c.code}>
-                                    {__(c.name)}
+                                    {c.name}
                                 </SelectItem>
                             ))}
                         </SelectContent>

--- a/resources/js/hooks/use-connect-flow.ts
+++ b/resources/js/hooks/use-connect-flow.ts
@@ -1,3 +1,4 @@
+import { useLocale } from '@/hooks/use-locale';
 import {
     alreadyConnectedBankNames,
     hasLiveConnectionForProvider,
@@ -17,26 +18,44 @@ import type {
 import { __ } from '@/utils/i18n';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-export const CONNECT_COUNTRIES = [
-    { code: 'ES', name: 'Spain' },
-    { code: 'DE', name: 'Germany' },
-    { code: 'FR', name: 'France' },
-    { code: 'IT', name: 'Italy' },
-    { code: 'NL', name: 'Netherlands' },
-    { code: 'PT', name: 'Portugal' },
-    { code: 'BE', name: 'Belgium' },
-    { code: 'AT', name: 'Austria' },
-    { code: 'FI', name: 'Finland' },
-    { code: 'IE', name: 'Ireland' },
-    { code: 'LT', name: 'Lithuania' },
-    { code: 'LV', name: 'Latvia' },
-    { code: 'EE', name: 'Estonia' },
-    { code: 'SE', name: 'Sweden' },
-    { code: 'NO', name: 'Norway' },
-    { code: 'DK', name: 'Denmark' },
-    { code: 'PL', name: 'Poland' },
-    { code: 'GB', name: 'United Kingdom' },
+/** Countries we can connect banks in, most-used first. */
+export const CONNECT_COUNTRY_CODES = [
+    'ES',
+    'DE',
+    'FR',
+    'IT',
+    'NL',
+    'PT',
+    'BE',
+    'AT',
+    'FI',
+    'IE',
+    'LT',
+    'LV',
+    'EE',
+    'SE',
+    'NO',
+    'DK',
+    'PL',
+    'GB',
 ] as const;
+
+/**
+ * The connectable countries named in the user's locale. Intl owns the country
+ * names, so they never need a translation entry of their own.
+ */
+export function useConnectCountries(): { code: string; name: string }[] {
+    const locale = useLocale();
+
+    return useMemo(() => {
+        const names = new Intl.DisplayNames([locale], { type: 'region' });
+
+        return CONNECT_COUNTRY_CODES.map((code) => ({
+            code,
+            name: names.of(code) ?? code,
+        }));
+    }, [locale]);
+}
 
 export type ConnectStep = 'country' | 'bank' | 'confirm';
 

--- a/resources/js/pages/settings/connections.test.tsx
+++ b/resources/js/pages/settings/connections.test.tsx
@@ -30,6 +30,7 @@ vi.mock('@inertiajs/react', () => ({
                 cashflow: true,
                 calculateBalancesOnImport: false,
             },
+            locale: 'en',
         },
     }),
     usePoll: () => ({

--- a/tests/Feature/IntegrationsPageTest.php
+++ b/tests/Feature/IntegrationsPageTest.php
@@ -44,8 +44,8 @@ function connectCountryCodes(): array
 {
     $flow = file_get_contents(base_path('resources/js/hooks/use-connect-flow.ts'));
 
-    preg_match('/CONNECT_COUNTRIES = \[(.*?)\] as const;/s', (string) $flow, $block);
-    preg_match_all("/code: '([A-Z]{2})'/", $block[1] ?? '', $matches);
+    preg_match('/CONNECT_COUNTRY_CODES = \[(.*?)\] as const;/s', (string) $flow, $block);
+    preg_match_all("/^\s*'([A-Z]{2})',$/m", $block[1] ?? '', $matches);
 
     return $matches[1];
 }


### PR DESCRIPTION
## What

The bank-connect country selector listed its countries as hardcoded English
names run through `__()`:

```tsx
{ code: 'ES', name: 'Spain' },
...
{__(c.name)}
```

Those keys were never added to `lang/es.json` or `lang/fr.json`, so `__()`
fell back to the key and Spanish and French users read "Spain", "Germany" and
"United Kingdom" in an otherwise translated dialog.

## How

`Intl.DisplayNames` already knows every country in every locale, so the list
now carries codes only and takes its names from there, keyed off the shared
Inertia `locale` prop:

```ts
export function useConnectCountries(): { code: string; name: string }[] {
    const locale = useLocale();

    return useMemo(() => {
        const names = new Intl.DisplayNames([locale], { type: 'region' });

        return CONNECT_COUNTRY_CODES.map((code) => ({
            code,
            name: names.of(code) ?? code,
        }));
    }, [locale]);
}
```

No `lang` entries to add, and no drift the day a country joins the list. Both
consumers of the flow — the desktop dialog and the mobile inline screen — go
through the hook, so they stay in step.

The option order is unchanged (most-used first), and the ISO code is still
what reaches `/open-banking/institutions`; only the label is localized. The
public integrations page keeps its own PHP country map: it is server-rendered
for SEO in `en`/`es` and is not tied to the runtime locale. Its consistency
test parses the renamed constant.

## Testing

- New test in `connect-account-dialog.test.tsx`: under `locale: 'es'` the
  select renders `España` and no longer renders `Spain`.
- Browser QA on `en`, `es` and `fr`, desktop dialog and mobile inline flow:
  names localized, the closed trigger shows the localized name, and Continue
  still issues `GET /open-banking/institutions?country=ES` in every locale.
- `pest` (2847 passed), `vitest` (650 passed), `pint`, `lint`, `format`,
  `dry`, `crap` and `build` all green locally.

## Demo

https://github.com/user-attachments/assets/2adeb0b8-de58-4925-b5b8-666fcdd7584b


<!-- PLACEHOLDER: drag the QA video here -->
