### PR TITLE
feat(summaries): show the share cards as 4:5 previews

### DIFF
--- a/app/Http/Controllers/MonthlySummaryController.php
+++ b/app/Http/Controllers/MonthlySummaryController.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Facades\Storage;
 use Inertia\Inertia;
 use Inertia\Response;
 use Laravel\Pennant\Feature;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Throwable;
 
 /**
@@ -67,8 +68,11 @@ class MonthlySummaryController extends Controller
     /**
      * Serve one card as a PNG. Rendered on first request and cached on the
      * public disk, so nobody pays for fifteen images a reader will never open.
+     *
+     * `?preview=1` paints the file instead of saving it: the screen shows the
+     * same 4:5 render it offers for download, so one route covers both.
      */
-    public function card(Request $request, MonthlySummary $summary, string $card, string $format)
+    public function card(Request $request, MonthlySummary $summary, string $card, string $format): StreamedResponse
     {
         abort_unless($summary->user_id === $request->user()->id, 404);
 
@@ -86,7 +90,16 @@ class MonthlySummaryController extends Controller
             abort(503);
         }
 
-        return Storage::disk('public')->download($path, $this->filename($summary, $cardType, $formatType));
+        $disk = Storage::disk('public');
+
+        if ($request->boolean('preview')) {
+            // Minutes, not days: `CardRenderer::forget()` exists so a redesign or
+            // a corrected figure replaces the picture, and a long-lived copy in
+            // the browser would outlive it.
+            return $disk->response($path, headers: ['Cache-Control' => 'private, max-age=300']);
+        }
+
+        return $disk->download($path, $this->filename($summary, $cardType, $formatType));
     }
 
     /**
@@ -128,8 +141,8 @@ class MonthlySummaryController extends Controller
     }
 
     /**
-     * The chosen card first, then the alternatives, each with the three formats
-     * it can be downloaded in.
+     * The chosen card first, then the alternatives, each with the picture the
+     * screen shows and the three formats it can be downloaded in.
      *
      * @return list<array<string, mixed>>
      */
@@ -140,6 +153,9 @@ class MonthlySummaryController extends Controller
         return array_map(fn (MonthlySummaryCard $card): array => [
             'card' => $card->value,
             'chosen' => $card === $summary->card,
+            'preview' => route('monthly-summaries.card', [
+                $summary, $card->value, MonthlySummaryFormat::default()->value, 'preview' => 1,
+            ]),
             'formats' => array_map(fn (MonthlySummaryFormat $format): array => [
                 'format' => $format->value,
                 'url' => route('monthly-summaries.card', [$summary, $card->value, $format->value]),

--- a/app/Jobs/Drip/SendMonthlySummaryEmailJob.php
+++ b/app/Jobs/Drip/SendMonthlySummaryEmailJob.php
@@ -58,6 +58,8 @@ class SendMonthlySummaryEmailJob extends SendDripEmailJob
 
         $this->summary->forceFill(['sent_at' => now()])->save();
 
+        app(Summaries::class)->warmShareCards($this->summary, $pro);
+
         return $mail;
     }
 

--- a/app/Services/MonthlySummary/EmailPresenter.php
+++ b/app/Services/MonthlySummary/EmailPresenter.php
@@ -6,6 +6,7 @@ use App\Models\MonthlySummary;
 use App\Support\Figures;
 use App\Support\Money;
 use Carbon\Carbon;
+use Illuminate\Support\Str;
 
 /**
  * Turns a frozen summary into the sentences and micro-charts the email prints.
@@ -34,7 +35,10 @@ class EmailPresenter
 
         return [
             'monthName' => $month->copy()->locale($locale)->isoFormat('MMMM'),
-            'monthLabel' => $month->copy()->locale($locale)->isoFormat('MMMM YYYY'),
+            // A title, unlike `monthName`, which is read inside a sentence: it
+            // lands in the breadcrumb and the browser tab, and Spanish and French
+            // print their month names in lower case.
+            'monthLabel' => Str::ucfirst($month->copy()->locale($locale)->isoFormat('MMMM YYYY')),
             'headline' => $this->headline($summary, $locale, $month),
             'lede' => $this->lede($summary, $locale),
             'rows' => $this->rows($summary, $locale, $month),

--- a/app/Services/MonthlySummary/Summaries.php
+++ b/app/Services/MonthlySummary/Summaries.php
@@ -96,6 +96,31 @@ class Summaries
     }
 
     /**
+     * Draw the rest of the cards the summary screen shows.
+     *
+     * The screen puts all five up as 4:5 pictures, and the renderer starts a
+     * Chromium run for any it has not drawn yet. Left to the screen, a first
+     * visit would start four of them inside four web requests at once; here they
+     * cost the one reader whose report this is, on the job that already owns a
+     * cold Chromium start.
+     *
+     * Only the 4:5 shape: nothing shows the story or the wide one, so those are
+     * still drawn the first time somebody asks for one.
+     */
+    public function warmShareCards(MonthlySummary $summary, bool $pro): void
+    {
+        foreach ($this->picker->alternatives($summary->payload, $summary->card) as $card) {
+            try {
+                $this->renderer->path($summary, $card, MonthlySummaryFormat::default(), $pro);
+            } catch (Throwable $exception) {
+                // A picture nobody has asked for yet is not worth failing a send
+                // over; the screen draws it on demand if it comes to that.
+                report($exception);
+            }
+        }
+    }
+
+    /**
      * A summary that was frozen mid-month and never sent is refrozen once the
      * month completes. One that has already gone out never moves: the reader has
      * the old figures in their inbox.

--- a/lang/es.json
+++ b/lang/es.json
@@ -2790,6 +2790,7 @@
     "Some of your accounts had not reported when this was worked out, so the figures may be short.": "Cuando se calculó esto, algunas de tus cuentas no habían reportado, así que las cifras pueden quedarse cortas.",
     "Share your month": "Comparte tu mes",
     "picked for you": "elegida por ti",
+    "This picture could not be drawn.": "No se ha podido dibujar esta imagen.",
     "Create a public link": "Crear un enlace público",
     "Anyone with the link sees the image and nothing else. No link exists until you make one.": "Quien tenga el enlace ve la imagen y nada más. Hasta que lo crees, no existe ningún enlace.",
     "Copied": "Copiado",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2418,6 +2418,7 @@
     "Some of your accounts had not reported when this was worked out, so the figures may be short.": "Certains de vos comptes n'avaient rien remonté au moment du calcul, les chiffres peuvent donc être incomplets.",
     "Share your month": "Partagez votre mois",
     "picked for you": "choisie pour vous",
+    "This picture could not be drawn.": "Cette image n'a pas pu être dessinée.",
     "Create a public link": "Créer un lien public",
     "Anyone with the link sees the image and nothing else. No link exists until you make one.": "Toute personne ayant le lien voit l'image et rien d'autre. Tant que vous ne le créez pas, aucun lien n'existe.",
     "Copied": "Copié",

--- a/resources/js/pages/monthly-summaries/show.tsx
+++ b/resources/js/pages/monthly-summaries/show.tsx
@@ -5,7 +5,10 @@ import {
     show,
 } from '@/actions/App/Http/Controllers/MonthlySummaryController';
 import { Button } from '@/components/ui/button';
+import { ButtonGroup } from '@/components/ui/button-group';
+import { Skeleton } from '@/components/ui/skeleton';
 import AppLayout from '@/layouts/app-layout';
+import { cn } from '@/lib/utils';
 import { type BreadcrumbItem } from '@/types';
 import { __ } from '@/utils/i18n';
 import { Head, router } from '@inertiajs/react';
@@ -24,7 +27,12 @@ import { useState } from 'react';
 type Row = { text: string };
 type Todo = { text: string; action: string };
 type CardFormat = { format: string; url: string };
-type CardOption = { card: string; chosen: boolean; formats: CardFormat[] };
+type CardOption = {
+    card: string;
+    chosen: boolean;
+    preview: string;
+    formats: CardFormat[];
+};
 
 interface Props {
     summary: { id: string; period: string; complete: boolean; shared: boolean };
@@ -56,6 +64,62 @@ function cardLabel(card: string): string {
     };
 
     return labels[card] ?? card;
+}
+
+/**
+ * The card as it will be posted, at the 4:5 the feeds want.
+ *
+ * The PNG is drawn on the server the first time anybody asks for it, so a
+ * preview can take a moment to arrive and can fail outright. Neither may leave a
+ * broken image sitting in the middle of the grid.
+ */
+function CardPreview({ label, src }: { label: string; src: string }) {
+    const [status, setStatus] = useState<'loading' | 'ready' | 'failed'>(
+        'loading',
+    );
+    // A render that timed out usually works on the next go, and the browser
+    // holds on to the failure, so a retry needs a URL it has not seen.
+    const [attempt, setAttempt] = useState(0);
+
+    if (status === 'failed') {
+        return (
+            <div className="flex size-full flex-col items-center justify-center gap-2 p-4 text-center">
+                <p className="text-xs text-muted-foreground">
+                    {__('This picture could not be drawn.')}
+                </p>
+                <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                        setAttempt(attempt + 1);
+                        setStatus('loading');
+                    }}
+                >
+                    {__('Try again')}
+                </Button>
+            </div>
+        );
+    }
+
+    return (
+        <>
+            {status === 'loading' && (
+                <Skeleton className="absolute inset-0 rounded-none" />
+            )}
+            <img
+                src={attempt === 0 ? src : `${src}&retry=${attempt}`}
+                alt={label}
+                loading="lazy"
+                decoding="async"
+                className={cn(
+                    'size-full object-cover transition-opacity',
+                    status === 'ready' ? 'opacity-100' : 'opacity-0',
+                )}
+                onLoad={() => setStatus('ready')}
+                onError={() => setStatus('failed')}
+            />
+        </>
+    );
 }
 
 export default function MonthlySummaryShow({
@@ -122,34 +186,51 @@ export default function MonthlySummaryShow({
                     <h2 className="text-sm font-semibold">
                         {__('Share your month')}
                     </h2>
-                    <div className="flex flex-col gap-3 rounded-lg border p-4">
+                    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
                         {cards.map((card) => (
                             <div
                                 key={card.card}
-                                className="flex flex-wrap items-center gap-3"
+                                className="flex flex-col gap-2"
                             >
-                                <span className="flex-1 text-sm font-medium">
+                                <span className="text-sm font-medium">
                                     {cardLabel(card.card)}
                                     {card.chosen && (
-                                        <span className="ml-2 text-xs font-normal text-muted-foreground">
+                                        <span className="ml-1.5 text-xs font-normal text-muted-foreground">
                                             {__('picked for you')}
                                         </span>
                                     )}
                                 </span>
-                                {card.formats.map((format) => (
-                                    <Button
-                                        key={format.format}
-                                        variant="outline"
-                                        size="sm"
-                                        asChild
-                                    >
-                                        <a href={format.url}>
-                                            <DownloadIcon className="size-3.5" />
-                                            {FORMAT_LABELS[format.format] ??
-                                                format.format}
-                                        </a>
-                                    </Button>
-                                ))}
+
+                                <div
+                                    className={cn(
+                                        'relative aspect-[4/5] overflow-hidden rounded-md border bg-card',
+                                        card.chosen &&
+                                            'ring-2 ring-primary ring-offset-2 ring-offset-background',
+                                    )}
+                                >
+                                    <CardPreview
+                                        label={cardLabel(card.card)}
+                                        src={card.preview}
+                                    />
+                                </div>
+
+                                <ButtonGroup className="w-full">
+                                    {card.formats.map((format) => (
+                                        <Button
+                                            key={format.format}
+                                            variant="outline"
+                                            size="sm"
+                                            className="h-9 flex-1 text-xs sm:h-8"
+                                            asChild
+                                        >
+                                            <a href={format.url}>
+                                                <DownloadIcon className="size-3.5" />
+                                                {FORMAT_LABELS[format.format] ??
+                                                    format.format}
+                                            </a>
+                                        </Button>
+                                    ))}
+                                </ButtonGroup>
                             </div>
                         ))}
                     </div>

--- a/tests/Feature/MonthlySummary/MonthlySummaryEmailTest.php
+++ b/tests/Feature/MonthlySummary/MonthlySummaryEmailTest.php
@@ -1,11 +1,15 @@
 <?php
 
 use App\Enums\DripEmailType;
+use App\Enums\MonthlySummaryCard;
+use App\Enums\MonthlySummaryFormat;
 use App\Jobs\Drip\SendMonthlySummaryEmailJob;
 use App\Mail\Drip\MonthlySummaryEmail;
 use App\Models\MonthlySummary;
 use App\Models\User;
 use App\Models\UserMailLog;
+use App\Services\MonthlySummary\CardPicker;
+use App\Services\MonthlySummary\CardRenderer;
 use App\Services\MonthlySummary\EmailPresenter;
 use Illuminate\Support\Facades\Mail;
 
@@ -13,6 +17,16 @@ use Illuminate\Support\Facades\Mail;
  * The report email itself: what it says, who sees the analysis, and how a reader
  * gets out of it.
  */
+
+beforeEach(function (): void {
+    // What is under test is what the email says, not Chromium: left real, every
+    // job test here starts a browser per card it draws.
+    $this->mock(CardRenderer::class, function ($mock): void {
+        $mock->shouldReceive('url')->andReturn('https://whisper.money/storage/card.png');
+        $mock->shouldReceive('path')->andReturn('monthly-summaries/x/card.png');
+        $mock->shouldReceive('forget')->andReturnNull();
+    });
+});
 
 /**
  * A summary belonging to a fresh reader, with every section filled.
@@ -129,6 +143,37 @@ it('records the send once per month and space', function (): void {
         ->count())->toBe(1);
 
     expect($summary->fresh()->sent_at)->not->toBeNull();
+});
+
+it('draws the rest of the screen\'s cards on the reader\'s own job', function (): void {
+    // Left to the screen, a first visit starts a Chromium run for each card it
+    // has not drawn yet, inside as many web requests as the browser opens.
+    Mail::fake();
+    $summary = sentSummaryFor();
+    $alternatives = app(CardPicker::class)->alternatives($summary->payload, $summary->card);
+
+    expect($alternatives)->not->toBeEmpty();
+
+    $drawn = [];
+    $renderer = Mockery::mock(CardRenderer::class);
+    $renderer->shouldReceive('url')->andReturn('https://whisper.money/storage/card.png');
+    $renderer->shouldReceive('forget')->andReturnNull();
+    $renderer->shouldReceive('path')->andReturnUsing(
+        function (MonthlySummary $drawnFor, MonthlySummaryCard $card, MonthlySummaryFormat $format) use (&$drawn): string {
+            $drawn[] = $card->value.':'.$format->value;
+
+            return 'monthly-summaries/x/card.png';
+        }
+    );
+    app()->instance(CardRenderer::class, $renderer);
+
+    (new SendMonthlySummaryEmailJob($summary->user, $summary))->handle();
+
+    // Only the 4:5 shape, because that is the only one the screen shows.
+    expect($drawn)->toBe(array_map(
+        fn (MonthlySummaryCard $card): string => $card->value.':feed',
+        $alternatives,
+    ));
 });
 
 it('does not send to a reader who turned the summary off', function (): void {

--- a/tests/Feature/MonthlySummary/MonthlySummaryPagesTest.php
+++ b/tests/Feature/MonthlySummary/MonthlySummaryPagesTest.php
@@ -76,6 +76,26 @@ it('shows one month with its figures and every card it can produce', function ()
             ->where('shareUrl', null));
 });
 
+it('titles the month, because the label is read as one', function (): void {
+    // Spanish and French print month names in lower case, and this label is not
+    // read inside a sentence: it is the breadcrumb and the browser tab.
+    $this->travelTo('2026-03-10');
+
+    $user = User::factory()->onboarded()->create(['currency_code' => 'EUR', 'locale' => 'es']);
+    $summary = MonthlySummary::factory()->sent()->create([
+        'user_id' => $user->id,
+        'space_id' => $user->activeSpace()->id,
+    ]);
+
+    $this->actingAs($user)
+        ->get("/summaries/{$summary->id}")
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('report.monthLabel', 'Febrero 2026')
+            // The one that goes inside a sentence stays as the language writes it.
+            ->where('report.monthName', 'febrero'));
+});
+
 it('hides the screens entirely while the feature is off', function (): void {
     Feature::define(MonthlySummaries::class, fn (): bool => false);
     $user = readerWithSummary();

--- a/tests/Feature/MonthlySummary/MonthlySummaryPagesTest.php
+++ b/tests/Feature/MonthlySummary/MonthlySummaryPagesTest.php
@@ -71,6 +71,8 @@ it('shows one month with its figures and every card it can produce', function ()
             ->has('cards')
             ->where('cards.0.chosen', true)
             ->has('cards.0.formats', 3)
+            // Every card carries the picture the screen paints, not just the links.
+            ->where('cards.0.preview', fn (string $url): bool => str_contains($url, 'card/'.$summary->card->value.'/feed?preview=1'))
             ->where('shareUrl', null));
 });
 

--- a/tests/Feature/MonthlySummary/SharedCardPageTest.php
+++ b/tests/Feature/MonthlySummary/SharedCardPageTest.php
@@ -4,6 +4,7 @@ use App\Enums\MonthlySummaryFormat;
 use App\Models\MonthlySummary;
 use App\Models\User;
 use App\Services\MonthlySummary\CardRenderer;
+use Illuminate\Support\Facades\Storage;
 
 /*
  * The public page a shared card unfurls from.
@@ -96,6 +97,28 @@ it('will not let one reader touch another reader\'s summary', function (): void 
     $this->actingAs($stranger)->get("/summaries/{$summary->id}/card/savings_rate/feed")->assertNotFound();
 
     expect($summary->fresh()->share_token)->toBeNull();
+});
+
+it('paints the card inside the screen and saves it on download', function (): void {
+    // The screen shows the 4:5 render as a preview, so one route has to be able
+    // to hand the browser a picture as well as a file to keep.
+    Storage::fake('public');
+    Storage::disk('public')->put('monthly-summaries/x/card.png', 'png-bytes');
+
+    $user = User::factory()->onboarded()->create();
+    $summary = summaryFor($user);
+
+    $preview = $this->actingAs($user)
+        ->get("/summaries/{$summary->id}/card/savings_rate/feed?preview=1")
+        ->assertOk();
+
+    expect($preview->headers->get('Content-Disposition'))->toStartWith('inline');
+    expect($preview->headers->get('Cache-Control'))->toContain('max-age=300');
+
+    $this->actingAs($user)
+        ->get("/summaries/{$summary->id}/card/savings_rate/feed")
+        ->assertOk()
+        ->assertDownload("whisper-money-{$summary->period}-savings_rate-feed.png");
 });
 
 it('refuses a card format or kind it does not have', function (): void {


### PR DESCRIPTION
## Why

The "Share your month" section was a list of card names with three download
buttons each. Nothing on screen told you what you were about to post — you had
to download a PNG to find out what it looked like.

## What

Every card now shows the picture itself, at the 4:5 the feeds want, in a grid of
three (two at phone width). Each tile reads **title → image → downloads**.

The three formats sit in one segmented group under every preview: always
visible, equal weight, and the same download icon the screen already used. So
nothing about downloading depends on a pointer — the earlier draft put the 4:5
behind a hover overlay, which is invisible on a phone — and 4:5 is what you
*see* rather than what you get pushed towards.

A month only shows the cards it has figures for, as before: a reader with no
savings goal gets four tiles, not five.

Second commit: `monthLabel` is now title-cased. It lands in the breadcrumb and
the browser tab, and Spanish and French write their month names in lower case,
so the screen read "agosto 2026" where it should read a title. `monthName` is
left alone — that one is read inside a sentence.

## How

- `?preview=1` on the existing card route paints the PNG instead of saving it,
  so one route serves both the preview and the download. The picture stays
  behind the same ownership check as before: nothing about a summary becomes
  public until the reader mints the share link. The browser copy is capped at
  five minutes, because `CardRenderer::forget()` exists to replace a picture
  after a redesign or a corrected figure.
- Only the chosen card's 4:5 was drawn up front, so a first visit would have
  started a Chromium run for each of the other four **inside as many web
  requests at once**. The send job draws them instead, right after it stamps the
  summary as sent: the cost lands on the one reader whose report it is, on the
  job whose whole reason for existing is that a cold Chromium start belongs to
  one reader. Only the 4:5 shape, because that is the only one the screen shows.
- Previews are lazy and carry a skeleton. A render that fails says so in place
  with a **Try again**, rather than leaving a broken image in the middle of the
  grid or making the reader reload the page.
- The email tests stub the renderer now. They are about what the email says, and
  left real every job test in the file started a browser per card it drew
  (24.6s → 15.5s, with more tests than before).

## Design

Drafted and reviewed on a canvas before implementing, with two alternatives
kept on a second page:
https://claude.ai/code/artifact/6caacf61-852d-4d57-9c8a-4e737eee18cf

## Testing

- `tests/Feature/MonthlySummary/SharedCardPageTest.php` — `?preview=1` returns
  `Content-Disposition: inline` and `Cache-Control: max-age=300`; without the
  flag the same route still downloads with its filename.
- `tests/Feature/MonthlySummary/MonthlySummaryPagesTest.php` — every card
  carries the picture the screen paints, and the month label is title-cased for
  a Spanish reader while `monthName` is not.
- `tests/Feature/MonthlySummary/MonthlySummaryEmailTest.php` — the send job draws
  the remaining cards, in the 4:5 shape only.
