### PR TITLE
fix(transactions): skip split parents when importing a CSV again

### DIFF
--- a/app/Http/Controllers/Api/TransactionController.php
+++ b/app/Http/Controllers/Api/TransactionController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\BulkUpdateTransactionRequest;
 use App\Http\Requests\Api\CheckDuplicateTransactionsRequest;
 use App\Models\Transaction;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -54,6 +55,13 @@ class TransactionController extends Controller
         $dates = array_map(fn (array $t): string => substr($t['transaction_date'], 0, 10), $incoming);
 
         $existing = $account->transactions()
+            // A split parent is soft-deleted but its money is still on the
+            // account, spread over its parts, so the row that produced it is
+            // already imported. Rows the user deleted on purpose stay invisible
+            // here and can be re-imported - as can a parent whose parts are all
+            // gone, since it has no live parts left to hold the money.
+            ->withTrashed()
+            ->where(fn (Builder $query) => $query->whereNull('deleted_at')->orWhereHas('splits'))
             ->whereBetween('transaction_date', [min($dates), max($dates)])
             ->get(['transaction_date', 'amount', 'description']);
 

--- a/tests/Feature/Api/TransactionDuplicateCheckTest.php
+++ b/tests/Feature/Api/TransactionDuplicateCheckTest.php
@@ -3,6 +3,7 @@
 use App\Models\Account;
 use App\Models\Transaction;
 use App\Models\User;
+use App\Services\TransactionSplitter;
 
 use function Pest\Laravel\actingAs;
 
@@ -138,4 +139,79 @@ it('validates the request payload', function () {
         'transactions.0.amount',
         'transactions.0.description',
     ]);
+});
+
+it('flags a row matching a split parent, so a re-import cannot double-count it', function () {
+    $parent = Transaction::factory()->create([
+        'user_id' => $this->user->id,
+        'account_id' => $this->account->id,
+        'transaction_date' => '2026-01-15',
+        'amount' => -5340,
+        'description' => 'Amazon',
+    ]);
+
+    app(TransactionSplitter::class)->split($parent, [
+        ['amount' => -3490],
+        ['amount' => -1850],
+    ]);
+
+    $response = $this->postJson('/api/transactions/check-duplicates', [
+        'account_id' => $this->account->id,
+        'transactions' => [
+            // The full amount the bank sent, which only the parent carries.
+            ['transaction_date' => '2026-01-15', 'amount' => -5340, 'description' => 'Amazon'],
+            // One part's own amount: the part is a live row holding that money,
+            // so it is already in the account too.
+            ['transaction_date' => '2026-01-15', 'amount' => -3490, 'description' => 'Amazon'],
+            ['transaction_date' => '2026-01-15', 'amount' => -900, 'description' => 'Amazon'],
+        ],
+    ]);
+
+    $response->assertOk()->assertJson(['duplicates' => [true, true, false]]);
+});
+
+it('lets a transaction the user deleted be imported again', function () {
+    Transaction::factory()->create([
+        'user_id' => $this->user->id,
+        'account_id' => $this->account->id,
+        'transaction_date' => '2026-01-15',
+        'amount' => 1234,
+        'description' => 'Coffee Shop',
+    ])->delete();
+
+    $response = $this->postJson('/api/transactions/check-duplicates', [
+        'account_id' => $this->account->id,
+        'transactions' => [
+            ['transaction_date' => '2026-01-15', 'amount' => 1234, 'description' => 'Coffee Shop'],
+        ],
+    ]);
+
+    $response->assertOk()->assertJson(['duplicates' => [false]]);
+});
+
+it('stops flagging a split parent once its parts are gone too', function () {
+    $parent = Transaction::factory()->create([
+        'user_id' => $this->user->id,
+        'account_id' => $this->account->id,
+        'transaction_date' => '2026-01-15',
+        'amount' => -5340,
+        'description' => 'Amazon',
+    ]);
+
+    $parts = app(TransactionSplitter::class)->split($parent, [
+        ['amount' => -3490],
+        ['amount' => -1850],
+    ]);
+
+    // No live part is left holding the money, so the row is importable again.
+    $parts->each->delete();
+
+    $response = $this->postJson('/api/transactions/check-duplicates', [
+        'account_id' => $this->account->id,
+        'transactions' => [
+            ['transaction_date' => '2026-01-15', 'amount' => -5340, 'description' => 'Amazon'],
+        ],
+    ]);
+
+    $response->assertOk()->assertJson(['duplicates' => [false]]);
 });

--- a/tests/Feature/OpenBanking/TransactionSyncServiceTest.php
+++ b/tests/Feature/OpenBanking/TransactionSyncServiceTest.php
@@ -11,6 +11,7 @@ use App\Models\Transaction;
 use App\Models\User;
 use App\Services\Banking\TransactionDescriptionFormatter;
 use App\Services\Banking\TransactionSyncService;
+use App\Services\TransactionSplitter;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
@@ -1067,4 +1068,43 @@ test('sync waits for the booked copy of a purchase it first saw as pending', fun
     $stored = $account->transactions()->first();
     expect($stored->amount)->toBe(-1382);
     expect($stored->raw_data['status'])->toBe('BOOK');
+});
+
+test('sync does not re-create a transaction the user split', function () {
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->create(['user_id' => $user->id]);
+    $account = Account::factory()->connected()->create([
+        'user_id' => $user->id,
+        'banking_connection_id' => $connection->id,
+        'external_account_id' => 'ext-123',
+    ]);
+
+    $payload = [
+        'transaction_id' => 'txn-001',
+        'transaction_amount' => ['amount' => '53.40', 'currency' => 'EUR'],
+        'credit_debit_indicator' => 'DBIT',
+        'booking_date' => '2025-05-12',
+        'creditor' => ['name' => 'Amazon'],
+        'remittance_information' => ['Order'],
+    ];
+
+    $mockProvider = Mockery::mock(BankingProviderInterface::class);
+    $mockProvider->shouldReceive('getTransactions')
+        ->twice()
+        ->andReturn(['transactions' => [$payload], 'continuation_key' => null]);
+
+    $service = new TransactionSyncService($mockProvider, new TransactionDescriptionFormatter);
+    $service->sync($account, '2025-05-01', '2025-05-31');
+
+    $parent = $account->transactions()->sole();
+    app(TransactionSplitter::class)->split($parent, [
+        ['amount' => -3490],
+        ['amount' => -1850],
+    ]);
+
+    $created = $service->sync($account, '2025-05-01', '2025-05-31');
+
+    expect($created)->toBe(0);
+    expect(Transaction::withTrashed()->find($parent->id)->trashed())->toBeTrue();
+    expect($account->transactions()->pluck('amount')->sort()->values()->all())->toBe([-3490, -1850]);
 });


### PR DESCRIPTION
## The bug

A user split an Amazon charge into two parts (clothes + tech, same shipment, paid by
card). The next day they imported the card's statement and **the parent transaction they
had just split came back as a new row** — so the expense would have been counted twice.
They expected the import to recognise it as already in the account and skip it.

## Why it happened

Splitting a transaction soft-deletes the original ("split parent") and creates the live
part rows that point at it via `split_parent_id`. The money is still on the account, just
spread over the parts.

The CSV-import duplicate check queried `$account->transactions()`, which applies the
soft-delete scope — so the split parent was invisible and the incoming row was never
flagged. Since a flagged row is hard-excluded from the import (`import-step-preview.tsx`
splits rows into importable/duplicates, select-all skips duplicates, the UI says "Won't be
imported"), this check is the only thing standing between the user and a duplicate.

## The fix

`checkDuplicates` now also considers soft-deleted rows **that still have live parts**:

```php
->withTrashed()
->where(fn (Builder $query) => $query->whereNull('deleted_at')->orWhereHas('splits'))
```

Deliberately **not** a blanket `withTrashed()`: a regular delete is a soft delete too, so
that would make a transaction the user deleted on purpose permanently unimportable — with
no way to override it in the UI. `splits()` carries the soft-delete scope, so a parent
whose parts were all deleted has nothing left holding the money and becomes re-importable
again.

## Connected banks were already covered

The bank-sync side needed no change: `TransactionSyncService::loadExistingDedupKeys()`
already reads `withTrashed()`, and `TransactionSplitter` deliberately leaves
`dedup_fingerprint` and `external_transaction_id` on the parent for exactly this reason.
The new sync test is a **regression guard proving that end to end**, not part of the fix.

## Tests

- `TransactionDuplicateCheckTest` — a row matching a split parent is flagged; a row
  matching a plain user-deleted transaction is still importable; a split parent stops
  being flagged once its parts are gone too.
- `TransactionSyncServiceTest` — sync a payload, split the transaction, sync the same
  payload again: nothing is created, the parent stays trashed, the parts are untouched.

## Known limitations (pre-existing, out of scope)

- If the parent came from a bank sync its description went through
  `TransactionDescriptionFormatter`, so a CSV row worded differently won't match on
  description. No fuzzy matching was attempted.
- Deleting *some* but not all parts leaves the parent flagged for its full amount, even
  though part of that money is no longer tracked.
- Matching is date + amount + normalised description, so an unrelated row that collides on
  all three is flagged. This change adds one more amount per split (the parent's total) to
  that surface.
