### PR TITLE
fix(summaries): give the card renderer a writable HOME

### DIFF
--- a/app/Services/MonthlySummary/CardRenderer.php
+++ b/app/Services/MonthlySummary/CardRenderer.php
@@ -22,6 +22,11 @@ use RuntimeException;
  * the one that rides inside the email and backs the public page's og:image. The
  * other two are rendered the first time somebody asks for them and then cached,
  * so nobody pays for twelve images a user will never open.
+ *
+ * Chromium needs a writable HOME to start, and it is started from two very
+ * different places — a queue worker for the feed card, a web request for the
+ * other two — so the requirement travels with the renderer rather than with
+ * whichever process manager happens to be calling it.
  */
 class CardRenderer
 {
@@ -102,14 +107,16 @@ class CardRenderer
 
     private function screenshot(string $htmlFile, string $pngFile, int $width, int $height): void
     {
-        $result = Process::timeout(self::TIMEOUT_SECONDS)->run([
-            (string) config('monthly_summary.node_binary'),
-            base_path('scripts/render-card.mjs'),
-            $htmlFile,
-            $pngFile,
-            (string) $width,
-            (string) $height,
-        ]);
+        $result = Process::timeout(self::TIMEOUT_SECONDS)
+            ->env(['HOME' => sys_get_temp_dir()])
+            ->run([
+                (string) config('monthly_summary.node_binary'),
+                base_path('scripts/render-card.mjs'),
+                $htmlFile,
+                $pngFile,
+                (string) $width,
+                (string) $height,
+            ]);
 
         if ($result->failed() || ! is_file($pngFile)) {
             throw new RuntimeException('Card render failed: '.trim($result->errorOutput() ?: $result->output()));

--- a/docker/supervisor/supervisord.conf
+++ b/docker/supervisor/supervisord.conf
@@ -59,8 +59,11 @@ stdout_logfile=/var/log/worker-inertia-ssr.log
 process_name=%(program_name)s
 command=php /app/artisan queue:work database --queue=emails --sleep=1 --tries=5 --max-time=3600
 user=www-data
-; The monthly summary renders its shareable card on this queue, and Chromium
-; lives outside this worker's home directory.
+; The monthly summary renders its shareable card on this queue. HOME is what
+; Chromium needs in order to start at all, and CardRenderer now sets it on the
+; render process itself - a card no longer depends on this line. This copy is
+; kept only because nothing has checked whether anything else on this queue
+; wants a writable home; drop it once someone has.
 environment=PLAYWRIGHT_BROWSERS_PATH="/usr/local/playwright",HOME="/tmp"
 autostart=true
 autorestart=true

--- a/tests/Feature/MonthlySummary/CardRendererTest.php
+++ b/tests/Feature/MonthlySummary/CardRendererTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use App\Enums\MonthlySummaryCard;
+use App\Enums\MonthlySummaryFormat;
+use App\Models\MonthlySummary;
+use App\Models\User;
+use App\Services\MonthlySummary\CardRenderer;
+use Illuminate\Process\PendingProcess;
+use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Facades\Storage;
+
+/*
+ * Chromium is started from two places: a queue worker for the feed card that
+ * rides in the email, and a plain web request for the two formats rendered on
+ * demand. Only the worker had been given a writable HOME, and without one the
+ * browser dies during launch — its crash handler refuses to start without a
+ * database directory — so every on-demand card 503'd (PHP-LARAVEL-5M).
+ */
+
+function summaryToRender(): MonthlySummary
+{
+    $user = User::factory()->onboarded()->create(['currency_code' => 'EUR', 'locale' => 'en']);
+
+    return MonthlySummary::factory()->sent()->create([
+        'user_id' => $user->id,
+        'space_id' => $user->activeSpace()->id,
+    ]);
+}
+
+it('hands the browser a writable home directory whoever started the render', function (): void {
+    Storage::fake('public');
+    Process::fake();
+
+    $summary = summaryToRender();
+
+    // A faked process writes no PNG, so the render still fails. What matters
+    // here is what reached the process before it did.
+    expect(fn (): string => app(CardRenderer::class)->path(
+        $summary,
+        MonthlySummaryCard::Streak,
+        MonthlySummaryFormat::Story,
+        pro: false,
+    ))->toThrow(RuntimeException::class);
+
+    Process::assertRan(function (PendingProcess $process): bool {
+        $home = $process->environment['HOME'] ?? null;
+
+        return is_string($home) && is_dir($home) && is_writable($home);
+    });
+});
+
+it('says what the renderer printed when it fails', function (): void {
+    Storage::fake('public');
+    Process::fake([
+        '*' => Process::result(errorOutput: 'browser has been closed', exitCode: 1),
+    ]);
+
+    expect(fn (): string => app(CardRenderer::class)->path(
+        summaryToRender(),
+        MonthlySummaryCard::Streak,
+        MonthlySummaryFormat::Story,
+        pro: false,
+    ))->toThrow(RuntimeException::class, 'Card render failed: browser has been closed');
+});

--- a/tests/Feature/MonthlySummary/CardRendererTest.php
+++ b/tests/Feature/MonthlySummary/CardRendererTest.php
@@ -27,6 +27,50 @@ function summaryToRender(): MonthlySummary
     ]);
 }
 
+/**
+ * Stand in for the render script, which is expected to leave a PNG behind at
+ * the path it was handed — the fourth argument of the command.
+ */
+function fakeRenderWritingAPng(): void
+{
+    Process::fake(function (PendingProcess $process) {
+        file_put_contents($process->command[3], 'png-bytes');
+
+        return Process::result();
+    });
+}
+
+it('stores the rendered card on the public disk and reuses it next time', function (): void {
+    Storage::fake('public');
+    fakeRenderWritingAPng();
+
+    $summary = summaryToRender();
+    $renderer = app(CardRenderer::class);
+
+    $path = $renderer->path($summary, MonthlySummaryCard::Streak, MonthlySummaryFormat::Story, pro: false);
+
+    expect(Storage::disk('public')->get($path))->toBe('png-bytes');
+    Process::assertRanTimes(fn (): bool => true, 1);
+
+    // Second ask: the file is already there, so nothing is rendered again.
+    expect($renderer->path($summary, MonthlySummaryCard::Streak, MonthlySummaryFormat::Story, pro: false))->toBe($path);
+    Process::assertRanTimes(fn (): bool => true, 1);
+});
+
+it('keeps the Pro badge out of the unbadged card by caching them apart', function (): void {
+    Storage::fake('public');
+    fakeRenderWritingAPng();
+
+    $summary = summaryToRender();
+    $renderer = app(CardRenderer::class);
+
+    $free = $renderer->path($summary, MonthlySummaryCard::Streak, MonthlySummaryFormat::Story, pro: false);
+    $pro = $renderer->path($summary, MonthlySummaryCard::Streak, MonthlySummaryFormat::Story, pro: true);
+
+    expect($pro)->not->toBe($free);
+    Process::assertRanTimes(fn (): bool => true, 2);
+});
+
 it('hands the browser a writable home directory whoever started the render', function (): void {
     Storage::fake('public');
     Process::fake();


### PR DESCRIPTION
Fixes PHP-LARAVEL-5M.

## The bug

Every shareable card rendered on demand failed in production. Chromium died during launch:

```
[pid=578][err] chrome_crashpad_handler: --database is required
[pid=578] <process did exit: exitCode=null, signal=SIGTRAP>
error: launch: Target page, context or browser has been closed
```

Chromium resolves its crash-dump database under `HOME` and refuses to start when it cannot. The evidence for that being the missing piece is already in this repo — `docker/supervisor/supervisord.conf` gives `HOME="/tmp"` to `queue-worker-emails` and says why in a comment.

That explains the split:

| format | rendered by | `HOME` | result |
| --- | --- | --- | --- |
| `feed` | `queue-worker-emails`, up front | `/tmp` | works |
| `story`, `wide` | `MonthlySummaryController@card`, on first request | php-fpm has no `environment=` line | 503, every time |

So the card in the email was fine and every "download" click on the other two formats returned 503.

`PLAYWRIGHT_BROWSERS_PATH` was never the problem: the failing production log shows Chromium being found at `/usr/local/playwright/chromium-1208/`, because `Dockerfile.production` sets that one container-wide. Only `HOME` was missing.

## The fix

`->env(['HOME' => sys_get_temp_dir()])` on the render process. Laravel merges onto the inherited environment rather than replacing it, so everything else the child needs is untouched.

Setting it here rather than adding a second `environment=` line to `[program:php-fpm]` keeps the requirement with the code that has it — it now holds from a worker, a web request, the scheduler, the preview command, or whatever calls it next. Giving the whole FPM pool a `HOME` to fix one subprocess is a wider change than the problem.

## What I deliberately did not do

**Removed `HOME="/tmp"` from `queue-worker-emails`.** It is redundant for cards now, and the review argued for deleting it. It is one env var, and nothing has established that the rest of that queue doesn't want a writable home — so deleting it to tidy up risks a production queue for no functional gain. The misleading half was the comment, which claimed that line is what makes cards work; that is what made php-fpm's missing copy so easy to overlook, so the comment now says where the real reason lives and when the line can go.

**Scoped `HOME` to a per-render directory** so Chromium's crashpad artifacts get cleaned up with the temp files. Playwright already hands the browser its own `--user-data-dir` and cleans that up; what is left under `HOME` is a small, bounded crash-dump directory in a container's `/tmp`. Creating and recursively deleting a directory per render costs more than it saves.

## Tests

`CardRenderer` had no direct coverage — every other test in the suite mocks it. This adds a test file that covers:

- the writable `HOME` reaching the process (red before this fix: *"An expected process was not invoked"*)
- the error output being surfaced in the exception message
- the happy path: the PNG landing on the public disk, the `exists()` short-circuit on the second ask, and the Pro badge being part of the cache key rather than overwriting the unbadged file

## Verification, and its limit

Red confirmed before the fix, green after. `tests/Feature/MonthlySummary` + the preview command: 82 passed. `pint --test`, `crap --base=origin/main` and `bun run dry` clean.

Worth being straight about the ceiling: the test fakes the process, so it proves the plumbing, not that a real Chromium starts. The diagnosis is inference from the crashpad error, the fpm-vs-queue split and this repo's own config comment — strong, but not executed against production. The change is additive and cannot break the path that already worked, so the downside of being wrong is that the bug persists rather than anything new breaking. A click on "download story" after deploy is the real check.

Nothing to clean up for affected users: `render()` only writes to the public disk after a successful screenshot, so no broken file was ever cached. Their next click renders.

## Follow-up worth a ticket, not this PR

A card render launches a cold Chromium with a 60s timeout synchronously inside a web request, and the failure path is a bare `abort(503)` with no product copy or retry. Both predate this bug.
