### PR TITLE
fix(settings): key table rows by record id so a rename can't reparent other categories

### DIFF
--- a/resources/js/components/automation-rules/automation-rules-dialog.tsx
+++ b/resources/js/components/automation-rules/automation-rules-dialog.tsx
@@ -262,6 +262,7 @@ export function AutomationRulesDialog({
         columns,
         onSortingChange: setSorting,
         onColumnFiltersChange: setColumnFilters,
+        getRowId: (row) => row.id,
         getCoreRowModel: getCoreRowModel(),
         getSortedRowModel: getSortedRowModel(),
         getFilteredRowModel: getFilteredRowModel(),

--- a/resources/js/components/categories/edit-category-dialog.tsx
+++ b/resources/js/components/categories/edit-category-dialog.tsx
@@ -49,6 +49,38 @@ export function EditCategoryDialog({
     onOpenChange,
     onSuccess,
 }: EditCategoryDialogProps) {
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent hasKeyboard className="sm:max-w-[425px]">
+                <DialogHeader>
+                    <DialogTitle>{__('Edit Category')}</DialogTitle>
+                    <DialogDescription>
+                        {__('Update the category information.')}
+                    </DialogDescription>
+                </DialogHeader>
+                <EditCategoryForm
+                    category={category}
+                    categories={categories}
+                    onOpenChange={onOpenChange}
+                    onSuccess={onSuccess}
+                />
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+/**
+ * The form body, deliberately a child of `DialogContent`: Radix unmounts that
+ * subtree while the dialog is closed, so the parent and type state below is
+ * rebuilt from the category on every open, just like the uncontrolled inputs
+ * beside it. Kept in the parent it would outlive the category it was built for.
+ */
+function EditCategoryForm({
+    category,
+    categories,
+    onOpenChange,
+    onSuccess,
+}: Omit<EditCategoryDialogProps, 'open'>) {
     const [selectedType, setSelectedType] = useState<CategoryType>(
         category.type,
     );
@@ -59,201 +91,173 @@ export function EditCategoryDialog({
     );
 
     return (
-        <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent hasKeyboard className="sm:max-w-[425px]">
-                <DialogHeader>
-                    <DialogTitle>{__('Edit Category')}</DialogTitle>
-                    <DialogDescription>
-                        {__('Update the category information.')}
-                    </DialogDescription>
-                </DialogHeader>
-                <Form
-                    {...update.form.patch(category.id)}
-                    onSuccess={() => {
-                        onOpenChange(false);
-                        onSuccess?.();
-                    }}
-                    className="space-y-4"
-                >
-                    {({ errors, processing }) => (
+        <Form
+            {...update.form.patch(category.id)}
+            onSuccess={() => {
+                onOpenChange(false);
+                onSuccess?.();
+            }}
+            className="space-y-4"
+        >
+            {({ errors, processing }) => (
+                <>
+                    <div className="space-y-2">
+                        <Label htmlFor="name">{__('Name')}</Label>
+                        <Input
+                            id="name"
+                            name="name"
+                            defaultValue={category.name}
+                            placeholder={__('Category name')}
+                            required
+                        />
+
+                        <InputError message={errors.name} />
+                    </div>
+
+                    <ParentCategoryField
+                        categories={categories}
+                        value={parent?.id ?? null}
+                        excludeId={category.id}
+                        onChange={(next) => {
+                            setParent(next);
+                            if (next) {
+                                setSelectedType(next.type);
+                            }
+                        }}
+                        error={errors.parent_id}
+                    />
+
+                    <div className="space-y-2">
+                        <Label htmlFor="icon">{__('Icon')}</Label>
+                        <Select
+                            name="icon"
+                            defaultValue={category.icon}
+                            required
+                        >
+                            <SelectTrigger>
+                                <SelectValue
+                                    placeholder={__('Select an icon')}
+                                />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {CATEGORY_ICONS.map((iconName) => {
+                                    const IconComponent = Icons[
+                                        iconName as keyof typeof Icons
+                                    ] as Icons.LucideIcon;
+                                    return (
+                                        <SelectItem
+                                            key={iconName}
+                                            value={iconName}
+                                        >
+                                            <div className="flex items-center gap-2">
+                                                <IconComponent className="h-4 w-4" />
+                                                <span>{iconName}</span>
+                                            </div>
+                                        </SelectItem>
+                                    );
+                                })}
+                            </SelectContent>
+                        </Select>
+                        <InputError message={errors.icon} />
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="color">{__('Color')}</Label>
+                        <Select
+                            name="color"
+                            defaultValue={category.color}
+                            required
+                        >
+                            <SelectTrigger>
+                                <SelectValue
+                                    placeholder={__('Select a color')}
+                                />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {CATEGORY_COLORS.map((color) => {
+                                    const colorClasses =
+                                        getCategoryColorClasses(color);
+                                    return (
+                                        <SelectItem key={color} value={color}>
+                                            <div className="flex items-center gap-2">
+                                                <Badge
+                                                    className={`${colorClasses.bg} ${colorClasses.text}`}
+                                                >
+                                                    {__(color)}
+                                                </Badge>
+                                            </div>
+                                        </SelectItem>
+                                    );
+                                })}
+                            </SelectContent>
+                        </Select>
+                        <InputError message={errors.color} />
+                    </div>
+
+                    {parent ? (
+                        <div className="space-y-2">
+                            <Label>{__('Type')}</Label>
+                            <input
+                                type="hidden"
+                                name="type"
+                                value={parent.type}
+                            />
+                            <p className="text-sm text-muted-foreground">
+                                {getCategoryTypeLabel(parent.type)}
+                                {' · '}
+                                {__('Inherited from parent')}
+                            </p>
+                        </div>
+                    ) : (
                         <>
                             <div className="space-y-2">
-                                <Label htmlFor="name">{__('Name')}</Label>
-                                <Input
-                                    id="name"
-                                    name="name"
-                                    defaultValue={category.name}
-                                    placeholder={__('Category name')}
+                                <Label htmlFor="type">{__('Type')}</Label>
+                                <Select
+                                    name="type"
+                                    defaultValue={category.type}
                                     required
-                                />
-
-                                <InputError message={errors.name} />
-                            </div>
-
-                            <ParentCategoryField
-                                categories={categories}
-                                value={parent?.id ?? null}
-                                excludeId={category.id}
-                                onChange={(next) => {
-                                    setParent(next);
-                                    if (next) {
-                                        setSelectedType(next.type);
+                                    onValueChange={(value) =>
+                                        setSelectedType(value as CategoryType)
                                     }
-                                }}
-                                error={errors.parent_id}
+                                >
+                                    <SelectTrigger>
+                                        <SelectValue
+                                            placeholder={__('Select a type')}
+                                        />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {CATEGORY_TYPES.map((type) => (
+                                            <SelectItem key={type} value={type}>
+                                                {getCategoryTypeLabel(type)}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                                <InputError message={errors.type} />
+                            </div>
+
+                            <CategoryCashflowDirectionFields
+                                selectedType={selectedType}
+                                defaultValue={category.cashflow_direction}
                             />
-
-                            <div className="space-y-2">
-                                <Label htmlFor="icon">{__('Icon')}</Label>
-                                <Select
-                                    name="icon"
-                                    defaultValue={category.icon}
-                                    required
-                                >
-                                    <SelectTrigger>
-                                        <SelectValue
-                                            placeholder={__('Select an icon')}
-                                        />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        {CATEGORY_ICONS.map((iconName) => {
-                                            const IconComponent = Icons[
-                                                iconName as keyof typeof Icons
-                                            ] as Icons.LucideIcon;
-                                            return (
-                                                <SelectItem
-                                                    key={iconName}
-                                                    value={iconName}
-                                                >
-                                                    <div className="flex items-center gap-2">
-                                                        <IconComponent className="h-4 w-4" />
-                                                        <span>{iconName}</span>
-                                                    </div>
-                                                </SelectItem>
-                                            );
-                                        })}
-                                    </SelectContent>
-                                </Select>
-                                <InputError message={errors.icon} />
-                            </div>
-
-                            <div className="space-y-2">
-                                <Label htmlFor="color">{__('Color')}</Label>
-                                <Select
-                                    name="color"
-                                    defaultValue={category.color}
-                                    required
-                                >
-                                    <SelectTrigger>
-                                        <SelectValue
-                                            placeholder={__('Select a color')}
-                                        />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        {CATEGORY_COLORS.map((color) => {
-                                            const colorClasses =
-                                                getCategoryColorClasses(color);
-                                            return (
-                                                <SelectItem
-                                                    key={color}
-                                                    value={color}
-                                                >
-                                                    <div className="flex items-center gap-2">
-                                                        <Badge
-                                                            className={`${colorClasses.bg} ${colorClasses.text}`}
-                                                        >
-                                                            {__(color)}
-                                                        </Badge>
-                                                    </div>
-                                                </SelectItem>
-                                            );
-                                        })}
-                                    </SelectContent>
-                                </Select>
-                                <InputError message={errors.color} />
-                            </div>
-
-                            {parent ? (
-                                <div className="space-y-2">
-                                    <Label>{__('Type')}</Label>
-                                    <input
-                                        type="hidden"
-                                        name="type"
-                                        value={parent.type}
-                                    />
-                                    <p className="text-sm text-muted-foreground">
-                                        {getCategoryTypeLabel(parent.type)}
-                                        {' · '}
-                                        {__('Inherited from parent')}
-                                    </p>
-                                </div>
-                            ) : (
-                                <>
-                                    <div className="space-y-2">
-                                        <Label htmlFor="type">
-                                            {__('Type')}
-                                        </Label>
-                                        <Select
-                                            name="type"
-                                            defaultValue={category.type}
-                                            required
-                                            onValueChange={(value) =>
-                                                setSelectedType(
-                                                    value as CategoryType,
-                                                )
-                                            }
-                                        >
-                                            <SelectTrigger>
-                                                <SelectValue
-                                                    placeholder={__(
-                                                        'Select a type',
-                                                    )}
-                                                />
-                                            </SelectTrigger>
-                                            <SelectContent>
-                                                {CATEGORY_TYPES.map((type) => (
-                                                    <SelectItem
-                                                        key={type}
-                                                        value={type}
-                                                    >
-                                                        {getCategoryTypeLabel(
-                                                            type,
-                                                        )}
-                                                    </SelectItem>
-                                                ))}
-                                            </SelectContent>
-                                        </Select>
-                                        <InputError message={errors.type} />
-                                    </div>
-
-                                    <CategoryCashflowDirectionFields
-                                        selectedType={selectedType}
-                                        defaultValue={
-                                            category.cashflow_direction
-                                        }
-                                    />
-                                </>
-                            )}
-
-                            <div className="flex justify-end gap-2">
-                                <Button
-                                    type="button"
-                                    variant="outline"
-                                    onClick={() => onOpenChange(false)}
-                                    disabled={processing}
-                                >
-                                    {__('Cancel')}
-                                </Button>
-                                <Button type="submit" disabled={processing}>
-                                    {processing
-                                        ? __('Updating...')
-                                        : __('Update')}
-                                </Button>
-                            </div>
                         </>
                     )}
-                </Form>
-            </DialogContent>
-        </Dialog>
+
+                    <div className="flex justify-end gap-2">
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => onOpenChange(false)}
+                            disabled={processing}
+                        >
+                            {__('Cancel')}
+                        </Button>
+                        <Button type="submit" disabled={processing}>
+                            {processing ? __('Updating...') : __('Update')}
+                        </Button>
+                    </div>
+                </>
+            )}
+        </Form>
     );
 }

--- a/resources/js/components/shared/settings-table.tsx
+++ b/resources/js/components/shared/settings-table.tsx
@@ -17,6 +17,10 @@ import { type ReactNode } from 'react';
  * The bordered table the settings pages list their records in. Deliberately not
  * the virtualized DataTable: these lists are short, and each page renders its
  * own row component (they carry a per-row context menu).
+ *
+ * Tables rendered here must set `getRowId` to the record id. Row keys fall back
+ * to the row index otherwise, and because these lists reorder on rename, React
+ * would hand a mounted row (and the edit dialog inside it) a different record.
  */
 export function SettingsTable<TData>({
     table,

--- a/resources/js/pages/settings/accounts.tsx
+++ b/resources/js/pages/settings/accounts.tsx
@@ -342,6 +342,7 @@ export default function Accounts({ accounts }: AccountsPageProps) {
         columns,
         onSortingChange: setSorting,
         onColumnFiltersChange: setColumnFilters,
+        getRowId: (row) => row.id,
         getCoreRowModel: getCoreRowModel(),
         getSortedRowModel: getSortedRowModel(),
         getFilteredRowModel: getFilteredRowModel(),

--- a/resources/js/pages/settings/automation-rules.tsx
+++ b/resources/js/pages/settings/automation-rules.tsx
@@ -257,6 +257,7 @@ export default function AutomationRules() {
         columns,
         onSortingChange: setSorting,
         onColumnFiltersChange: setColumnFilters,
+        getRowId: (row) => row.id,
         getCoreRowModel: getCoreRowModel(),
         getSortedRowModel: getSortedRowModel(),
         getFilteredRowModel: getFilteredRowModel(),

--- a/resources/js/pages/settings/categories.test.tsx
+++ b/resources/js/pages/settings/categories.test.tsx
@@ -1,0 +1,179 @@
+import { EditCategoryDialog } from '@/components/categories/edit-category-dialog';
+import type { Category } from '@/types/category';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import CategoriesPage from './categories';
+
+globalThis.ResizeObserver ??= class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+};
+
+const page = vi.hoisted(() => ({ categories: [] as unknown[] }));
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ title }: { title: string }) => <title>{title}</title>,
+    usePage: () => ({ props: { categories: page.categories } }),
+    Form: ({
+        children,
+        action,
+    }: {
+        children: (args: {
+            errors: Record<string, string>;
+            processing: boolean;
+        }) => ReactNode;
+        action?: string;
+    }) => (
+        <form action={action}>
+            {children({ errors: {}, processing: false })}
+        </form>
+    ),
+}));
+
+vi.mock('@/layouts/app-layout', () => ({
+    default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/layouts/settings/layout', () => ({
+    default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+function makeCategory(overrides: Partial<Category>): Category {
+    return {
+        id: 'category-1',
+        name: 'Category',
+        icon: 'Utensils',
+        color: 'blue',
+        type: 'expense',
+        cashflow_direction: 'hidden',
+        parent_id: null,
+        ...overrides,
+    };
+}
+
+const food = makeCategory({ id: 'food', name: 'Food' });
+const groceries = makeCategory({
+    id: 'groceries',
+    name: 'Groceries',
+    icon: 'ShoppingBasket',
+    parent_id: 'food',
+});
+const transportation = makeCategory({
+    id: 'transportation',
+    name: 'Transportation',
+    icon: 'Car',
+});
+const fuel = makeCategory({
+    id: 'fuel',
+    name: 'Fuel',
+    icon: 'Fuel',
+    parent_id: 'transportation',
+});
+const salary = makeCategory({
+    id: 'salary',
+    name: 'Salary',
+    icon: 'Banknote',
+    type: 'income',
+    cashflow_direction: 'inflow',
+});
+const bonus = makeCategory({
+    id: 'bonus',
+    name: 'Bonus',
+    icon: 'Gift',
+    type: 'income',
+    cashflow_direction: 'inflow',
+    parent_id: 'salary',
+});
+
+const allCategories = [food, groceries, transportation, fuel, salary, bonus];
+
+/**
+ * Renaming a top-level category moves it and its children to the front of the
+ * alphabetical list, shifting the position of every row below it.
+ */
+function renameTransportation() {
+    page.categories = [
+        food,
+        groceries,
+        { ...transportation, name: 'Automovil' },
+        fuel,
+    ];
+}
+
+function openEditDialogFor(name: string) {
+    const row = screen.getByText(name).closest('tr');
+    expect(row).not.toBeNull();
+
+    fireEvent.contextMenu(row!);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Edit' }));
+}
+
+/** What the open dialog would actually send on Update. */
+function submittedField(name: string): string | undefined {
+    return screen
+        .getByRole('dialog')
+        .querySelector<HTMLInputElement>(`input[name="${name}"]`)?.value;
+}
+
+function submittedCategoryId(): string | undefined {
+    return screen
+        .getByRole('dialog')
+        .querySelector('form')
+        ?.getAttribute('action')
+        ?.split('?')[0]
+        .split('/')
+        .pop();
+}
+
+describe('CategoriesPage', () => {
+    it('keeps every category with its own parent after a rename reorders the table', () => {
+        page.categories = [food, groceries, transportation, fuel];
+        const { rerender } = render(<CategoriesPage />);
+
+        renameTransportation();
+        rerender(<CategoriesPage />);
+
+        openEditDialogFor('Groceries');
+
+        // Positional row keys handed this row the dialog built for whichever
+        // category sat at its index before, silently reparenting on submit.
+        expect(submittedField('parent_id')).toBe('food');
+    });
+
+    it('keeps an open dialog on the category it was opened from when the table reorders', () => {
+        page.categories = [food, groceries, transportation, fuel];
+        const { rerender } = render(<CategoriesPage />);
+
+        openEditDialogFor('Fuel');
+        expect(submittedCategoryId()).toBe('fuel');
+
+        renameTransportation();
+        rerender(<CategoriesPage />);
+
+        expect(submittedCategoryId()).toBe('fuel');
+    });
+});
+
+describe('EditCategoryDialog', () => {
+    const renderDialog = (category: Category, open: boolean) => (
+        <EditCategoryDialog
+            category={category}
+            categories={allCategories}
+            open={open}
+            onOpenChange={vi.fn()}
+        />
+    );
+
+    it('rebuilds the parent and type it submits from the category it is handed on each open', () => {
+        // The row this dialog belongs to can be re-pointed at another category
+        // while the dialog is closed; what it submits has to follow.
+        const { rerender } = render(renderDialog(bonus, false));
+
+        rerender(renderDialog(groceries, true));
+
+        expect(submittedField('parent_id')).toBe('food');
+        expect(submittedField('type')).toBe('expense');
+    });
+});

--- a/resources/js/pages/settings/categories.tsx
+++ b/resources/js/pages/settings/categories.tsx
@@ -323,6 +323,7 @@ export default function Categories() {
         columns,
         onSortingChange: setSorting,
         onColumnFiltersChange: setColumnFilters,
+        getRowId: (row) => row.id,
         getCoreRowModel: getCoreRowModel(),
         getSortedRowModel: getSortedRowModel(),
         getFilteredRowModel: getFilteredRowModel(),

--- a/resources/js/pages/settings/labels.tsx
+++ b/resources/js/pages/settings/labels.tsx
@@ -134,6 +134,7 @@ export default function Labels() {
         columns,
         onSortingChange: setSorting,
         onColumnFiltersChange: setColumnFilters,
+        getRowId: (row) => row.id,
         getCoreRowModel: getCoreRowModel(),
         getSortedRowModel: getSortedRowModel(),
         getFilteredRowModel: getFilteredRowModel(),


### PR DESCRIPTION
## The bug

Renaming a top-level category left the *other* categories' edit dialogs pointing at
the wrong parent, and pressing **Update** then silently reparented the category and
rewrote its type.

Reported as:

> When I change the name of a top-level category (e.g. Transportation -> Automovil),
> going to edit its child categories shows a different parent category. Or no parent
> at all. [...] editing categories I never touched shows them under a parent that
> isn't theirs.

## Root cause: rows were keyed by position

The settings tables call `useReactTable` without `getRowId`. TanStack then falls back
to the row **index** for `row.id`:

```ts
// @tanstack/table-core — core/table.ts
_getRowId: (row, index, parent) =>
  table.options.getRowId?.(row, index, parent) ??
  `${parent ? [parent.id, index].join('.') : index}`,
```

…and the pages key their rows with exactly that. Categories are ordered by name
(`Category::scopeForDisplay`, then `flattenCategoryTree` per level), so renaming
`Transportation` to `Automovil` moves it *and its whole subtree* and shifts the
position of every row below it. Because the keys are positional, React does not
remount anything: it reuses each row component instance and hands it a **different**
record, while the state that lives inside the row stays behind.

Two things leaked:

- **The open dialog.** The `editOpen` flag lives in the row. An open edit dialog
  stayed open on a row that now pointed at another category, so `Update` targeted the
  wrong record.
- **The category's parent and type.** `EditCategoryDialog` held `parent` and
  `selectedType` in `useState` placed *outside* `DialogContent`. Radix does remount
  `DialogContent`'s subtree on every open — which is why the name, icon and colour
  `defaultValue`s were always right — but that state sat above it and was initialised
  once, when the page mounted.

So the hidden `parent_id` and `type` inputs carried the previous category's values,
`CategoryController::update` wrote them, and `syncDescendantTypes` cascaded the wrong
type down. Not a display glitch: a silent reparent plus a type rewrite.

## The fix

1. `getRowId: (row) => row.id` on every settings table, following the convention the
   transactions tables already use (`transaction-list.tsx`, `transactions/index.tsx`).
   Rows now keep their identity through a reorder.
2. The category edit form moved into an `EditCategoryForm` child of `DialogContent`,
   taking the `parent` / `selectedType` state with it. Radix's `Presence` then rebuilds
   it from the category on every open, exactly like the uncontrolled inputs beside it —
   which also fixes a cancelled edit leaving its parent choice behind for the next open.
   The exit animation is untouched.
3. The `getRowId` invariant is recorded on `SettingsTable`, the component all four
   pages render through, so it isn't quietly dropped again.

## Regression test

`resources/js/pages/settings/categories.test.tsx` (vitest, no browser suite — this is
pure React state). Three cases, each verified to fail without the change that fixes it:

| Case | Fails without |
| --- | --- |
| a child keeps its own parent after a sibling rename reorders the table | either fix (the reported bug) |
| an open dialog stays on the category it was opened from | `getRowId` |
| the dialog rebuilds the parent and type it submits on each open | the `EditCategoryForm` move |

## Notes

- `automation-rules-dialog.tsx` has the same table shape and the same defect, so it
  gets the same one-line fix.
- `create-category-dialog.tsx` keeps the same state-outside-`DialogContent` pattern:
  a cancelled create still remembers the parent you picked on the next open. Left out
  to keep this diff to the reported bug; worth a follow-up.

## QA

Browser QA against the demo account, reproducing the reported flow: renamed the
top-level `Transportation` to `Automovil` and then, without reloading, opened the edit
dialog of its children (`Fuel`, `Parking`, `Vehicle purchase`), of a child in an
untouched branch (`Electricity`) and of a top-level category (`Salary`) — every one
showed its real parent and type. Updating `Electricity` without touching its parent
left it under `Utility services` with type `EXPENSE`, where it previously would have
been reparented. Checked through both the `...` menu and the right-click context menu,
plus the cancel-then-reopen case. Labels and Accounts still open the right row's
dialog. Console clean.

## Demo

<!-- VIDEO PLACEHOLDER — drag settings-row-state-reuse-qa.mp4 here -->

https://github.com/user-attachments/assets/ed4fe329-e5a4-4d12-99ec-0e4c73e353d5


