### PR TITLE
feat(summaries): light and dark share cards, drawn in the reader's language

### DIFF
--- a/app/Console/Commands/PreviewMonthlySummaryCommand.php
+++ b/app/Console/Commands/PreviewMonthlySummaryCommand.php
@@ -13,6 +13,7 @@ use Carbon\Carbon;
 use Illuminate\Console\Command;
 use Illuminate\Mail\Mailable;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Traits\Localizable;
 use Throwable;
 
 /**
@@ -38,6 +39,8 @@ use Throwable;
  */
 class PreviewMonthlySummaryCommand extends Command
 {
+    use Localizable;
+
     protected $signature = 'email:monthly-summary-preview
         {email : Where to send the previews}
         {--source= : The account whose real figures to build from (defaults to the press account)}
@@ -140,9 +143,15 @@ class PreviewMonthlySummaryCommand extends Command
         // up front; a preview that drew only the one in the email would leave
         // the screen looking broken for exactly as long as it takes to blame
         // the wrong thing.
-        $summaries->prepareCards($summary, pro: true, dropEarlierMonths: false);
+        //
+        // In the reader's language, like the real send: the copy is baked into
+        // the picture, so a preview drawn in the console's locale would show an
+        // English card next to a Spanish email.
+        $cardUrl = $this->withLocale($user->preferredLocale(), function () use ($summaries, $summary): ?string {
+            $summaries->prepareCards($summary, pro: true, dropEarlierMonths: false);
 
-        $cardUrl = $summaries->primaryCardUrl($summary, true);
+            return $summaries->primaryCardUrl($summary, true);
+        });
 
         if ($cardUrl === null) {
             $this->warn('No card image: the renderer could not draw one, so the share block goes out without it.');

--- a/app/Enums/MonthlySummaryTheme.php
+++ b/app/Enums/MonthlySummaryTheme.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * The two skins every card can be drawn in. Light is what the email carries and
+ * what the public page unfurls; the report screen offers both, because a card
+ * posted into a dark feed reads better dark.
+ */
+enum MonthlySummaryTheme: string
+{
+    case Light = 'light';
+    case Dark = 'dark';
+
+    public function isDark(): bool
+    {
+        return $this === self::Dark;
+    }
+
+    /**
+     * The theme the email image and the public page's og:image are drawn in.
+     */
+    public static function default(): self
+    {
+        return self::Light;
+    }
+}

--- a/app/Http/Controllers/MonthlySummaryController.php
+++ b/app/Http/Controllers/MonthlySummaryController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Enums\MonthlySummaryCard;
 use App\Enums\MonthlySummaryFormat;
+use App\Enums\MonthlySummaryTheme;
 use App\Features\MonthlySummaries;
 use App\Models\MonthlySummary;
 use App\Services\MonthlySummary\AnalysisWriter;
@@ -60,31 +61,32 @@ class MonthlySummaryController extends Controller
             'summary' => $this->listRow($summary),
             'report' => $this->presenter->present($summary, app()->getLocale(), $pro),
             'analysis' => $summary->ai_analysis,
-            'cards' => $this->cardOptions($summary, $pro),
+            'cards' => $this->cardOptions($summary),
             'shareUrl' => $summary->share_token === null ? null : route('monthly-summaries.shared', $summary->share_token),
         ]);
     }
 
     /**
      * Serve one card as a PNG. Rendered on first request and cached on the
-     * public disk, so nobody pays for fifteen images a reader will never open.
+     * public disk, so nobody pays for thirty images a reader will never open.
      *
      * `?preview=1` paints the file instead of saving it: the screen shows the
      * same 4:5 render it offers for download, so one route covers both.
      */
-    public function card(Request $request, MonthlySummary $summary, string $card, string $format): StreamedResponse
+    public function card(Request $request, MonthlySummary $summary, string $card, string $format, string $theme): StreamedResponse
     {
         abort_unless($summary->user_id === $request->user()->id, 404);
 
         $cardType = MonthlySummaryCard::tryFrom($card);
         $formatType = MonthlySummaryFormat::tryFrom($format);
-        abort_if($cardType === null || $formatType === null, 404);
+        $themeType = MonthlySummaryTheme::tryFrom($theme);
+        abort_if($cardType === null || $formatType === null || $themeType === null, 404);
 
         // A month with no savings goal has no savings-goal card, whatever the URL says.
         abort_unless($this->picker->canDraw($cardType, $summary->payload), 404);
 
         try {
-            $path = $this->renderer->path($summary, $cardType, $formatType, $this->analysis->eligible($request->user()));
+            $path = $this->renderer->path($summary, $cardType, $formatType, $themeType, $this->analysis->eligible($request->user()));
         } catch (Throwable $exception) {
             report($exception);
             abort(503);
@@ -99,7 +101,7 @@ class MonthlySummaryController extends Controller
             return $disk->response($path, headers: ['Cache-Control' => 'private, max-age=300']);
         }
 
-        return $disk->download($path, $this->filename($summary, $cardType, $formatType));
+        return $disk->download($path, $this->filename($summary, $cardType, $formatType, $themeType));
     }
 
     /**
@@ -141,30 +143,48 @@ class MonthlySummaryController extends Controller
     }
 
     /**
-     * The chosen card first, then the alternatives, each with the picture the
-     * screen shows and the three formats it can be downloaded in.
+     * The chosen card first, then the alternatives, each in both themes: the
+     * screen carries one light/dark switch for the whole section and flips every
+     * preview and every download link with it, without a round trip.
      *
      * @return list<array<string, mixed>>
      */
-    private function cardOptions(MonthlySummary $summary, bool $pro): array
+    private function cardOptions(MonthlySummary $summary): array
     {
         $cards = [$summary->card, ...$this->picker->alternatives($summary->payload, $summary->card)];
 
         return array_map(fn (MonthlySummaryCard $card): array => [
             'card' => $card->value,
             'chosen' => $card === $summary->card,
-            'preview' => route('monthly-summaries.card', [
-                $summary, $card->value, MonthlySummaryFormat::default()->value, 'preview' => 1,
-            ]),
-            'formats' => array_map(fn (MonthlySummaryFormat $format): array => [
-                'format' => $format->value,
-                'url' => route('monthly-summaries.card', [$summary, $card->value, $format->value]),
-            ], MonthlySummaryFormat::cases()),
+            'themes' => collect(MonthlySummaryTheme::cases())
+                ->mapWithKeys(fn (MonthlySummaryTheme $theme): array => [
+                    $theme->value => $this->cardLinks($summary, $card, $theme),
+                ])
+                ->all(),
         ], $cards);
     }
 
-    private function filename(MonthlySummary $summary, MonthlySummaryCard $card, MonthlySummaryFormat $format): string
+    /**
+     * The picture the screen paints and the three files it offers, for one card
+     * in one theme.
+     *
+     * @return array{preview: string, formats: list<array{format: string, url: string}>}
+     */
+    private function cardLinks(MonthlySummary $summary, MonthlySummaryCard $card, MonthlySummaryTheme $theme): array
     {
-        return "whisper-money-{$summary->period}-{$card->value}-{$format->value}.png";
+        return [
+            'preview' => route('monthly-summaries.card', [
+                $summary, $card->value, MonthlySummaryFormat::default()->value, $theme->value, 'preview' => 1,
+            ]),
+            'formats' => array_map(fn (MonthlySummaryFormat $format): array => [
+                'format' => $format->value,
+                'url' => route('monthly-summaries.card', [$summary, $card->value, $format->value, $theme->value]),
+            ], MonthlySummaryFormat::cases()),
+        ];
+    }
+
+    private function filename(MonthlySummary $summary, MonthlySummaryCard $card, MonthlySummaryFormat $format, MonthlySummaryTheme $theme): string
+    {
+        return "whisper-money-{$summary->period}-{$card->value}-{$format->value}-{$theme->value}.png";
     }
 }

--- a/app/Http/Controllers/MonthlySummaryShareController.php
+++ b/app/Http/Controllers/MonthlySummaryShareController.php
@@ -3,11 +3,13 @@
 namespace App\Http\Controllers;
 
 use App\Enums\MonthlySummaryFormat;
+use App\Enums\MonthlySummaryTheme;
 use App\Models\MonthlySummary;
 use App\Services\MonthlySummary\AnalysisWriter;
 use App\Services\MonthlySummary\CardRenderer;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\View;
+use Illuminate\Support\Traits\Localizable;
 use Throwable;
 
 /**
@@ -21,6 +23,8 @@ use Throwable;
  */
 class MonthlySummaryShareController extends Controller
 {
+    use Localizable;
+
     public function __construct(
         private CardRenderer $renderer,
         private AnalysisWriter $analysis,
@@ -31,11 +35,21 @@ class MonthlySummaryShareController extends Controller
         $summary = MonthlySummary::query()->where('share_token', $token)->firstOrFail();
 
         try {
-            $imageUrl = $this->renderer->url(
-                $summary,
-                $summary->card,
-                MonthlySummaryFormat::default(),
-                $this->analysis->eligible($summary->user),
+            // Nobody is logged in here, so the request's locale is the
+            // visitor's language, not the owner's. Left at that, a French
+            // visitor to a Spanish reader's link mints a French cut of somebody
+            // else's card and unfurls that — one copy per language anyone
+            // happens to browse in. The card belongs to its owner, so it is
+            // drawn in the owner's.
+            $imageUrl = $this->withLocale(
+                $summary->user->preferredLocale(),
+                fn (): string => $this->renderer->url(
+                    $summary,
+                    $summary->card,
+                    MonthlySummaryFormat::default(),
+                    MonthlySummaryTheme::default(),
+                    $this->analysis->eligible($summary->user),
+                ),
             );
         } catch (Throwable $exception) {
             report($exception);

--- a/app/Jobs/Drip/SendMonthlySummaryEmailJob.php
+++ b/app/Jobs/Drip/SendMonthlySummaryEmailJob.php
@@ -26,11 +26,12 @@ class SendMonthlySummaryEmailJob extends SendDripEmailJob
 
     /**
      * Long, because this job waits on the analysis the model writes and on the
-     * one card the message carries, which is allowed a cold Chromium start and a
-     * webfont fetch. Without it the worker's 60-second default would kill the
-     * send mid-render, and a killed process is not an exception the renderer can
-     * shrug off. The screen's other twenty-nine cards are drawn by
-     * {@see WarmMonthlySummaryCardsJob} and cost this job nothing.
+     * one card the message carries, which the renderer allows 70 seconds for: a
+     * cold Chromium start and a webfont fetch are not instant. Under the
+     * worker's 60-second default the send would be killed mid-render, and a
+     * killed process is not an exception the renderer can shrug off. The screen's
+     * other twenty-nine cards are drawn by {@see WarmMonthlySummaryCardsJob} and
+     * cost this job nothing.
      */
     public int $timeout = 300;
 

--- a/app/Jobs/Drip/SendMonthlySummaryEmailJob.php
+++ b/app/Jobs/Drip/SendMonthlySummaryEmailJob.php
@@ -3,12 +3,15 @@
 namespace App\Jobs\Drip;
 
 use App\Enums\DripEmailType;
+use App\Jobs\WarmMonthlySummaryCardsJob;
 use App\Mail\Drip\MonthlySummaryEmail;
 use App\Models\MonthlySummary;
 use App\Models\User;
 use App\Services\MonthlySummary\AnalysisWriter;
 use App\Services\MonthlySummary\Summaries;
+use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Mail\Mailable;
+use Illuminate\Support\Traits\Localizable;
 
 /**
  * Sends one frozen monthly summary.
@@ -19,12 +22,15 @@ use Illuminate\Mail\Mailable;
  */
 class SendMonthlySummaryEmailJob extends SendDripEmailJob
 {
+    use Localizable;
+
     /**
-     * Long, because this job draws a month's cards before it writes anything:
-     * fifteen of them, each allowed to wait on a webfont, plus the analysis the
-     * model writes. Without it the worker's 60-second default would kill the
-     * send mid-render — and a killed process is not an exception the renderer
-     * can shrug off. Stays well under the database queue's retry_after.
+     * Long, because this job waits on the analysis the model writes and on the
+     * one card the message carries, which is allowed a cold Chromium start and a
+     * webfont fetch. Without it the worker's 60-second default would kill the
+     * send mid-render, and a killed process is not an exception the renderer can
+     * shrug off. The screen's other twenty-nine cards are drawn by
+     * {@see WarmMonthlySummaryCardsJob} and cost this job nothing.
      */
     public int $timeout = 300;
 
@@ -52,23 +58,38 @@ class SendMonthlySummaryEmailJob extends SendDripEmailJob
         return $this->user->wantsMonthlySummaryEmail();
     }
 
+    /**
+     * The cards are drawn here, so they have to be drawn in the reader's
+     * language here too. `Mail::to($user)->send()` does switch the locale for a
+     * {@see HasLocalePreference} recipient, but this method is evaluated as the
+     * argument to that call — long before the mailer gets a say — so every card
+     * came out in the queue worker's English, whatever language the reader
+     * reads in.
+     */
     protected function buildMail(): Mailable
     {
-        $pro = app(AnalysisWriter::class)->eligible($this->user);
-        $summaries = app(Summaries::class);
+        return $this->withLocale($this->user->preferredLocale(), fn (): Mailable => $this->reportEmail());
+    }
 
-        // Every card, drawn now, while there is a browser and a queue worker to
-        // draw them with — and last month's thrown away.
-        $summaries->prepareCards($this->summary, $pro);
+    private function reportEmail(): Mailable
+    {
+        $pro = app(AnalysisWriter::class)->eligible($this->user);
 
         $mail = new MonthlySummaryEmail(
             $this->user,
             $this->summary,
             app(AnalysisWriter::class)->write($this->summary, $this->user),
-            $summaries->primaryCardUrl($this->summary, $pro),
+            // The one card the message carries, drawn here because the message
+            // cannot go out without it.
+            app(Summaries::class)->primaryCardUrl($this->summary, $pro),
             $pro,
             $this->spaceName(),
         );
+
+        // The screen's other twenty-nine, and last month's thrown away, on a job
+        // of their own: the reader has a message to read before any of the
+        // download buttons matter, and this worker has the next reader waiting.
+        WarmMonthlySummaryCardsJob::dispatch($this->summary, $pro);
 
         $this->summary->forceFill(['sent_at' => now()])->save();
 

--- a/app/Jobs/WarmMonthlySummaryCardsJob.php
+++ b/app/Jobs/WarmMonthlySummaryCardsJob.php
@@ -21,11 +21,13 @@ use Illuminate\Support\Traits\Localizable;
  * Chromium run per preview inside as many concurrent web requests as the browser
  * opens.
  *
- * Hence a job of its own, on a queue of its own. Inside the send, thirty
- * screenshots were thirty the next reader waited for, the emails worker being a
- * single process. On `default` they would instead sit on one of the two workers
- * that also categorise transactions and run automation rules, for minutes at a
- * time, once per reader in the timezone bucket. Neither queue should have to
+ * Hence a job of its own, on a queue of its own. A batch is quick when it goes
+ * well — eighteen cards measured at 2.3 seconds on a warm machine — but it is
+ * one Chromium launch and up to eight seconds of waiting on Google Fonts before
+ * the first screenshot, once per reader in the timezone bucket. Inside the send
+ * that was time the next reader waited for, the emails worker being a single
+ * process; on `default` it would land on one of the two workers that also
+ * categorise transactions and run automation rules. Neither queue should have to
  * care: the reader whose report this is has an email to open before any download
  * button matters.
  */
@@ -41,10 +43,12 @@ class WarmMonthlySummaryCardsJob implements ShouldQueue
     public int $tries = 1;
 
     /**
-     * The renderer gives a batch of thirty 60 + 10 × 30 = 360 seconds of its
-     * own, and a killed process is not an exception it can shrug off. Stays
-     * under the database queue's retry_after, and under the 600-second ceiling
-     * config/queue.php sets for any one job's timeout.
+     * Not how long a batch takes, but longer than the renderer's own ceiling:
+     * it allows a batch of thirty 60 + 10 × 30 = 360 seconds before abandoning
+     * it, and a job killed before that point leaves a dead process rather than
+     * an exception the renderer can shrug off. Stays under the database queue's
+     * retry_after, and under the 600-second ceiling config/queue.php sets for
+     * any one job's timeout.
      */
     public int $timeout = 600;
 

--- a/app/Jobs/WarmMonthlySummaryCardsJob.php
+++ b/app/Jobs/WarmMonthlySummaryCardsJob.php
@@ -21,10 +21,13 @@ use Illuminate\Support\Traits\Localizable;
  * Chromium run per preview inside as many concurrent web requests as the browser
  * opens.
  *
- * Hence a job of its own, on the default queue. The emails worker is a single
- * process, and thirty screenshots inside the send are thirty screenshots the
- * next reader waits for — while the one whose report it is has an email to open
- * before any download button matters.
+ * Hence a job of its own, on a queue of its own. Inside the send, thirty
+ * screenshots were thirty the next reader waited for, the emails worker being a
+ * single process. On `default` they would instead sit on one of the two workers
+ * that also categorise transactions and run automation rules, for minutes at a
+ * time, once per reader in the timezone bucket. Neither queue should have to
+ * care: the reader whose report this is has an email to open before any download
+ * button matters.
  */
 class WarmMonthlySummaryCardsJob implements ShouldQueue
 {
@@ -40,15 +43,17 @@ class WarmMonthlySummaryCardsJob implements ShouldQueue
     /**
      * The renderer gives a batch of thirty 60 + 10 × 30 = 360 seconds of its
      * own, and a killed process is not an exception it can shrug off. Stays
-     * under the database queue's retry_after, which config/queue.php pins at 600
-     * as the longest job timeout on the connection.
+     * under the database queue's retry_after, and under the 600-second ceiling
+     * config/queue.php sets for any one job's timeout.
      */
     public int $timeout = 600;
 
     public function __construct(
         public MonthlySummary $summary,
         public bool $pro,
-    ) {}
+    ) {
+        $this->onQueue('cards');
+    }
 
     public function handle(Summaries $summaries): void
     {

--- a/app/Jobs/WarmMonthlySummaryCardsJob.php
+++ b/app/Jobs/WarmMonthlySummaryCardsJob.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\MonthlySummary;
+use App\Services\MonthlySummary\Summaries;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Traits\Localizable;
+
+/**
+ * Draws the rest of a month's cards, off the send.
+ *
+ * The email carries one picture and cannot go out without it, so that one is
+ * drawn inside the send. The other twenty-nine — five kinds by three formats by
+ * two themes — belong to the report screen, and the screen cannot draw them
+ * itself: it paints all five previews at once, so a first visit would start a
+ * Chromium run per preview inside as many concurrent web requests as the browser
+ * opens.
+ *
+ * Hence a job of its own, on the default queue. The emails worker is a single
+ * process, and thirty screenshots inside the send are thirty screenshots the
+ * next reader waits for — while the one whose report it is has an email to open
+ * before any download button matters.
+ */
+class WarmMonthlySummaryCardsJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Localizable, Queueable, SerializesModels;
+
+    /**
+     * One attempt. This is a warm cache: a second go costs thirty more renders,
+     * and whatever it left undrawn is drawn on demand the first time somebody
+     * asks for it anyway.
+     */
+    public int $tries = 1;
+
+    /**
+     * The renderer gives a batch of thirty 60 + 10 × 30 = 360 seconds of its
+     * own, and a killed process is not an exception it can shrug off. Stays
+     * under the database queue's retry_after, which config/queue.php pins at 600
+     * as the longest job timeout on the connection.
+     */
+    public int $timeout = 600;
+
+    public function __construct(
+        public MonthlySummary $summary,
+        public bool $pro,
+    ) {}
+
+    public function handle(Summaries $summaries): void
+    {
+        // The copy is baked into the picture, so the language is part of what is
+        // drawn — and a queue worker's locale is nobody's in particular.
+        $this->withLocale(
+            $this->summary->user->preferredLocale(),
+            fn () => $summaries->prepareCards($this->summary, $this->pro),
+        );
+    }
+}

--- a/app/Services/MonthlySummary/CardPresenter.php
+++ b/app/Services/MonthlySummary/CardPresenter.php
@@ -4,6 +4,7 @@ namespace App\Services\MonthlySummary;
 
 use App\Enums\MonthlySummaryCard;
 use App\Enums\MonthlySummaryFormat;
+use App\Enums\MonthlySummaryTheme;
 use App\Models\MonthlySummary;
 use App\Support\Figures;
 use Carbon\Carbon;
@@ -19,10 +20,17 @@ use Carbon\Carbon;
 class CardPresenter
 {
     /**
-     * Shades used for the spending split, darkest first, matching the app's
-     * monochrome chart palette.
+     * Shades used for the spending split, in the order the ranking reads,
+     * matching the app's monochrome chart palette.
+     *
+     * The ramp has to flip with the theme rather than live in the template: on a
+     * dark card the light ramp's first block is the background colour, so the
+     * biggest category of the month came out invisible.
      */
-    private const SPLIT_SHADES = ['#18181b', '#52525b', '#a1a1aa', '#e4e4e7'];
+    private const SPLIT_SHADES = [
+        MonthlySummaryTheme::Light->value => ['#18181b', '#52525b', '#a1a1aa', '#e4e4e7'],
+        MonthlySummaryTheme::Dark->value => ['#fafafa', '#d4d4d8', '#71717a', '#3f3f46'],
+    ];
 
     /**
      * Viewbox width the net worth path is drawn into.
@@ -32,7 +40,7 @@ class CardPresenter
     /**
      * @return array<string, mixed>
      */
-    public function viewData(MonthlySummary $summary, MonthlySummaryCard $card, MonthlySummaryFormat $format, bool $pro): array
+    public function viewData(MonthlySummary $summary, MonthlySummaryCard $card, MonthlySummaryFormat $format, MonthlySummaryTheme $theme, bool $pro): array
     {
         $locale = app()->getLocale();
         $month = $summary->periodStart();
@@ -41,22 +49,23 @@ class CardPresenter
             'summary' => $summary,
             'card' => $card,
             'format' => $format,
+            'theme' => $theme,
             'pro' => $pro,
             'monthLabel' => $this->monthLabel($month, $locale),
             'heroSize' => $card === MonthlySummaryCard::Streak ? 340 : 268,
-            ...$this->contentFor($card, $summary, $locale, $month),
+            ...$this->contentFor($card, $summary, $theme, $locale, $month),
         ];
     }
 
     /**
      * @return array<string, mixed>
      */
-    private function contentFor(MonthlySummaryCard $card, MonthlySummary $summary, string $locale, Carbon $month): array
+    private function contentFor(MonthlySummaryCard $card, MonthlySummary $summary, MonthlySummaryTheme $theme, string $locale, Carbon $month): array
     {
         return match ($card) {
             MonthlySummaryCard::SavingsRate => $this->savingsRate($summary, $locale, $month),
             MonthlySummaryCard::Streak => $this->streak($summary, $locale, $month),
-            MonthlySummaryCard::SpendingSplit => $this->spendingSplit($summary, $locale, $month),
+            MonthlySummaryCard::SpendingSplit => $this->spendingSplit($summary, $theme, $locale, $month),
             MonthlySummaryCard::NetWorth => $this->netWorth($summary, $locale, $month),
             MonthlySummaryCard::SavingsGoal => $this->savingsGoal($summary, $locale),
         };
@@ -106,7 +115,7 @@ class CardPresenter
     /**
      * @return array<string, mixed>
      */
-    private function spendingSplit(MonthlySummary $summary, string $locale, Carbon $month): array
+    private function spendingSplit(MonthlySummary $summary, MonthlySummaryTheme $theme, string $locale, Carbon $month): array
     {
         return [
             'kicker' => __('Where it went'),
@@ -115,7 +124,7 @@ class CardPresenter
                 'month' => $this->monthName($month, $locale),
             ]),
             'viz' => 'viz-split',
-            'rows' => $this->splitRows($summary, $locale),
+            'rows' => $this->splitRows($summary, $theme, $locale),
             'chips' => [
                 __('<strong>:count categories</strong> in total', [
                     'count' => Figures::count((int) $summary->figure('categories.count', 0), $locale),
@@ -235,8 +244,9 @@ class CardPresenter
     /**
      * @return list<array<string, mixed>>
      */
-    private function splitRows(MonthlySummary $summary, string $locale): array
+    private function splitRows(MonthlySummary $summary, MonthlySummaryTheme $theme, string $locale): array
     {
+        $shades = self::SPLIT_SHADES[$theme->value];
         $top = (array) $summary->figure('categories.top', []);
         $rows = [];
 
@@ -245,7 +255,7 @@ class CardPresenter
                 'name' => $category['name'],
                 'share' => (float) $category['share'],
                 'label' => Figures::percent((float) $category['share'], $locale),
-                'colour' => self::SPLIT_SHADES[$index] ?? self::SPLIT_SHADES[2],
+                'colour' => $shades[$index] ?? $shades[2],
             ];
         }
 
@@ -256,7 +266,7 @@ class CardPresenter
                 'name' => __('Everything else'),
                 'share' => $rest,
                 'label' => Figures::percent($rest, $locale),
-                'colour' => self::SPLIT_SHADES[3],
+                'colour' => $shades[3],
             ];
         }
 

--- a/app/Services/MonthlySummary/CardRenderer.php
+++ b/app/Services/MonthlySummary/CardRenderer.php
@@ -4,6 +4,7 @@ namespace App\Services\MonthlySummary;
 
 use App\Enums\MonthlySummaryCard;
 use App\Enums\MonthlySummaryFormat;
+use App\Enums\MonthlySummaryTheme;
 use App\Models\MonthlySummary;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Facades\Storage;
@@ -16,7 +17,7 @@ use Throwable;
  *
  * The card is a Blade view rendered to a temporary HTML file and photographed by
  * headless Chromium — the same browser the Pest suite already installs — because
- * the alternative was redrawing fifteen designs in PHP with GD and watching them
+ * the alternative was redrawing thirty designs in PHP with GD and watching them
  * drift from the design on the first change.
  *
  * Every card the month can draw is rendered just before the email goes out, in
@@ -35,7 +36,7 @@ class CardRenderer
 
     /**
      * Added to the timeout for each card in the batch. Screenshots after the
-     * first are cheap — the browser is already up — but fifteen of them are not
+     * first are cheap — the browser is already up — but thirty of them are not
      * free either.
      */
     private const TIMEOUT_PER_CARD_SECONDS = 10;
@@ -45,12 +46,12 @@ class CardRenderer
     /**
      * The path on the public disk, rendering it first if it is not there yet.
      */
-    public function path(MonthlySummary $summary, MonthlySummaryCard $card, MonthlySummaryFormat $format, bool $pro): string
+    public function path(MonthlySummary $summary, MonthlySummaryCard $card, MonthlySummaryFormat $format, MonthlySummaryTheme $theme, bool $pro): string
     {
-        $path = $this->pathFor($summary, $card, $format, $pro);
+        $path = $this->pathFor($summary, $card, $format, $theme, $pro);
 
         if (! Storage::disk('public')->exists($path)) {
-            $this->render($summary, $card, $format, $pro, $path);
+            $this->render($summary, $card, $format, $theme, $pro, $path);
         }
 
         return $path;
@@ -59,9 +60,9 @@ class CardRenderer
     /**
      * The absolute URL the email and the public page reference.
      */
-    public function url(MonthlySummary $summary, MonthlySummaryCard $card, MonthlySummaryFormat $format, bool $pro): string
+    public function url(MonthlySummary $summary, MonthlySummaryCard $card, MonthlySummaryFormat $format, MonthlySummaryTheme $theme, bool $pro): string
     {
-        return Storage::disk('public')->url($this->path($summary, $card, $format, $pro));
+        return Storage::disk('public')->url($this->path($summary, $card, $format, $theme, $pro));
     }
 
     /**
@@ -86,13 +87,15 @@ class CardRenderer
 
         foreach ($cards as $card) {
             foreach (MonthlySummaryFormat::cases() as $format) {
-                $path = $this->pathFor($summary, $card, $format, $pro);
+                foreach (MonthlySummaryTheme::cases() as $theme) {
+                    $path = $this->pathFor($summary, $card, $format, $theme, $pro);
 
-                if (Storage::disk('public')->exists($path)) {
-                    continue;
+                    if (Storage::disk('public')->exists($path)) {
+                        continue;
+                    }
+
+                    $jobs[] = $this->job($summary, $card, $format, $theme, $pro, $path);
                 }
-
-                $jobs[] = $this->job($summary, $card, $format, $pro, $path);
             }
         }
 
@@ -119,14 +122,19 @@ class CardRenderer
     }
 
     /**
-     * The Pro badge is part of the picture, so it is part of the cache key: a
-     * user who upgrades gets a new file rather than yesterday's unbadged one.
+     * Everything that changes what comes out of the browser is part of the cache
+     * key. The Pro badge, so a user who upgrades gets a new file rather than
+     * yesterday's unbadged one. The theme, so the light and dark cuts of the same
+     * card do not overwrite each other. And the language — read from the app
+     * rather than passed in, exactly like {@see CardPresenter} reads it, so the
+     * key and the copy inside the picture cannot disagree.
      */
-    private function pathFor(MonthlySummary $summary, MonthlySummaryCard $card, MonthlySummaryFormat $format, bool $pro): string
+    private function pathFor(MonthlySummary $summary, MonthlySummaryCard $card, MonthlySummaryFormat $format, MonthlySummaryTheme $theme, bool $pro): string
     {
         $suffix = $pro ? '-pro' : '';
+        $locale = app()->getLocale();
 
-        return $this->directoryFor($summary->id)."/{$card->value}-{$format->value}{$suffix}.png";
+        return $this->directoryFor($summary->id)."/{$card->value}-{$format->value}-{$theme->value}-{$locale}{$suffix}.png";
     }
 
     private function directoryFor(string $summaryId): string
@@ -134,9 +142,9 @@ class CardRenderer
         return "monthly-summaries/{$summaryId}";
     }
 
-    private function render(MonthlySummary $summary, MonthlySummaryCard $card, MonthlySummaryFormat $format, bool $pro, string $path): void
+    private function render(MonthlySummary $summary, MonthlySummaryCard $card, MonthlySummaryFormat $format, MonthlySummaryTheme $theme, bool $pro, string $path): void
     {
-        $this->renderJobs([$this->job($summary, $card, $format, $pro, $path)]);
+        $this->renderJobs([$this->job($summary, $card, $format, $theme, $pro, $path)]);
     }
 
     /**
@@ -144,12 +152,12 @@ class CardRenderer
      *
      * @return array{path: string, html: string, png: string, width: int, height: int}
      */
-    private function job(MonthlySummary $summary, MonthlySummaryCard $card, MonthlySummaryFormat $format, bool $pro, string $path): array
+    private function job(MonthlySummary $summary, MonthlySummaryCard $card, MonthlySummaryFormat $format, MonthlySummaryTheme $theme, bool $pro, string $path): array
     {
         [$width, $height] = $format->dimensions();
 
         $htmlFile = tempnam(sys_get_temp_dir(), 'wm-card-').'.html';
-        file_put_contents($htmlFile, View::make('cards.monthly-summary', $this->presenter->viewData($summary, $card, $format, $pro))->render());
+        file_put_contents($htmlFile, View::make('cards.monthly-summary', $this->presenter->viewData($summary, $card, $format, $theme, $pro))->render());
 
         return [
             'path' => $path,
@@ -165,7 +173,7 @@ class CardRenderer
      *
      * A run that dies halfway still keeps the cards it managed to draw: the
      * missing ones are what the exception is about, and they cost one more
-     * render rather than fifteen.
+     * render rather than thirty.
      *
      * HOME is stated rather than inherited. Chromium puts its crash database
      * under $HOME, and without a writable one the crash handler exits before

--- a/app/Services/MonthlySummary/Summaries.php
+++ b/app/Services/MonthlySummary/Summaries.php
@@ -3,6 +3,8 @@
 namespace App\Services\MonthlySummary;
 
 use App\Enums\MonthlySummaryFormat;
+use App\Enums\MonthlySummaryTheme;
+use App\Jobs\WarmMonthlySummaryCardsJob;
 use App\Models\MonthlySummary;
 use App\Models\User;
 use Carbon\Carbon;
@@ -77,13 +79,14 @@ class Summaries
     /**
      * Draw every card this month can show, and drop the months before it.
      *
-     * Called on the way out of a send rather than on a page view: fifteen
-     * pictures in one browser take seconds a queue worker has and a web request
-     * does not. The screen puts all five cards up as 4:5 previews, so left to
-     * the screen a first visit would start a Chromium run for each one it has
-     * not drawn yet, inside as many web requests as the browser opens; here
-     * they cost the one reader whose report this is, and by the time they open
-     * it the previews and the download buttons have nothing left to do.
+     * Called from a queued job rather than on a page view: thirty pictures in
+     * one browser take seconds a queue worker has and a web request does not.
+     * The screen puts all five cards up as 4:5 previews and lets the reader flip
+     * the lot between light and dark, so left to the screen a first visit would
+     * start a Chromium run for each one it has not drawn yet, inside as many web
+     * requests as the browser opens; drawn here, by the time the reader opens
+     * their report the previews and the download buttons have nothing left to
+     * do. {@see WarmMonthlySummaryCardsJob}
      *
      * The earlier months' pictures go at the same time: the disk is not an
      * archive, and an old report that does get opened draws them again. The
@@ -111,7 +114,13 @@ class Summaries
     public function primaryCardUrl(MonthlySummary $summary, bool $pro): ?string
     {
         try {
-            return $this->renderer->url($summary, $summary->card, MonthlySummaryFormat::default(), $pro);
+            return $this->renderer->url(
+                $summary,
+                $summary->card,
+                MonthlySummaryFormat::default(),
+                MonthlySummaryTheme::default(),
+                $pro,
+            );
         } catch (Throwable $exception) {
             report($exception);
 

--- a/app/Services/MonthlySummary/Summaries.php
+++ b/app/Services/MonthlySummary/Summaries.php
@@ -4,7 +4,6 @@ namespace App\Services\MonthlySummary;
 
 use App\Enums\MonthlySummaryFormat;
 use App\Enums\MonthlySummaryTheme;
-use App\Jobs\WarmMonthlySummaryCardsJob;
 use App\Models\MonthlySummary;
 use App\Models\User;
 use Carbon\Carbon;
@@ -86,7 +85,8 @@ class Summaries
      * start a Chromium run for each one it has not drawn yet, inside as many web
      * requests as the browser opens; drawn here, by the time the reader opens
      * their report the previews and the download buttons have nothing left to
-     * do. {@see WarmMonthlySummaryCardsJob}
+     * do. The send hands this to WarmMonthlySummaryCardsJob; the preview command
+     * calls it inline, wanting the pictures before it returns.
      *
      * The earlier months' pictures go at the same time: the disk is not an
      * archive, and an old report that does get opened draws them again. The

--- a/composer.json
+++ b/composer.json
@@ -67,12 +67,12 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "URL=$(npx --no-install portless get dev.whisper.money 2>/dev/null); if [ -n \"$URL\" ]; then if command -v pbcopy >/dev/null 2>&1; then printf %s \"$URL\" | pbcopy; elif command -v wl-copy >/dev/null 2>&1; then printf %s \"$URL\" | wl-copy; elif command -v xclip >/dev/null 2>&1; then printf %s \"$URL\" | xclip -selection clipboard; fi; echo \"\u2713 $URL copied to clipboard\"; fi; PORT=$(awk 'BEGIN{srand(); print 8000 + int(rand()*1000)}'); npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74,#2dd4bf\" \"npx portless run --name dev.whisper.money --app-port $PORT php artisan serve --port=$PORT\" \"php artisan queue:listen --tries=1 --queue=emails,ai\" \"php artisan pail --timeout=0\" \"bun run dev\" \"stripe listen --forward-to https://dev.whisper.money.localhost/stripe/webhook\" --names=server,queue,logs,vite,stripe"
+            "URL=$(npx --no-install portless get dev.whisper.money 2>/dev/null); if [ -n \"$URL\" ]; then if command -v pbcopy >/dev/null 2>&1; then printf %s \"$URL\" | pbcopy; elif command -v wl-copy >/dev/null 2>&1; then printf %s \"$URL\" | wl-copy; elif command -v xclip >/dev/null 2>&1; then printf %s \"$URL\" | xclip -selection clipboard; fi; echo \"\u2713 $URL copied to clipboard\"; fi; PORT=$(awk 'BEGIN{srand(); print 8000 + int(rand()*1000)}'); npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74,#2dd4bf\" \"npx portless run --name dev.whisper.money --app-port $PORT php artisan serve --port=$PORT\" \"php artisan queue:listen --tries=1 --queue=emails,ai,cards\" \"php artisan pail --timeout=0\" \"bun run dev\" \"stripe listen --forward-to https://dev.whisper.money.localhost/stripe/webhook\" --names=server,queue,logs,vite,stripe"
         ],
         "dev:ssr": [
             "bun run build:ssr",
             "Composer\\Config::disableProcessTimeout",
-            "PORT=$(awk 'BEGIN{srand(); print 8000 + int(rand()*1000)}'); npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74,#2dd4bf\" \"npx portless run --name dev.whisper.money --app-port $PORT php artisan serve --port=$PORT\" \"php artisan queue:listen --tries=1 --queue=emails,ai\" \"php artisan pail --timeout=0\" \"php artisan inertia:start-ssr --runtime=bun\" --names=server,queue,logs,ssr,stripe --kill-others"
+            "PORT=$(awk 'BEGIN{srand(); print 8000 + int(rand()*1000)}'); npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74,#2dd4bf\" \"npx portless run --name dev.whisper.money --app-port $PORT php artisan serve --port=$PORT\" \"php artisan queue:listen --tries=1 --queue=emails,ai,cards\" \"php artisan pail --timeout=0\" \"php artisan inertia:start-ssr --runtime=bun\" --names=server,queue,logs,ssr,stripe --kill-others"
         ],
         "test": [
             "@php artisan config:clear --ansi",

--- a/docker/supervisor/supervisord.conf
+++ b/docker/supervisor/supervisord.conf
@@ -82,10 +82,11 @@ stdout_logfile=/var/log/queue-worker.log
 stopwaitsecs=3600
 numprocs=2
 
-; Draws the monthly-summary share cards. Its own worker because one batch is
-; thirty headless-Chromium screenshots and can hold a process for minutes: on
-; `default` it would stall transaction categorisation and automation rules, and
-; on `emails` it would stall the next reader's send.
+; Draws the monthly-summary share cards. Its own worker because one batch is a
+; headless-Chromium launch plus thirty screenshots, once per reader in the
+; timezone bucket: on `default` it would sit in front of transaction
+; categorisation and automation rules, and on `emails` in front of the next
+; reader's send.
 [program:queue-worker-cards]
 process_name=%(program_name)s
 command=php /app/artisan queue:work database --queue=cards --sleep=5 --tries=1 --max-time=3600

--- a/docker/supervisor/supervisord.conf
+++ b/docker/supervisor/supervisord.conf
@@ -82,6 +82,21 @@ stdout_logfile=/var/log/queue-worker.log
 stopwaitsecs=3600
 numprocs=2
 
+; Draws the monthly-summary share cards. Its own worker because one batch is
+; thirty headless-Chromium screenshots and can hold a process for minutes: on
+; `default` it would stall transaction categorisation and automation rules, and
+; on `emails` it would stall the next reader's send.
+[program:queue-worker-cards]
+process_name=%(program_name)s
+command=php /app/artisan queue:work database --queue=cards --sleep=5 --tries=1 --max-time=3600
+user=www-data
+autostart=true
+autorestart=true
+redirect_stderr=true
+stdout_logfile=/var/log/queue-worker-cards.log
+stopwaitsecs=3600
+numprocs=1
+
 [program:queue-worker-ai]
 process_name=%(program_name)s_%(process_num)02d
 command=php /app/artisan queue:work database --queue=ai --sleep=1 --tries=3 --max-time=3600

--- a/resources/js/pages/monthly-summaries/show.tsx
+++ b/resources/js/pages/monthly-summaries/show.tsx
@@ -7,12 +7,20 @@ import {
 import { Button } from '@/components/ui/button';
 import { ButtonGroup } from '@/components/ui/button-group';
 import { Skeleton } from '@/components/ui/skeleton';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import AppLayout from '@/layouts/app-layout';
 import { cn } from '@/lib/utils';
 import { type BreadcrumbItem } from '@/types';
 import { __ } from '@/utils/i18n';
 import { Head, router } from '@inertiajs/react';
-import { CheckIcon, CopyIcon, DownloadIcon, SparklesIcon } from 'lucide-react';
+import {
+    CheckIcon,
+    CopyIcon,
+    DownloadIcon,
+    MoonIcon,
+    SparklesIcon,
+    SunIcon,
+} from 'lucide-react';
 import { useState } from 'react';
 
 /**
@@ -27,11 +35,12 @@ import { useState } from 'react';
 type Row = { text: string };
 type Todo = { text: string; action: string };
 type CardFormat = { format: string; url: string };
+type CardTheme = 'light' | 'dark';
+type CardLinks = { preview: string; formats: CardFormat[] };
 type CardOption = {
     card: string;
     chosen: boolean;
-    preview: string;
-    formats: CardFormat[];
+    themes: Record<CardTheme, CardLinks>;
 };
 
 interface Props {
@@ -53,6 +62,24 @@ const FORMAT_LABELS: Record<string, string> = {
     story: '9:16',
     wide: '16:9',
 };
+
+/**
+ * Which theme to show the cards in first.
+ *
+ * The reader's own choice — light, dark or whatever the OS says — is already
+ * resolved onto the document by the time React mounts, so reading it back off
+ * the class is both shorter and less wrong than working it out a second time
+ * from the preference and a media query.
+ */
+function initialCardTheme(): CardTheme {
+    if (typeof document === 'undefined') {
+        return 'light';
+    }
+
+    return document.documentElement.classList.contains('dark')
+        ? 'dark'
+        : 'light';
+}
 
 function cardLabel(card: string): string {
     const labels: Record<string, string> = {
@@ -130,6 +157,7 @@ export default function MonthlySummaryShow({
     shareUrl,
 }: Props) {
     const [copied, setCopied] = useState(false);
+    const [theme, setTheme] = useState<CardTheme>(initialCardTheme);
 
     const breadcrumbs: BreadcrumbItem[] = [
         { title: 'Summaries', href: index().url },
@@ -183,9 +211,39 @@ export default function MonthlySummaryShow({
                 )}
 
                 <div className="flex flex-col gap-4">
-                    <h2 className="text-sm font-semibold">
-                        {__('Share your month')}
-                    </h2>
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                        <h2 className="text-sm font-semibold">
+                            {__('Share your month')}
+                        </h2>
+                        {/* One switch for the whole section: every preview and
+                            every download link follows it. */}
+                        <ToggleGroup
+                            type="single"
+                            value={theme}
+                            onValueChange={(picked) => {
+                                if (picked) {
+                                    setTheme(picked as CardTheme);
+                                }
+                            }}
+                            variant="outline"
+                            size="sm"
+                        >
+                            <ToggleGroupItem
+                                value="light"
+                                className="cursor-pointer gap-1.5 px-2.5 text-xs aria-checked:bg-primary/10"
+                            >
+                                <SunIcon className="size-3.5" />
+                                {__('Light')}
+                            </ToggleGroupItem>
+                            <ToggleGroupItem
+                                value="dark"
+                                className="cursor-pointer gap-1.5 px-2.5 text-xs aria-checked:bg-primary/10"
+                            >
+                                <MoonIcon className="size-3.5" />
+                                {__('Dark')}
+                            </ToggleGroupItem>
+                        </ToggleGroup>
+                    </div>
                     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
                         {cards.map((card) => (
                             <div
@@ -203,28 +261,35 @@ export default function MonthlySummaryShow({
                                             'ring-2 ring-primary ring-offset-2 ring-offset-background',
                                     )}
                                 >
+                                    {/* Keyed by theme so switching starts the
+                                        other picture over the skeleton rather
+                                        than on top of the one it replaces. */}
                                     <CardPreview
+                                        key={theme}
                                         label={cardLabel(card.card)}
-                                        src={card.preview}
+                                        src={card.themes[theme].preview}
                                     />
                                 </div>
 
                                 <ButtonGroup className="w-full">
-                                    {card.formats.map((format) => (
-                                        <Button
-                                            key={format.format}
-                                            variant="outline"
-                                            size="sm"
-                                            className="h-9 flex-1 text-xs sm:h-8"
-                                            asChild
-                                        >
-                                            <a href={format.url}>
-                                                <DownloadIcon className="size-3.5" />
-                                                {FORMAT_LABELS[format.format] ??
-                                                    format.format}
-                                            </a>
-                                        </Button>
-                                    ))}
+                                    {card.themes[theme].formats.map(
+                                        (format) => (
+                                            <Button
+                                                key={format.format}
+                                                variant="outline"
+                                                size="sm"
+                                                className="h-9 flex-1 text-xs sm:h-8"
+                                                asChild
+                                            >
+                                                <a href={format.url}>
+                                                    <DownloadIcon className="size-3.5" />
+                                                    {FORMAT_LABELS[
+                                                        format.format
+                                                    ] ?? format.format}
+                                                </a>
+                                            </Button>
+                                        ),
+                                    )}
                                 </ButtonGroup>
                             </div>
                         ))}

--- a/resources/js/pages/monthly-summaries/show.tsx
+++ b/resources/js/pages/monthly-summaries/show.tsx
@@ -21,7 +21,7 @@ import {
     SparklesIcon,
     SunIcon,
 } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 /**
  * One month's report, and the cards it can produce.
@@ -64,18 +64,16 @@ const FORMAT_LABELS: Record<string, string> = {
 };
 
 /**
- * Which theme to show the cards in first.
+ * Which theme to show the cards in.
  *
  * The reader's own choice — light, dark or whatever the OS says — is already
- * resolved onto the document by the time React mounts, so reading it back off
- * the class is both shorter and less wrong than working it out a second time
- * from the preference and a media query.
+ * resolved onto the document by the time React runs, so reading it back off the
+ * class is shorter and less wrong than working it out a second time from the
+ * preference and a media query. It has to be read after mount rather than as the
+ * initial state, because the page is server-rendered and the server cannot know
+ * what the OS says — the same reason use-appearance hydrates in an effect.
  */
-function initialCardTheme(): CardTheme {
-    if (typeof document === 'undefined') {
-        return 'light';
-    }
-
+function currentCardTheme(): CardTheme {
     return document.documentElement.classList.contains('dark')
         ? 'dark'
         : 'light';
@@ -157,7 +155,9 @@ export default function MonthlySummaryShow({
     shareUrl,
 }: Props) {
     const [copied, setCopied] = useState(false);
-    const [theme, setTheme] = useState<CardTheme>(initialCardTheme);
+    const [theme, setTheme] = useState<CardTheme>('light');
+
+    useEffect(() => setTheme(currentCardTheme()), []);
 
     const breadcrumbs: BreadcrumbItem[] = [
         { title: 'Summaries', href: index().url },

--- a/resources/views/cards/monthly-summary.blade.php
+++ b/resources/views/cards/monthly-summary.blade.php
@@ -1,9 +1,10 @@
 {{--
-    One template for every shareable card: five kinds by three formats.
+    One template for every shareable card: five kinds by three formats by two
+    themes.
 
-    Kept as a single parameterised view on purpose. Fifteen near-identical files
+    Kept as a single parameterised view on purpose. Thirty near-identical files
     would trip the duplication check that gates the merge, and a change to the
-    footer lockup would then have to be made fifteen times.
+    footer lockup would then have to be made thirty times.
 
     Not a single absolute amount appears here. Percentages, streaks and counts
     are what a person shares without thinking twice; their net worth is not, and
@@ -11,7 +12,7 @@
 --}}
 @php
     [$width, $height] = $format->dimensions();
-    $dark = $format === \App\Enums\MonthlySummaryFormat::Story;
+    $dark = $theme->isDark();
     $wide = $format === \App\Enums\MonthlySummaryFormat::Wide;
 
     // One scale factor drives the whole type ramp, so the 16:9 card is the same

--- a/routes/web.php
+++ b/routes/web.php
@@ -208,7 +208,7 @@ Route::middleware(['auth', 'verified', 'onboarded', 'subscribed'])->group(functi
     // share. Behind the same feature flag as the email that produces them.
     Route::get('summaries', [MonthlySummaryController::class, 'index'])->name('monthly-summaries.index');
     Route::get('summaries/{summary}', [MonthlySummaryController::class, 'show'])->name('monthly-summaries.show');
-    Route::get('summaries/{summary}/card/{card}/{format}', [MonthlySummaryController::class, 'card'])->name('monthly-summaries.card');
+    Route::get('summaries/{summary}/card/{card}/{format}/{theme}', [MonthlySummaryController::class, 'card'])->name('monthly-summaries.card');
     Route::post('summaries/{summary}/share', [MonthlySummaryController::class, 'share'])->name('monthly-summaries.share');
     Route::delete('summaries/{summary}/share', [MonthlySummaryController::class, 'revoke'])->name('monthly-summaries.share.destroy');
     // Renders the dashboard with the integration-requests drawer opened on top.

--- a/tests/Feature/MonthlySummary/CardRenderTest.php
+++ b/tests/Feature/MonthlySummary/CardRenderTest.php
@@ -14,15 +14,21 @@ use Illuminate\Support\Facades\Storage;
  * Chromium is faked — writing a file where each job asked for its PNG — because
  * what is under test is that one run draws every card the month can show, and
  * that the months before it stop taking up room.
+ *
+ * The HTML each job was drawn from is kept as it goes past, which is where the
+ * copy inside a card can be read without decoding a picture.
  */
 
 beforeEach(function (): void {
     Storage::fake('public');
 
+    $this->drawnHtml = [];
+
     Process::fake(function (PendingProcess $process) {
         $manifest = json_decode((string) file_get_contents((string) last($process->command)), true);
 
         foreach ($manifest as $job) {
+            $this->drawnHtml[$job['path']] = (string) file_get_contents($job['html']);
             file_put_contents($job['png'], 'png');
         }
 
@@ -52,9 +58,63 @@ it('draws every card the month can show in a single browser run', function (): v
 
     app(Summaries::class)->prepareCards($summary, pro: false);
 
-    // Five cards the full payload can draw, in three formats, one Chromium.
+    // Five cards the full payload can draw, in three formats, light and dark,
+    // one Chromium.
     Process::assertRanTimes(ranTheRenderer(), 1);
-    expect(Storage::disk('public')->files("monthly-summaries/{$summary->id}"))->toHaveCount(15);
+    expect(Storage::disk('public')->files("monthly-summaries/{$summary->id}"))->toHaveCount(30);
+});
+
+it('keeps the theme and the language in the name of the file it caches', function (): void {
+    // Neither used to be in the key, so the dark cut overwrote the light one and
+    // a Spanish reader was served whichever language happened to be drawn first.
+    $summary = summaryToSend(User::factory()->onboarded()->create(), '2026-08');
+
+    app(Summaries::class)->prepareCards($summary, pro: false);
+
+    expect(Storage::disk('public')->files("monthly-summaries/{$summary->id}"))
+        ->toContain("monthly-summaries/{$summary->id}/savings_rate-feed-light-en.png")
+        ->toContain("monthly-summaries/{$summary->id}/savings_rate-feed-dark-en.png");
+});
+
+it('draws a second set for a second language rather than reusing the first', function (): void {
+    $summary = summaryToSend(User::factory()->onboarded()->create(), '2026-08');
+
+    app(Summaries::class)->prepareCards($summary, pro: false);
+    app()->setLocale('es');
+    app(Summaries::class)->prepareCards($summary, pro: false);
+
+    Process::assertRanTimes(ranTheRenderer(), 2);
+    expect(Storage::disk('public')->files("monthly-summaries/{$summary->id}"))->toHaveCount(60)
+        ->toContain("monthly-summaries/{$summary->id}/savings_rate-feed-light-es.png");
+});
+
+it('writes the card in the language the app is speaking', function (): void {
+    app()->setLocale('es');
+    $summary = summaryToSend(User::factory()->onboarded()->create(), '2026-08');
+
+    app(Summaries::class)->prepareCards($summary, pro: false);
+
+    expect($this->drawnHtml["monthly-summaries/{$summary->id}/savings_rate-feed-light-es.png"])
+        ->toContain('Tasa de ahorro')
+        ->toContain('lang="es"')
+        ->not->toContain('Savings rate');
+});
+
+it('flips the spending split\'s shades so the biggest slice is visible on a dark card', function (): void {
+    // The ramp is a fixed monochrome scale. Left at its light values, the block
+    // for the largest category is the dark card's own background colour.
+    $summary = summaryToSend(User::factory()->onboarded()->create(), '2026-08');
+
+    app(Summaries::class)->prepareCards($summary, pro: false);
+
+    // #d4d4d8 belongs to the dark ramp alone and #52525b to the light one, so
+    // each card proves it used its own scale and not the other's.
+    expect($this->drawnHtml["monthly-summaries/{$summary->id}/spending_split-feed-light-en.png"])
+        ->toContain('#52525b')
+        ->not->toContain('#d4d4d8')
+        ->and($this->drawnHtml["monthly-summaries/{$summary->id}/spending_split-feed-dark-en.png"])
+        ->toContain('#d4d4d8')
+        ->not->toContain('#52525b');
 });
 
 it('gives chromium a writable home', function (): void {
@@ -84,13 +144,13 @@ it('throws away the cards of the months before', function (): void {
     $otherSpace = summaryToSend($user, '2026-07', Space::factory()->create());
 
     foreach ([$previous, $other, $otherSpace] as $summary) {
-        Storage::disk('public')->put("monthly-summaries/{$summary->id}/streak-feed.png", 'png');
+        Storage::disk('public')->put("monthly-summaries/{$summary->id}/streak-feed-light-en.png", 'png');
     }
 
     app(Summaries::class)->prepareCards($current, pro: false);
 
-    expect(Storage::disk('public')->exists("monthly-summaries/{$previous->id}/streak-feed.png"))->toBeFalse()
-        ->and(Storage::disk('public')->exists("monthly-summaries/{$other->id}/streak-feed.png"))->toBeTrue()
-        ->and(Storage::disk('public')->exists("monthly-summaries/{$otherSpace->id}/streak-feed.png"))->toBeTrue()
-        ->and(Storage::disk('public')->files("monthly-summaries/{$current->id}"))->toHaveCount(15);
+    expect(Storage::disk('public')->exists("monthly-summaries/{$previous->id}/streak-feed-light-en.png"))->toBeFalse()
+        ->and(Storage::disk('public')->exists("monthly-summaries/{$other->id}/streak-feed-light-en.png"))->toBeTrue()
+        ->and(Storage::disk('public')->exists("monthly-summaries/{$otherSpace->id}/streak-feed-light-en.png"))->toBeTrue()
+        ->and(Storage::disk('public')->files("monthly-summaries/{$current->id}"))->toHaveCount(30);
 });

--- a/tests/Feature/MonthlySummary/MonthlySummaryEmailTest.php
+++ b/tests/Feature/MonthlySummary/MonthlySummaryEmailTest.php
@@ -3,6 +3,7 @@
 use App\Enums\DripEmailType;
 use App\Enums\MonthlySummaryCard;
 use App\Jobs\Drip\SendMonthlySummaryEmailJob;
+use App\Jobs\WarmMonthlySummaryCardsJob;
 use App\Mail\Drip\MonthlySummaryEmail;
 use App\Models\MonthlySummary;
 use App\Models\User;
@@ -10,7 +11,9 @@ use App\Models\UserMailLog;
 use App\Services\MonthlySummary\CardPicker;
 use App\Services\MonthlySummary\CardRenderer;
 use App\Services\MonthlySummary\EmailPresenter;
+use App\Services\MonthlySummary\Summaries;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Queue;
 
 /*
  * The report email itself: what it says, who sees the analysis, and how a reader
@@ -146,10 +149,24 @@ it('records the send once per month and space', function (): void {
     expect($summary->fresh()->sent_at)->not->toBeNull();
 });
 
-it('draws the rest of the screen\'s cards on the reader\'s own job', function (): void {
-    // Left to the screen, a first visit starts a Chromium run for each card it
-    // has not drawn yet, inside as many web requests as the browser opens.
+it('leaves the screen\'s other cards to a job of their own', function (): void {
+    // The emails worker is one process, so thirty screenshots inside the send
+    // are thirty the next reader waits for. Left to the screen instead, a first
+    // visit starts a Chromium run for each preview it has not drawn yet, inside
+    // as many web requests as the browser opens — hence a job.
     Mail::fake();
+    Queue::fake();
+    $summary = sentSummaryFor();
+
+    (new SendMonthlySummaryEmailJob($summary->user, $summary))->handle();
+
+    Queue::assertPushed(
+        WarmMonthlySummaryCardsJob::class,
+        fn (WarmMonthlySummaryCardsJob $job): bool => $job->summary->is($summary) && $job->pro === false,
+    );
+});
+
+it('hands that job the chosen card and every alternative', function (): void {
     $summary = sentSummaryFor();
     $alternatives = app(CardPicker::class)->alternatives($summary->payload, $summary->card);
 
@@ -157,8 +174,6 @@ it('draws the rest of the screen\'s cards on the reader\'s own job', function ()
 
     $drawn = [];
     $renderer = Mockery::mock(CardRenderer::class);
-    $renderer->shouldReceive('url')->andReturn('https://whisper.money/storage/card.png');
-    $renderer->shouldReceive('forget')->andReturnNull();
     $renderer->shouldReceive('forgetBefore')->andReturnNull();
     $renderer->shouldReceive('warm')->andReturnUsing(
         function (MonthlySummary $drawnFor, array $cards) use (&$drawn): void {
@@ -167,13 +182,62 @@ it('draws the rest of the screen\'s cards on the reader\'s own job', function ()
     );
     app()->instance(CardRenderer::class, $renderer);
 
-    (new SendMonthlySummaryEmailJob($summary->user, $summary))->handle();
+    (new WarmMonthlySummaryCardsJob($summary, pro: false))->handle(app(Summaries::class));
 
     // The chosen card and every alternative, handed over in one run.
     expect($drawn)->toBe([
         $summary->card->value,
         ...array_map(fn (MonthlySummaryCard $card): string => $card->value, $alternatives),
     ]);
+});
+
+it('draws the email\'s card in the reader\'s language, not the worker\'s', function (): void {
+    // buildMail() runs as the argument to Mail::to()->send(), so the mailer's
+    // own switch for a HasLocalePreference recipient comes too late for the
+    // picture: it used to come out in the worker's English.
+    Mail::fake();
+    Queue::fake();
+    app()->setLocale('en');
+    $summary = sentSummaryFor(User::factory()->onboarded()->create([
+        'currency_code' => 'EUR',
+        'locale' => 'es',
+    ]));
+
+    $drawnIn = null;
+    $renderer = Mockery::mock(CardRenderer::class);
+    $renderer->shouldReceive('url')->andReturnUsing(function () use (&$drawnIn): string {
+        $drawnIn = app()->getLocale();
+
+        return 'https://whisper.money/storage/card.png';
+    });
+    app()->instance(CardRenderer::class, $renderer);
+
+    (new SendMonthlySummaryEmailJob($summary->user, $summary))->handle();
+
+    expect($drawnIn)->toBe('es')
+        // And the worker is handed back the locale it came in with, so the next
+        // reader on the same process is not sent someone else's language.
+        ->and(app()->getLocale())->toBe('en');
+});
+
+it('draws the screen\'s cards in the reader\'s language too', function (): void {
+    app()->setLocale('en');
+    $summary = sentSummaryFor(User::factory()->onboarded()->create([
+        'currency_code' => 'EUR',
+        'locale' => 'es',
+    ]));
+
+    $drawnIn = null;
+    $renderer = Mockery::mock(CardRenderer::class);
+    $renderer->shouldReceive('forgetBefore')->andReturnNull();
+    $renderer->shouldReceive('warm')->andReturnUsing(function () use (&$drawnIn): void {
+        $drawnIn = app()->getLocale();
+    });
+    app()->instance(CardRenderer::class, $renderer);
+
+    (new WarmMonthlySummaryCardsJob($summary, pro: false))->handle(app(Summaries::class));
+
+    expect($drawnIn)->toBe('es')->and(app()->getLocale())->toBe('en');
 });
 
 it('does not send to a reader who turned the summary off', function (): void {

--- a/tests/Feature/MonthlySummary/MonthlySummaryEmailTest.php
+++ b/tests/Feature/MonthlySummary/MonthlySummaryEmailTest.php
@@ -160,7 +160,8 @@ it('leaves the screen\'s other cards to a job of their own', function (): void {
 
     (new SendMonthlySummaryEmailJob($summary->user, $summary))->handle();
 
-    Queue::assertPushed(
+    Queue::assertPushedOn(
+        'cards',
         WarmMonthlySummaryCardsJob::class,
         fn (WarmMonthlySummaryCardsJob $job): bool => $job->summary->is($summary) && $job->pro === false,
     );

--- a/tests/Feature/MonthlySummary/MonthlySummaryPagesTest.php
+++ b/tests/Feature/MonthlySummary/MonthlySummaryPagesTest.php
@@ -70,9 +70,13 @@ it('shows one month with its figures and every card it can produce', function ()
             ->has('report.rows')
             ->has('cards')
             ->where('cards.0.chosen', true)
-            ->has('cards.0.formats', 3)
+            // Both themes, so the screen's light/dark switch flips every preview
+            // and every download link without a round trip.
+            ->has('cards.0.themes.light.formats', 3)
+            ->has('cards.0.themes.dark.formats', 3)
             // Every card carries the picture the screen paints, not just the links.
-            ->where('cards.0.preview', fn (string $url): bool => str_contains($url, 'card/'.$summary->card->value.'/feed?preview=1'))
+            ->where('cards.0.themes.light.preview', fn (string $url): bool => str_contains($url, 'card/'.$summary->card->value.'/feed/light?preview=1'))
+            ->where('cards.0.themes.dark.preview', fn (string $url): bool => str_contains($url, 'card/'.$summary->card->value.'/feed/dark?preview=1'))
             ->where('shareUrl', null));
 });
 

--- a/tests/Feature/MonthlySummary/SharedCardPageTest.php
+++ b/tests/Feature/MonthlySummary/SharedCardPageTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Enums\MonthlySummaryFormat;
+use App\Enums\MonthlySummaryTheme;
 use App\Models\MonthlySummary;
 use App\Models\User;
 use App\Services\MonthlySummary\CardRenderer;
@@ -94,7 +95,7 @@ it('will not let one reader touch another reader\'s summary', function (): void 
     $stranger = User::factory()->onboarded()->create();
 
     $this->actingAs($stranger)->post("/summaries/{$summary->id}/share")->assertNotFound();
-    $this->actingAs($stranger)->get("/summaries/{$summary->id}/card/savings_rate/feed")->assertNotFound();
+    $this->actingAs($stranger)->get("/summaries/{$summary->id}/card/savings_rate/feed/light")->assertNotFound();
 
     expect($summary->fresh()->share_token)->toBeNull();
 });
@@ -109,24 +110,40 @@ it('paints the card inside the screen and saves it on download', function (): vo
     $summary = summaryFor($user);
 
     $preview = $this->actingAs($user)
-        ->get("/summaries/{$summary->id}/card/savings_rate/feed?preview=1")
+        ->get("/summaries/{$summary->id}/card/savings_rate/feed/light?preview=1")
         ->assertOk();
 
     expect($preview->headers->get('Content-Disposition'))->toStartWith('inline');
     expect($preview->headers->get('Cache-Control'))->toContain('max-age=300');
 
     $this->actingAs($user)
-        ->get("/summaries/{$summary->id}/card/savings_rate/feed")
+        ->get("/summaries/{$summary->id}/card/savings_rate/feed/light")
         ->assertOk()
-        ->assertDownload("whisper-money-{$summary->period}-savings_rate-feed.png");
+        ->assertDownload("whisper-money-{$summary->period}-savings_rate-feed-light.png");
 });
 
-it('refuses a card format or kind it does not have', function (): void {
+it('offers both themes of the same card, each under its own name', function (): void {
+    Storage::fake('public');
+    Storage::disk('public')->put('monthly-summaries/x/card.png', 'png-bytes');
+
     $user = User::factory()->onboarded()->create();
     $summary = summaryFor($user);
 
-    $this->actingAs($user)->get("/summaries/{$summary->id}/card/savings_rate/billboard")->assertNotFound();
-    $this->actingAs($user)->get("/summaries/{$summary->id}/card/vibes/feed")->assertNotFound();
+    foreach (MonthlySummaryTheme::cases() as $theme) {
+        $this->actingAs($user)
+            ->get("/summaries/{$summary->id}/card/savings_rate/story/{$theme->value}")
+            ->assertOk()
+            ->assertDownload("whisper-money-{$summary->period}-savings_rate-story-{$theme->value}.png");
+    }
+});
+
+it('refuses a card format, theme or kind it does not have', function (): void {
+    $user = User::factory()->onboarded()->create();
+    $summary = summaryFor($user);
+
+    $this->actingAs($user)->get("/summaries/{$summary->id}/card/savings_rate/billboard/light")->assertNotFound();
+    $this->actingAs($user)->get("/summaries/{$summary->id}/card/savings_rate/feed/sepia")->assertNotFound();
+    $this->actingAs($user)->get("/summaries/{$summary->id}/card/vibes/feed/light")->assertNotFound();
 });
 
 it('refuses a card the month has no figures for', function (): void {
@@ -139,7 +156,28 @@ it('refuses a card the month has no figures for', function (): void {
         'payload' => ['currency' => 'EUR', 'has_history' => true, 'goal' => null],
     ]);
 
-    $this->actingAs($user)->get("/summaries/{$summary->id}/card/savings_goal/feed")->assertNotFound();
+    $this->actingAs($user)->get("/summaries/{$summary->id}/card/savings_goal/feed/light")->assertNotFound();
+});
+
+it('draws the card in the owner\'s language, whatever the visitor reads in', function (): void {
+    // The page is public, so the request locale is the visitor's. Left at that,
+    // a French visitor mints a French cut of somebody else's card and unfurls
+    // that — one copy per language anyone happens to browse in.
+    $owner = User::factory()->onboarded()->create(['locale' => 'es']);
+    $token = summaryFor($owner)->mintShareToken();
+
+    $drawnIn = null;
+    $this->mock(CardRenderer::class, function ($mock) use (&$drawnIn): void {
+        $mock->shouldReceive('url')->andReturnUsing(function () use (&$drawnIn): string {
+            $drawnIn = app()->getLocale();
+
+            return 'https://whisper.money/storage/card.png';
+        });
+    });
+
+    $this->withHeader('Accept-Language', 'fr')->get("/s/{$token}")->assertOk();
+
+    expect($drawnIn)->toBe('es');
 });
 
 it('names every format the card can be downloaded in', function (): void {


### PR DESCRIPTION
Two things for the shareable monthly-summary cards — the PNGs behind "Share your month":

1. **A light and a dark version of every card**, with one toggle on the report screen that picks which one you download.
2. **They are drawn in the reader's language.** They were not.

## The theme

A new `App\Enums\MonthlySummaryTheme` (`light` / `dark`), sibling of `MonthlySummaryFormat`, threaded through `CardRenderer` and `CardPresenter` and read by the one card template. It replaces the single line that hardcoded Story as the dark format: Story now follows the chosen theme like the other two, and Light is the default everywhere — the emailed image and the public page's og:image included.

The download route gained a segment, `summaries/{summary}/card/{card}/{format}/{theme}`, validated with `tryFrom` + `abort_if` like the other two, and the theme is in the downloaded filename.

The spending-split ramp had to flip with the theme, which is why the theme reaches the **presenter** and not just the template. `CardPresenter::SPLIT_SHADES` is a fixed monochrome scale whose first block is `#18181b` — the dark card's own background. The month's biggest category was invisible on the Story card already, and would have been on every format once all three could be dark.

Deliberately still **one** parameterised Blade view for what is now thirty variants. Thirty near-copies would redden `bun run dry`, and the footer lockup would then be thirty edits.

## The language

A card's copy is baked into the picture, so the locale is part of what gets drawn — and it was whoever's the process happened to be speaking:

- `SendMonthlySummaryEmailJob::buildMail()` is evaluated as the *argument* to `Mail::to($user)->send()` in `SendDripEmailJob::handle()`, so the mailer's own switch for a `HasLocalePreference` recipient comes too late for the cards. **A Spanish reader's emailed card was in English.**
- `MonthlySummaryShareController` is public and unauthenticated, so `SetLocale` puts the *visitor's* language on the request. A French visitor to a Spanish reader's link minted a French cut of somebody else's card and unfurled that — one copy per language anyone happened to browse in.

Both now wrap the card work in `Localizable::withLocale()`, which is what `Illuminate\Mail\Mailer` itself uses; each test asserts the process is handed its original locale back afterwards. The report screen was already correct — `SetLocale` has the user's locale on the request. The preview command got the same wrap, so a preview matches the email it sits next to.

The theme and the locale both ride in the cache key — `{card}-{format}-{theme}-{locale}{-pro}.png` — with the locale read from `app()->getLocale()`, the same place the presenter reads it, so the key and the copy inside the picture cannot disagree.

## The send

Warming both themes is thirty renders (5 kinds × 3 formats × 2 themes), and they do not belong inside the send: the `emails` worker is a single process, so they were thirty screenshots the next reader waited for. Nor can they go in a web request — the screen paints five previews at once, so a first visit would start a Chromium per preview in as many concurrent requests as the browser opens, which is the thing `Summaries::prepareCards()` exists to avoid.

So the send draws only the one card the message carries, and hands the rest to a new `WarmMonthlySummaryCardsJob` on a **`cards` queue with a worker of its own** (`docker/supervisor/supervisord.conf`). On `default` a batch would land in front of transaction categorisation and automation rules, once per reader in the timezone bucket; `PLAYWRIGHT_BROWSERS_PATH` and `HOME` are set on `[supervisord]`, so the new worker inherits what Chromium needs. `SendMonthlySummaryEmailJob::$timeout` stays at 300 — it now waits on one card, not thirty.

Measured on a warm machine: **eighteen cards in one Chromium run in 2.3s.** A batch is seconds, not minutes. The warm job's 600s timeout is there to outlive the renderer's own 360s ceiling for a batch of thirty, not because a batch takes that long.

## Tests

- `CardRenderTest`: the warm run produces thirty files in **one** Chromium run; theme and locale both appear in the cached path; a second render in another language draws a second set instead of reusing the first; a card is written in the language the app is speaking; the split ramp uses its own scale per theme. The fake Chromium now keeps the HTML each job was drawn from, which is where the copy can be read without decoding a picture.
- `MonthlySummaryEmailTest`: the email's own card is drawn in the reader's locale and the worker gets its locale back; so are the screen's cards, on the warm job; the send leaves those to a job pushed on `cards` rather than doing them inline.
- `SharedCardPageTest`: the public page draws in the owner's language whatever the visitor's `Accept-Language` says; the download route 404s on an unknown theme and serves both valid ones under their own filenames.
- `MonthlySummaryPagesTest`: the screen carries both themes' previews and format links.

Both locale tests were checked against the unfixed code first — they fail with `'en'` and `'fr'` respectively, so they are real guards.

`bun run build`, `./vendor/bin/pest`, `vendor/bin/pint --test`, `bun run format`, `bun run lint`, `bun run dry` (3.48%, threshold 5.4) and `php artisan crap --base=origin/main --no-coverage` (24 methods, none over 10) all pass locally.

## Demo

https://github.com/user-attachments/assets/dcd7b159-903d-4ae1-94d4-e491114755b3



## Notes

- **Cards cached before this deploy** have no theme or locale in their name, so the current month's are redrawn once on first hit and the old files are pruned by `forgetBefore()` on the next send. No action needed.
- **No new UI strings**: `Light` and `Dark` are already in `lang/es.json` and `lang/fr.json`.
- **Unrelated, found while QA-ing**: a card cannot be drawn locally on macOS. `CardRenderer` sets `HOME` to the tmpdir so Chromium's crash handler has somewhere writable, and Playwright resolves its browser cache from `HOME` too, so it does not find the browser. Production is unaffected because the image sets `PLAYWRIGHT_BROWSERS_PATH`. Worth a separate one-liner for `.env` or `worktree.sh`.
