### PR TITLE
feat(summaries): preview one report case, or with the real analysis

### DIFF
--- a/app/Console/Commands/PreviewMonthlySummaryCommand.php
+++ b/app/Console/Commands/PreviewMonthlySummaryCommand.php
@@ -7,6 +7,7 @@ use App\Mail\Drip\MonthlySummaryReminderEmail;
 use App\Models\MonthlySummary;
 use App\Models\Transaction;
 use App\Models\User;
+use App\Services\MonthlySummary\AnalysisWriter;
 use App\Services\MonthlySummary\Summaries;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
@@ -20,7 +21,8 @@ use Throwable;
  * The report has more states than a screenshot can show — with and without the
  * analysis, paying and not, a month that closed short, a first month with
  * nothing to compare against — and they only differ in ways you have to see in
- * a real client. This puts all of them in Mailhog in one go.
+ * a real client. This puts all of them in Mailhog in one go, or just the one
+ * `--type` names.
  *
  * It builds from a real account's real figures rather than a fixture, because
  * the whole point of looking is to catch what invented data hides: an empty
@@ -29,16 +31,34 @@ use Throwable;
  *
  * Nothing here writes a mail log or marks a summary as sent: it bypasses the
  * job and hands the mailable straight to the mailer, so a preview can never
- * stop the real send going out later.
+ * stop the real send going out later. `--ai` keeps that promise too — the model
+ * writes the analysis and nobody stores it — but it does send `--source`'s real
+ * figures to the provider, past the consent gate the real send honours. Point it
+ * at an account whose month you may show a model.
  */
 class PreviewMonthlySummaryCommand extends Command
 {
     protected $signature = 'email:monthly-summary-preview
         {email : Where to send the previews}
         {--source= : The account whose real figures to build from (defaults to the press account)}
-        {--month= : The closed month to report, as YYYY-MM (defaults to last month)}';
+        {--month= : The closed month to report, as YYYY-MM (defaults to last month)}
+        {--type= : Send this case only: pro, free, pro-without-ai, short-closed-month, first-month, reminder}
+        {--ai : Have the model write the analysis instead of using the sample text}';
 
     protected $description = 'Send every state of the monthly summary email to one inbox for review';
+
+    /**
+     * The cases, in the order they go out, keyed by the slug `--type` picks them
+     * with. The values are what the console prints beside each one.
+     */
+    private const CASES = [
+        'pro' => '1 · Pro, with the analysis',
+        'free' => '2 · Free, analysis locked',
+        'pro-without-ai' => '3 · Pro without AI consent',
+        'short-closed-month' => '4 · The month closed short',
+        'first-month' => '5 · A first month',
+        'reminder' => '6 · The 3rd-of-the-month reminder',
+    ];
 
     /**
      * Stands in for the analysis when no model is reachable. Written by hand and
@@ -53,12 +73,20 @@ class PreviewMonthlySummaryCommand extends Command
     Al ritmo de los últimos tres meses, tu objetivo llega a la meta en septiembre de 2027.
     TEXT;
 
-    public function handle(Summaries $summaries): int
+    public function handle(Summaries $summaries, AnalysisWriter $writer): int
     {
         $email = (string) $this->argument('email');
 
         if (! filter_var($email, FILTER_VALIDATE_EMAIL)) {
             $this->error("Invalid email address: {$email}");
+
+            return self::FAILURE;
+        }
+
+        $type = $this->option('type');
+
+        if ($type !== null && ! isset(self::CASES[$type])) {
+            $this->error("Unknown type: {$type}. Pick one of: ".implode(', ', array_keys(self::CASES)).'.');
 
             return self::FAILURE;
         }
@@ -82,8 +110,14 @@ class PreviewMonthlySummaryCommand extends Command
 
         $this->info("Building from {$user->email}, {$month->format('Y-m')}.");
 
-        foreach ($this->cases($user, $summary, $summaries, $month) as $label => $build) {
-            $this->send($email, $user->preferredLocale(), $label, $build);
+        $cases = $this->cases($user, $summary, $summaries, $month, $writer);
+
+        if ($type !== null) {
+            $cases = array_intersect_key($cases, [$type => null]);
+        }
+
+        foreach ($cases as $slug => $build) {
+            $this->send($email, $user->preferredLocale(), self::CASES[$slug], $build);
         }
 
         $this->newLine();
@@ -93,9 +127,13 @@ class PreviewMonthlySummaryCommand extends Command
     }
 
     /**
+     * Every case behind a callable, so the one `--type` names is the only one
+     * that does any work: an unpicked case never freezes a month or asks a model
+     * for anything.
+     *
      * @return array<string, callable(): Mailable>
      */
-    private function cases(User $user, MonthlySummary $summary, Summaries $summaries, Carbon $month): array
+    private function cases(User $user, MonthlySummary $summary, Summaries $summaries, Carbon $month, AnalysisWriter $writer): array
     {
         $cardUrl = $summaries->primaryCardUrl($summary, true);
 
@@ -103,18 +141,58 @@ class PreviewMonthlySummaryCommand extends Command
             $this->warn('No card image: the renderer could not draw one, so the share block goes out without it.');
         }
 
+        $analysis = $this->analysis($user, $summary, $writer);
+
         return [
-            '1 · Pro, with the analysis' => fn () => $this->report($user, $summary, self::SAMPLE_ANALYSIS, $cardUrl, pro: true),
-            '2 · Free, analysis locked' => fn () => $this->locked($this->freeReader($user), $summary, $cardUrl),
-            '3 · Pro without AI consent' => fn () => $this->locked($user, $summary, $cardUrl),
-            '4 · The month closed short' => fn () => $this->report($user, $this->incomplete($summary), self::SAMPLE_ANALYSIS, $cardUrl, pro: true),
-            '5 · A first month' => fn () => $this->firstMonth($user, $summaries, $cardUrl),
-            '6 · The 3rd-of-the-month reminder' => fn () => new MonthlySummaryReminderEmail(
+            'pro' => fn () => $this->report($user, $summary, $analysis(), $cardUrl, pro: true),
+            'free' => fn () => $this->locked($this->freeReader($user), $summary, $cardUrl),
+            'pro-without-ai' => fn () => $this->locked($user, $summary, $cardUrl),
+            'short-closed-month' => fn () => $this->report($user, $this->incomplete($summary), $analysis(), $cardUrl, pro: true),
+            'first-month' => fn () => $this->firstMonth($user, $summaries, $cardUrl),
+            'reminder' => fn () => new MonthlySummaryReminderEmail(
                 $user,
                 $month,
                 $month->copy()->addMonth()->startOfMonth()->addDays((int) config('monthly_summary.last_day') - 1),
             ),
         ];
+    }
+
+    /**
+     * The text the two reporting cases share. Behind a closure and remembered,
+     * so `--ai` pays for one generation whichever of them go out, and for none
+     * at all when `--type` picks a case that carries no analysis.
+     *
+     * It drafts rather than writes: `write()` would store the text on the real
+     * summary, and the send later this month would hand the reader a preview's
+     * analysis. Drafting also skips the plan and consent gates, which is the
+     * point — the press account has neither, and the pro case is what we want to
+     * look at.
+     *
+     * @return callable(): string
+     */
+    private function analysis(User $user, MonthlySummary $summary, AnalysisWriter $writer): callable
+    {
+        if (! $this->option('ai')) {
+            return fn (): string => self::SAMPLE_ANALYSIS;
+        }
+
+        $drafted = false;
+        $text = null;
+
+        return function () use (&$drafted, &$text, $user, $summary, $writer): string {
+            if (! $drafted) {
+                $drafted = true;
+                $text = $writer->draft($summary, $user);
+
+                if ($text === null) {
+                    $this->warn('The model wrote nothing: falling back to the sample text.');
+                }
+            }
+
+            // An empty analysis block would read as the free case and mislead
+            // whoever is reviewing, so the sample stands in for it.
+            return $text ?? self::SAMPLE_ANALYSIS;
+        };
     }
 
     private function report(User $user, MonthlySummary $summary, ?string $analysis, ?string $cardUrl, bool $pro): MonthlySummaryEmail

--- a/app/Services/MonthlySummary/AnalysisWriter.php
+++ b/app/Services/MonthlySummary/AnalysisWriter.php
@@ -56,7 +56,7 @@ class AnalysisWriter
             return null;
         }
 
-        $analysis = $this->generate($summary, $user);
+        $analysis = $this->draft($summary, $user);
 
         if ($analysis === null) {
             return null;
@@ -72,8 +72,12 @@ class AnalysisWriter
      * it is worth a few attempts. What it is never worth is delaying the report:
      * once the attempts are spent this returns null and the email goes without
      * the section.
+     *
+     * Nothing is written here: the caller decides whether the text is kept. That
+     * is what lets the preview command show a real analysis without leaving one
+     * on the summary the real send will read later in the month.
      */
-    private function generate(MonthlySummary $summary, User $user): ?string
+    public function draft(MonthlySummary $summary, User $user): ?string
     {
         $attempts = max(1, (int) config('ai_monthly_summary.attempts'));
 

--- a/tests/Feature/Console/PreviewMonthlySummaryCommandTest.php
+++ b/tests/Feature/Console/PreviewMonthlySummaryCommandTest.php
@@ -5,8 +5,10 @@ use App\Mail\Drip\MonthlySummaryEmail;
 use App\Mail\Drip\MonthlySummaryReminderEmail;
 use App\Models\Account;
 use App\Models\Category;
+use App\Models\MonthlySummary;
 use App\Models\Transaction;
 use App\Models\User;
+use App\Services\MonthlySummary\AnalysisWriter;
 use App\Services\MonthlySummary\CardRenderer;
 use Illuminate\Support\Facades\Mail;
 
@@ -90,4 +92,84 @@ it('refuses an address that is not one', function (): void {
     $this->artisan('email:monthly-summary-preview', ['email' => 'not-an-address'])->assertFailed();
 
     Mail::assertNothingSent();
+});
+
+it('sends one case only when asked for one', function (string $type, string $mailable): void {
+    Mail::fake();
+
+    $this->artisan('email:monthly-summary-preview', [
+        'email' => 'look@whisper.test',
+        '--source' => previewSource()->email,
+        '--type' => $type,
+    ])->assertSuccessful();
+
+    Mail::assertSentCount(1);
+    Mail::assertSent($mailable);
+})->with([
+    // Every slug, because a label in CASES with no matching case sends nothing
+    // at all and still reports success.
+    ['pro', MonthlySummaryEmail::class],
+    ['free', MonthlySummaryEmail::class],
+    ['pro-without-ai', MonthlySummaryEmail::class],
+    ['short-closed-month', MonthlySummaryEmail::class],
+    ['first-month', MonthlySummaryEmail::class],
+    ['reminder', MonthlySummaryReminderEmail::class],
+]);
+
+it('refuses a case it does not have', function (): void {
+    Mail::fake();
+
+    $this->artisan('email:monthly-summary-preview', [
+        'email' => 'look@whisper.test',
+        '--source' => previewSource()->email,
+        '--type' => 'pro-with-sprinkles',
+    ])->expectsOutputToContain('short-closed-month')->assertFailed();
+
+    Mail::assertNothingSent();
+});
+
+it('writes the analysis with the model on --ai, once, and stores none of it', function (): void {
+    // Storing it would be worse than useless: the real send reads `ai_analysis`
+    // first, so the reader's own report would arrive as this preview's text.
+    Mail::fake();
+    $this->mock(AnalysisWriter::class, fn ($mock) => $mock->shouldReceive('draft')->once()->andReturn('El modelo ha escrito esto.'));
+
+    $this->artisan('email:monthly-summary-preview', [
+        'email' => 'look@whisper.test',
+        '--source' => previewSource()->email,
+        '--ai' => true,
+    ])->assertSuccessful();
+
+    Mail::assertSent(MonthlySummaryEmail::class, fn (MonthlySummaryEmail $mail): bool => $mail->analysis === 'El modelo ha escrito esto.');
+    expect(MonthlySummary::query()->whereNotNull('ai_analysis')->exists())->toBeFalse();
+});
+
+it('never asks the model for a case that carries no analysis', function (): void {
+    Mail::fake();
+    $this->mock(AnalysisWriter::class, fn ($mock) => $mock->shouldNotReceive('draft'));
+
+    $this->artisan('email:monthly-summary-preview', [
+        'email' => 'look@whisper.test',
+        '--source' => previewSource()->email,
+        '--type' => 'free',
+        '--ai' => true,
+    ])->assertSuccessful();
+
+    Mail::assertSentCount(1);
+});
+
+it('falls back to the sample text when the model gives up', function (): void {
+    // An empty analysis block reads exactly like the locked one, which would
+    // send whoever is reviewing looking for a bug that is not there.
+    Mail::fake();
+    $this->mock(AnalysisWriter::class, fn ($mock) => $mock->shouldReceive('draft')->andReturnNull());
+
+    $this->artisan('email:monthly-summary-preview', [
+        'email' => 'look@whisper.test',
+        '--source' => previewSource()->email,
+        '--type' => 'pro',
+        '--ai' => true,
+    ])->assertSuccessful();
+
+    Mail::assertSent(MonthlySummaryEmail::class, fn (MonthlySummaryEmail $mail): bool => str_contains((string) $mail->analysis, '[TEXTO DE MUESTRA]'));
 });


### PR DESCRIPTION
## Why

`email:monthly-summary-preview` sends six states of the monthly report in one go. That is the right default when you are looking at the design, and the wrong one when you are looking at a single case — and the analysis it showed was always a hand-written sample, so the one section written by a model was the one section you could not review.

## What

**`--type=<slug>`** sends just one case: `pro`, `free`, `pro-without-ai`, `short-closed-month`, `first-month`, `reminder`. Without it, behaviour is unchanged — all six go out. An unknown slug prints the valid list, exits non-zero and sends nothing.

The filter is applied to the case map before any case is built, so an unpicked case never freezes a month, renders nothing and asks no model for anything.

**`--ai`** has the model write the analysis instead of the sample text.

## The one thing worth reviewing carefully

`--ai` calls the now-public `AnalysisWriter::draft()` — the former private `generate()` — which returns the text **without storing it**. It deliberately does not call `write()`: that persists to `ai_analysis` and returns the stored value first, so a preview that wrote there would hand the reader a preview's analysis when the real send goes out later in the month. `write()` itself is unchanged and still calls `draft()` internally; its gates, retry policy and persistence are untouched.

Drafting also bypasses `eligible()` (paid plan + active AI consent). That is intended: the press account has neither, and seeing the pro-with-analysis state is the whole point. The trade-off is that `--source=someone-real@example.com --ai` sends that account's figures to the provider past the consent gate the real send honours, so the class docblock now says so plainly. It is not gated, because the command already mails a real account's full financial report to an arbitrary address via its `email` argument — gating only the provider sink while the inbox sink stays open would be theatre.

The analysis sits behind a memoised closure, so `--ai` prompts **once** for the two cases that carry an analysis (`pro`, `short-closed-month`) and **not at all** when `--type` picks one that does not. When the provider gives up, the command warns and falls back to the sample rather than sending an empty block — an empty analysis section reads exactly like the locked/free case and would send a reviewer hunting a bug that is not there.

## Tests

Extended `PreviewMonthlySummaryCommandTest` rather than rewriting it; the existing `assertSentCount(6)` still passes. Added: every slug sends exactly one mail of the right mailable (all six, because a label with no matching case would send nothing and still report success — verified by mutating a slug), an unknown slug fails and sends nothing, `--ai` puts the writer's text in the mailable and leaves `ai_analysis` untouched, `--ai` never prompts for a case with no analysis, and `--ai` falls back to the sample when the writer returns null.

## QA

Ran for real against the local DB and Mailhog, with a live Gemini key:

- baseline (no options) → 6 messages; each of the six slugs → exactly 1, with the matching console label; `--type=reminder` sends the reminder mailable, not a report
- `--type=nope` and `--type=` → exit 1, 0 messages
- the press account's `2026-08` row already held a stored `ai_analysis` from an earlier real send: **byte-identical before and after every `--ai` run**
- `--type=pro --ai` → real generated Spanish text, no `[TEXTO DE MUESTRA]` marker; `pro` and `short-closed-month` in the same run carry identical text from one call (~13s for all six vs ~12s for one, so one round-trip)
- `--type=free --ai` returned in 1.3s with no provider call
- `--type=pro --month=2026-07` → correct month's figures

The provider-failure fallback is covered by test, not by QA — the provider answered on every run here.

`pest` (14 in the command's file, 55 in `tests/Feature/MonthlySummary`), `pint --test`, `bun run dry` and `php artisan crap --base=origin/main` all clean.