### PR TITLE
feat(summaries): put the monthly summaries rollout behind MONTHLY_SUMMARIES_ENABLED

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -214,3 +214,10 @@ AI_SUGGESTIONS_REPORT_EXCLUDED_EMAILS=
 DISCORD_WEBHOOK_URL=
 # Optional dedicated channel for the AI cohort report; falls back to DISCORD_WEBHOOK_URL.
 DISCORD_AI_COHORT_WEBHOOK_URL=
+
+# Monthly summary report (email + share cards + history screen). Off unless set.
+# Pennant stores the resolved value per user, so turning this on only reaches
+# users who have never been resolved; run
+# `php artisan feature:enable MonthlySummaries all` alongside it to move the
+# ones already stored.
+# MONTHLY_SUMMARIES_ENABLED=true

--- a/app/Features/MonthlySummaries.php
+++ b/app/Features/MonthlySummaries.php
@@ -5,12 +5,26 @@ namespace App\Features;
 use App\Models\User;
 
 /**
- * Gates the monthly summary email, its shareable cards and the history screen
- * while it is being rolled out. Off by default: through September it is enabled
- * for the founders and the demo/press accounts only, rehearsing on August's real
- * data, and turned on for everyone in time for the October 3rd send.
+ * Gates the monthly summary email, its shareable cards and the history screen.
+ * Off unless `MONTHLY_SUMMARIES_ENABLED` says otherwise, so the rollout is a
+ * variable in Coolify rather than a deploy.
  *
- * Toggle with `php artisan feature:enable App\\Features\\MonthlySummaries <target>`.
+ * Pennant persists whatever `resolve()` returns: the first check for a scope
+ * writes a row to the `features` table and this method is never consulted for
+ * that scope again. Flipping the env var therefore only reaches users with no
+ * row yet — everyone already resolved to `false` stays off. Whoever flips it
+ * must also run one of:
+ *
+ * - `php artisan feature:enable MonthlySummaries all` — updates the stored rows
+ *   in place.
+ * - `php artisan pennant:purge "App\\Features\\MonthlySummaries"` — drops them
+ *   so every scope falls through to `resolve()` again.
+ *
+ * The names differ on purpose: `feature:enable` is ours and takes the short
+ * class name, `pennant:purge` is Laravel's and takes the fully qualified one.
+ *
+ * The production entrypoint runs `php artisan config:cache`, so the var is read
+ * at container boot: the change lands on the restart, not live.
  *
  * @api
  */
@@ -21,6 +35,6 @@ class MonthlySummaries
      */
     public function resolve(?User $user): bool
     {
-        return false;
+        return (bool) config('monthly_summary.enabled');
     }
 }

--- a/config/monthly_summary.php
+++ b/config/monthly_summary.php
@@ -4,6 +4,24 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Rollout
+    |--------------------------------------------------------------------------
+    |
+    | Whether the feature resolves on for a reader who has never been resolved
+    | before. Off, so the report stays invisible until someone deliberately
+    | turns it on: the switch lives here rather than in the code so the rollout
+    | is a variable in Coolify, not a deploy.
+    |
+    | Pennant stores the resolved value per reader, so turning this on only
+    | reaches readers with no stored row. See App\Features\MonthlySummaries for
+    | the command that has to run alongside it.
+    |
+    */
+
+    'enabled' => (bool) env('MONTHLY_SUMMARIES_ENABLED', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Send window
     |--------------------------------------------------------------------------
     |

--- a/tests/Feature/MonthlySummary/RolloutFlagTest.php
+++ b/tests/Feature/MonthlySummary/RolloutFlagTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use App\Features\MonthlySummaries;
+use App\Models\User;
+use Illuminate\Support\Facades\Artisan;
+use Laravel\Pennant\Feature;
+
+/*
+ * The flag reads `monthly_summary.enabled` so the rollout can be flipped from
+ * the environment. Pennant only asks `resolve()` once per reader, so these go
+ * through fresh readers with no stored value.
+ */
+
+it('is off by default', function (): void {
+    expect(config('monthly_summary.enabled'))->toBeFalse();
+});
+
+it('resolves off when the config says so', function (): void {
+    config()->set('monthly_summary.enabled', false);
+
+    expect(Feature::for(User::factory()->create())->active(MonthlySummaries::class))->toBeFalse();
+});
+
+it('resolves on when the config says so', function (): void {
+    config()->set('monthly_summary.enabled', true);
+
+    expect(Feature::for(User::factory()->create())->active(MonthlySummaries::class))->toBeTrue();
+});
+
+/*
+ * The caveat the docblock warns about, and the command it points at. Pinned
+ * because the command only accepts the short class name: the fully qualified
+ * one resolves to App\Features\App\Features\... and quietly fails.
+ */
+
+it('leaves a stored value alone when the config flips', function (): void {
+    config()->set('monthly_summary.enabled', false);
+
+    $user = User::factory()->create();
+    Feature::for($user)->active(MonthlySummaries::class);
+
+    config()->set('monthly_summary.enabled', true);
+    Feature::flushCache();
+
+    expect(Feature::for($user)->active(MonthlySummaries::class))->toBeFalse();
+});
+
+it('moves the stored value with the documented command', function (): void {
+    config()->set('monthly_summary.enabled', false);
+
+    $user = User::factory()->create();
+    Feature::for($user)->active(MonthlySummaries::class);
+
+    expect(Artisan::call('feature:enable', ['feature' => 'MonthlySummaries', 'target' => 'all']))->toBe(0);
+
+    Feature::flushCache();
+
+    expect(Feature::for($user)->active(MonthlySummaries::class))->toBeTrue();
+});


### PR DESCRIPTION
`App\Features\MonthlySummaries::resolve()` returned a hardcoded `false`, so the
rollout could only move with a deploy. It now reads a config key backed by an
env var, and the rollout becomes a variable in Coolify.

```
MONTHLY_SUMMARIES_ENABLED=true
```

Default is `false`. This PR changes nothing for anybody: with the var unset the
flag resolves exactly as it did before.

The old docblock described a September calendar (founders and demo accounts
first, everyone by the October 3rd send). That stopped being true the moment the
switch moved to the environment, so it is gone — the schedule is now whatever
the var says.

## Flipping it: the second command is not optional

**Pennant persists whatever `resolve()` returns.** The first check for a scope
writes a row to the `features` table, and `resolve()` is never consulted for
that scope again. Production currently holds 102 rows for this feature — 101
`false` and 1 `true` — against 2437 onboarded users.

So setting the var to `true` only reaches the ~2335 users who have no row yet.
The 101 stored `false` rows keep winning, and the feature will look broken when
it isn't. Whoever flips it must also run one of:

```bash
# updates the stored rows in place
php artisan feature:enable MonthlySummaries all

# or drops them, so every scope falls through to resolve() again
php artisan pennant:purge "App\\Features\\MonthlySummaries"
```

Mind the two name forms: `feature:enable` is ours and takes the short class
name — handing it the fully qualified one builds `App\Features\App\Features\...`
and fails with "not found". `pennant:purge` is Laravel's and takes the fully
qualified name. Both are verified against a stored-off user; see QA below.

Second, smaller thing: the production entrypoint runs `php artisan config:cache`
(`docker/entrypoint.sh:97`), so the var is read at container boot. Changing it in
Coolify takes effect on the restart that change triggers, not live.

All of the above is written into the `MonthlySummaries` docblock too, so it is
in front of whoever reads the class next.

## Changes

- `app/Features/MonthlySummaries.php` — `resolve()` reads the config; docblock
  rewritten to describe the switch and the stored-rows caveat.
- `config/monthly_summary.php` — new `enabled` key, alongside the other knobs
  this feature already owns.
- `.env.example` — the var, commented out, with the caveat.
- `tests/Feature/MonthlySummary/RolloutFlagTest.php` — the default is off,
  `resolve()` follows the config both ways, a stored value survives the config
  flipping, and `feature:enable MonthlySummaries all` moves it. The last two pin
  the caveat and the command so this description cannot quietly go stale.

The three read sites (`DashboardController`, `MonthlySummaryController`,
`SendMonthlySummariesCommand`) all go through `Feature::active()` and needed no
change. Existing tests define the feature explicitly, so they override
`resolve()` and are unaffected.

## QA

No UI in this change, so it was exercised the way it is actually used:

- `php artisan config:show monthly_summary.enabled` → `false`; the same with
  `MONTHLY_SUMMARIES_ENABLED=true` in the environment → `true`.
- A fresh user with no stored row resolves off by default and on with the var
  set.
- A user stored as `false` stays off after the var flips, and both documented
  commands move them.

That last check caught a real error in the first draft of this PR: the
`feature:enable` invocation was written with the fully qualified class name,
which `ResolvesFeatures::resolveFeatureClass()` prefixes again into
`App\Features\App\Features\MonthlySummaries` and rejects with "not found".
Whoever flipped the var in production would have hit that and left the stored
users off. The docs now use the short name and a test holds them to it.

Affected suites (`tests/Feature/MonthlySummary`, `SendMonthlySummariesCommandTest`,
`DashboardTest`) pass: 99 tests, 274 assertions. `pint`, `crap` and `dry` are clean.
