### PR TITLE
fix(summaries): stop selling Pro to a reader whose analysis the model could not write

### DIFF
--- a/app/Mail/Drip/MonthlySummaryEmail.php
+++ b/app/Mail/Drip/MonthlySummaryEmail.php
@@ -83,6 +83,7 @@ class MonthlySummaryEmail extends DripMail
                 'incompleteNotice' => $this->incompleteNotice(),
                 'spaceName' => $this->spaceName,
                 'analysis' => $this->analysis,
+                'pro' => $this->pro,
                 'lockedPitch' => $this->lockedPitch(),
                 'lockedAction' => $this->lockedAction(),
                 'lockedUrl' => $this->lockedUrl(),

--- a/app/Services/MonthlySummary/AnalysisWriter.php
+++ b/app/Services/MonthlySummary/AnalysisWriter.php
@@ -10,6 +10,7 @@ use App\Support\Figures;
 use App\Support\Money;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Exceptions\FailoverableException;
@@ -98,7 +99,7 @@ class AnalysisWriter
                     'exception' => $exception->getMessage(),
                 ]);
 
-                usleep($attempt * 500_000);
+                Sleep::for($attempt * 500)->milliseconds();
             } catch (Throwable $exception) {
                 // A misconfigured provider or an SDK change is a real bug worth
                 // reporting, and retrying it would only waste the window.

--- a/lang/es.json
+++ b/lang/es.json
@@ -2747,6 +2747,7 @@
     "…and your :month card, ready to share.": "…y tu tarjeta de :month, lista para compartir.",
     "Worked out on :date. If you have imported or synced anything since, the app has the fuller picture.": "Calculado el :date. Si has importado o sincronizado algo después, en la app está la foto completa.",
     "That figure did not come out of nowhere, and Pro tells you where from: what moved it, what is going to repeat next month, and which budget is about to fall short.": "Esa cifra no sale de la nada, y con Pro te contamos de dónde: qué la ha movido, qué se va a repetir el mes que viene y qué presupuesto se te va a quedar corto.",
+    "We could not write your analysis this month. Every figure below is unaffected.": "No hemos podido escribir tu análisis este mes. Ninguna de las cifras de abajo se ve afectada.",
     "Turn AI on in Settings": "Activar la IA en Ajustes",
     "See Pro": "Ver Pro",
     "Your :month summary is waiting on your data": "Tu resumen de :month espera tus datos",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2375,6 +2375,7 @@
     "…and your :month card, ready to share.": "…et votre carte de :month, prête à partager.",
     "Worked out on :date. If you have imported or synced anything since, the app has the fuller picture.": "Calculé le :date. Si vous avez importé ou synchronisé quelque chose depuis, l'application a la vue complète.",
     "That figure did not come out of nowhere, and Pro tells you where from: what moved it, what is going to repeat next month, and which budget is about to fall short.": "Ce chiffre ne sort pas de nulle part, et Pro vous dit d'où il vient : ce qui l'a fait bouger, ce qui va se répéter le mois prochain et quel budget va devenir trop juste.",
+    "We could not write your analysis this month. Every figure below is unaffected.": "Nous n'avons pas pu écrire votre analyse ce mois-ci. Aucun des chiffres ci-dessous n'est affecté.",
     "Turn AI on in Settings": "Activer l'IA dans les réglages",
     "See Pro": "Découvrir Pro",
     "Your :month summary is waiting on your data": "Votre bilan de :month attend vos données",

--- a/resources/views/mail/summary/analysis.blade.php
+++ b/resources/views/mail/summary/analysis.blade.php
@@ -1,9 +1,17 @@
-{{-- The analysis block, in one of two states.
+{{-- The analysis block, in one of three states.
 
-     A Pro reader with AI consent gets the real thing. Everyone else gets the
-     same locked block: the free reader because it is what Pro buys, and the Pro
-     reader without consent because nothing about them may reach a model until
-     they say so. The only thing that differs between those two is the button. --}}
+     A Pro reader with AI consent gets the real thing.
+
+     When the model could not be reached they get a plain line saying so. The
+     locked block below would be a lie to them: it sells the plan they already
+     pay for and its button points at a setting that is already on. That is the
+     state a provider outage puts every consenting reader in at once - the whole
+     batch on the 3rd - so it cannot borrow the paywall's copy.
+
+     Everyone else gets the locked block: the free reader because it is what Pro
+     buys, and the Pro reader without consent because nothing about them may
+     reach a model until they say so. The only thing that differs between those
+     two is the button. --}}
 @if ($analysis !== null)
     <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="margin-top:24px;"><tr>
         <td width="4" style="background:#18181b;font-size:0;line-height:0;">&nbsp;</td>
@@ -18,6 +26,14 @@
             @endforeach
 
             <p style="margin:13px 0 0;padding-top:11px;border-top:1px solid #e4e4e7;font-size:11px;line-height:1.5;color:#a1a1aa;">{{ __('Written by a model from your month\'s totals and the names of your accounts, never from your individual transactions. You can turn it off in Settings → AI.') }}</p>
+        </td>
+    </tr></table>
+@elseif ($pro)
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="margin-top:24px;"><tr>
+        <td width="4" style="background:#d4d4d8;font-size:0;line-height:0;">&nbsp;</td>
+        <td style="background:#fafafa;padding:18px 20px;">
+            <p style="margin:0;font-size:10px;font-weight:600;letter-spacing:0.09em;text-transform:uppercase;color:#a1a1aa;">{{ __('Why this happened') }}</p>
+            <p style="margin:12px 0 0;font-size:14px;line-height:1.55;color:#52525b;">{{ __('We could not write your analysis this month. Every figure below is unaffected.') }}</p>
         </td>
     </tr></table>
 @else

--- a/tests/Feature/MonthlySummary/AnalysisWriterTest.php
+++ b/tests/Feature/MonthlySummary/AnalysisWriterTest.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use App\Services\MonthlySummary\AnalysisWriter;
 use Illuminate\Support\Facades\Exceptions;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Sleep;
 
 /*
  * The analysis is worth a few attempts: a provider hiccup costs a paying reader
@@ -13,6 +14,11 @@ use Illuminate\Support\Facades\Log;
  * so one that did not answer at all - a 30s timeout reaching Gemini - burned the
  * month on the first try and was filed as a bug (PHP-LARAVEL-5Q).
  */
+
+beforeEach(function (): void {
+    // Every case here exhausts the attempts, and the backoff between them grows.
+    Sleep::fake();
+});
 
 function readerAwaitingAnalysis(): array
 {

--- a/tests/Feature/MonthlySummary/MonthlySummaryEmailTest.php
+++ b/tests/Feature/MonthlySummary/MonthlySummaryEmailTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Ai\Agents\MonthlySummaryAgent;
 use App\Enums\DripEmailType;
 use App\Enums\MonthlySummaryCard;
 use App\Jobs\Drip\SendMonthlySummaryEmailJob;
@@ -12,6 +13,8 @@ use App\Services\MonthlySummary\CardPicker;
 use App\Services\MonthlySummary\CardRenderer;
 use App\Services\MonthlySummary\EmailPresenter;
 use App\Services\MonthlySummary\Summaries;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Exceptions;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Queue;
 
@@ -255,6 +258,44 @@ it('draws the screen\'s cards in the reader\'s language too', function (): void 
     (new WarmMonthlySummaryCardsJob($summary, pro: false))->handle(app(Summaries::class));
 
     expect($drawnIn)->toBe('es')->and(app()->getLocale())->toBe('en');
+});
+
+it('spends every attempt on a provider that never answers, and sends the report regardless', function (): void {
+    // The report has always gone out without the section - a read timeout was
+    // caught as an unexpected bug, reported, and the remaining attempts thrown
+    // away (PHP-LARAVEL-5Q). What the reader lost was the analysis itself, to a
+    // single blip that a second attempt would usually have got past.
+    config(['subscriptions.enabled' => false, 'ai_monthly_summary.attempts' => 2]);
+    Mail::fake();
+    Queue::fake();
+    Exceptions::fake();
+
+    $summary = sentSummaryFor();
+    $summary->user->recordAiConsent();
+
+    $attempts = 0;
+    MonthlySummaryAgent::fake(function () use (&$attempts): never {
+        $attempts++;
+
+        throw new ConnectionException(
+            'cURL error 28: Operation timed out after 30002 milliseconds with 0 bytes received',
+        );
+    });
+
+    (new SendMonthlySummaryEmailJob($summary->user->fresh(), $summary))->handle();
+
+    // Sent, addressed to a reader the email knows is entitled - which is what
+    // keeps the paywall block out of it - and with no analysis.
+    Mail::assertQueued(
+        MonthlySummaryEmail::class,
+        fn (MonthlySummaryEmail $mail): bool => $mail->analysis === null && $mail->pro,
+    );
+
+    expect($attempts)->toBe(2)
+        ->and($summary->fresh()->sent_at)->not->toBeNull()
+        ->and(UserMailLog::where('user_id', $summary->user_id)
+            ->where('email_type', DripEmailType::MonthlySummary)
+            ->exists())->toBeTrue();
 });
 
 it('does not send to a reader who turned the summary off', function (): void {

--- a/tests/Feature/MonthlySummary/MonthlySummaryEmailTest.php
+++ b/tests/Feature/MonthlySummary/MonthlySummaryEmailTest.php
@@ -17,6 +17,7 @@ use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Exceptions;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Sleep;
 
 /*
  * The report email itself: what it says, who sees the analysis, and how a reader
@@ -24,6 +25,9 @@ use Illuminate\Support\Facades\Queue;
  */
 
 beforeEach(function (): void {
+    // The analysis backs off between attempts; no test here is about waiting.
+    Sleep::fake();
+
     // What is under test is what the email says, not Chromium: left real, every
     // job test here draws a month's worth of cards.
     $this->mock(CardRenderer::class, function ($mock): void {

--- a/tests/Feature/MonthlySummary/MonthlySummaryEmailTest.php
+++ b/tests/Feature/MonthlySummary/MonthlySummaryEmailTest.php
@@ -98,6 +98,22 @@ it('points a paying reader at the AI setting instead of at the paywall', functio
     expect($rendered)->toContain('Turn AI on in Settings')->not->toContain('See Pro');
 });
 
+it('says the analysis could not be written rather than selling Pro to someone who has it', function (): void {
+    // A provider outage leaves a consenting reader with no analysis, which used
+    // to fall into the locked block above: it pitches the plan they already pay
+    // for and its button sends them to switch on a setting that is already on.
+    config(['subscriptions.enabled' => true]);
+    $summary = sentSummaryFor();
+
+    $rendered = (new MonthlySummaryEmail($summary->user, $summary, pro: true))->render();
+
+    expect($rendered)
+        ->toContain('We could not write your analysis this month')
+        ->not->toContain('Pro tells you where from')
+        ->not->toContain('Turn AI on in Settings')
+        ->not->toContain('See Pro');
+});
+
 it('says so when the month was reported incomplete', function (): void {
     $user = User::factory()->onboarded()->create(['currency_code' => 'EUR', 'locale' => 'en']);
     $summary = MonthlySummary::factory()->create([

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -50,10 +50,12 @@ pest()->browser()->timeout(15000);
 | Transient AI provider failures
 |--------------------------------------------------------------------------
 |
-| The two ways an AI provider fails with nobody having a bug to fix: it answers
-| badly (overloaded, rate-limiting us) or it does not answer at all (DNS, connect
-| timeout). Every service that prompts a provider has to treat the two the same
-| way, so they assert against one shared list rather than each keeping its own.
+| The ways an AI provider fails with nobody having a bug to fix: it answers badly
+| (overloaded, rate-limiting us), it cannot be reached at all (DNS, connect
+| timeout), or it accepts the request and then never answers - the 30s read
+| timeout that cost readers their monthly analysis in PHP-LARAVEL-5Q. Every
+| service that prompts a provider has to treat all of them the same way, so they
+| assert against one shared list rather than each keeping its own.
 |
 */
 
@@ -61,6 +63,9 @@ dataset('transient provider failures', [
     'provider overloaded' => fn (): Throwable => ProviderOverloadedException::forProvider('gemini'),
     'provider unreachable' => fn (): Throwable => new ConnectionException(
         'cURL error 6: Could not resolve host: generativelanguage.googleapis.com',
+    ),
+    'provider timed out' => fn (): Throwable => new ConnectionException(
+        'cURL error 28: Operation timed out after 30002 milliseconds with 0 bytes received',
     ),
 ]);
 


### PR DESCRIPTION
Follow-up to #917. That PR made a provider timeout transient so the analysis is retried instead of abandoned on the first blip; this one is what fell out of checking what the reader actually receives when every attempt is spent.

Rebased onto main, so the retry commits are gone from here and only these four remain.

## The reader was being sent the paywall

This predates #917 — it is reachable from any `null` analysis — but retrying a timeout is what made it worth chasing.

The analysis block picked between two states on `$analysis` alone, so a null analysis always meant *"this reader is not entitled to one"*. That held while the only ways to reach null were a free reader and a Pro one who never granted AI consent. A **consenting Pro subscriber whose analysis could not be written** is neither, and got their copy anyway:

> That figure did not come out of nowhere, and **Pro tells you where from**…

under a **"Turn AI on in Settings"** button pointing at a setting that is already on, over the three grey placeholder bars that read as *you did not pay for this*. During a provider wobble that is not one reader, it is every consenting subscriber in that morning's batch.

They now get one plain line, no pitch and no button:

> We could not write your analysis this month. Every figure below is unaffected.

## Commits

| | |
|---|---|
| `efb4a03b` | **Stop selling Pro to a reader whose analysis the model could not write** |
| `90992c88` | Pin the send path a timeout goes through — the report goes out, carries no analysis, and is addressed as entitled |
| `7bcf0dac` | Back off through the `Sleep` facade so the tests need not wait (~6s off the run) |
| `6a8fa64f` | Name the read timeout in the shared transient-failure dataset |

`90992c88` is the regression guard for the block above and for #917 both: it fails on one attempt instead of two without the widened catch, and it asserts the mail is built with `analysis: null, pro: true`.

`6a8fa64f` closes a gap in the shared dataset: it held a DNS failure and an overloaded provider, so the cURL 28 read timeout the whole fix exists for was never a case anyone asserted against. The three sibling services inherit it and pass.

## Checks

`pest` 2977 green · `phpstan` 0 errors · `pint` green · `format` / `lint` clean · `dry` 3.77% vs 5.4 · `crap` none above 10.

## Deliberately not in here

- **The copy is mine, not a human's** — `en`, `es`, `fr`. Reword freely; one string in each `lang/*.json`.
- **Backfilling a lost analysis.** The email has gone by then, but the archive screen and the share card keep showing nothing for that month, and `hasAlreadyBeenSent()` stops any later pass retrying. `CategorizeTransactions` solves the same problem with a delayed retry job. A feature, not this fix.
- **A distinct exception for the exhausted-attempts report.** Sentry keeps grouping it under PHP-LARAVEL-5Q with the signature it had before #917, now meaning "every attempt failed" rather than "one blip". Volume drops sharply so the noise is small, but the issue will look like it regressed on the next 3rd. Wrapping it needs a new exception class for one call site.
- **Retuning `attempts`/`timeout`.** Worst case is ~92s inside `draft()` against the job's 300s timeout and the queue's 900s `retry_after`, so nothing is at risk. The `emails` worker is single-process, so an outage serialises readers more slowly than before — worth `AI_MONTHLY_SUMMARY_ATTEMPTS=2` if that ever bites, but it is an env change, not a code one.
