### PR TITLE
fix(summaries): remember the dashboard notice dismissal on the summary, not the browser

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -45,6 +45,10 @@ class DashboardController extends Controller
      * queries on the first paint, and it rides the follow-up request the
      * dashboard already makes rather than adding one of its own.
      *
+     * One notice at most, and only for the newest month. Dismissing it hides
+     * the notice entirely rather than surfacing an older undismissed month:
+     * "your February summary is ready" in April reads as a bug, not a reminder.
+     *
      * @return array<string, mixed>|null
      */
     private function latestSummary(Request $request): ?array
@@ -58,7 +62,7 @@ class DashboardController extends Controller
             ->orderByDesc('period')
             ->first();
 
-        if ($summary === null) {
+        if ($summary === null || $summary->dismissed_at !== null) {
             return null;
         }
 

--- a/app/Http/Controllers/MonthlySummaryController.php
+++ b/app/Http/Controllers/MonthlySummaryController.php
@@ -13,6 +13,7 @@ use App\Services\MonthlySummary\CardRenderer;
 use App\Services\MonthlySummary\EmailPresenter;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response as HttpResponse;
 use Illuminate\Support\Facades\Storage;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -124,6 +125,20 @@ class MonthlySummaryController extends Controller
         $summary->revokeShareToken();
 
         return back();
+    }
+
+    /**
+     * Put the dashboard notice away. Answers with no content on purpose: the
+     * dashboard hides the banner locally, and a redirect would make Inertia
+     * reload every deferred prop on the page just to hide one row.
+     */
+    public function dismiss(Request $request, MonthlySummary $summary): HttpResponse
+    {
+        abort_unless($summary->user_id === $request->user()->id, 404);
+
+        $summary->dismiss();
+
+        return response()->noContent();
     }
 
     /**

--- a/app/Models/MonthlySummary.php
+++ b/app/Models/MonthlySummary.php
@@ -28,6 +28,7 @@ use Illuminate\Support\Str;
  * @property ?string $share_token
  * @property ?Carbon $shared_at
  * @property ?Carbon $sent_at
+ * @property ?Carbon $dismissed_at
  */
 class MonthlySummary extends Model
 {
@@ -62,6 +63,7 @@ class MonthlySummary extends Model
             'ai_generated_at' => 'datetime',
             'shared_at' => 'datetime',
             'sent_at' => 'datetime',
+            'dismissed_at' => 'datetime',
         ];
     }
 
@@ -115,5 +117,14 @@ class MonthlySummary extends Model
     public function revokeShareToken(): void
     {
         $this->forceFill(['share_token' => null, 'shared_at' => null])->save();
+    }
+
+    /**
+     * Put the dashboard notice away. Kept on the summary rather than in the
+     * browser, so it stays away on every device and across logins.
+     */
+    public function dismiss(): void
+    {
+        $this->forceFill(['dismissed_at' => now()])->save();
     }
 }

--- a/database/factories/MonthlySummaryFactory.php
+++ b/database/factories/MonthlySummaryFactory.php
@@ -38,6 +38,11 @@ class MonthlySummaryFactory extends Factory
         return $this->state(fn (): array => ['share_token' => str()->random(48), 'shared_at' => now()]);
     }
 
+    public function dismissed(): self
+    {
+        return $this->state(fn (): array => ['dismissed_at' => now()]);
+    }
+
     /**
      * A payload with every section filled, so a test that renders the email or a
      * card exercises all the rows rather than the empty-state path.

--- a/database/migrations/2026_09_03_091344_add_dismissed_at_to_monthly_summaries_table.php
+++ b/database/migrations/2026_09_03_091344_add_dismissed_at_to_monthly_summaries_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * The dashboard notice used to remember its dismissal per browser, so it came
+     * back on every other device and after every login. The summary owns that
+     * state now: one summary, one reader, one dismissal.
+     */
+    public function up(): void
+    {
+        Schema::table('monthly_summaries', function (Blueprint $table) {
+            $table->timestamp('dismissed_at')->nullable()->after('sent_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('monthly_summaries', function (Blueprint $table) {
+            $table->dropColumn('dismissed_at');
+        });
+    }
+};

--- a/resources/js/components/dashboard/monthly-summary-notice.tsx
+++ b/resources/js/components/dashboard/monthly-summary-notice.tsx
@@ -1,7 +1,10 @@
-import { show } from '@/actions/App/Http/Controllers/MonthlySummaryController';
+import {
+    dismiss,
+    show,
+} from '@/actions/App/Http/Controllers/MonthlySummaryController';
 import { Button } from '@/components/ui/button';
 import { __ } from '@/utils/i18n';
-import { Link } from '@inertiajs/react';
+import { Link, useHttp } from '@inertiajs/react';
 import { XIcon } from 'lucide-react';
 import { useState } from 'react';
 
@@ -12,9 +15,11 @@ import { useState } from 'react';
  * gets the report, and the card that goes with it. It appears when the summary
  * exists rather than on a fixed day, because the send window spans eight days.
  *
- * Dismissal is remembered per browser rather than server-side. It is a monthly
- * notice, so "I closed it on this device" is as much memory as it needs, and it
- * costs no column and no request.
+ * Dismissal is stored on the summary itself, so closing it once puts it away on
+ * every device and across logins. The banner disappears the moment it is clicked
+ * and the request goes out on its own: a full Inertia visit would reload every
+ * deferred prop on the dashboard just to hide one row. Should the request fail,
+ * the notice is back on the next load, which is harmless.
  */
 export type MonthlySummaryNoticeData = {
     id: string;
@@ -22,40 +27,17 @@ export type MonthlySummaryNoticeData = {
     headline: string;
 };
 
-const STORAGE_PREFIX = 'monthly-summary-dismissed:';
-
-function alreadyDismissed(id: string): boolean {
-    try {
-        return localStorage.getItem(STORAGE_PREFIX + id) !== null;
-    } catch {
-        // A private window or blocked site data: showing the notice again beats
-        // crashing the dashboard over it.
-        return false;
-    }
-}
-
 export default function MonthlySummaryNotice({
     summary,
 }: {
     summary: MonthlySummaryNoticeData;
 }) {
-    const [dismissed, setDismissed] = useState(() =>
-        alreadyDismissed(summary.id),
-    );
+    const [dismissed, setDismissed] = useState(false);
+    const { post } = useHttp();
 
     if (dismissed) {
         return null;
     }
-
-    const dismiss = () => {
-        try {
-            localStorage.setItem(STORAGE_PREFIX + summary.id, '1');
-        } catch {
-            // Nothing to do: it will show again next load, which is harmless.
-        }
-
-        setDismissed(true);
-    };
 
     return (
         <div className="flex flex-wrap items-center gap-4 rounded-lg border bg-muted/40 p-4">
@@ -73,7 +55,10 @@ export default function MonthlySummaryNotice({
             <Button
                 size="icon"
                 variant="ghost"
-                onClick={dismiss}
+                onClick={() => {
+                    setDismissed(true);
+                    post(dismiss(summary.id).url);
+                }}
                 aria-label={__('Dismiss')}
             >
                 <XIcon className="size-4" />

--- a/routes/web.php
+++ b/routes/web.php
@@ -212,6 +212,7 @@ Route::middleware(['auth', 'verified', 'onboarded', 'subscribed'])->group(functi
     Route::get('summaries/{summary}/card/{card}/{format}/{theme}', [MonthlySummaryController::class, 'card'])->name('monthly-summaries.card');
     Route::post('summaries/{summary}/share', [MonthlySummaryController::class, 'share'])->name('monthly-summaries.share');
     Route::delete('summaries/{summary}/share', [MonthlySummaryController::class, 'revoke'])->name('monthly-summaries.share.destroy');
+    Route::post('summaries/{summary}/dismiss', [MonthlySummaryController::class, 'dismiss'])->name('monthly-summaries.dismiss');
     // Renders the dashboard with the integration-requests drawer opened on top.
     Route::get('integration-requests', [IntegrationRequestController::class, 'index'])->name('integration-requests.index');
     Route::get('cashflow', CashflowController::class)->name('cashflow');

--- a/tests/Feature/MonthlySummary/MonthlySummaryPagesTest.php
+++ b/tests/Feature/MonthlySummary/MonthlySummaryPagesTest.php
@@ -152,3 +152,70 @@ it('does not run its queries on the first paint', function (): void {
         ->assertOk()
         ->assertInertia(fn (AssertableInertia $page) => $page->missing('monthlySummary'));
 });
+
+it('shows one notice at most, for the newest month, however many are waiting', function (): void {
+    $user = readerWithSummary();
+    MonthlySummary::factory()->sent()->create([
+        'user_id' => $user->id,
+        'space_id' => $user->activeSpace()->id,
+        'period' => now()->subMonths(2)->format('Y-m'),
+    ]);
+
+    $this->actingAs($user)->withoutVite();
+
+    expect(dashboardNotice()['monthLabel'])->toBe(now()->subMonth()->locale('en')->isoFormat('MMMM'));
+});
+
+it('puts the notice away for good once dismissed', function (): void {
+    $user = readerWithSummary();
+    $summary = $user->monthlySummaries()->first();
+
+    $this->actingAs($user)->withoutVite();
+    $this->post("/summaries/{$summary->id}/dismiss")->assertNoContent();
+
+    expect($summary->fresh()->dismissed_at)->not->toBeNull()
+        ->and(dashboardNotice())->toBeNull();
+});
+
+it('does not fall back to an older month once the newest is dismissed', function (): void {
+    // "Your February summary is ready" in April reads as a bug, not a reminder.
+    $user = User::factory()->onboarded()->create(['currency_code' => 'EUR', 'locale' => 'en']);
+    $space = $user->activeSpace()->id;
+    MonthlySummary::factory()->sent()->dismissed()->create(['user_id' => $user->id, 'space_id' => $space]);
+    MonthlySummary::factory()->sent()->create([
+        'user_id' => $user->id,
+        'space_id' => $space,
+        'period' => now()->subMonths(2)->format('Y-m'),
+    ]);
+
+    $this->actingAs($user)->withoutVite();
+
+    expect(dashboardNotice())->toBeNull();
+});
+
+it('will not let one reader dismiss another reader\'s notice', function (): void {
+    $summary = MonthlySummary::query()->where('user_id', readerWithSummary()->id)->first();
+
+    $this->actingAs(User::factory()->onboarded()->create())
+        ->post("/summaries/{$summary->id}/dismiss")
+        ->assertNotFound();
+
+    expect($summary->fresh()->dismissed_at)->toBeNull();
+});
+
+it('offers the next month again after the previous one was dismissed', function (): void {
+    // The dismissal belongs to one summary, not to the reader: closing August
+    // must not silence September.
+    $user = User::factory()->onboarded()->create(['currency_code' => 'EUR', 'locale' => 'en']);
+    $space = $user->activeSpace()->id;
+    MonthlySummary::factory()->sent()->dismissed()->create([
+        'user_id' => $user->id,
+        'space_id' => $space,
+        'period' => now()->subMonths(2)->format('Y-m'),
+    ]);
+    MonthlySummary::factory()->sent()->create(['user_id' => $user->id, 'space_id' => $space]);
+
+    $this->actingAs($user)->withoutVite();
+
+    expect(dashboardNotice()['monthLabel'])->toBe(now()->subMonth()->locale('en')->isoFormat('MMMM'));
+});


### PR DESCRIPTION
## Why

Dismissing the dashboard notice "Your <month> summary is ready" wrote a key to `localStorage`, so the notice came back on every other device and after every logout/login. A monthly notice that keeps reappearing reads as a bug.

## What

- **`dismissed_at` on `monthly_summaries`** (nullable timestamp, cast to `datetime`). The summary owns its own notice state: one summary, one reader, one dismissal. `MonthlySummary::dismiss()` sets it through `forceFill`, the same shape as `mintShareToken()` / `revokeShareToken()`.
- **`POST summaries/{summary}/dismiss`** (`MonthlySummaryController::dismiss`), next to `share` / `revoke`, with the same ownership check (404 for another reader's summary). Returns `204 No Content` on purpose: the dashboard hides the banner locally and a redirect would make Inertia reload every deferred prop on the page just to hide one row.
- **Notice component rewritten without `localStorage`.** It hides the banner immediately with local state and fires the request on its own with Inertia v3 `useHttp`. Should the request fail, the notice is back on the next load, which is harmless. Old `localStorage` keys are left alone; they rot harmlessly.
- **One notice at most, for the newest month.** `DashboardController::latestSummary()` still picks the newest sent summary and now returns `null` when that one is dismissed. It deliberately does **not** fall back to an older undismissed month: "your February summary is ready" in April reads as a bug, not a reminder. Because the dismissal belongs to the summary and not the reader, the next month's summary shows its own notice again.
- Factory state `dismissed()`.

Scope is the dashboard notice only. The email, the history screen, the cards, the share flow and `listRow()` are untouched.

## Tests

`tests/Feature/MonthlySummary/MonthlySummaryPagesTest.php`:

- dismissing via the route sets `dismissed_at` and the dashboard notice becomes `null`
- dismissing another reader's summary is a 404 and writes nothing
- two sent summaries, none dismissed: the notice is the newer period
- two sent summaries, newer dismissed: no notice at all (no fallback to the older month)
- older month dismissed, newer month sent: the newer month's notice shows

## Demo

https://github.com/user-attachments/assets/e396af24-89f7-4dee-9bdc-c2ef5e21a220



The recording (51 s) shows, against the local app as the demo user: the notice visible on the dashboard; "Open it" navigating to the summary; dismissing it (banner gone at once, one `POST …/dismiss → 204`, no dashboard reload, no console errors); a full reload with the notice still gone; logout + login with the notice still gone; a fresh browser context ("another device") with the notice still gone; and the notice coming back after `dismissed_at` is reset in the database, proving the row is the source of truth.

## Notes for review

- Migration is a plain nullable column addition, no backfill: existing rows read as not dismissed.
- `dismissed_at` is not exposed anywhere the model is serialised for the screens (`listRow()` builds a hand-picked array).
