### PR TITLE
fix(summaries): give the report room at the top and let the share cards breathe

### DIFF
--- a/lang/es.json
+++ b/lang/es.json
@@ -2789,7 +2789,6 @@
     "shared": "compartido",
     "Some of your accounts had not reported when this was worked out, so the figures may be short.": "Cuando se calculó esto, algunas de tus cuentas no habían reportado, así que las cifras pueden quedarse cortas.",
     "Share your month": "Comparte tu mes",
-    "picked for you": "elegida por ti",
     "This picture could not be drawn.": "No se ha podido dibujar esta imagen.",
     "Create a public link": "Crear un enlace público",
     "Anyone with the link sees the image and nothing else. No link exists until you make one.": "Quien tenga el enlace ve la imagen y nada más. Hasta que lo crees, no existe ningún enlace.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2417,7 +2417,6 @@
     "shared": "partagé",
     "Some of your accounts had not reported when this was worked out, so the figures may be short.": "Certains de vos comptes n'avaient rien remonté au moment du calcul, les chiffres peuvent donc être incomplets.",
     "Share your month": "Partagez votre mois",
-    "picked for you": "choisie pour vous",
     "This picture could not be drawn.": "Cette image n'a pas pu être dessinée.",
     "Create a public link": "Créer un lien public",
     "Anyone with the link sees the image and nothing else. No link exists until you make one.": "Toute personne ayant le lien voit l'image et rien d'autre. Tant que vous ne le créez pas, aucun lien n'existe.",

--- a/resources/js/pages/monthly-summaries/show.tsx
+++ b/resources/js/pages/monthly-summaries/show.tsx
@@ -150,7 +150,7 @@ export default function MonthlySummaryShow({
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title={report.monthLabel} />
 
-            <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 p-4">
+            <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 p-6 md:pt-16">
                 <div className="flex flex-col gap-2">
                     <span className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
                         {report.monthLabel}
@@ -186,7 +186,7 @@ export default function MonthlySummaryShow({
                     <h2 className="text-sm font-semibold">
                         {__('Share your month')}
                     </h2>
-                    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
                         {cards.map((card) => (
                             <div
                                 key={card.card}
@@ -194,11 +194,6 @@ export default function MonthlySummaryShow({
                             >
                                 <span className="text-sm font-medium">
                                     {cardLabel(card.card)}
-                                    {card.chosen && (
-                                        <span className="ml-1.5 text-xs font-normal text-muted-foreground">
-                                            {__('picked for you')}
-                                        </span>
-                                    )}
                                 </span>
 
                                 <div


### PR DESCRIPTION
## What

Two spacing fixes on the monthly summary detail screen (`/summaries/{id}`).

**Top padding.** The content container used `p-4`, so the eyebrow and headline sat 16px under the breadcrumb header — tighter than every other top-level page in the app, which all pad to `p-6` (`dashboard.tsx`, `cashflow/index.tsx`, `accounts/index.tsx`, `transactions/index.tsx`). It now matches, and takes more room from the `md` breakpoint up so the headline is not crowded against the header on desktop.

**Share-card buttons overflowing their column.** The three download buttons under each card spilled out of their grid track and past the container — on narrow phones *and* at mid-width desktop with the sidebar open, not just mobile.

Measured in the browser, the button group needs **193px** to lay out. The old grid (`grid-cols-2 sm:grid-cols-3`) handed it a track as narrow as **128px** on a small phone and **162px** at 822px desktop, and flex items cannot shrink below their content width.

The fix widens the track rather than thinning the buttons: `grid-cols-1 sm:grid-cols-2 lg:grid-cols-3`. The download icon stays — it is what tells you the button downloads. Card previews get bigger on a phone as a side effect.

**`picked for you`.** Removed, so card labels stay on one line and the columns align. The ring around the chosen card already marks it. The two orphaned translation entries go with it.

## Verification

Measured at 320, 768, 822, 1024 and 1440px. Narrowest track by width, against the 193px the group needs:

| Viewport | Columns | Narrowest track |
| --- | --- | --- |
| 320 | 1 | 272px |
| 768 | 2 | 220px |
| 822 | 2 | 247px |
| 1024 | 3 | 227px |

No horizontal page overflow at any of them, no group spilling its column, all 9 download icons present.

`php artisan test --filter=MonthlySummary` — 81 passed, 237 assertions. `format`, `lint`, `dry` clean.

## No test

The change is Tailwind classes plus one removed label. A test asserting on class names would only restate the markup, so none is added.

## Note

The share-card previews render as "This picture could not be drawn." in local screenshots of this branch — an unrelated known bug (the PNG renderer needs a writable HOME), fixed separately on `fix/card-render-home-env`. Untouched here.