### PR TITLE
fix(summaries): render the monthly-report cards from a web request too

### DIFF
--- a/app/Console/Commands/PreviewMonthlySummaryCommand.php
+++ b/app/Console/Commands/PreviewMonthlySummaryCommand.php
@@ -135,6 +135,13 @@ class PreviewMonthlySummaryCommand extends Command
      */
     private function cases(User $user, MonthlySummary $summary, Summaries $summaries, Carbon $month, AnalysisWriter $writer): array
     {
+        // The email carries one card, but the report screen puts all of them up
+        // as previews and offers each format for download. A send draws the lot
+        // up front; a preview that drew only the one in the email would leave
+        // the screen looking broken for exactly as long as it takes to blame
+        // the wrong thing.
+        $summaries->prepareCards($summary, pro: true, dropEarlierMonths: false);
+
         $cardUrl = $summaries->primaryCardUrl($summary, true);
 
         if ($cardUrl === null) {

--- a/app/Services/MonthlySummary/CardRenderer.php
+++ b/app/Services/MonthlySummary/CardRenderer.php
@@ -167,6 +167,14 @@ class CardRenderer
      * missing ones are what the exception is about, and they cost one more
      * render rather than fifteen.
      *
+     * HOME is stated rather than inherited. Chromium puts its crash database
+     * under $HOME, and without a writable one the crash handler exits before
+     * the browser is usable — `chrome_crashpad_handler: --database is required`,
+     * then SIGTRAP. php-fpm does not hand its workers the environment the image
+     * sets, so setting it in the container only ever fixed the queue worker:
+     * every card drawn inside a web request still died. Set here, it holds
+     * whichever process is doing the drawing.
+     *
      * @param  list<array{path: string, html: string, png: string, width: int, height: int}>  $jobs
      */
     private function renderJobs(array $jobs): void
@@ -179,11 +187,13 @@ class CardRenderer
         file_put_contents($manifest, json_encode($jobs));
 
         try {
-            $result = Process::timeout(self::TIMEOUT_SECONDS + self::TIMEOUT_PER_CARD_SECONDS * count($jobs))->run([
-                (string) config('monthly_summary.node_binary'),
-                base_path('scripts/render-card.mjs'),
-                $manifest,
-            ]);
+            $result = Process::env(['HOME' => sys_get_temp_dir()])
+                ->timeout(self::TIMEOUT_SECONDS + self::TIMEOUT_PER_CARD_SECONDS * count($jobs))
+                ->run([
+                    (string) config('monthly_summary.node_binary'),
+                    base_path('scripts/render-card.mjs'),
+                    $manifest,
+                ]);
 
             $missing = 0;
 

--- a/app/Services/MonthlySummary/Summaries.php
+++ b/app/Services/MonthlySummary/Summaries.php
@@ -86,9 +86,11 @@ class Summaries
      * it the previews and the download buttons have nothing left to do.
      *
      * The earlier months' pictures go at the same time: the disk is not an
-     * archive, and an old report that does get opened draws them again.
+     * archive, and an old report that does get opened draws them again. The
+     * preview command keeps them, being a way of looking at a report rather
+     * than a send, and nobody wants a look to cost a real reader their images.
      */
-    public function prepareCards(MonthlySummary $summary, bool $pro): void
+    public function prepareCards(MonthlySummary $summary, bool $pro, bool $dropEarlierMonths = true): void
     {
         $this->renderer->warm(
             $summary,
@@ -96,7 +98,9 @@ class Summaries
             $pro,
         );
 
-        $this->renderer->forgetBefore($summary);
+        if ($dropEarlierMonths) {
+            $this->renderer->forgetBefore($summary);
+        }
     }
 
     /**

--- a/docker/supervisor/supervisord.conf
+++ b/docker/supervisor/supervisord.conf
@@ -3,9 +3,10 @@ file=/var/run/supervisor.sock
 chmod=0700
 
 [supervisord]
-; Chromium renders the shareable monthly-summary cards and needs a writable
-; HOME: php-fpm's www-data children inherited root's, so every card rendered
-; on request died in the crash handler. Set here so every process gets it.
+; Where Chromium lives, for the workers that photograph the monthly-summary
+; cards. HOME is here for the same reason but does not reach the php-fpm
+; workers, which get none of this environment — CardRenderer states it on the
+; process it starts instead, and that is what makes a card render on request.
 environment=PLAYWRIGHT_BROWSERS_PATH="/usr/local/playwright",HOME="/tmp"
 logfile=/var/log/supervisord.log
 logfile_maxbytes=50MB

--- a/tests/Feature/Console/PreviewMonthlySummaryCommandTest.php
+++ b/tests/Feature/Console/PreviewMonthlySummaryCommandTest.php
@@ -19,7 +19,10 @@ use Illuminate\Support\Facades\Mail;
  */
 
 beforeEach(function (): void {
-    $this->mock(CardRenderer::class, fn ($mock) => $mock->shouldReceive('url')->andReturn('https://whisper.money/card.png'));
+    $this->mock(CardRenderer::class, function ($mock): void {
+        $mock->shouldReceive('url')->andReturn('https://whisper.money/card.png');
+        $mock->shouldReceive('warm');
+    });
 });
 
 function previewSource(): User
@@ -52,6 +55,25 @@ it('sends every state of the report in one go', function (): void {
 
     Mail::assertSentCount(6);
     Mail::assertSent(MonthlySummaryReminderEmail::class);
+});
+
+it('draws every card the report screen shows, and keeps the earlier months', function (): void {
+    // The email carries one card; the screen puts all of them up. A preview that
+    // drew only the one in the email left the screen looking broken. Nor may a
+    // look at a report cost a real reader the pictures of their older ones.
+    Mail::fake();
+
+    $this->mock(CardRenderer::class, function ($mock): void {
+        $mock->shouldReceive('url')->andReturn('https://whisper.money/card.png');
+        $mock->shouldReceive('warm')->once();
+        $mock->shouldNotReceive('forgetBefore');
+    });
+
+    $this->artisan('email:monthly-summary-preview', [
+        'email' => 'look@whisper.test',
+        '--source' => previewSource()->email,
+        '--type' => 'pro',
+    ])->assertSuccessful();
 });
 
 it('sends now rather than queueing, so the cases do not collapse into one', function (): void {

--- a/tests/Feature/MonthlySummary/CardRenderTest.php
+++ b/tests/Feature/MonthlySummary/CardRenderTest.php
@@ -57,6 +57,16 @@ it('draws every card the month can show in a single browser run', function (): v
     expect(Storage::disk('public')->files("monthly-summaries/{$summary->id}"))->toHaveCount(15);
 });
 
+it('gives chromium a writable home', function (): void {
+    // Without it the crash handler exits before the browser is usable, and
+    // php-fpm hands its workers none of the environment the image sets — so
+    // every card drawn inside a web request failed.
+    app(Summaries::class)->prepareCards(summaryToSend(User::factory()->onboarded()->create(), '2026-08'), pro: false);
+
+    Process::assertRan(fn (PendingProcess $process): bool => ranTheRenderer()($process)
+        && is_writable((string) ($process->environment['HOME'] ?? '')));
+});
+
 it('leaves an already rendered card alone', function (): void {
     $summary = summaryToSend(User::factory()->onboarded()->create(), '2026-08');
 


### PR DESCRIPTION
Two things were keeping the monthly report down to a single 4:5 image.

## Chromium had no writable HOME under php-fpm

`#910` moved `HOME` up to `[supervisord]` to fix this, but php-fpm hands its
workers none of that environment. Only the queue worker ever got it, which is
why the feed card inside the email came out and every card the report screen
asks for returned 503. The same crash is back on the new code as
[PHP-LARAVEL-5N](https://whisper-money.sentry.io/issues/PHP-LARAVEL-5N), with
the same message as the issue it was supposed to close:

```
chrome_crashpad_handler: --database is required
[pid=1230] <process did exit: exitCode=null, signal=SIGTRAP>
```

Chromium keeps its crash database under `$HOME`; without a writable one the
crash handler exits before the browser is usable. The renderer now states
`HOME` on the process it starts rather than inheriting it, so it holds in
fpm, in the worker and on the CLI alike, whatever the container sets.

Fixes PHP-LARAVEL-5N

## The preview command drew one card of fifteen

`prepareCards()` went into the send job in `#910` but not into
`email:monthly-summary-preview`, which still asked for the one card the email
carries. Running the command left the report screen — five cards as 4:5
previews, each format downloadable — with fourteen images missing, and every
one of those a Chromium start inside a web request.

It now warms them the way a send does, minus the cleanup: a preview keeps the
earlier months' pictures, because looking at a report should not cost a real
reader the images of their older ones.

## Testing

- `CardRenderTest` asserts the renderer starts with a writable HOME
- `PreviewMonthlySummaryCommandTest` asserts the command warms every card and
  keeps the earlier months
- 86 tests across `tests/Feature/MonthlySummary` and the command, green
- `pint`, `crap` and `dry` clean

The HOME fix only takes effect once the image is rebuilt and running.