### PR TITLE
fix(summaries): report figures the reader can find in the app

### DIFF
--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -117,6 +117,18 @@ class Account extends Model
     }
 
     /**
+     * Whether the account was already archived on that date. An archived
+     * account contributes nothing from then on, so every figure built from a
+     * balance history has to ask this rather than read the balance straight
+     * through — the dashboard chart and the monthly summary both do, and their
+     * totals only agree because they agree on this.
+     */
+    public function isArchivedOn(Carbon $date): bool
+    {
+        return $this->archived_at !== null && $date->gte($this->archived_at);
+    }
+
+    /**
      * The owner's share of an amount held in this account, in the same minor
      * units. A shared account (say 50% with a partner) only contributes that
      * slice of every transaction to the user's own figures.

--- a/app/Services/AccountMetricsService.php
+++ b/app/Services/AccountMetricsService.php
@@ -243,7 +243,7 @@ class AccountMetricsService
      */
     private function balanceAt(BalanceLookup $lookup, Account $account, Carbon $date): int
     {
-        if ($this->isArchivedOn($account, $date)) {
+        if ($account->isArchivedOn($date)) {
             return 0;
         }
 
@@ -256,16 +256,11 @@ class AccountMetricsService
      */
     private function investedAmountAt(BalanceLookup $lookup, Account $account, Carbon $date): ?int
     {
-        if ($this->isArchivedOn($account, $date)) {
+        if ($account->isArchivedOn($date)) {
             return null;
         }
 
         return $lookup->getInvestedAmountAt($account->id, $date);
-    }
-
-    private function isArchivedOn(Account $account, Carbon $date): bool
-    {
-        return $account->archived_at !== null && $date->gte($account->archived_at);
     }
 
     private function convertBalance(int $balance, string $sourceCurrency, string $targetCurrency, string $date): int

--- a/app/Services/MonthlySummary/CardPicker.php
+++ b/app/Services/MonthlySummary/CardPicker.php
@@ -28,6 +28,16 @@ class CardPicker
     private const NET_WORTH_THRESHOLD = 10.0;
 
     /**
+     * What the reader had to be worth a year ago for that growth to mean
+     * anything, in minor units. A percentage measured against nothing is not a
+     * result: one reader started the year on 25.45 EUR and closed August 1,593
+     * EUR in the red, having lost 92% of their net worth that month — and the
+     * ranking handed them a card reading "+4,848.7% more than I had twelve
+     * months ago" to post.
+     */
+    private const NET_WORTH_MEANINGFUL_BASE = 100000;
+
+    /**
      * @param  array<string, mixed>  $payload
      * @param  ?float  $previousGoalPercent  the same goal's percentage last month, if it was reported
      */
@@ -80,9 +90,25 @@ class CardPicker
             MonthlySummaryCard::Streak->value => (int) data_get($payload, 'streak_months', 0) >= self::STREAK_THRESHOLD,
             MonthlySummaryCard::SavingsRate->value => (bool) data_get($payload, 'best_savings_rate_in_year', false),
             MonthlySummaryCard::SavingsGoal->value => $this->goalIsNewsworthy($payload, $previousGoalPercent),
-            MonthlySummaryCard::NetWorth->value => (float) data_get($payload, 'net_worth.year_percent', 0) > self::NET_WORTH_THRESHOLD,
+            MonthlySummaryCard::NetWorth->value => $this->netWorthGrewMeaningfully($payload),
             MonthlySummaryCard::SpendingSplit->value => true,
         ];
+    }
+
+    /**
+     * Growth worth publishing has to be growth on something. A year measured
+     * from nearly nothing produces a percentage that says only that the reader
+     * used to have nothing, and the card says it in the first person.
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    private function netWorthGrewMeaningfully(array $payload): bool
+    {
+        $history = (array) data_get($payload, 'net_worth.history', []);
+        $yearAgo = (int) ($history[0]['value'] ?? 0);
+
+        return (float) data_get($payload, 'net_worth.year_percent', 0) > self::NET_WORTH_THRESHOLD
+            && $yearAgo >= self::NET_WORTH_MEANINGFUL_BASE;
     }
 
     /**

--- a/app/Services/MonthlySummary/EmailPresenter.php
+++ b/app/Services/MonthlySummary/EmailPresenter.php
@@ -240,8 +240,8 @@ class EmailPresenter
             'viz' => 'bar',
             'data' => [
                 'segments' => [
-                    ['width' => (int) round((int) $invested['contributed'] / $value * 100), 'colour' => '#d4d4d8'],
-                    ['width' => max(0, (int) round($gain / $value * 100)), 'colour' => $gain > 0 ? '#059669' : '#dc2626'],
+                    ['width' => $this->barWidth((int) $invested['contributed'] / $value * 100), 'colour' => '#d4d4d8'],
+                    ['width' => $this->barWidth($gain / $value * 100), 'colour' => $gain > 0 ? '#059669' : '#dc2626'],
                 ],
                 'left' => __('Paid in'),
                 'right' => $this->money($summary, (int) $invested['value']),
@@ -427,6 +427,16 @@ class EmailPresenter
         $span = max(1, max($values) - $low);
 
         return array_map(fn (int $value): int => (int) round(($value - $low) / $span * 100), $values);
+    }
+
+    /**
+     * A segment width, as a percentage of the bar it sits in. Clamped because a
+     * ratio taken against a near-zero denominator is not a width: an account
+     * emptied to nothing once produced a "paid in" segment 349,899,800% wide.
+     */
+    private function barWidth(float $percent): int
+    {
+        return max(0, min(100, (int) round($percent)));
     }
 
     private function money(MonthlySummary $summary, int $amount): string

--- a/app/Services/MonthlySummary/SummaryBuilder.php
+++ b/app/Services/MonthlySummary/SummaryBuilder.php
@@ -15,6 +15,7 @@ use App\Services\Ai\RuleSuggestionAvailability;
 use App\Services\BalanceLookup;
 use App\Services\CashflowSummaryService;
 use App\Services\CategorySpendingService;
+use App\Services\ExchangeRateService;
 use App\Services\NetWorthCalculator;
 use App\Services\PeriodComparator;
 use Carbon\Carbon;
@@ -51,6 +52,7 @@ class SummaryBuilder
         private CategorySpendingService $categorySpending,
         private Readiness $readiness,
         private RuleSuggestionAvailability $ruleSuggestions,
+        private ExchangeRateService $exchangeRates,
     ) {}
 
     /**
@@ -78,7 +80,7 @@ class SummaryBuilder
             'net_worth' => $this->netWorthSection($user, $accounts, $lookup, $month, $currency),
             'cashflow' => $this->cashflowSection($months, $month),
             'savings_rate_history' => $this->savingsRateHistory($months),
-            'streak_months' => $this->streakMonths($months, $month),
+            'streak_months' => $this->streakMonths($months, $month, $user, $currency),
             'best_savings_rate_in_year' => $this->isBestSavingsRate($months, $month),
             'categories' => $this->categoriesSection($user, $month),
             'biggest_drop' => $this->biggestDrop($user, $month),
@@ -191,14 +193,39 @@ class SummaryBuilder
      * out. It is the figure that takes months to earn, which is why it leads the
      * card ranking.
      *
+     * The payload's twelve-month window is not enough to count it. A reader
+     * whose whole window is in the black has a streak of at least thirteen, and
+     * reporting thirteen would be a number they can disprove — so once the count
+     * reaches the edge, older months are loaded a year at a time until one of
+     * them breaks the run or the reader's history runs out. Almost nobody pays
+     * for the extra query: it only fires on a streak that already spans the year.
+     *
      * @param  array<string, array<string, mixed>>  $months
      */
-    private function streakMonths(array $months, Carbon $month): int
+    private function streakMonths(array $months, Carbon $month, User $user, string $currency): int
     {
         $streak = 0;
         $cursor = $month->copy();
+        $loadedFrom = $month->copy()->subMonths(self::HISTORY_MONTHS)->startOfMonth();
 
-        while (isset($months[$cursor->format('Y-m')])) {
+        while (true) {
+            if (! isset($months[$cursor->format('Y-m')])) {
+                if (! $this->readiness->hasDataFor($user, $cursor)) {
+                    break;
+                }
+
+                $months = $this->cashflow->forMonths(
+                    $user->id,
+                    $currency,
+                    $loadedFrom->copy()->subMonths(self::HISTORY_MONTHS),
+                    $loadedFrom->copy()->subMonth()->endOfMonth(),
+                ) + $months;
+
+                $loadedFrom->subMonths(self::HISTORY_MONTHS);
+
+                continue;
+            }
+
             if ((int) ($months[$cursor->format('Y-m')]['net'] ?? 0) <= 0) {
                 break;
             }
@@ -305,7 +332,7 @@ class SummaryBuilder
         $value = 0;
 
         foreach ($accounts as $account) {
-            if (! $account->type->supportsInvestedAmount()) {
+            if (! $account->type->supportsInvestedAmount() || $account->isArchivedOn($end)) {
                 continue;
             }
 
@@ -315,8 +342,8 @@ class SummaryBuilder
                 continue;
             }
 
-            $contributed += $invested;
-            $value += $lookup->getBalanceAt($account->id, $end);
+            $contributed += $this->inUserCurrency($account, $invested, $end, $currency);
+            $value += $this->inUserCurrency($account, $lookup->getBalanceAt($account->id, $end), $end, $currency);
         }
 
         if ($contributed === 0) {
@@ -327,30 +354,62 @@ class SummaryBuilder
     }
 
     /**
+     * A balance in the reader's currency. Balances are stored in the account's
+     * own currency, so without this a BTC or USD account is added to euros as
+     * though the numbers were the same kind of thing — which is how a €6,954
+     * gain was about to be reported as €34,622.
+     */
+    private function inUserCurrency(Account $account, int $amount, Carbon $date, string $currency): int
+    {
+        return $this->exchangeRates->convert(
+            $account->currency_code,
+            $currency,
+            $amount,
+            $date->toDateString(),
+        );
+    }
+
+    /**
+     * How the reader's budgets went, judged only on the periods that a report
+     * about this month is entitled to judge.
+     *
+     * Two rules the naive overlap query got wrong. A period is only counted when
+     * it sits entirely inside the closed month: a yearly period is still running
+     * and cannot be "met" in August, and a weekly one straddling the 1st carries
+     * spending from the month either side — {@see BudgetPeriod::spentAmount()}
+     * sums the whole period, so an overlapping one drags foreign months in.
+     *
+     * And the count is of budgets, not periods. A weekly budget has four or five
+     * periods in a month; counting those told a reader with four budgets that
+     * they had met eleven of fourteen, and named the same budget three times.
+     *
      * @return array<string, mixed>
      */
     private function budgetsSection(User $user, Carbon $month): array
     {
         $periods = BudgetPeriod::query()
             ->whereIn('budget_id', Budget::query()->where('user_id', $user->id)->notArchived()->select('id'))
-            ->whereDate('start_date', '<=', $month->copy()->endOfMonth())
-            ->whereDate('end_date', '>=', $month->copy()->startOfMonth())
+            ->whereDate('start_date', '>=', $month->copy()->startOfMonth())
+            ->whereDate('end_date', '<=', $month->copy()->endOfMonth())
             ->with('budget:id,name')
             ->get();
 
         $overspent = [];
+        $budgets = $periods->groupBy('budget_id');
 
-        foreach ($periods as $period) {
-            $over = $period->spentAmount() - $period->allocated_amount;
+        foreach ($budgets as $budgetPeriods) {
+            $over = $budgetPeriods->sum(
+                fn (BudgetPeriod $period): int => max(0, $period->spentAmount() - $period->allocated_amount),
+            );
 
             if ($over > 0) {
-                $overspent[] = ['name' => $period->budget?->name, 'over_by' => $over];
+                $overspent[] = ['name' => $budgetPeriods->first()->budget?->name, 'over_by' => $over];
             }
         }
 
         return [
-            'total' => $periods->count(),
-            'met' => $periods->count() - count($overspent),
+            'total' => $budgets->count(),
+            'met' => $budgets->count() - count($overspent),
             'overspent' => $overspent,
         ];
     }

--- a/app/Services/MonthlySummary/SummaryBuilder.php
+++ b/app/Services/MonthlySummary/SummaryBuilder.php
@@ -71,6 +71,8 @@ class SummaryBuilder
             $month->copy()->endOfMonth(),
         );
 
+        $cashflow = $this->cashflowSection($months, $month);
+
         return [
             'period' => $month->format('Y-m'),
             'currency' => $currency,
@@ -78,11 +80,11 @@ class SummaryBuilder
             'complete' => $complete,
             'has_history' => $this->readiness->hasHistoryBefore($user, $month),
             'net_worth' => $this->netWorthSection($user, $accounts, $lookup, $month, $currency),
-            'cashflow' => $this->cashflowSection($months, $month),
+            'cashflow' => $cashflow,
             'savings_rate_history' => $this->savingsRateHistory($months),
             'streak_months' => $this->streakMonths($months, $month, $user, $currency),
             'best_savings_rate_in_year' => $this->isBestSavingsRate($months, $month),
-            'categories' => $this->categoriesSection($user, $month),
+            'categories' => $this->categoriesSection($user, $month, $cashflow['expense']),
             'biggest_drop' => $this->biggestDrop($user, $month),
             'invested' => $this->investedSection($accounts, $lookup, $month, $currency),
             'budgets' => $this->budgetsSection($user, $month),
@@ -259,14 +261,28 @@ class SummaryBuilder
     }
 
     /**
+     * The three biggest categories, and what they took of the month.
+     *
+     * `$spent` is the month's whole expense side, not the sum of the categorised
+     * rows: {@see CategorySpendingService::forPeriod()} inner-joins `categories`
+     * and so cannot see a transaction that has none, while the cashflow screen
+     * shows those as an "Unknown Expense" row and counts them. Dividing by the
+     * categorised sum told a reader with three quarters of their month
+     * uncategorised that three categories took 97.9% of the 3,677.96 EUR they
+     * spent, on a month the screen beside it totalled at 15,291.43 EUR.
+     *
+     * The top three stay categories the reader named. An unknown bucket is not a
+     * finding worth a sentence — the uncategorised to-do at the foot of the
+     * email is where that belongs.
+     *
      * @return array<string, mixed>
      */
-    private function categoriesSection(User $user, Carbon $month): array
+    private function categoriesSection(User $user, Carbon $month, int $spent): array
     {
         $period = $this->periodFor($month);
         $current = $this->categorySpending->forPeriod($user->id, $period->from, $period->to);
         $previous = $this->previousSpending($user, $month);
-        $total = (int) $current->sum('amount');
+        $total = $spent;
 
         $top = $current->sortByDesc('amount')->take(3)->map(fn (array $item): array => [
             'name' => $item['category']?->name,
@@ -337,13 +353,21 @@ class SummaryBuilder
             }
 
             $invested = $lookup->getInvestedAmountAt($account->id, $end);
+            $balance = $lookup->getBalanceAt($account->id, $end);
 
-            if ($invested === null) {
+            // An emptied account still reports the last invested amount it ever
+            // had, because BalanceLookup carries the newest non-null one forward
+            // over the nulls that follow. Read together with a zero balance that
+            // says the reader lost every penny, when what they did was move the
+            // money out: one reader was going to be told their investments were
+            // 34,989.98 EUR down, the month after transferring exactly that to
+            // their current account.
+            if ($invested === null || $balance === 0) {
                 continue;
             }
 
             $contributed += $this->inUserCurrency($account, $invested, $end, $currency);
-            $value += $this->inUserCurrency($account, $lookup->getBalanceAt($account->id, $end), $end, $currency);
+            $value += $this->inUserCurrency($account, $balance, $end, $currency);
         }
 
         if ($contributed === 0) {

--- a/app/Services/NetWorthCalculator.php
+++ b/app/Services/NetWorthCalculator.php
@@ -19,7 +19,8 @@ use Illuminate\Support\Collection;
  * The chart the dashboard draws honours two per-user toggles (loans and real
  * estate), so this takes them too: pass the user's preferences and the total
  * matches what they see. Credit cards are excluded whatever the preferences say
- * — they are spending accounts, not wealth.
+ * — they are spending accounts, not wealth, and an account is dropped from the
+ * day it was archived, both matching what the chart draws.
  */
 class NetWorthCalculator
 {
@@ -54,7 +55,7 @@ class NetWorthCalculator
         $total = 0;
 
         foreach ($accounts as $account) {
-            if (! $this->counts($account, $excludedTypes)) {
+            if (! $this->counts($account, $excludedTypes, $date)) {
                 continue;
             }
 
@@ -67,10 +68,11 @@ class NetWorthCalculator
     /**
      * @param  list<AccountType>  $excludedTypes
      */
-    private function counts(Account $account, array $excludedTypes): bool
+    private function counts(Account $account, array $excludedTypes, Carbon $date): bool
     {
         return $account->type->countsInNetWorth()
-            && ! in_array($account->type, $excludedTypes, true);
+            && ! in_array($account->type, $excludedTypes, true)
+            && ! $account->isArchivedOn($date);
     }
 
     /**

--- a/tests/Feature/DashboardAnalyticsTest.php
+++ b/tests/Feature/DashboardAnalyticsTest.php
@@ -1753,3 +1753,37 @@ test('unarchiving an account puts its transactions back into the totals', functi
         ->assertOk()
         ->assertJsonPath('current', 14000);
 });
+
+test('net worth drops an archived account, matching the chart beside it', function () {
+    $open = Account::factory()->create([
+        'user_id' => $this->user->id,
+        'type' => AccountType::Checking,
+        'currency_code' => 'USD',
+    ]);
+    AccountBalance::factory()->create([
+        'account_id' => $open->id,
+        'balance_date' => now(),
+        'balance' => 500000,
+    ]);
+
+    // The evolution chart zeroes an archived account from the day it was
+    // archived. The card sitting above it read the balance straight through, so
+    // the two contradicted each other on the same screen — and the monthly
+    // summary, which shares this calculator, quoted the card's version.
+    $archived = Account::factory()->create([
+        'user_id' => $this->user->id,
+        'type' => AccountType::Checking,
+        'currency_code' => 'USD',
+        'archived_at' => now()->subMonths(2),
+    ]);
+    AccountBalance::factory()->create([
+        'account_id' => $archived->id,
+        'balance_date' => now(),
+        'balance' => 900000,
+    ]);
+
+    $this->getJson('/api/dashboard/net-worth?'.http_build_query([
+        'from' => now()->subDays(29)->toDateString(),
+        'to' => now()->toDateString(),
+    ]))->assertOk()->assertJson(['current' => 500000]);
+});

--- a/tests/Feature/MonthlySummary/CardPickerTest.php
+++ b/tests/Feature/MonthlySummary/CardPickerTest.php
@@ -24,7 +24,7 @@ function payload(array $overrides = []): array
         'best_savings_rate_in_year' => false,
         'cashflow' => ['income' => 300000, 'savings_rate' => 12.0],
         'categories' => ['total' => 200000, 'count' => 8, 'top_share' => 60.0],
-        'net_worth' => ['current' => 1000000, 'year_percent' => 2.0],
+        'net_worth' => ['current' => 1000000, 'year_percent' => 2.0, 'history' => [['month' => '2025-08', 'value' => 900000]]],
         'goal' => null,
     ], $overrides);
 }
@@ -115,4 +115,19 @@ it('leaves out alternatives with no data behind them', function (): void {
 
     expect($alternatives)->not->toContain(MonthlySummaryCard::SavingsGoal)
         ->and($alternatives)->not->toContain(MonthlySummaryCard::Streak);
+});
+
+it('will not celebrate a year measured from nearly nothing', function (): void {
+    // 25.45 EUR a year ago and 1,259.44 today is +4,848.7%, and it says only
+    // that the reader used to have nothing. One real account earned that card
+    // for a month it closed 1,593 EUR in the red.
+    $picked = app(CardPicker::class)->pick(payload([
+        'net_worth' => [
+            'current' => 125944,
+            'year_percent' => 4848.7,
+            'history' => [['month' => '2025-08', 'value' => 2545]],
+        ],
+    ]));
+
+    expect($picked)->toBe(MonthlySummaryCard::SpendingSplit);
 });

--- a/tests/Feature/MonthlySummary/MonthlySummaryEmailTest.php
+++ b/tests/Feature/MonthlySummary/MonthlySummaryEmailTest.php
@@ -6,6 +6,7 @@ use App\Mail\Drip\MonthlySummaryEmail;
 use App\Models\MonthlySummary;
 use App\Models\User;
 use App\Models\UserMailLog;
+use App\Services\MonthlySummary\EmailPresenter;
 use Illuminate\Support\Facades\Mail;
 
 /*
@@ -165,4 +166,27 @@ it('refuses an unsigned unsubscribe link', function (): void {
     $this->get("/unsubscribe/monthly-summary/{$user->id}")->assertForbidden();
 
     expect($user->fresh()->wantsMonthlySummaryEmail())->toBeTrue();
+});
+
+it('keeps a bar segment inside the bar it sits in', function (): void {
+    $user = User::factory()->onboarded()->create(['currency_code' => 'EUR', 'locale' => 'en']);
+    $summary = MonthlySummary::factory()->create([
+        'user_id' => $user->id,
+        'space_id' => $user->activeSpace()->id,
+    ]);
+
+    // A ratio against a near-zero denominator is not a width. This one rendered
+    // a segment 349,899,800% wide in a real reader's email.
+    $summary->forceFill(['payload' => [
+        ...$summary->payload,
+        'invested' => ['contributed' => 3498998, 'value' => 1, 'gain' => -3498997, 'currency' => 'EUR'],
+    ]])->save();
+
+    $rows = app(EmailPresenter::class)->present($summary->fresh(), 'en');
+    $invested = collect($rows['rows'])->firstWhere('viz', 'bar');
+    $widths = array_column(collect($rows['rows'])->pluck('data.segments')->flatten(1)->all(), 'width');
+
+    expect($invested)->not->toBeNull()
+        ->and(max($widths))->toBeLessThanOrEqual(100)
+        ->and(min($widths))->toBeGreaterThanOrEqual(0);
 });

--- a/tests/Feature/MonthlySummary/SummaryBuilderTest.php
+++ b/tests/Feature/MonthlySummary/SummaryBuilderTest.php
@@ -345,3 +345,54 @@ it('drops an archived account from net worth, as the dashboard chart does', func
 
     expect($payload['net_worth']['current'])->toBe(500000);
 });
+
+it('measures the top categories against everything spent, not just what was categorised', function (): void {
+    $user = summaryUser();
+    $account = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'EUR', 'type' => AccountType::Checking]);
+
+    monthlyTransaction($user, $account, 100000, CategoryType::Income);
+    monthlyTransaction($user, $account, -20000, CategoryType::Expense, 'Housing');
+
+    // Spending the category service cannot see, because it joins `categories`.
+    // The cashflow screen shows it as an "Unknown Expense" row and counts it, so
+    // a share taken over the categorised sum alone reads far too high.
+    Transaction::factory()->plaintext()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'category_id' => null,
+        'currency_code' => 'EUR',
+        'amount' => -60000,
+        'transaction_date' => $this->month->copy()->addDays(4),
+    ]);
+
+    $payload = app(SummaryBuilder::class)->build($user, $this->month, complete: true);
+
+    expect($payload['categories']['total'])->toBe(80000)
+        ->and($payload['categories']['top'][0]['share'])->toBe(25.0)
+        ->and($payload['todos']['uncategorised']['count'])->toBe(1);
+});
+
+it('leaves an emptied account out of the investment figures', function (): void {
+    $user = summaryUser();
+    $end = $this->month->copy()->endOfMonth();
+
+    $account = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'EUR', 'type' => AccountType::Investment]);
+
+    // The invested amount stops being recorded once the money is moved out, and
+    // BalanceLookup carries the last non-null one forward over the nulls. Read
+    // against a zero balance it says the reader lost the lot.
+    AccountBalance::factory()->create([
+        'account_id' => $account->id,
+        'balance_date' => $this->month->copy()->startOfMonth(),
+        'balance' => 500000,
+        'invested_amount' => 450000,
+    ]);
+    AccountBalance::factory()->create([
+        'account_id' => $account->id,
+        'balance_date' => $this->month->copy()->addDays(10),
+        'balance' => 0,
+        'invested_amount' => null,
+    ]);
+
+    expect(app(SummaryBuilder::class)->build($user, $this->month, complete: true)['invested'])->toBeNull();
+});

--- a/tests/Feature/MonthlySummary/SummaryBuilderTest.php
+++ b/tests/Feature/MonthlySummary/SummaryBuilderTest.php
@@ -4,7 +4,10 @@ use App\Enums\AccountType;
 use App\Enums\CategoryType;
 use App\Models\Account;
 use App\Models\AccountBalance;
+use App\Models\Budget;
+use App\Models\BudgetPeriod;
 use App\Models\Category;
+use App\Models\ExchangeRate;
 use App\Models\MonthlySummary;
 use App\Models\Transaction;
 use App\Models\User;
@@ -202,4 +205,143 @@ it('hands the model amounts a person can read, not minor units', function (): vo
         // Counts are not money and must survive untouched.
         ->and($payload['budgets']['met'])->toBe(4)
         ->and($payload['todos']['uncategorised']['count'])->toBe(12);
+});
+
+it('counts a streak that runs past the twelve months the payload carries', function (): void {
+    $user = summaryUser();
+    $account = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'EUR', 'type' => AccountType::Checking]);
+
+    $salary = Category::factory()->create(['user_id' => $user->id, 'type' => CategoryType::Income, 'name' => 'Salary']);
+    $rent = Category::factory()->create(['user_id' => $user->id, 'type' => CategoryType::Expense, 'name' => 'Rent']);
+
+    $book = function (Category $category, int $amount, Carbon\Carbon $month) use ($user, $account): void {
+        Transaction::factory()->plaintext()->create([
+            'user_id' => $user->id,
+            'account_id' => $account->id,
+            'category_id' => $category->id,
+            'currency_code' => 'EUR',
+            'amount' => $amount,
+            'transaction_date' => $month->copy()->addDays(4),
+        ]);
+    };
+
+    // Fifteen months in the black. The payload only carries twelve, so a streak
+    // counted from it alone would stop at the edge of the window and report a
+    // number the reader can disprove by scrolling their own history.
+    foreach (range(0, 14) as $ago) {
+        $month = $this->month->copy()->subMonths($ago);
+        $book($salary, 300000, $month);
+        $book($rent, -100000, $month);
+    }
+
+    $red = $this->month->copy()->subMonths(15);
+    $book($salary, 100000, $red);
+    $book($rent, -300000, $red);
+
+    $payload = app(SummaryBuilder::class)->build($user, $this->month, complete: true);
+
+    expect($payload['streak_months'])->toBe(15);
+});
+
+it('counts budgets rather than budget periods', function (): void {
+    $user = summaryUser();
+
+    // A weekly budget has four or five periods inside a month. Counting those
+    // told a reader with one budget that they had four, and named it four times.
+    $budget = Budget::factory()->weekly()->create(['user_id' => $user->id, 'name' => 'Groceries']);
+
+    foreach (range(0, 3) as $week) {
+        $start = $this->month->copy()->startOfMonth()->addWeeks($week);
+
+        BudgetPeriod::factory()->create([
+            'budget_id' => $budget->id,
+            'start_date' => $start,
+            'end_date' => $start->copy()->addDays(6),
+            'allocated_amount' => 5000,
+        ]);
+    }
+
+    $payload = app(SummaryBuilder::class)->build($user, $this->month, complete: true);
+
+    expect($payload['budgets']['total'])->toBe(1)
+        ->and($payload['budgets']['met'])->toBe(1);
+});
+
+it('judges only the budget periods that closed inside the month', function (): void {
+    $user = summaryUser();
+
+    // A yearly period is still running when the month closes: it cannot be met
+    // or missed yet, and its spend covers months this report is not about.
+    $yearly = Budget::factory()->yearly()->create(['user_id' => $user->id, 'name' => 'Insurance']);
+    BudgetPeriod::factory()->create([
+        'budget_id' => $yearly->id,
+        'start_date' => $this->month->copy()->startOfYear(),
+        'end_date' => $this->month->copy()->endOfYear(),
+        'allocated_amount' => 100000,
+    ]);
+
+    $monthly = Budget::factory()->monthly()->create(['user_id' => $user->id, 'name' => 'Groceries']);
+    BudgetPeriod::factory()->create([
+        'budget_id' => $monthly->id,
+        'start_date' => $this->month->copy()->startOfMonth(),
+        'end_date' => $this->month->copy()->endOfMonth(),
+        'allocated_amount' => 50000,
+    ]);
+
+    $payload = app(SummaryBuilder::class)->build($user, $this->month, complete: true);
+
+    expect($payload['budgets']['total'])->toBe(1);
+});
+
+it('converts investment balances into the reader currency before adding them up', function (): void {
+    $user = summaryUser();
+    $end = $this->month->copy()->endOfMonth();
+
+    ExchangeRate::factory()->create([
+        'base_currency' => 'eur',
+        'date' => $end->toDateString(),
+        'rates' => ['usd' => 2.0],
+    ]);
+
+    // Balances are stored in the account's own currency. Added up raw, a $200
+    // gain on a dollar account reaches a euro reader as €200.
+    $account = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'USD', 'type' => AccountType::Investment]);
+    AccountBalance::factory()->create([
+        'account_id' => $account->id,
+        'balance_date' => $end,
+        'balance' => 120000,
+        'invested_amount' => 100000,
+    ]);
+
+    $payload = app(SummaryBuilder::class)->build($user, $this->month, complete: true);
+
+    // $1,200 and $1,000 at 2 USD per EUR: €600 held against €500 paid in.
+    expect($payload['invested']['value'])->toBe(60000)
+        ->and($payload['invested']['contributed'])->toBe(50000)
+        ->and($payload['invested']['gain'])->toBe(10000);
+});
+
+it('drops an archived account from net worth, as the dashboard chart does', function (): void {
+    $user = summaryUser();
+    $end = $this->month->copy()->endOfMonth();
+
+    $open = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'EUR', 'type' => AccountType::Checking]);
+    $archived = Account::factory()->create([
+        'user_id' => $user->id,
+        'currency_code' => 'EUR',
+        'type' => AccountType::Checking,
+        'archived_at' => $this->month->copy()->startOfMonth(),
+    ]);
+
+    foreach ([$open, $archived] as $account) {
+        AccountBalance::factory()->create([
+            'account_id' => $account->id,
+            'balance_date' => $end,
+            'balance' => 500000,
+        ]);
+    }
+
+    $payload = app(SummaryBuilder::class)->build($user, $this->month, complete: true);
+
+    expect($payload['net_worth']['current'])->toBe(500000);
 });


### PR DESCRIPTION
QA of the monthly report against a production dump, before the flag goes on for
everyone. Every figure the August report would quote for a real account was
compared against that account's own dashboard and cashflow screens. Most of them
matched to the cent — income, expenses, the savings rate, the category split,
the biggest drop, the net worth trend. Five did not.

## The streak was capped by the window it was counted from

The payload carries twelve months and the count stopped when it ran out of them
rather than when a month closed in the red, so a reader twenty months in the
black was told thirteen — on the card they were being invited to publish. Four
of the five readers with a streak of thirteen or more were about to be given a
number they could disprove by scrolling their own history.

Older months are now loaded a year at a time until one breaks the run. It costs
a handful of extra queries, only for a streak that already spans the year, in a
queued job: 26–34 queries either way on the accounts measured.

## Budgets were counted by period, not by budget

A weekly budget has four to six periods in a month. One reader with four budgets
was going to be told:

> You met 11 of 14 budgets. You went over on Hosteleria, Hosteleria, Hosteleria.

Eighteen accounts in the dump hold a weekly or biweekly budget.

## And periods that do not close inside the month were judged anyway

`BudgetPeriod::spentAmount()` sums the whole period, so an overlapping one drags
in spending from either side: the August report credited a yearly budget with
239 EUR spent on 1 September. A year that is still running cannot be met or
missed in August either way, so only periods that close inside the month are
judged now. Fourteen accounts have a yearly budget open.

## Net worth counted archived accounts

The dashboard chart zeroes an account from the day it was archived and the
calculator did not, so the two disagreed on the same screen and the email quoted
the disagreeing half:

| Account | Email said | Dashboard showed | Apart by |
| --- | ---: | ---: | ---: |
| A | 57,901.13 | 37,537.45 | 20,363.68 |
| B | 14,847.59 | 10,870.16 | 3,977.43 |
| C | 1,015.48 | 946.53 | 68.95 |

The rule now lives on `Account`, where both callers read it. This also settles
the net worth card against the chart beside it, and `get_net_worth`'s `current`
against its own `evolution` — both went through the same calculator.

## Investment gains added currencies together

Balances are stored in the account's own currency and were summed raw before
being labelled with the reader's. A reader with a BTC account was about to be
told they held 34,622.51 EUR in gains on 6,954.67 EUR of them; a COP reader's
loss was understated thirtyfold. Fifteen accounts in the dump hold an invested
amount in a foreign currency.

## Verification

Every fix was checked against the dump as well as in tests: the streak now reads
20 where it read 13, the budgets 2 where they read 3, and the three accounts
whose net worth disagreed with their dashboard now match it to the cent. Each
new test fails on the old code and passes on the new one.

Not fixed here, found on the way and worth their own issues: the cashflow
screen's Sankey reads savings and investments as expense, so it shows a net of
-3,186 EUR beside a card reading 64 EUR for the same month; and "Saved &
Invested" renders 5083.7% when the month's net cashflow is near zero.


---

# Second pass: five more accounts

The same comparison run against `invernovah` plus four active accounts picked at
random (`datbeat`, `a.perosini`, `carmesefer`, `2003biz`). One matched its
screens on every figure. The other four turned up three more problems.

## The category sentence divided by the wrong total

`CategorySpendingService::forPeriod()` inner-joins `categories`, so a transaction
without one is invisible to it. The cashflow screen shows those as an "Unknown
Expense" row and counts them, so the email and the screen were describing
different months:

| Account | Email said you spent | Cashflow screen | Email's "top three took" | Actually |
| --- | ---: | ---: | ---: | ---: |
| datbeat | 3,677.96 | 15,291.43 | 97.9% | 23.5% |
| a.perosini | 556.57 | 3,414.45 | 76.4% | 12.4% |

The share is now taken over the month's whole expense side — the figure the
cashflow card shows. The top three stay categories the reader named; an unknown
bucket is not a finding worth a sentence, and the uncategorised to-do already
sits at the foot of the email.

One caveat worth knowing: the cashflow screen disagrees with *itself* by 80 EUR
on this account — its summary card reads 15,211.43 and its category list 15,291.43,
because a category whose net comes out positive is dropped from the list but
still netted into the card. The email now matches the card. That inconsistency is
pre-existing and wants its own issue.

## An emptied investment account reported a total loss

`BalanceLookup` carries the newest non-null invested amount forward over the
nulls that follow, so an account whose balance had gone to zero still claimed
everything ever paid into it. One reader moved 34,989.98 EUR out to their current
account in June; August's report was ready to tell them their investments were
34,989.98 EUR down. An account at zero has no gain to report, so it is left out.

## The same figures drew a bar 349,899,800% wide

The width is a ratio against a value that had become zero. Clamped now, whatever
the ratio.

## And the net worth card celebrated a year measured from nearly nothing

One reader started the year on 25.45 EUR and closed August 1,593 EUR in the red,
having lost 92% of their net worth that month. The ranking handed them
"+4,848.7% more than I had twelve months ago" to post. The card now needs a base
worth growing from.

## Also seen, not fixed here

- `percentChange()` returns 0 when the previous value is 0, so a category that
  went from nothing to something reads as "unchanged". Not user-visible in the
  rows the email prints today.
- `biggestDrop()` only considers categories with spending in the current month,
  so a category that fell to zero can never be the biggest drop.
- The cashflow screen's "Saved & Invested" renders 5083.7% when the month's net
  cashflow is near zero, and its Sankey reads savings and investments as expense
  — a net of -3,186 EUR beside a card reading 64 EUR for the same month.
