### PR TITLE
fix(transactions): fall back to the profile currency in the transaction dialog

### DIFF
--- a/resources/js/components/transactions/edit-transaction-dialog.test.tsx
+++ b/resources/js/components/transactions/edit-transaction-dialog.test.tsx
@@ -41,6 +41,16 @@ vi.mock('@/services/transaction-sync', () => ({
     },
 }));
 
+vi.mock('@inertiajs/react', () => ({
+    router: {
+        visit: vi.fn(),
+        reload: vi.fn(),
+    },
+    usePage: () => ({
+        props: { auth: { user: { currency_code: 'EUR' } } },
+    }),
+}));
+
 vi.mock('sonner', () => ({
     toast: {
         success: vi.fn(),
@@ -230,6 +240,52 @@ describe('EditTransactionDialog', () => {
             'data-value',
             '',
         );
+    });
+
+    it('falls back to the profile currency while no account is selected', () => {
+        render(
+            <EditTransactionDialog
+                transaction={null}
+                categories={[]}
+                accounts={[checkingAccount]}
+                banks={[]}
+                labels={[]}
+                open
+                onOpenChange={vi.fn()}
+                onSuccess={vi.fn()}
+                mode="create"
+            />,
+        );
+
+        expect(screen.getByText('€')).toBeInTheDocument();
+        expect(screen.queryByText('$')).not.toBeInTheDocument();
+    });
+
+    it('shows each account currency in the account options', async () => {
+        render(
+            <EditTransactionDialog
+                transaction={null}
+                categories={[]}
+                accounts={[
+                    checkingAccount,
+                    {
+                        ...checkingAccount,
+                        id: 'account-2',
+                        name: 'Savings',
+                        currency_code: 'PEN',
+                    },
+                ]}
+                banks={[]}
+                labels={[]}
+                open
+                onOpenChange={vi.fn()}
+                onSuccess={vi.fn()}
+                mode="create"
+            />,
+        );
+
+        expect(await screen.findByText('Checking · EUR')).toBeInTheDocument();
+        expect(screen.getByText('Savings · PEN')).toBeInTheDocument();
     });
 
     it('auto-selects the account matching initialAccountId (account page)', () => {

--- a/resources/js/components/transactions/edit-transaction-dialog.tsx
+++ b/resources/js/components/transactions/edit-transaction-dialog.tsx
@@ -34,6 +34,7 @@ import { readStoredValue, writeStoredValue } from '@/lib/safe-storage';
 import { canSplit } from '@/lib/transaction-splits';
 import { appendNoteIfNotPresent } from '@/lib/utils';
 import { transactionSyncService } from '@/services/transaction-sync';
+import { type SharedData } from '@/types';
 import {
     filterTransactionalAccounts,
     type Account,
@@ -46,7 +47,7 @@ import { type DecryptedTransaction } from '@/types/transaction';
 import { formatCurrency, toMajorUnits } from '@/utils/currency';
 import { formatDate } from '@/utils/date';
 import { __ } from '@/utils/i18n';
-import { router } from '@inertiajs/react';
+import { router, usePage } from '@inertiajs/react';
 import { getYear, parseISO } from 'date-fns';
 import {
     FileText,
@@ -114,6 +115,8 @@ export function EditTransactionDialog({
     initialAccountId = null,
 }: EditTransactionDialogProps) {
     const locale = useLocale();
+    const userCurrencyCode =
+        usePage<SharedData>().props.auth.user.currency_code;
     const STORAGE_KEY_UPDATE_BALANCE =
         'whisper_money_update_balance_on_transaction';
 
@@ -284,7 +287,7 @@ export function EditTransactionDialog({
                 amount: toMajorUnits(
                     signedAmount,
                     accounts.find((acc) => acc.id === accountId)
-                        ?.currency_code ?? 'USD',
+                        ?.currency_code ?? userCurrencyCode,
                 ),
                 transaction_date: transactionDate,
                 account_id: accountId,
@@ -901,7 +904,7 @@ export function EditTransactionDialog({
                                                 }
                                                 currencyCode={
                                                     selectedAccount?.currency_code ||
-                                                    'USD'
+                                                    userCurrencyCode
                                                 }
                                                 disabled={isSubmitting}
                                                 required
@@ -970,12 +973,7 @@ export function EditTransactionDialog({
                                                                 account.id,
                                                             )}
                                                         >
-                                                            {decryptedAccountNames.get(
-                                                                account.id,
-                                                            ) ||
-                                                                __(
-                                                                    '[Loading...]',
-                                                                )}
+                                                            {`${decryptedAccountNames.get(account.id) || __('[Loading...]')} · ${account.currency_code}`}
                                                         </SelectItem>
                                                     ),
                                                 )}


### PR DESCRIPTION
## Problem

A user reported on Discord that their profile currency is EUR, but the "Add
Transaction" dialog showed the amount with the **US$** symbol and offered no
visible way to pick a currency. Their screenshot showed **Account** still
unselected — which is the whole story:

```tsx
currencyCode={selectedAccount?.currency_code || 'USD'}
```

With no account picked yet, the input fell back to a hardcoded `USD` and ignored
the profile currency entirely.

Nothing was ever *saved* wrong. A transaction's currency always comes from its
account (both the create and update paths read `selectedAccount.currency_code`,
and the account is validated as required), so the symbol was purely cosmetic
until an account was chosen. The bug was that the cosmetic default was the wrong
currency, and that nothing told the user where the currency actually comes from.

## Changes

1. **Fall back to the profile currency** instead of `'USD'`, read the way the
   rest of the app reads it (`usePage<SharedData>().props.auth.user.currency_code`,
   same as `update-balance-dialog.tsx`). The third `?? 'USD'` in the rule-engine
   `toMajorUnits` call got the same value for consistency — unreachable in
   practice, since the account is validated before it runs.

2. **Make the source of the currency discoverable.** Each account option now
   shows its currency code: `Primary Checking · EUR`. The ISO code rather than
   the symbol on purpose — this user juggles EUR / USD / PEN, and `$` vs `US$`
   vs `S/` is exactly what confused them in the first place. Shown always, not
   gated on holding more than one currency: one line beats a `useMemo` over the
   account list, and the label is useful even with a single account.

## Out of scope

A per-transaction currency independent of the account (a USD expense inside a EUR
account, with an FX rate) is what the report implicitly asks for, but it's a much
bigger change: schema, conversion at read time, and every total that sums across
accounts. Not built here. The account → transaction currency inheritance is
untouched.

## Follow-up worth filing

The identical `selectedAccount?.currency_code || 'USD'` fallback still exists in
the import flows — `import-transactions-drawer.tsx` (2 sites) and
`import-balances-drawer.tsx` (4 sites). Not touched here to keep this diff
focused, but the same report can come back from those screens.

## Tests

Two new cases in `edit-transaction-dialog.test.tsx`:

- the amount input shows the profile currency (`€`) while no account is selected;
- the account options show each account's currency code (`Checking · EUR`,
  `Savings · PEN`).

Both verified red before the fix and green after. The file had no
`@inertiajs/react` mock, so adding `usePage` needed one — added with `router`
kept, since the dialog uses it.

`bun run test` 651/651 · `bun run lint`, `bun run format`, `bun run dry` clean.

## QA

Real browser QA against the dev server, logged in as a EUR-profile account with
three transactional accounts in EUR / USD / PEN:

| Check | Result |
| --- | --- |
| Amount symbol with **no account selected** | `€` (was `US$`) |
| Account options | `Emergency Fund · PEN`, `Joint Checking · USD`, `Primary Checking · EUR` |
| Pick PEN account → symbol | `PEN` |
| Pick USD account → symbol | `$` |
| Pick EUR account → symbol | `€` |
| Save a transaction | persisted `amount=-1234`, `currency_code=EUR`, matching the account |
| Console errors | none |
| Mobile (390×844) | symbol `€`, options render correctly |

Note: with `en-US` formatting, `Intl` has no short symbol for PEN so the input
renders the literal `PEN`. That's pre-existing `AmountInput` behaviour, and it's
another argument for showing ISO codes in the picker.

## Demo

https://github.com/user-attachments/assets/e925d565-107e-4cfc-bba7-0de565c9f8fb


