### PR TITLE
fix(ssr): render /summaries on the server again, and with translations

### DIFF
--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -29,6 +29,7 @@ import { installChunkLoadRecovery } from './lib/chunk-load-recovery';
 import { installDeferredPropsRecovery } from './lib/deferred-props-recovery';
 import { installFailedNavigationToast } from './lib/failed-navigation-toast';
 import { leavePage } from './lib/leave-page';
+import { seedPageState } from './lib/page-state';
 import { initializePostHog } from './lib/posthog';
 import {
     isBrowserExtensionNoise,
@@ -42,8 +43,7 @@ import {
 import { installSessionExpiryRecovery } from './lib/session-expiry-recovery';
 import { trackUnattendedRequests } from './lib/unattended-requests';
 import type { ExpiredBankingConnectionNotification, SharedData } from './types';
-import { setCurrencyDecimals } from './utils/currency';
-import { __, setTranslations } from './utils/i18n';
+import { __ } from './utils/i18n';
 
 installChunkLoadRecovery();
 installDeferredPropsRecovery();
@@ -238,24 +238,15 @@ createInertiaApp({
             }
         };
 
-        // Initialize translations from server-rendered page data
-        setTranslations(
-            (initialPageProps?.translations as Record<string, string>) ?? {},
-        );
+        // Translations and the currency scale, both read before the first
+        // paint. Seeded from the server-rendered page data, then kept in sync on
+        // every Inertia navigation.
+        seedPageState(initialPageProps);
 
-        // How many decimals each currency's minor unit has. Every amount is
-        // divided by this before rendering, so it has to be in place before the
-        // first paint.
-        setCurrencyDecimals(initialPageProps?.currencies?.decimals);
-
-        // Keep translations in sync on every Inertia navigation
         router.on('navigate', (event) => {
             const pageProps = event.detail.page.props as unknown as SharedData;
-            setTranslations(
-                (pageProps?.translations as Record<string, string>) ?? {},
-            );
-            setCurrencyDecimals(pageProps?.currencies?.decimals);
 
+            seedPageState(pageProps);
             void syncUserTimezone(pageProps);
         });
 

--- a/resources/js/lib/page-state.test.ts
+++ b/resources/js/lib/page-state.test.ts
@@ -1,0 +1,27 @@
+import { seedPageState } from '@/lib/page-state';
+import { formatCurrency } from '@/utils/currency';
+import { __ } from '@/utils/i18n';
+import { describe, expect, it } from 'vitest';
+
+describe('seedPageState', () => {
+    it('seeds the translations a render reads before its first paint', () => {
+        seedPageState({ translations: { Summary: 'Resumen' } });
+
+        expect(__('Summary')).toBe('Resumen');
+    });
+
+    it('seeds the currency scale from the server table', () => {
+        seedPageState({
+            currencies: { profile: [], accounts: [], decimals: { BTC: 8 } },
+        });
+
+        expect(formatCurrency(1, 'BTC', 'en-US')).toContain('0.00000001');
+    });
+
+    it('clears both when the page carries neither', () => {
+        seedPageState({ translations: { Summary: 'Resumen' } });
+        seedPageState(undefined);
+
+        expect(__('Summary')).toBe('Summary');
+    });
+});

--- a/resources/js/lib/page-state.ts
+++ b/resources/js/lib/page-state.ts
@@ -1,0 +1,18 @@
+import type { SharedData } from '@/types';
+import { setCurrencyDecimals } from '@/utils/currency';
+import { setTranslations } from '@/utils/i18n';
+
+/**
+ * Seed the module-level state that every render reads before its first paint
+ * from the Inertia page props.
+ *
+ * One function rather than a pair of calls at each site, because the sites
+ * drifted: `app.tsx` seeded both, `ssr.tsx` only the currency scale, so the
+ * server-rendered pass emitted English copy to a Spanish reader and flipped to
+ * the translation on hydration. Anything else a render has to know before its
+ * first paint belongs here too, for the same reason.
+ */
+export function seedPageState(props: Partial<SharedData> | undefined): void {
+    setTranslations(props?.translations ?? {});
+    setCurrencyDecimals(props?.currencies?.decimals);
+}

--- a/resources/js/pages/monthly-summaries/index.test.tsx
+++ b/resources/js/pages/monthly-summaries/index.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment node
+//
+// Node, not jsdom, on purpose: this page is server-rendered, and the bug this
+// guards against - reading the locale off `document.documentElement` during
+// render - only shows up where there is no `document`. Under jsdom it passes
+// either way while production SSR keeps failing.
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import MonthlySummariesIndex from './index';
+
+vi.mock('@inertiajs/react', () => ({
+    Head: () => null,
+    Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+    usePage: () => ({ props: { locale: 'en' } }),
+}));
+
+vi.mock('@/layouts/app-layout', () => ({
+    default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const summary = {
+    id: '01a05c04-4125-722f-a229-273a346f35b2',
+    period: '2026-01',
+    card: 'streak',
+    complete: true,
+    sent_at: '2026-02-03T09:00:00Z',
+    shared: false,
+    payload: { cashflow: { savings_rate: 21 } },
+};
+
+describe('MonthlySummariesIndex', () => {
+    it('renders without a DOM, as the SSR server does', () => {
+        const html = renderToStaticMarkup(
+            <MonthlySummariesIndex summaries={[summary]} />,
+        );
+
+        expect(html).toContain('January 2026');
+        expect(html).toContain('21% saved');
+    });
+
+    it('renders the empty state without a DOM', () => {
+        const html = renderToStaticMarkup(
+            <MonthlySummariesIndex summaries={[]} />,
+        );
+
+        expect(html).toContain('Nothing here yet');
+    });
+});

--- a/resources/js/pages/monthly-summaries/index.tsx
+++ b/resources/js/pages/monthly-summaries/index.tsx
@@ -2,6 +2,7 @@ import {
     index,
     show,
 } from '@/actions/App/Http/Controllers/MonthlySummaryController';
+import { useLocale } from '@/hooks/use-locale';
 import AppLayout from '@/layouts/app-layout';
 import { type BreadcrumbItem } from '@/types';
 import { __ } from '@/utils/i18n';
@@ -46,7 +47,7 @@ function monthLabel(period: string, locale: string): string {
 }
 
 export default function MonthlySummariesIndex({ summaries }: Props) {
-    const locale = document.documentElement.lang || 'en';
+    const locale = useLocale();
 
     return (
         <AppLayout breadcrumbs={breadcrumbs}>

--- a/resources/js/ssr.tsx
+++ b/resources/js/ssr.tsx
@@ -5,8 +5,8 @@ import ReactDOMServer from 'react-dom/server';
 import { EncryptionKeyProvider } from './contexts/encryption-key-context';
 import { PrivacyModeProvider } from './contexts/privacy-mode-context';
 import { SyncProvider } from './contexts/sync-context';
+import { seedPageState } from './lib/page-state';
 import type { SharedData } from './types';
-import { setCurrencyDecimals } from './utils/currency';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 
@@ -34,9 +34,9 @@ createServer((page) =>
                 (initialPageProps?.hasEncryptionSetup as boolean) ?? false;
 
             // Without this the server-rendered pass falls back to the CLDR
-            // scale, which disagrees with the client on BTC and would swap the
-            // amount on hydration.
-            setCurrencyDecimals(initialPageProps?.currencies?.decimals);
+            // scale and to the untranslated keys, both of which disagree with
+            // the client and would swap the text on hydration.
+            seedPageState(initialPageProps);
 
             return (
                 <EncryptionKeyProvider hasEncryptionSetup={hasEncryptionSetup}>

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,31 +1,39 @@
 import '@testing-library/jest-dom/vitest';
 import { beforeEach } from 'vitest';
 
-/**
- * jsdom exposes `window.localStorage` as a getter that hands back undefined, so
- * every test sees what a browser with site data blocked sees. Give the suite a
- * working in-memory Storage, emptied between tests; the tests that care about a
- * hostile localStorage still replace it themselves (see lib/safe-storage.test.ts).
- */
 const store = new Map<string, string>();
 
-Object.defineProperty(window, 'localStorage', {
-    configurable: true,
-    value: {
-        getItem: (key: string) => store.get(key) ?? null,
-        setItem: (key: string, value: string) => void store.set(key, value),
-        removeItem: (key: string) => void store.delete(key),
-        clear: () => store.clear(),
-    },
-});
-
 /**
- * jsdom ships no `PointerEvent`, so `fireEvent.pointerDown` falls back to a plain
- * `Event` and Radix triggers (dropdowns, selects) never open. `MouseEvent` already
- * carries the `button` / `ctrlKey` fields they check.
+ * Guarded because the suite also runs files under the `node` environment, where
+ * there is no `window` to patch - that is the whole point of those files, which
+ * render server-side and would otherwise never notice a page reaching for the
+ * DOM during render.
  */
-if (!('PointerEvent' in window)) {
-    window.PointerEvent = MouseEvent as unknown as typeof window.PointerEvent;
+if (typeof window !== 'undefined') {
+    /**
+     * jsdom exposes `window.localStorage` as a getter that hands back undefined, so
+     * every test sees what a browser with site data blocked sees. Give the suite a
+     * working in-memory Storage, emptied between tests; the tests that care about a
+     * hostile localStorage still replace it themselves (see lib/safe-storage.test.ts).
+     */
+    Object.defineProperty(window, 'localStorage', {
+        configurable: true,
+        value: {
+            getItem: (key: string) => store.get(key) ?? null,
+            setItem: (key: string, value: string) => void store.set(key, value),
+            removeItem: (key: string) => void store.delete(key),
+            clear: () => store.clear(),
+        },
+    });
+
+    /**
+     * jsdom ships no `PointerEvent`, so `fireEvent.pointerDown` falls back to a plain
+     * `Event` and Radix triggers (dropdowns, selects) never open. `MouseEvent` already
+     * carries the `button` / `ctrlKey` fields they check.
+     */
+    if (!('PointerEvent' in window)) {
+        window.PointerEvent = MouseEvent as unknown as typeof window.PointerEvent;
+    }
 }
 
 beforeEach(() => {


### PR DESCRIPTION
## What

Two SSR bugs, one behind the other.

**1. `/summaries` never server-rendered.** `resources/js/pages/monthly-summaries/index.tsx` read its locale off `document.documentElement.lang` during render. There is no `document` in the Node process that renders Inertia pages, so every request for `/summaries` threw `ReferenceError: document is not defined` and fell back to a client-only render — 9 `SsrException`s in production over 8 days, still firing this morning.

`useLocale()` reads the same value off the shared Inertia prop, which the server already has. Both sides come from `app()->getLocale()` (`HandleInertiaRequests::share()` and the `lang` attribute in `app.blade.php`), and the `Locale` enum has no region-qualified codes, so the string is byte-identical to what the DOM was handing back: **no month label changes for anyone**. The old `|| 'en'` fallback was dead — `app()->getLocale()` is never empty.

**2. The server-rendered pass had no translations.** Surfaced by fixing #1. `app.tsx` seeded both the translations and the currency scale from the page props; `ssr.tsx` seeded only the currency scale. So the server HTML carried the raw English keys and a Spanish or French reader watched the copy flip to their own language on hydration. Both sides now go through one `seedPageState()`, so the pair cannot drift again — the drift is what caused this.

Fixes PHP-LARAVEL-5H

## Verification

- New regression test runs under the **`node`** vitest environment on purpose. Under jsdom `document` exists, so the old code passes while production keeps failing; in node it reproduces the exact production `ReferenceError`. That required guarding the DOM patches in `vitest.setup.ts` behind `typeof window !== 'undefined'` — jsdom files are unaffected, they still get the patches.
- End-to-end against the real SSR server: posting a `monthly-summaries/index` page with a Spanish payload to `bootstrap/ssr/ssr.js` renders `Resúmenes mensuales` and `enero de 2026` in the server HTML, with no `SSR ERROR`. Before, the same request died on `document`.
- `bun run test` (663 tests), `bun run lint`, `bun run format`, `bun run dry`, `vite build`, `vite build --ssr` all green.

## Not in this PR

- `monthLabel()` in that page duplicates the job of `formatMonthYear()` / `formatMonthFromYearMonth()` in `utils/date.ts` — three code paths for "period → long month label", one via `Intl` and two via date-fns. Pre-existing, untouched here, and consolidating it would change the Spanish wording (`enero de 2026` vs `Enero 2026`). Worth its own PR.
- CI's `bun run build` only builds the client bundle, so an SSR-only break is invisible to it. Building the SSR bundle would not have caught this either — the failure is at render time, not build time. A real guard would be a smoke render of each page against `ssr.js`.