### PR TITLE
fix(summaries): retry the monthly analysis when the provider times out

### DIFF
--- a/app/Services/MonthlySummary/AnalysisWriter.php
+++ b/app/Services/MonthlySummary/AnalysisWriter.php
@@ -81,6 +81,7 @@ class AnalysisWriter
     public function draft(MonthlySummary $summary, User $user): ?string
     {
         $attempts = max(1, (int) config('ai_monthly_summary.attempts'));
+        $lastTransient = null;
 
         for ($attempt = 1; $attempt <= $attempts; $attempt++) {
             try {
@@ -89,6 +90,8 @@ class AnalysisWriter
                 // Overloaded, rate-limited or simply not answering in time is
                 // expected, not a bug. Back off and try again; only give up once
                 // the attempts run out.
+                $lastTransient = $exception;
+
                 Log::warning('Monthly summary analysis attempt failed.', [
                     'summary_id' => $summary->id,
                     'attempt' => $attempt,
@@ -103,6 +106,13 @@ class AnalysisWriter
 
                 return null;
             }
+        }
+
+        // One hiccup is expected and stays in the logs. Every attempt failing is
+        // an outage that just cost a paying reader their month, and a provider
+        // that is never reachable would otherwise be invisible here.
+        if ($lastTransient !== null) {
+            report($lastTransient);
         }
 
         return null;

--- a/app/Services/MonthlySummary/AnalysisWriter.php
+++ b/app/Services/MonthlySummary/AnalysisWriter.php
@@ -8,6 +8,7 @@ use App\Models\MonthlySummary;
 use App\Models\User;
 use App\Support\Figures;
 use App\Support\Money;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Laravel\Ai\Enums\Lab;
@@ -84,9 +85,10 @@ class AnalysisWriter
         for ($attempt = 1; $attempt <= $attempts; $attempt++) {
             try {
                 return $this->promptOnce($summary, $user);
-            } catch (FailoverableException $exception) {
-                // Overloaded or rate-limited is expected, not a bug. Back off and
-                // try again; only give up once the attempts run out.
+            } catch (ConnectionException|FailoverableException $exception) {
+                // Overloaded, rate-limited or simply not answering in time is
+                // expected, not a bug. Back off and try again; only give up once
+                // the attempts run out.
                 Log::warning('Monthly summary analysis attempt failed.', [
                     'summary_id' => $summary->id,
                     'attempt' => $attempt,

--- a/tests/Feature/MonthlySummary/AnalysisWriterTest.php
+++ b/tests/Feature/MonthlySummary/AnalysisWriterTest.php
@@ -53,6 +53,31 @@ it('spends every attempt on a transient provider failure before giving up', func
     Exceptions::assertReportedCount(1);
 })->with('transient provider failures');
 
+it('recovers when a later attempt gets through', function (Closure $makeFailure): void {
+    config()->set('ai_monthly_summary.attempts', 3);
+
+    Exceptions::fake();
+
+    $calls = 0;
+    MonthlySummaryAgent::fake(function () use (&$calls, $makeFailure) {
+        $calls++;
+
+        if ($calls === 1) {
+            throw $makeFailure();
+        }
+
+        return 'A steady month: you saved more than you spent.';
+    });
+
+    [$summary, $user] = readerAwaitingAnalysis();
+
+    expect(app(AnalysisWriter::class)->draft($summary, $user))
+        ->toBe('A steady month: you saved more than you spent.')
+        ->and($calls)->toBe(2);
+
+    Exceptions::assertNothingReported();
+})->with('transient provider failures');
+
 it('reports an unexpected failure once and does not burn the remaining attempts', function (): void {
     config()->set('ai_monthly_summary.attempts', 3);
 

--- a/tests/Feature/MonthlySummary/AnalysisWriterTest.php
+++ b/tests/Feature/MonthlySummary/AnalysisWriterTest.php
@@ -5,6 +5,7 @@ use App\Models\MonthlySummary;
 use App\Models\User;
 use App\Services\MonthlySummary\AnalysisWriter;
 use Illuminate\Support\Facades\Exceptions;
+use Illuminate\Support\Facades\Log;
 
 /*
  * The analysis is worth a few attempts: a provider hiccup costs a paying reader
@@ -25,10 +26,11 @@ function readerAwaitingAnalysis(): array
     return [$summary, $user];
 }
 
-it('spends its attempts on a transient provider failure instead of reporting it', function (Closure $makeFailure): void {
+it('spends every attempt on a transient provider failure before giving up', function (Closure $makeFailure): void {
     config()->set('ai_monthly_summary.attempts', 2);
 
     Exceptions::fake();
+    Log::spy();
 
     $calls = 0;
     MonthlySummaryAgent::fake(function () use (&$calls, $makeFailure) {
@@ -42,7 +44,13 @@ it('spends its attempts on a transient provider failure instead of reporting it'
     expect(app(AnalysisWriter::class)->draft($summary, $user))->toBeNull()
         ->and($calls)->toBe(2);
 
-    Exceptions::assertNothingReported();
+    Log::shouldHaveReceived('warning')
+        ->withArgs(fn (string $message): bool => $message === 'Monthly summary analysis attempt failed.')
+        ->twice();
+
+    // Quiet per attempt, but a run that never got through is an outage the logs
+    // alone would bury.
+    Exceptions::assertReportedCount(1);
 })->with('transient provider failures');
 
 it('reports an unexpected failure once and does not burn the remaining attempts', function (): void {

--- a/tests/Feature/MonthlySummary/AnalysisWriterTest.php
+++ b/tests/Feature/MonthlySummary/AnalysisWriterTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use App\Ai\Agents\MonthlySummaryAgent;
+use App\Models\MonthlySummary;
+use App\Models\User;
+use App\Services\MonthlySummary\AnalysisWriter;
+use Illuminate\Support\Facades\Exceptions;
+
+/*
+ * The analysis is worth a few attempts: a provider hiccup costs a paying reader
+ * their whole month. The retry only ever covered a provider that answered badly,
+ * so one that did not answer at all - a 30s timeout reaching Gemini - burned the
+ * month on the first try and was filed as a bug (PHP-LARAVEL-5Q).
+ */
+
+function readerAwaitingAnalysis(): array
+{
+    $user = User::factory()->onboarded()->create(['currency_code' => 'EUR', 'locale' => 'en']);
+
+    $summary = MonthlySummary::factory()->create([
+        'user_id' => $user->id,
+        'space_id' => $user->activeSpace()->id,
+    ]);
+
+    return [$summary, $user];
+}
+
+it('spends its attempts on a transient provider failure instead of reporting it', function (Closure $makeFailure): void {
+    config()->set('ai_monthly_summary.attempts', 2);
+
+    Exceptions::fake();
+
+    $calls = 0;
+    MonthlySummaryAgent::fake(function () use (&$calls, $makeFailure) {
+        $calls++;
+
+        throw $makeFailure();
+    });
+
+    [$summary, $user] = readerAwaitingAnalysis();
+
+    expect(app(AnalysisWriter::class)->draft($summary, $user))->toBeNull()
+        ->and($calls)->toBe(2);
+
+    Exceptions::assertNothingReported();
+})->with('transient provider failures');
+
+it('reports an unexpected failure once and does not burn the remaining attempts', function (): void {
+    config()->set('ai_monthly_summary.attempts', 3);
+
+    Exceptions::fake();
+
+    $calls = 0;
+    MonthlySummaryAgent::fake(function () use (&$calls) {
+        $calls++;
+
+        throw new RuntimeException('malformed response');
+    });
+
+    [$summary, $user] = readerAwaitingAnalysis();
+
+    expect(app(AnalysisWriter::class)->draft($summary, $user))->toBeNull()
+        ->and($calls)->toBe(1);
+
+    Exceptions::assertReported(fn (RuntimeException $e): bool => $e->getMessage() === 'malformed response');
+});


### PR DESCRIPTION
Fixes PHP-LARAVEL-5Q.

## The bug

A 30-second timeout reaching Gemini, thrown from `AnalysisWriter::promptOnce`:

```
cURL error 28: Operation timed out after 30002 milliseconds with 0 bytes received
for .../gemini-flash-latest:generateContent
```

`AnalysisWriter::draft()` exists to retry — it loops up to `ai_monthly_summary.attempts` (3), logging and backing off on `FailoverableException`. Its own comment says why:

> A provider hiccup costs a paying user their analysis for a whole month, so it is worth a few attempts.

`ConnectionException` fell into the generic `Throwable` arm below it, which reports and returns immediately. So the three attempts were only ever spent on a provider that answered *badly*; one that did not answer *at all* got a single try and the reader lost the section.

This is the same classification the other AI call sites were given in #899, applied to the fourth one — which did not exist when that landed. All four now agree, and there is no fifth: `catch (FailoverableException` and `->prompt(` between them cover `CategorizeTransactions`, `LaravelAiRuleSuggestionGenerator`, `ReportSummarizer` and this file.

## What a reader actually lost

Worth being precise, because it is narrower than it first looks. `write()` only persists a non-null analysis, so the in-app and shared views re-draft on a later visit. The **email** does not: `SendMonthlySummariesCommand::candidates()` skips anyone with a `UserMailLog` row for that month, so the emailed copy is one-shot. Before this fix, a single timeout permanently cost that reader the analysis in the message they actually receive.

## The visibility trade-off, handled this time

Making the failure transient also silences it, and `enable_logs` is off — the per-attempt warning only reaches Sentry as a breadcrumb on someone else's event. A wrong endpoint or a revoked key surfacing as connect failures would have gone dark.

So exhausting *every* attempt now reports once. That is a different event from one hiccup: ~90 seconds of a provider not answering, and a reader down an analysis. One blip stays in the logs; a run that never got through raises an issue.

**Note this changes behaviour for an exhausted overload too**, which used to be silent. Three failures in a row is an outage either way, and splitting the two by exception type would report less than the situation deserves. Say the word if you'd rather keep overloads quiet.

A consequence worth stating plainly: **PHP-LARAVEL-5Q can still fire after this** — but only when all three attempts failed, which means something real. A lone timeout no longer opens it.

## Timeout budget

Checked, since the fix makes failure slower rather than faster. Worst case is 3 x 30s plus 1.5s of backoff, about 92s, inside `SendMonthlySummaryEmailJob` (`$timeout = 300`), whose docblock already earmarks ~70s for card rendering. Roughly 137s of slack left. Nothing validates `attempts` x `timeout` against that budget, so raising either later wants re-checking.

## Tests

`AnalysisWriter` had no direct coverage. Added, reusing the `transient provider failures` dataset #899 left in `tests/Pest.php`, so both transient kinds run every case:

- **every attempt spent before giving up** — red before the fix: 1 call instead of 2
- **recovery** — a first attempt lost to the failure, a second that returns the analysis. This is the one that proves what the retry is *for*; the other cases only prove it fails gracefully.
- **exhaustion reports exactly once**, with the per-attempt warning logged each time
- **an unexpected failure still reports immediately and does not burn the remaining attempts** — the guard against someone later widening the transient arm to `Throwable`

`tests/Feature/MonthlySummary` + `tests/Feature/Ai` + the preview command: 249 passed. `pint --test`, `crap --base=origin/main`, `bun run dry` clean.

## Follow-up worth a ticket, not this PR

The `timeout` passed to the SDK becomes Guzzle's **total** request timeout, not connect-only, and this call is non-streaming. So "0 bytes received after 30s" is equally consistent with the model simply taking longer than 30s to generate — in which case retrying the same prompt against the same ceiling may hit the same wall, and a longer single attempt would beat three short ones. One event is not enough to tell the two apart; worth revisiting if these cluster.

Also left alone deliberately: `write()`'s two short-circuits (analysis already present, user not eligible) are still untested. Unrelated to this bug, so not smuggled in here.
