### PR TITLE
fix(summaries): render every monthly-report card before the email goes out

### DIFF
--- a/app/Enums/MonthlySummaryFormat.php
+++ b/app/Enums/MonthlySummaryFormat.php
@@ -24,7 +24,7 @@ enum MonthlySummaryFormat: string
 
     /**
      * The format that rides inside the email and backs the public page's
-     * og:image. It is the only one rendered up front.
+     * og:image.
      */
     public static function default(): self
     {

--- a/app/Jobs/Drip/SendMonthlySummaryEmailJob.php
+++ b/app/Jobs/Drip/SendMonthlySummaryEmailJob.php
@@ -46,12 +46,17 @@ class SendMonthlySummaryEmailJob extends SendDripEmailJob
     protected function buildMail(): Mailable
     {
         $pro = app(AnalysisWriter::class)->eligible($this->user);
+        $summaries = app(Summaries::class);
+
+        // Every card, drawn now, while there is a browser and a queue worker to
+        // draw them with — and last month's thrown away.
+        $summaries->prepareCards($this->summary, $pro);
 
         $mail = new MonthlySummaryEmail(
             $this->user,
             $this->summary,
             app(AnalysisWriter::class)->write($this->summary, $this->user),
-            app(Summaries::class)->primaryCardUrl($this->summary, $pro),
+            $summaries->primaryCardUrl($this->summary, $pro),
             $pro,
             $this->spaceName(),
         );

--- a/app/Jobs/Drip/SendMonthlySummaryEmailJob.php
+++ b/app/Jobs/Drip/SendMonthlySummaryEmailJob.php
@@ -19,6 +19,15 @@ use Illuminate\Mail\Mailable;
  */
 class SendMonthlySummaryEmailJob extends SendDripEmailJob
 {
+    /**
+     * Long, because this job draws a month's cards before it writes anything:
+     * fifteen of them, each allowed to wait on a webfont, plus the analysis the
+     * model writes. Without it the worker's 60-second default would kill the
+     * send mid-render — and a killed process is not an exception the renderer
+     * can shrug off. Stays well under the database queue's retry_after.
+     */
+    public int $timeout = 300;
+
     public function __construct(User $user, public MonthlySummary $summary)
     {
         parent::__construct($user);
@@ -62,8 +71,6 @@ class SendMonthlySummaryEmailJob extends SendDripEmailJob
         );
 
         $this->summary->forceFill(['sent_at' => now()])->save();
-
-        app(Summaries::class)->warmShareCards($this->summary, $pro);
 
         return $mail;
     }

--- a/app/Services/MonthlySummary/CardRenderer.php
+++ b/app/Services/MonthlySummary/CardRenderer.php
@@ -104,14 +104,15 @@ class CardRenderer
     }
 
     /**
-     * Throw away the cards of the months before this one. They were rendered for
-     * an email that has already been read; a reader who browses back to an old
-     * report gets them drawn again on the spot.
+     * Throw away the cards of the months before this one, for this reader and
+     * this space. A reader who browses back to an old report gets them drawn
+     * again on the spot.
      */
     public function forgetBefore(MonthlySummary $summary): void
     {
         MonthlySummary::query()
             ->where('user_id', $summary->user_id)
+            ->where('space_id', $summary->space_id)
             ->where('period', '<', $summary->period)
             ->pluck('id')
             ->each(fn (string $id) => Storage::disk('public')->deleteDirectory($this->directoryFor($id)));

--- a/app/Services/MonthlySummary/CardRenderer.php
+++ b/app/Services/MonthlySummary/CardRenderer.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\View;
 use RuntimeException;
+use Throwable;
 
 /**
  * Renders a shareable card to a PNG on the public disk.
@@ -18,10 +19,10 @@ use RuntimeException;
  * the alternative was redrawing fifteen designs in PHP with GD and watching them
  * drift from the design on the first change.
  *
- * Only the feed format is rendered up front, when the summary is built: it is
- * the one that rides inside the email and backs the public page's og:image. The
- * other two are rendered the first time somebody asks for them and then cached,
- * so nobody pays for twelve images a user will never open.
+ * Every card the month can draw is rendered just before the email goes out, in
+ * one browser, so the download buttons in the report are instant and nothing has
+ * to start Chromium inside a web request. Anything the batch missed is still
+ * rendered on demand the first time somebody asks for it.
  */
 class CardRenderer
 {
@@ -31,6 +32,13 @@ class CardRenderer
      * what to do without an image.
      */
     private const TIMEOUT_SECONDS = 60;
+
+    /**
+     * Added to the timeout for each card in the batch. Screenshots after the
+     * first are cheap — the browser is already up — but fifteen of them are not
+     * free either.
+     */
+    private const TIMEOUT_PER_CARD_SECONDS = 10;
 
     public function __construct(private CardPresenter $presenter) {}
 
@@ -62,7 +70,51 @@ class CardRenderer
      */
     public function forget(MonthlySummary $summary): void
     {
-        Storage::disk('public')->deleteDirectory($this->directoryFor($summary));
+        Storage::disk('public')->deleteDirectory($this->directoryFor($summary->id));
+    }
+
+    /**
+     * Render everything this month can show, in one browser, before anybody asks
+     * for it. Best-effort by design: this is a warm cache, and a card that does
+     * not come out here is still rendered the first time it is downloaded.
+     *
+     * @param  list<MonthlySummaryCard>  $cards
+     */
+    public function warm(MonthlySummary $summary, array $cards, bool $pro): void
+    {
+        $jobs = [];
+
+        foreach ($cards as $card) {
+            foreach (MonthlySummaryFormat::cases() as $format) {
+                $path = $this->pathFor($summary, $card, $format, $pro);
+
+                if (Storage::disk('public')->exists($path)) {
+                    continue;
+                }
+
+                $jobs[] = $this->job($summary, $card, $format, $pro, $path);
+            }
+        }
+
+        try {
+            $this->renderJobs($jobs);
+        } catch (Throwable $exception) {
+            report($exception);
+        }
+    }
+
+    /**
+     * Throw away the cards of the months before this one. They were rendered for
+     * an email that has already been read; a reader who browses back to an old
+     * report gets them drawn again on the spot.
+     */
+    public function forgetBefore(MonthlySummary $summary): void
+    {
+        MonthlySummary::query()
+            ->where('user_id', $summary->user_id)
+            ->where('period', '<', $summary->period)
+            ->pluck('id')
+            ->each(fn (string $id) => Storage::disk('public')->deleteDirectory($this->directoryFor($id)));
     }
 
     /**
@@ -73,46 +125,87 @@ class CardRenderer
     {
         $suffix = $pro ? '-pro' : '';
 
-        return $this->directoryFor($summary)."/{$card->value}-{$format->value}{$suffix}.png";
+        return $this->directoryFor($summary->id)."/{$card->value}-{$format->value}{$suffix}.png";
     }
 
-    private function directoryFor(MonthlySummary $summary): string
+    private function directoryFor(string $summaryId): string
     {
-        return "monthly-summaries/{$summary->id}";
+        return "monthly-summaries/{$summaryId}";
     }
 
     private function render(MonthlySummary $summary, MonthlySummaryCard $card, MonthlySummaryFormat $format, bool $pro, string $path): void
     {
-        [$width, $height] = $format->dimensions();
-
-        $html = View::make('cards.monthly-summary', $this->presenter->viewData($summary, $card, $format, $pro))->render();
-
-        $htmlFile = tempnam(sys_get_temp_dir(), 'wm-card-').'.html';
-        $pngFile = $htmlFile.'.png';
-        file_put_contents($htmlFile, $html);
-
-        try {
-            $this->screenshot($htmlFile, $pngFile, $width, $height);
-            Storage::disk('public')->put($path, (string) file_get_contents($pngFile));
-        } finally {
-            @unlink($htmlFile);
-            @unlink($pngFile);
-        }
+        $this->renderJobs([$this->job($summary, $card, $format, $pro, $path)]);
     }
 
-    private function screenshot(string $htmlFile, string $pngFile, int $width, int $height): void
+    /**
+     * One card written out as HTML, ready to be photographed.
+     *
+     * @return array{path: string, html: string, png: string, width: int, height: int}
+     */
+    private function job(MonthlySummary $summary, MonthlySummaryCard $card, MonthlySummaryFormat $format, bool $pro, string $path): array
     {
-        $result = Process::timeout(self::TIMEOUT_SECONDS)->run([
-            (string) config('monthly_summary.node_binary'),
-            base_path('scripts/render-card.mjs'),
-            $htmlFile,
-            $pngFile,
-            (string) $width,
-            (string) $height,
-        ]);
+        [$width, $height] = $format->dimensions();
 
-        if ($result->failed() || ! is_file($pngFile)) {
-            throw new RuntimeException('Card render failed: '.trim($result->errorOutput() ?: $result->output()));
+        $htmlFile = tempnam(sys_get_temp_dir(), 'wm-card-').'.html';
+        file_put_contents($htmlFile, View::make('cards.monthly-summary', $this->presenter->viewData($summary, $card, $format, $pro))->render());
+
+        return [
+            'path' => $path,
+            'html' => $htmlFile,
+            'png' => $htmlFile.'.png',
+            'width' => $width,
+            'height' => $height,
+        ];
+    }
+
+    /**
+     * Photograph a batch of cards in one browser and store whatever came out.
+     *
+     * A run that dies halfway still keeps the cards it managed to draw: the
+     * missing ones are what the exception is about, and they cost one more
+     * render rather than fifteen.
+     *
+     * @param  list<array{path: string, html: string, png: string, width: int, height: int}>  $jobs
+     */
+    private function renderJobs(array $jobs): void
+    {
+        if ($jobs === []) {
+            return;
+        }
+
+        $manifest = tempnam(sys_get_temp_dir(), 'wm-cards-').'.json';
+        file_put_contents($manifest, json_encode($jobs));
+
+        try {
+            $result = Process::timeout(self::TIMEOUT_SECONDS + self::TIMEOUT_PER_CARD_SECONDS * count($jobs))->run([
+                (string) config('monthly_summary.node_binary'),
+                base_path('scripts/render-card.mjs'),
+                $manifest,
+            ]);
+
+            $missing = 0;
+
+            foreach ($jobs as $job) {
+                if (! is_file($job['png'])) {
+                    $missing++;
+
+                    continue;
+                }
+
+                Storage::disk('public')->put($job['path'], (string) file_get_contents($job['png']));
+            }
+
+            if ($missing > 0) {
+                throw new RuntimeException("Card render failed for {$missing} of ".count($jobs).' card(s): '.trim($result->errorOutput() ?: $result->output()));
+            }
+        } finally {
+            @unlink($manifest);
+
+            foreach ($jobs as $job) {
+                @unlink($job['html']);
+                @unlink($job['png']);
+            }
         }
     }
 }

--- a/app/Services/MonthlySummary/Summaries.php
+++ b/app/Services/MonthlySummary/Summaries.php
@@ -75,6 +75,26 @@ class Summaries
     }
 
     /**
+     * Draw every card this month can show, and drop the months before it.
+     *
+     * Called on the way out of a send rather than on a page view: fifteen
+     * pictures in one browser take seconds a queue worker has and a web request
+     * does not, and by the time the reader opens their report the download
+     * buttons have nothing left to do. Last month's pictures go at the same
+     * time — that email has been read, and the disk is not an archive.
+     */
+    public function prepareCards(MonthlySummary $summary, bool $pro): void
+    {
+        $this->renderer->warm(
+            $summary,
+            [$summary->card, ...$this->picker->alternatives($summary->payload, $summary->card)],
+            $pro,
+        );
+
+        $this->renderer->forgetBefore($summary);
+    }
+
+    /**
      * Draw the card that rides inside the email. Failing to render must not cost
      * the reader their report, so the caller gets null and the email drops the
      * image rather than the whole send.

--- a/app/Services/MonthlySummary/Summaries.php
+++ b/app/Services/MonthlySummary/Summaries.php
@@ -79,9 +79,14 @@ class Summaries
      *
      * Called on the way out of a send rather than on a page view: fifteen
      * pictures in one browser take seconds a queue worker has and a web request
-     * does not, and by the time the reader opens their report the download
-     * buttons have nothing left to do. Last month's pictures go at the same
-     * time — that email has been read, and the disk is not an archive.
+     * does not. The screen puts all five cards up as 4:5 previews, so left to
+     * the screen a first visit would start a Chromium run for each one it has
+     * not drawn yet, inside as many web requests as the browser opens; here
+     * they cost the one reader whose report this is, and by the time they open
+     * it the previews and the download buttons have nothing left to do.
+     *
+     * The earlier months' pictures go at the same time: the disk is not an
+     * archive, and an old report that does get opened draws them again.
      */
     public function prepareCards(MonthlySummary $summary, bool $pro): void
     {
@@ -112,31 +117,6 @@ class Summaries
             ]);
 
             return null;
-        }
-    }
-
-    /**
-     * Draw the rest of the cards the summary screen shows.
-     *
-     * The screen puts all five up as 4:5 pictures, and the renderer starts a
-     * Chromium run for any it has not drawn yet. Left to the screen, a first
-     * visit would start four of them inside four web requests at once; here they
-     * cost the one reader whose report this is, on the job that already owns a
-     * cold Chromium start.
-     *
-     * Only the 4:5 shape: nothing shows the story or the wide one, so those are
-     * still drawn the first time somebody asks for one.
-     */
-    public function warmShareCards(MonthlySummary $summary, bool $pro): void
-    {
-        foreach ($this->picker->alternatives($summary->payload, $summary->card) as $card) {
-            try {
-                $this->renderer->path($summary, $card, MonthlySummaryFormat::default(), $pro);
-            } catch (Throwable $exception) {
-                // A picture nobody has asked for yet is not worth failing a send
-                // over; the screen draws it on demand if it comes to that.
-                report($exception);
-            }
         }
     }
 

--- a/docker/supervisor/supervisord.conf
+++ b/docker/supervisor/supervisord.conf
@@ -3,6 +3,10 @@ file=/var/run/supervisor.sock
 chmod=0700
 
 [supervisord]
+; Chromium renders the shareable monthly-summary cards and needs a writable
+; HOME: php-fpm's www-data children inherited root's, so every card rendered
+; on request died in the crash handler. Set here so every process gets it.
+environment=PLAYWRIGHT_BROWSERS_PATH="/usr/local/playwright",HOME="/tmp"
 logfile=/var/log/supervisord.log
 logfile_maxbytes=50MB
 logfile_backups=10
@@ -59,9 +63,6 @@ stdout_logfile=/var/log/worker-inertia-ssr.log
 process_name=%(program_name)s
 command=php /app/artisan queue:work database --queue=emails --sleep=1 --tries=5 --max-time=3600
 user=www-data
-; The monthly summary renders its shareable card on this queue, and Chromium
-; lives outside this worker's home directory.
-environment=PLAYWRIGHT_BROWSERS_PATH="/usr/local/playwright",HOME="/tmp"
 autostart=true
 autorestart=true
 redirect_stderr=true

--- a/scripts/render-card.mjs
+++ b/scripts/render-card.mjs
@@ -1,26 +1,35 @@
-// Turns one rendered card into a PNG.
+// Turns rendered cards into PNGs.
 //
-// The card is a Blade view that PHP has already rendered to a standalone HTML
-// file; this only opens it and takes the picture. Playwright is used rather than
-// a second browser stack because it is already a dependency of the Pest browser
-// suite, so the image carries the same Chromium the tests run on.
+// The cards are Blade views that PHP has already rendered to standalone HTML
+// files; this only opens them and takes the pictures. Playwright is used rather
+// than a second browser stack because it is already a dependency of the Pest
+// browser suite, so the images carry the same Chromium the tests run on.
+//
+// A whole month's worth of cards arrives in one manifest and shares one browser:
+// starting Chromium costs more than the fifteen screenshots that follow, and the
+// send window is an hour wide.
 //
 // Fonts come from Google Fonts over the network, so the run waits for them: a
 // card that falls back to a system face is subtly but visibly wrong, and it is
 // the one artefact users publish under their own name.
 //
 // Usage:
-//   bun scripts/render-card.mjs <input.html> <output.png> <width> <height>
+//   bun scripts/render-card.mjs <manifest.json>
+//
+// Manifest: [{ "html": "in.html", "png": "out.png", "width": 1080, "height": 1350 }]
 
+import { readFile } from 'node:fs/promises';
 import { chromium } from 'playwright';
 import process from 'node:process';
 
-const [input, output, width, height] = process.argv.slice(2);
+const [manifestPath] = process.argv.slice(2);
 
-if (!input || !output || !width || !height) {
-    console.error('usage: render-card.mjs <input.html> <output.png> <width> <height>');
+if (!manifestPath) {
+    console.error('usage: render-card.mjs <manifest.json>');
     process.exit(2);
 }
+
+const jobs = JSON.parse(await readFile(manifestPath, 'utf8'));
 
 // Fonts are the only thing on the wire, and a slow CDN must not hang a queue
 // worker: fall through to the fallback stack rather than wait forever.
@@ -35,23 +44,23 @@ const browser = await chromium.launch({
 });
 
 try {
-    const page = await browser.newPage({
-        viewport: { width: Number(width), height: Number(height) },
-        deviceScaleFactor: 1,
-    });
+    const page = await browser.newPage({ deviceScaleFactor: 1 });
 
-    await page.goto(`file://${input}`, { waitUntil: 'load' });
+    for (const { html, png, width, height } of jobs) {
+        await page.setViewportSize({ width: Number(width), height: Number(height) });
+        await page.goto(`file://${html}`, { waitUntil: 'load' });
 
-    try {
-        await page.evaluate(() => document.fonts.ready);
-        await page.waitForFunction(() => document.fonts.status === 'loaded', null, {
-            timeout: FONT_TIMEOUT_MS,
-        });
-    } catch {
-        // Rendering with the fallback face beats not rendering at all.
+        try {
+            await page.evaluate(() => document.fonts.ready);
+            await page.waitForFunction(() => document.fonts.status === 'loaded', null, {
+                timeout: FONT_TIMEOUT_MS,
+            });
+        } catch {
+            // Rendering with the fallback face beats not rendering at all.
+        }
+
+        await page.screenshot({ path: png, type: 'png' });
     }
-
-    await page.screenshot({ path: output, type: 'png' });
 } finally {
     await browser.close();
 }

--- a/tests/Feature/MonthlySummary/CardRenderTest.php
+++ b/tests/Feature/MonthlySummary/CardRenderTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use App\Models\MonthlySummary;
+use App\Models\User;
+use App\Services\MonthlySummary\Summaries;
+use Illuminate\Process\PendingProcess;
+use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Facades\Storage;
+
+/*
+ * The cards are drawn on the way out of the send, not while a reader waits.
+ *
+ * Chromium is faked — writing a file where each job asked for its PNG — because
+ * what is under test is that one run draws every card the month can show, and
+ * that the months before it stop taking up room.
+ */
+
+beforeEach(function (): void {
+    Storage::fake('public');
+
+    Process::fake(function (PendingProcess $process) {
+        $manifest = json_decode((string) file_get_contents((string) last($process->command)), true);
+
+        foreach ($manifest as $job) {
+            file_put_contents($job['png'], 'png');
+        }
+
+        return Process::result('');
+    });
+});
+
+/**
+ * @return callable(PendingProcess): bool
+ */
+function ranTheRenderer(): callable
+{
+    return fn (PendingProcess $process): bool => in_array(base_path('scripts/render-card.mjs'), $process->command, true);
+}
+
+function summaryToSend(User $user, string $period): MonthlySummary
+{
+    return MonthlySummary::factory()->create([
+        'user_id' => $user->id,
+        'space_id' => $user->activeSpace()->id,
+        'period' => $period,
+    ]);
+}
+
+it('draws every card the month can show in a single browser run', function (): void {
+    $summary = summaryToSend(User::factory()->onboarded()->create(), '2026-08');
+
+    app(Summaries::class)->prepareCards($summary, pro: false);
+
+    // Five cards the full payload can draw, in three formats, one Chromium.
+    Process::assertRanTimes(ranTheRenderer(), 1);
+    expect(Storage::disk('public')->files("monthly-summaries/{$summary->id}"))->toHaveCount(15);
+});
+
+it('leaves an already rendered card alone', function (): void {
+    $summary = summaryToSend(User::factory()->onboarded()->create(), '2026-08');
+
+    app(Summaries::class)->prepareCards($summary, pro: false);
+    app(Summaries::class)->prepareCards($summary, pro: false);
+
+    Process::assertRanTimes(ranTheRenderer(), 1);
+});
+
+it('throws away the cards of the months before', function (): void {
+    $user = User::factory()->onboarded()->create();
+    $previous = summaryToSend($user, '2026-07');
+    $current = summaryToSend($user, '2026-08');
+    $other = summaryToSend(User::factory()->onboarded()->create(), '2026-07');
+
+    Storage::disk('public')->put("monthly-summaries/{$previous->id}/streak-feed.png", 'png');
+    Storage::disk('public')->put("monthly-summaries/{$other->id}/streak-feed.png", 'png');
+
+    app(Summaries::class)->prepareCards($current, pro: false);
+
+    expect(Storage::disk('public')->exists("monthly-summaries/{$previous->id}/streak-feed.png"))->toBeFalse()
+        ->and(Storage::disk('public')->exists("monthly-summaries/{$other->id}/streak-feed.png"))->toBeTrue()
+        ->and(Storage::disk('public')->files("monthly-summaries/{$current->id}"))->toHaveCount(15);
+});

--- a/tests/Feature/MonthlySummary/CardRenderTest.php
+++ b/tests/Feature/MonthlySummary/CardRenderTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\MonthlySummary;
+use App\Models\Space;
 use App\Models\User;
 use App\Services\MonthlySummary\Summaries;
 use Illuminate\Process\PendingProcess;
@@ -37,11 +38,11 @@ function ranTheRenderer(): callable
     return fn (PendingProcess $process): bool => in_array(base_path('scripts/render-card.mjs'), $process->command, true);
 }
 
-function summaryToSend(User $user, string $period): MonthlySummary
+function summaryToSend(User $user, string $period, ?Space $space = null): MonthlySummary
 {
     return MonthlySummary::factory()->create([
         'user_id' => $user->id,
-        'space_id' => $user->activeSpace()->id,
+        'space_id' => ($space ?? $user->activeSpace())->id,
         'period' => $period,
     ]);
 }
@@ -70,13 +71,16 @@ it('throws away the cards of the months before', function (): void {
     $previous = summaryToSend($user, '2026-07');
     $current = summaryToSend($user, '2026-08');
     $other = summaryToSend(User::factory()->onboarded()->create(), '2026-07');
+    $otherSpace = summaryToSend($user, '2026-07', Space::factory()->create());
 
-    Storage::disk('public')->put("monthly-summaries/{$previous->id}/streak-feed.png", 'png');
-    Storage::disk('public')->put("monthly-summaries/{$other->id}/streak-feed.png", 'png');
+    foreach ([$previous, $other, $otherSpace] as $summary) {
+        Storage::disk('public')->put("monthly-summaries/{$summary->id}/streak-feed.png", 'png');
+    }
 
     app(Summaries::class)->prepareCards($current, pro: false);
 
     expect(Storage::disk('public')->exists("monthly-summaries/{$previous->id}/streak-feed.png"))->toBeFalse()
         ->and(Storage::disk('public')->exists("monthly-summaries/{$other->id}/streak-feed.png"))->toBeTrue()
+        ->and(Storage::disk('public')->exists("monthly-summaries/{$otherSpace->id}/streak-feed.png"))->toBeTrue()
         ->and(Storage::disk('public')->files("monthly-summaries/{$current->id}"))->toHaveCount(15);
 });

--- a/tests/Feature/MonthlySummary/MonthlySummaryEmailTest.php
+++ b/tests/Feature/MonthlySummary/MonthlySummaryEmailTest.php
@@ -2,7 +2,6 @@
 
 use App\Enums\DripEmailType;
 use App\Enums\MonthlySummaryCard;
-use App\Enums\MonthlySummaryFormat;
 use App\Jobs\Drip\SendMonthlySummaryEmailJob;
 use App\Mail\Drip\MonthlySummaryEmail;
 use App\Models\MonthlySummary;
@@ -20,8 +19,10 @@ use Illuminate\Support\Facades\Mail;
 
 beforeEach(function (): void {
     // What is under test is what the email says, not Chromium: left real, every
-    // job test here starts a browser per card it draws.
+    // job test here draws a month's worth of cards.
     $this->mock(CardRenderer::class, function ($mock): void {
+        $mock->shouldReceive('warm')->andReturnNull();
+        $mock->shouldReceive('forgetBefore')->andReturnNull();
         $mock->shouldReceive('url')->andReturn('https://whisper.money/storage/card.png');
         $mock->shouldReceive('path')->andReturn('monthly-summaries/x/card.png');
         $mock->shouldReceive('forget')->andReturnNull();
@@ -158,22 +159,21 @@ it('draws the rest of the screen\'s cards on the reader\'s own job', function ()
     $renderer = Mockery::mock(CardRenderer::class);
     $renderer->shouldReceive('url')->andReturn('https://whisper.money/storage/card.png');
     $renderer->shouldReceive('forget')->andReturnNull();
-    $renderer->shouldReceive('path')->andReturnUsing(
-        function (MonthlySummary $drawnFor, MonthlySummaryCard $card, MonthlySummaryFormat $format) use (&$drawn): string {
-            $drawn[] = $card->value.':'.$format->value;
-
-            return 'monthly-summaries/x/card.png';
+    $renderer->shouldReceive('forgetBefore')->andReturnNull();
+    $renderer->shouldReceive('warm')->andReturnUsing(
+        function (MonthlySummary $drawnFor, array $cards) use (&$drawn): void {
+            $drawn = array_map(fn (MonthlySummaryCard $card): string => $card->value, $cards);
         }
     );
     app()->instance(CardRenderer::class, $renderer);
 
     (new SendMonthlySummaryEmailJob($summary->user, $summary))->handle();
 
-    // Only the 4:5 shape, because that is the only one the screen shows.
-    expect($drawn)->toBe(array_map(
-        fn (MonthlySummaryCard $card): string => $card->value.':feed',
-        $alternatives,
-    ));
+    // The chosen card and every alternative, handed over in one run.
+    expect($drawn)->toBe([
+        $summary->card->value,
+        ...array_map(fn (MonthlySummaryCard $card): string => $card->value, $alternatives),
+    ]);
 });
 
 it('does not send to a reader who turned the summary off', function (): void {


### PR DESCRIPTION
Every download button on a monthly report 503'd except the one card that rides inside the email, and the images a reader did get were the only ones that had ever been rendered. Three things were wrong; this fixes all of them.

Fixes PHP-LARAVEL-5M

## Chromium could not start from a web request

`supervisord` handed php-fpm root's `HOME`, which its `www-data` children cannot write, so Chromium's crash handler died on launch:

```
[err] chrome_crashpad_handler: --database is required
error: launch: Target page, context or browser has been closed
```

The emails worker already had `HOME="/tmp"` for exactly this reason — that is why the `feed` card, rendered in the send job, survived while every card rendered on request failed. `HOME` and `PLAYWRIGHT_BROWSERS_PATH` move up to `[supervisord]`, so every process in the image gets them.

## The cards are drawn before the email, not while a reader waits

`SendMonthlySummaryEmailJob` now calls `Summaries::prepareCards()`: every card the month can draw, in every format — up to 5 x 3 — rendered before the message goes out, so the download buttons have nothing left to do. It is best-effort by design; a failure is reported and the email still goes out, and anything the batch missed is still drawn on demand the first time it is asked for.

Fifteen Chromium starts would cost more than the fifteen screenshots, so `scripts/render-card.mjs` takes a manifest instead of a single file and photographs the batch in one browser, reusing one page. Measured on a full payload: **3.86s for all fifteen**.

The job also declares `$timeout = 300`. Without it the worker's 60-second default would kill the send mid-render — and a killed process is not an exception the renderer can shrug off, so the months with the most cards to draw would be the ones whose report never arrived.

## Last month's pictures go with each send

`CardRenderer::forgetBefore()` drops the card directories of that reader and space's earlier summaries. At ~42KB a card that is ~630KB per reader per month, now constant instead of accumulating; a reader who browses back to an old report gets its cards drawn again on the spot.

## Testing

New `tests/Feature/MonthlySummary/CardRenderTest.php` (Chromium faked): one process for the whole batch, nothing re-rendered on a second pass, and the cleanup touching the right month without touching another reader's or another space's.

QA'd the way it is used — the send job run for real against a full month:

- 15/15 PNGs on the public disk at the right dimensions per format (1080x1350 feed, 1080x1920 story, 1200x675 wide), 37-78KB each, three of them opened and confirmed fully drawn.
- One browser launch for the batch, sampled while it ran; a second pass rendered nothing.
- The older month's directory gone, another reader's untouched.
- The download route serving the cached PNG byte-identical on the second request with no re-render, and 404 for a card the picker would not offer.
- With the renderer pointed at a binary that does not exist: the email still sent, `sent_at` recorded, both failures reported, and no temp files left behind.

One deviation: the render was exercised with the system Chrome because Playwright's Chromium download hangs on this machine. Only the `channel:` line differed, and it is unchanged in the diff.

`MonthlySummaryEmailTest` now stubs the renderer — it is about what the message says, and asking it to photograph fifteen cards per send took the file from 25s to 91s.