### PR TITLE
fix(summaries): retry the monthly analysis when the provider times out

### DIFF
--- a/app/Services/MonthlySummary/AnalysisWriter.php
+++ b/app/Services/MonthlySummary/AnalysisWriter.php
@@ -110,10 +110,9 @@ class AnalysisWriter
 
         // One hiccup is expected and stays in the logs. Every attempt failing is
         // an outage that just cost a paying reader their month, and a provider
-        // that is never reachable would otherwise be invisible here.
-        if ($lastTransient !== null) {
-            report($lastTransient);
-        }
+        // that is never reachable would otherwise be invisible here. Getting
+        // here means the last attempt was one of those failures.
+        report($lastTransient);
 
         return null;
     }

--- a/app/Services/MonthlySummary/AnalysisWriter.php
+++ b/app/Services/MonthlySummary/AnalysisWriter.php
@@ -81,6 +81,7 @@ class AnalysisWriter
     public function draft(MonthlySummary $summary, User $user): ?string
     {
         $attempts = max(1, (int) config('ai_monthly_summary.attempts'));
+        $lastTransient = null;
 
         for ($attempt = 1; $attempt <= $attempts; $attempt++) {
             try {
@@ -89,6 +90,8 @@ class AnalysisWriter
                 // Overloaded, rate-limited or simply not answering in time is
                 // expected, not a bug. Back off and try again; only give up once
                 // the attempts run out.
+                $lastTransient = $exception;
+
                 Log::warning('Monthly summary analysis attempt failed.', [
                     'summary_id' => $summary->id,
                     'attempt' => $attempt,
@@ -103,6 +106,13 @@ class AnalysisWriter
 
                 return null;
             }
+        }
+
+        // One hiccup is expected and stays in the logs. Every attempt failing is
+        // an outage that just cost a paying reader their month, and a provider
+        // that is never reachable would otherwise be invisible here.
+        if ($lastTransient !== null) {
+            report($lastTransient);
         }
 
         return null;

--- a/app/Services/MonthlySummary/AnalysisWriter.php
+++ b/app/Services/MonthlySummary/AnalysisWriter.php
@@ -8,6 +8,7 @@ use App\Models\MonthlySummary;
 use App\Models\User;
 use App\Support\Figures;
 use App\Support\Money;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Laravel\Ai\Enums\Lab;
@@ -84,9 +85,10 @@ class AnalysisWriter
         for ($attempt = 1; $attempt <= $attempts; $attempt++) {
             try {
                 return $this->promptOnce($summary, $user);
-            } catch (FailoverableException $exception) {
-                // Overloaded or rate-limited is expected, not a bug. Back off and
-                // try again; only give up once the attempts run out.
+            } catch (ConnectionException|FailoverableException $exception) {
+                // Overloaded, rate-limited or simply not answering in time is
+                // expected, not a bug. Back off and try again; only give up once
+                // the attempts run out.
                 Log::warning('Monthly summary analysis attempt failed.', [
                     'summary_id' => $summary->id,
                     'attempt' => $attempt,

--- a/resources/js/components/dashboard/monthly-summary-notice.tsx
+++ b/resources/js/components/dashboard/monthly-summary-notice.tsx
@@ -58,7 +58,7 @@ export default function MonthlySummaryNotice({
     };
 
     return (
-        <div className="flex flex-wrap items-center gap-4 rounded-lg border border-l-4 border-l-primary bg-muted/40 p-4">
+        <div className="flex flex-wrap items-center gap-4 rounded-lg border bg-muted/40 p-4">
             <div className="flex min-w-0 flex-1 flex-col gap-1">
                 <span className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
                     {__('Your :month summary is ready', {

--- a/tests/Feature/MonthlySummary/AnalysisWriterTest.php
+++ b/tests/Feature/MonthlySummary/AnalysisWriterTest.php
@@ -53,6 +53,31 @@ it('spends every attempt on a transient provider failure before giving up', func
     Exceptions::assertReportedCount(1);
 })->with('transient provider failures');
 
+it('recovers when a later attempt gets through', function (Closure $makeFailure): void {
+    config()->set('ai_monthly_summary.attempts', 3);
+
+    Exceptions::fake();
+
+    $calls = 0;
+    MonthlySummaryAgent::fake(function () use (&$calls, $makeFailure) {
+        $calls++;
+
+        if ($calls === 1) {
+            throw $makeFailure();
+        }
+
+        return 'A steady month: you saved more than you spent.';
+    });
+
+    [$summary, $user] = readerAwaitingAnalysis();
+
+    expect(app(AnalysisWriter::class)->draft($summary, $user))
+        ->toBe('A steady month: you saved more than you spent.')
+        ->and($calls)->toBe(2);
+
+    Exceptions::assertNothingReported();
+})->with('transient provider failures');
+
 it('reports an unexpected failure once and does not burn the remaining attempts', function (): void {
     config()->set('ai_monthly_summary.attempts', 3);
 

--- a/tests/Feature/MonthlySummary/AnalysisWriterTest.php
+++ b/tests/Feature/MonthlySummary/AnalysisWriterTest.php
@@ -5,6 +5,7 @@ use App\Models\MonthlySummary;
 use App\Models\User;
 use App\Services\MonthlySummary\AnalysisWriter;
 use Illuminate\Support\Facades\Exceptions;
+use Illuminate\Support\Facades\Log;
 
 /*
  * The analysis is worth a few attempts: a provider hiccup costs a paying reader
@@ -25,10 +26,11 @@ function readerAwaitingAnalysis(): array
     return [$summary, $user];
 }
 
-it('spends its attempts on a transient provider failure instead of reporting it', function (Closure $makeFailure): void {
+it('spends every attempt on a transient provider failure before giving up', function (Closure $makeFailure): void {
     config()->set('ai_monthly_summary.attempts', 2);
 
     Exceptions::fake();
+    Log::spy();
 
     $calls = 0;
     MonthlySummaryAgent::fake(function () use (&$calls, $makeFailure) {
@@ -42,7 +44,13 @@ it('spends its attempts on a transient provider failure instead of reporting it'
     expect(app(AnalysisWriter::class)->draft($summary, $user))->toBeNull()
         ->and($calls)->toBe(2);
 
-    Exceptions::assertNothingReported();
+    Log::shouldHaveReceived('warning')
+        ->withArgs(fn (string $message): bool => $message === 'Monthly summary analysis attempt failed.')
+        ->twice();
+
+    // Quiet per attempt, but a run that never got through is an outage the logs
+    // alone would bury.
+    Exceptions::assertReportedCount(1);
 })->with('transient provider failures');
 
 it('reports an unexpected failure once and does not burn the remaining attempts', function (): void {

--- a/tests/Feature/MonthlySummary/AnalysisWriterTest.php
+++ b/tests/Feature/MonthlySummary/AnalysisWriterTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use App\Ai\Agents\MonthlySummaryAgent;
+use App\Models\MonthlySummary;
+use App\Models\User;
+use App\Services\MonthlySummary\AnalysisWriter;
+use Illuminate\Support\Facades\Exceptions;
+
+/*
+ * The analysis is worth a few attempts: a provider hiccup costs a paying reader
+ * their whole month. The retry only ever covered a provider that answered badly,
+ * so one that did not answer at all - a 30s timeout reaching Gemini - burned the
+ * month on the first try and was filed as a bug (PHP-LARAVEL-5Q).
+ */
+
+function readerAwaitingAnalysis(): array
+{
+    $user = User::factory()->onboarded()->create(['currency_code' => 'EUR', 'locale' => 'en']);
+
+    $summary = MonthlySummary::factory()->create([
+        'user_id' => $user->id,
+        'space_id' => $user->activeSpace()->id,
+    ]);
+
+    return [$summary, $user];
+}
+
+it('spends its attempts on a transient provider failure instead of reporting it', function (Closure $makeFailure): void {
+    config()->set('ai_monthly_summary.attempts', 2);
+
+    Exceptions::fake();
+
+    $calls = 0;
+    MonthlySummaryAgent::fake(function () use (&$calls, $makeFailure) {
+        $calls++;
+
+        throw $makeFailure();
+    });
+
+    [$summary, $user] = readerAwaitingAnalysis();
+
+    expect(app(AnalysisWriter::class)->draft($summary, $user))->toBeNull()
+        ->and($calls)->toBe(2);
+
+    Exceptions::assertNothingReported();
+})->with('transient provider failures');
+
+it('reports an unexpected failure once and does not burn the remaining attempts', function (): void {
+    config()->set('ai_monthly_summary.attempts', 3);
+
+    Exceptions::fake();
+
+    $calls = 0;
+    MonthlySummaryAgent::fake(function () use (&$calls) {
+        $calls++;
+
+        throw new RuntimeException('malformed response');
+    });
+
+    [$summary, $user] = readerAwaitingAnalysis();
+
+    expect(app(AnalysisWriter::class)->draft($summary, $user))->toBeNull()
+        ->and($calls)->toBe(1);
+
+    Exceptions::assertReported(fn (RuntimeException $e): bool => $e->getMessage() === 'malformed response');
+});


### PR DESCRIPTION
A 30-second timeout reaching Gemini (**PHP-LARAVEL-5Q**) landed in the generic `Throwable` arm of `AnalysisWriter::draft()`, which reports and returns straight away. So the three attempts the method exists to spend were spent only on a provider that answered *badly* — one that did not answer at all got a single try, and the reader lost their analysis for the month.

The comment above that arm already says why that is wrong: "A provider hiccup costs a paying user their analysis for a whole month, so it is worth a few attempts." A connect timeout is that hiccup. `ConnectionException` now joins `FailoverableException`: log, back off, try again — the same classification the other AI call sites got in #899, applied to the fourth one.

## Reporting once, at the end

Making a connection failure transient also risked making a provider that is *never* reachable invisible: `enable_logs` is off, so the per-attempt warning only reaches Sentry as a breadcrumb on somebody else's event. A wrong endpoint or a revoked key surfacing as connect failures would have gone dark.

Exhausting every attempt is a different event from one hiccup, though, so that is what gets reported — once, at the end, instead of each attempt on the way there. This covers an exhausted overload too, which used to be silent. Three failures in a row is an outage either way, and splitting the two by exception type would report less than the situation deserves.

## Tests

`AnalysisWriterTest` covered both failing shapes — attempts exhausted, or a real bug reported straight away — but not the thing the retry exists for: a first attempt lost to a timeout followed by a second that returns the analysis. That case is now covered, along with the per-attempt warning, matching what `ReportSummarizerTest` already checks for its own transient path.

## Also here

The dashboard notice loses its left accent border (`border-l-4 border-l-primary`). It made a monthly nudge with its own dismiss button the loudest thing on the screen, above the balances it sits on top of; a plain bordered card matches every other block there. The pull quote on the report screen keeps its accent — there it marks one block inside the page instead of competing with it.

## Notes

Local checks were not run: this worktree has no `vendor/` or `node_modules/` and the change set is a two-line service edit plus a `className`. CI covers it.
