### PR TITLE
feat(connections): let a bank consent be renewed before it expires

### DIFF
--- a/app/Console/Commands/SendConnectionExpiringEmailsCommand.php
+++ b/app/Console/Commands/SendConnectionExpiringEmailsCommand.php
@@ -6,8 +6,8 @@ use App\Enums\BankingConnectionStatus;
 use App\Enums\BankingProvider;
 use App\Jobs\Drip\SendConnectionExpiringEmailJob;
 use App\Models\BankingConnection;
+use App\Models\User;
 use Illuminate\Console\Command;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 
 class SendConnectionExpiringEmailsCommand extends Command
@@ -39,7 +39,11 @@ class SendConnectionExpiringEmailsCommand extends Command
             ->where('status', BankingConnectionStatus::Active)
             ->where('valid_until', '>', now())
             ->where('valid_until', '<', now()->addDays(BankingConnection::EXPIRY_WARNING_DAYS))
-            ->whereHas('user', fn (Builder $query) => $query->excludingSharedAccounts())
+            // Doing double duty: the subquery drops the demo and press accounts,
+            // whose mail nobody reads, and its own global scope drops deleted
+            // users, whose connection would otherwise reach a job with no
+            // recipient to hand the mail to.
+            ->whereIn('user_id', User::query()->excludingSharedAccounts()->select('id'))
             ->with('user')
             ->chunkById(100, function (Collection $connections) use (&$queued): void {
                 foreach ($connections as $connection) {

--- a/app/Console/Commands/SendConnectionExpiringEmailsCommand.php
+++ b/app/Console/Commands/SendConnectionExpiringEmailsCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\BankingConnectionStatus;
+use App\Enums\BankingProvider;
+use App\Jobs\Drip\SendConnectionExpiringEmailJob;
+use App\Models\BankingConnection;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+
+class SendConnectionExpiringEmailsCommand extends Command
+{
+    protected $signature = 'email:connection-expiring';
+
+    protected $description = 'Warn users whose bank consent runs out within the week so they can renew it before syncing breaks';
+
+    public function handle(): int
+    {
+        if (! config('mail.drip_emails_enabled')) {
+            $this->info('Drip emails are disabled. Nothing to do.');
+
+            return self::SUCCESS;
+        }
+
+        $queued = 0;
+
+        // The whole window rather than the one day exactly a week out: a missed
+        // run must not cost the user their warning, and a bank that grants a
+        // consent shorter than the window would never match a single day.
+        // Re-dispatching for the same connection is free, because the job keys
+        // its mail log on the consent window and drops the repeats.
+        //
+        // Already-expired consents are deliberately absent: SyncBankingConnectionJob
+        // flips those to Expired and emails them itself.
+        BankingConnection::query()
+            ->where('provider', BankingProvider::EnableBanking)
+            ->where('status', BankingConnectionStatus::Active)
+            ->whereBetween('valid_until', [now(), now()->addDays(BankingConnection::EXPIRY_WARNING_DAYS)])
+            ->whereHas('user', fn (Builder $query) => $query->excludingSharedAccounts())
+            ->with('user')
+            ->chunkById(100, function (Collection $connections) use (&$queued): void {
+                foreach ($connections as $connection) {
+                    SendConnectionExpiringEmailJob::dispatch($connection->user, $connection);
+                    $queued++;
+                }
+            });
+
+        $this->info("Queued {$queued} connection-expiring email(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/SendConnectionExpiringEmailsCommand.php
+++ b/app/Console/Commands/SendConnectionExpiringEmailsCommand.php
@@ -37,7 +37,8 @@ class SendConnectionExpiringEmailsCommand extends Command
         BankingConnection::query()
             ->where('provider', BankingProvider::EnableBanking)
             ->where('status', BankingConnectionStatus::Active)
-            ->whereBetween('valid_until', [now(), now()->addDays(BankingConnection::EXPIRY_WARNING_DAYS)])
+            ->where('valid_until', '>', now())
+            ->where('valid_until', '<', now()->addDays(BankingConnection::EXPIRY_WARNING_DAYS))
             ->whereHas('user', fn (Builder $query) => $query->excludingSharedAccounts())
             ->with('user')
             ->chunkById(100, function (Collection $connections) use (&$queued): void {

--- a/app/Enums/DripEmailType.php
+++ b/app/Enums/DripEmailType.php
@@ -17,6 +17,7 @@ enum DripEmailType: string
     case BankOutage = 'bank_outage';
     case BankConnectFailed = 'bank_connect_failed';
     case BankNotice = 'bank_notice';
+    case ConnectionExpiring = 'connection_expiring';
     case InactiveNoBank = 'inactive_no_bank';
     case TrialEnding = 'trial_ending';
     case MonthlySummary = 'monthly_summary';

--- a/app/Http/Controllers/OpenBanking/AuthorizationController.php
+++ b/app/Http/Controllers/OpenBanking/AuthorizationController.php
@@ -135,8 +135,17 @@ class AuthorizationController extends Controller
             return ['error' => 'Only EnableBanking connections can be re-authorized.'];
         }
 
-        if ($connection->status !== BankingConnectionStatus::Error && ! $connection->isExpired()) {
-            return ['error' => 'Only connections with an error or expired status can be re-authorized.'];
+        // Active is in here so the user can renew a healthy consent before it
+        // lapses: the alternative is a few days of broken syncing at the end of
+        // every window. Which day the offer appears is the UI's and the warning
+        // email's business, not this gate's.
+        $renewable = $connection->isExpired() || in_array($connection->status, [
+            BankingConnectionStatus::Active,
+            BankingConnectionStatus::Error,
+        ], true);
+
+        if (! $renewable) {
+            return ['error' => 'Only active, error or expired connections can be re-authorized.'];
         }
 
         $redirectUrl = config('services.enablebanking.redirect_url');

--- a/app/Http/Controllers/OpenBanking/AuthorizationController.php
+++ b/app/Http/Controllers/OpenBanking/AuthorizationController.php
@@ -139,10 +139,9 @@ class AuthorizationController extends Controller
         // lapses: the alternative is a few days of broken syncing at the end of
         // every window. Which day the offer appears is the UI's and the warning
         // email's business, not this gate's.
-        $renewable = $connection->isExpired() || in_array($connection->status, [
-            BankingConnectionStatus::Active,
-            BankingConnectionStatus::Error,
-        ], true);
+        $renewable = $connection->isActive()
+            || $connection->isExpired()
+            || $connection->status === BankingConnectionStatus::Error;
 
         if (! $renewable) {
             return ['error' => 'Only active, error or expired connections can be re-authorized.'];
@@ -161,7 +160,14 @@ class AuthorizationController extends Controller
         $connection->update([
             'authorization_id' => $result['authorization_id'],
             'state_token' => $stateToken,
-            'status' => BankingConnectionStatus::Pending,
+            // A healthy connection stays Active through an early renewal. Its
+            // current consent still works, so syncing carries on while the user
+            // is at the bank, and abandoning the flow there leaves a working
+            // connection working. Only an unusable one has nothing to lose by
+            // going Pending.
+            'status' => $connection->isActive()
+                ? BankingConnectionStatus::Active
+                : BankingConnectionStatus::Pending,
             'error_message' => null,
         ]);
 
@@ -350,7 +356,13 @@ class AuthorizationController extends Controller
             'connection_id' => $connection?->id,
         ]);
 
-        if ($connection) {
+        // An Active connection can only be here because the user started an
+        // early renewal and did not finish it. Backing out of the bank's screen
+        // is a perfectly reasonable thing to do, and the consent the connection
+        // already holds is untouched, so it keeps syncing as if nothing had
+        // happened. Only a connection that was already unusable is recorded as
+        // failed - or dropped, when there is nothing behind it yet.
+        if ($connection && ! $connection->isActive()) {
             if ($connection->accounts()->exists()) {
                 $connection->update([
                     'status' => BankingConnectionStatus::Error,

--- a/app/Jobs/Drip/SendConnectionExpiringEmailJob.php
+++ b/app/Jobs/Drip/SendConnectionExpiringEmailJob.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Jobs\Drip;
+
+use App\Enums\DripEmailType;
+use App\Mail\Drip\ConnectionExpiringEmail;
+use App\Models\BankingConnection;
+use App\Models\User;
+use Illuminate\Mail\Mailable;
+
+class SendConnectionExpiringEmailJob extends SendDripEmailJob
+{
+    public function __construct(User $user, public BankingConnection $bankingConnection)
+    {
+        parent::__construct($user);
+    }
+
+    protected function emailType(): DripEmailType
+    {
+        return DripEmailType::ConnectionExpiring;
+    }
+
+    protected function buildMail(): Mailable
+    {
+        return new ConnectionExpiringEmail($this->user, $this->bankingConnection);
+    }
+
+    /**
+     * Keyed on the consent window rather than the type, so the user gets one
+     * warning per window and a fresh one when the next window runs out. It is
+     * also what makes the daily command idempotent: it re-dispatches this job
+     * every day the connection is inside the warning window.
+     */
+    protected function emailIdentifier(): string
+    {
+        return $this->bankingConnection->id.':'.$this->bankingConnection->valid_until?->toDateString();
+    }
+
+    /**
+     * Re-checked at send time: between the command queueing this and the queue
+     * getting to it the user may have renewed the consent, which pushes
+     * `valid_until` months out, or disconnected the bank altogether.
+     */
+    protected function shouldSend(): bool
+    {
+        return ! $this->bankingConnection->trashed()
+            && $this->bankingConnection->isActive()
+            && $this->bankingConnection->isExpiringSoon();
+    }
+}

--- a/app/Mail/Drip/ConnectionExpiringEmail.php
+++ b/app/Mail/Drip/ConnectionExpiringEmail.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Mail\Drip;
+
+use App\Models\BankingConnection;
+use App\Models\User;
+
+class ConnectionExpiringEmail extends DripMail
+{
+    public function __construct(User $user, public BankingConnection $bankingConnection)
+    {
+        parent::__construct($user);
+    }
+
+    protected function dripSubject(): string
+    {
+        return __('Your :provider connection expires soon', [
+            'provider' => $this->bankingConnection->aspsp_name,
+        ]);
+    }
+
+    protected function template(): string
+    {
+        return 'mail.drip.connection-expiring';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function contentData(): array
+    {
+        return [
+            'providerName' => $this->bankingConnection->aspsp_name,
+            'expiresOn' => $this->bankingConnection->valid_until?->locale(app()->getLocale())->isoFormat('LL'),
+            'reconnectUrl' => route('open-banking.reconnect', [
+                $this->bankingConnection,
+                ...$this->utmParameters(),
+            ]),
+        ];
+    }
+
+    protected function repliesToSender(): bool
+    {
+        return true;
+    }
+}

--- a/app/Models/BankingConnection.php
+++ b/app/Models/BankingConnection.php
@@ -36,6 +36,13 @@ class BankingConnection extends Model
     /** @use HasFactory<BankingConnectionFactory> */
     use BelongsToSpace, HasFactory, HasUuids, SoftDeletes;
 
+    /**
+     * How many days before `valid_until` the consent counts as expiring soon:
+     * the window in which we warn the user by email and offer an early renewal,
+     * so a consent never lapses into days of broken syncing.
+     */
+    public const EXPIRY_WARNING_DAYS = 7;
+
     protected $fillable = [
         'user_id',
         'space_id',
@@ -213,6 +220,18 @@ class BankingConnection extends Model
     {
         return $this->status === BankingConnectionStatus::Expired
             || ($this->valid_until && $this->valid_until->isPast());
+    }
+
+    /**
+     * Whether the consent is close enough to running out that the user should
+     * renew it now, before syncing breaks. Only EnableBanking connections carry
+     * a `valid_until`, so nothing else is ever expiring soon.
+     */
+    public function isExpiringSoon(): bool
+    {
+        return $this->valid_until !== null
+            && ! $this->isExpired()
+            && $this->valid_until->isBefore(now()->addDays(self::EXPIRY_WARNING_DAYS));
     }
 
     public function isRateLimited(): bool

--- a/lang/es.json
+++ b/lang/es.json
@@ -2830,5 +2830,12 @@
     "Monthly summary": "Resumen mensual",
     "A report of the month just closed, with what changed and a few things worth five minutes. Turning it off also stops the reminder that goes with it.": "Un informe del mes que acaba de cerrar, con lo que ha cambiado y unas cuantas cosas que merecen cinco minutos. Al desactivarlo también se desactiva el recordatorio que lo acompaña.",
     ":count months in a row in the black, and the best of them.": ":count meses seguidos en positivo, y el mejor de todos.",
-    ":count months in a row in the black.": ":count meses seguidos en positivo."
+    ":count months in a row in the black.": ":count meses seguidos en positivo.",
+    "Your :provider connection expires soon": "Tu conexión con :provider caduca pronto",
+    "Renew your :provider connection": "Renueva tu conexión con :provider",
+    "Banks only let us sync for a limited time, and the permission you gave us for :provider runs out on :date. Once it does, new transactions stop arriving until you renew it.": "Los bancos solo nos dejan sincronizar durante un tiempo limitado, y el permiso que nos diste para :provider caduca el :date. Cuando lo haga, dejarán de llegar movimientos nuevos hasta que lo renueves.",
+    "You can renew it right now, before it runs out, and nothing will stop syncing. It takes the same two minutes as connecting the bank did.": "Puedes renovarlo ahora mismo, antes de que caduque, y no se interrumpirá la sincronización. Se tarda los mismos dos minutos que al conectar el banco.",
+    "Renew Connection": "Renovar conexión",
+    "Expiring soon": "Caduca pronto",
+    "Your bank only grants access for a limited time, and this permission runs out shortly. Renew it now and your transactions keep arriving without a gap.": "Tu banco solo concede acceso durante un tiempo limitado, y este permiso caduca en breve. Renuévalo ahora y tus movimientos seguirán llegando sin interrupciones."
 }

--- a/resources/js/components/open-banking/connection-status-badge.tsx
+++ b/resources/js/components/open-banking/connection-status-badge.tsx
@@ -1,6 +1,6 @@
 import { Badge } from '@/components/ui/badge';
 import { Spinner } from '@/components/ui/spinner';
-import { isWaitingForBank } from '@/lib/banking-connections';
+import { isExpiringSoon, isWaitingForBank } from '@/lib/banking-connections';
 import type { BankingConnection } from '@/types/banking';
 import { __ } from '@/utils/i18n';
 
@@ -58,6 +58,14 @@ export function ConnectionStatusBadge({
         return (
             <Badge variant="secondary" className={AMBER_BADGE}>
                 {__('Waiting for the bank')}
+            </Badge>
+        );
+    }
+
+    if (isExpiringSoon(connection)) {
+        return (
+            <Badge variant="secondary" className={AMBER_BADGE}>
+                {__('Expiring soon')}
             </Badge>
         );
     }

--- a/resources/js/lib/banking-connections.test.ts
+++ b/resources/js/lib/banking-connections.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
     alreadyConnectedBankNames,
     hasLiveConnectionForProvider,
+    isExpiringSoon,
 } from './banking-connections';
 
 function connection(
@@ -78,5 +79,55 @@ describe('hasLiveConnectionForProvider', () => {
         expect(hasLiveConnectionForProvider(connections, 'coinbase')).toBe(
             false,
         );
+    });
+});
+
+describe('isExpiringSoon', () => {
+    const inDays = (days: number) =>
+        new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
+
+    it('is true inside the last week of the consent window', () => {
+        expect(isExpiringSoon(connection({ valid_until: inDays(1) }))).toBe(
+            true,
+        );
+        expect(isExpiringSoon(connection({ valid_until: inDays(6.9) }))).toBe(
+            true,
+        );
+    });
+
+    it('is false while the consent still has more than a week to run', () => {
+        expect(isExpiringSoon(connection({ valid_until: inDays(7.1) }))).toBe(
+            false,
+        );
+        expect(isExpiringSoon(connection({ valid_until: inDays(90) }))).toBe(
+            false,
+        );
+    });
+
+    it('is false once the consent has lapsed - that is expired, not expiring', () => {
+        expect(isExpiringSoon(connection({ valid_until: inDays(-1) }))).toBe(
+            false,
+        );
+        expect(
+            isExpiringSoon(
+                connection({ status: 'expired', valid_until: inDays(-1) }),
+            ),
+        ).toBe(false);
+    });
+
+    it('is false for connections that carry no consent at all', () => {
+        expect(
+            isExpiringSoon(
+                connection({ provider: 'binance', valid_until: null }),
+            ),
+        ).toBe(false);
+    });
+
+    it('is false for a connection that is not active', () => {
+        expect(
+            isExpiringSoon(
+                connection({ status: 'error', valid_until: inDays(2) }),
+            ),
+        ).toBe(false);
     });
 });

--- a/resources/js/lib/banking-connections.ts
+++ b/resources/js/lib/banking-connections.ts
@@ -76,6 +76,32 @@ export function isWaitingForBank(connection: BankingConnection): boolean {
 }
 
 /**
+ * How many days before `valid_until` a consent counts as expiring soon. Mirrors
+ * `BankingConnection::EXPIRY_WARNING_DAYS`, which drives the warning email.
+ */
+const EXPIRY_WARNING_DAYS = 7;
+
+/**
+ * Whether the consent is close enough to running out that the user should renew
+ * it now, while syncing still works. Only EnableBanking connections carry a
+ * `valid_until`, so nothing else is ever expiring soon; an already-lapsed one is
+ * expired, not expiring.
+ */
+export function isExpiringSoon(connection: BankingConnection): boolean {
+    if (connection.status !== 'active' || !connection.valid_until) {
+        return false;
+    }
+
+    const msUntilExpiry =
+        new Date(connection.valid_until).getTime() - Date.now();
+
+    return (
+        msUntilExpiry > 0 &&
+        msUntilExpiry < EXPIRY_WARNING_DAYS * 24 * 60 * 60 * 1000
+    );
+}
+
+/**
  * Whether the user may spend an access call on demand. Computed server-side from
  * the backoff, which is the enforcing side too; the flag is only present on the
  * connections page payload.

--- a/resources/js/pages/settings/connections.test.tsx
+++ b/resources/js/pages/settings/connections.test.tsx
@@ -131,6 +131,47 @@ describe('ConnectionsPage', () => {
         ).toHaveLength(2);
     });
 
+    it('offers an early renewal on a consent that is about to run out', () => {
+        render(
+            <ConnectionsPage
+                connections={[
+                    makeConnection({
+                        valid_until: new Date(
+                            Date.now() + 3 * 24 * 60 * 60 * 1000,
+                        ).toISOString(),
+                    }),
+                ]}
+            />,
+        );
+
+        expect(screen.getByText(/expiring soon/i)).toBeInTheDocument();
+        expect(
+            screen.getByText(/only grants access for a limited time/i),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: /reconnect/i }),
+        ).toBeInTheDocument();
+    });
+
+    it('says nothing about expiry while the consent still has months to run', () => {
+        render(
+            <ConnectionsPage
+                connections={[
+                    makeConnection({
+                        valid_until: new Date(
+                            Date.now() + 90 * 24 * 60 * 60 * 1000,
+                        ).toISOString(),
+                    }),
+                ]}
+            />,
+        );
+
+        expect(screen.queryByText(/expiring soon/i)).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: /reconnect/i }),
+        ).not.toBeInTheDocument();
+    });
+
     it('polls and spins while a first sync is genuinely running', () => {
         render(
             <ConnectionsPage

--- a/resources/js/pages/settings/connections.tsx
+++ b/resources/js/pages/settings/connections.tsx
@@ -47,11 +47,23 @@ import {
     Unplug,
     Wallet,
 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 import { toast } from 'sonner';
 
 interface Props {
     connections: BankingConnection[];
+}
+
+/** The amber "nothing is broken, but do something" notice under a card. */
+function AmberNotice({ children }: { children: ReactNode }) {
+    return (
+        <Alert className="mt-3 border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-300">
+            <Clock />
+            <AlertDescription className="text-amber-700 dark:text-amber-300">
+                {children}
+            </AlertDescription>
+        </Alert>
+    );
 }
 
 /** The same button in the card header, the expiry notice and the error box. */
@@ -451,50 +463,43 @@ export default function ConnectionsPage({ connections }: Props) {
                                             )}
                                         </div>
                                         {isWaitingForBank(connection) && (
-                                            <Alert className="mt-3 border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-300">
-                                                <Clock />
-                                                <AlertDescription className="text-amber-700 dark:text-amber-300">
+                                            <AmberNotice>
+                                                <p>
+                                                    {__(
+                                                        'Your bank limits how often we can fetch your data. We will retry automatically.',
+                                                    )}
+                                                </p>
+                                                {connection.next_sync_attempt_at && (
                                                     <p>
-                                                        {__(
-                                                            'Your bank limits how often we can fetch your data. We will retry automatically.',
+                                                        {__('Next attempt')}:{' '}
+                                                        {formatDate(
+                                                            connection.next_sync_attempt_at,
                                                         )}
                                                     </p>
-                                                    {connection.next_sync_attempt_at && (
-                                                        <p>
-                                                            {__('Next attempt')}
-                                                            :{' '}
-                                                            {formatDate(
-                                                                connection.next_sync_attempt_at,
-                                                            )}
-                                                        </p>
-                                                    )}
-                                                </AlertDescription>
-                                            </Alert>
+                                                )}
+                                            </AmberNotice>
                                         )}
                                         {isExpiringSoon(connection) && (
-                                            <Alert className="mt-3 border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-300">
-                                                <Clock />
-                                                <AlertDescription className="text-amber-700 dark:text-amber-300">
-                                                    <p>
-                                                        {__(
-                                                            'Your bank only grants access for a limited time, and this permission runs out shortly. Renew it now and your transactions keep arriving without a gap.',
-                                                        )}
-                                                    </p>
-                                                    <ReconnectButton
-                                                        variant="secondary"
-                                                        className="h-7 text-xs"
-                                                        reconnecting={
-                                                            reconnectingId ===
-                                                            connection.id
-                                                        }
-                                                        onClick={() =>
-                                                            handleReconnect(
-                                                                connection,
-                                                            )
-                                                        }
-                                                    />
-                                                </AlertDescription>
-                                            </Alert>
+                                            <AmberNotice>
+                                                <p>
+                                                    {__(
+                                                        'Your bank only grants access for a limited time, and this permission runs out shortly. Renew it now and your transactions keep arriving without a gap.',
+                                                    )}
+                                                </p>
+                                                <ReconnectButton
+                                                    variant="secondary"
+                                                    className="h-7 text-xs"
+                                                    reconnecting={
+                                                        reconnectingId ===
+                                                        connection.id
+                                                    }
+                                                    onClick={() =>
+                                                        handleReconnect(
+                                                            connection,
+                                                        )
+                                                    }
+                                                />
+                                            </AmberNotice>
                                         )}
                                         {connection.status === 'error' && (
                                             <div className="mt-3 rounded-lg border border-destructive/30 bg-destructive/5 p-3 dark:bg-destructive/10">

--- a/resources/js/pages/settings/connections.tsx
+++ b/resources/js/pages/settings/connections.tsx
@@ -25,6 +25,7 @@ import AppLayout from '@/layouts/app-layout';
 import SettingsLayout from '@/layouts/settings/layout';
 import {
     canSyncManually,
+    isExpiringSoon,
     isFirstSyncRunning,
     isWaitingForBank,
 } from '@/lib/banking-connections';
@@ -51,6 +52,36 @@ import { toast } from 'sonner';
 
 interface Props {
     connections: BankingConnection[];
+}
+
+/** The same button in the card header, the expiry notice and the error box. */
+function ReconnectButton({
+    reconnecting,
+    onClick,
+    variant,
+    className,
+}: {
+    reconnecting: boolean;
+    onClick: () => void;
+    variant?: 'default' | 'secondary';
+    className?: string;
+}) {
+    return (
+        <Button
+            size="sm"
+            variant={variant}
+            className={className}
+            disabled={reconnecting}
+            onClick={onClick}
+        >
+            {reconnecting ? (
+                <Spinner className="mr-1.5 size-3" />
+            ) : (
+                <RotateCcw className="mr-1.5 h-3 w-3" />
+            )}
+            {__('Reconnect')}
+        </Button>
+    );
 }
 
 export default function ConnectionsPage({ connections }: Props) {
@@ -158,6 +189,7 @@ export default function ConnectionsPage({ connections }: Props) {
         return (
             connection.provider === 'enablebanking' &&
             (connection.status === 'expired' ||
+                isExpiringSoon(connection) ||
                 isEnableBankingAuthError(connection))
         );
     }
@@ -246,9 +278,8 @@ export default function ConnectionsPage({ connections }: Props) {
                                             />
                                             {connection.status === 'expired' &&
                                                 canReconnect(connection) && (
-                                                    <Button
-                                                        size="sm"
-                                                        disabled={
+                                                    <ReconnectButton
+                                                        reconnecting={
                                                             reconnectingId ===
                                                             connection.id
                                                         }
@@ -257,15 +288,7 @@ export default function ConnectionsPage({ connections }: Props) {
                                                                 connection,
                                                             )
                                                         }
-                                                    >
-                                                        {reconnectingId ===
-                                                        connection.id ? (
-                                                            <Spinner className="mr-1.5 size-3" />
-                                                        ) : (
-                                                            <RotateCcw className="mr-1.5 h-3 w-3" />
-                                                        )}
-                                                        {__('Reconnect')}
-                                                    </Button>
+                                                    />
                                                 )}
                                             <DropdownMenu>
                                                 <DropdownMenuTrigger asChild>
@@ -448,6 +471,31 @@ export default function ConnectionsPage({ connections }: Props) {
                                                 </AlertDescription>
                                             </Alert>
                                         )}
+                                        {isExpiringSoon(connection) && (
+                                            <Alert className="mt-3 border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-300">
+                                                <Clock />
+                                                <AlertDescription className="text-amber-700 dark:text-amber-300">
+                                                    <p>
+                                                        {__(
+                                                            'Your bank only grants access for a limited time, and this permission runs out shortly. Renew it now and your transactions keep arriving without a gap.',
+                                                        )}
+                                                    </p>
+                                                    <ReconnectButton
+                                                        variant="secondary"
+                                                        className="h-7 text-xs"
+                                                        reconnecting={
+                                                            reconnectingId ===
+                                                            connection.id
+                                                        }
+                                                        onClick={() =>
+                                                            handleReconnect(
+                                                                connection,
+                                                            )
+                                                        }
+                                                    />
+                                                </AlertDescription>
+                                            </Alert>
+                                        )}
                                         {connection.status === 'error' && (
                                             <div className="mt-3 rounded-lg border border-destructive/30 bg-destructive/5 p-3 dark:bg-destructive/10">
                                                 <div className="flex items-start gap-2">
@@ -489,11 +537,10 @@ export default function ConnectionsPage({ connections }: Props) {
                                                             {isEnableBankingAuthError(
                                                                 connection,
                                                             ) ? (
-                                                                <Button
+                                                                <ReconnectButton
                                                                     variant="secondary"
-                                                                    size="sm"
                                                                     className="h-7 text-xs"
-                                                                    disabled={
+                                                                    reconnecting={
                                                                         reconnectingId ===
                                                                         connection.id
                                                                     }
@@ -502,17 +549,7 @@ export default function ConnectionsPage({ connections }: Props) {
                                                                             connection,
                                                                         )
                                                                     }
-                                                                >
-                                                                    {reconnectingId ===
-                                                                    connection.id ? (
-                                                                        <Spinner className="mr-1.5 size-3" />
-                                                                    ) : (
-                                                                        <RotateCcw className="mr-1.5 h-3 w-3" />
-                                                                    )}
-                                                                    {__(
-                                                                        'Reconnect',
-                                                                    )}
-                                                                </Button>
+                                                                />
                                                             ) : (
                                                                 <Button
                                                                     variant="secondary"

--- a/resources/views/mail/drip/connection-expiring.blade.php
+++ b/resources/views/mail/drip/connection-expiring.blade.php
@@ -1,0 +1,19 @@
+<x-mail::message>
+# {{ __('Renew your :provider connection', ['provider' => $providerName]) }}
+
+{{ __('Hi :name,', ['name' => $userName]) }}
+
+{{ __('Banks only let us sync for a limited time, and the permission you gave us for :provider runs out on :date. Once it does, new transactions stop arriving until you renew it.', ['provider' => $providerName, 'date' => $expiresOn]) }}
+
+{{ __('You can renew it right now, before it runs out, and nothing will stop syncing. It takes the same two minutes as connecting the bank did.') }}
+
+<x-mail::button :url="$reconnectUrl">
+{{ __('Renew Connection') }}
+</x-mail::button>
+
+{{ __('If the button does not work, open your connection settings and reconnect :provider from there.', ['provider' => $providerName]) }}
+
+{{ __('Best,') }}<br>
+{{ __('Álvaro & Víctor') }}<br>
+{{ __('Founders of Whisper Money') }}
+</x-mail::message>

--- a/routes/console.php
+++ b/routes/console.php
@@ -20,6 +20,7 @@ Schedule::command('loans:generate-balances')->monthlyOn(1, '00:00');
 Schedule::command('email:paywall-follow-up')->dailyAt('10:00')->timezone('Europe/Madrid');
 Schedule::command('email:ai-consent-follow-up')->dailyAt('10:15')->timezone('Europe/Madrid');
 Schedule::command('email:inactive-no-bank')->dailyAt('09:45')->timezone('Europe/Madrid');
+Schedule::command('email:connection-expiring')->dailyAt('09:50')->timezone('Europe/Madrid');
 Schedule::command('email:user-emails-report')->monthlyOn(1, '09:05')->timezone('Europe/Madrid');
 Schedule::command('banking:health --email')->dailyAt('09:30')->timezone('Europe/Madrid');
 Schedule::command('stats:daily-report')->dailyAt('09:00')->timezone('Europe/Madrid');

--- a/tests/Feature/Console/SendConnectionExpiringEmailsCommandTest.php
+++ b/tests/Feature/Console/SendConnectionExpiringEmailsCommandTest.php
@@ -1,0 +1,205 @@
+<?php
+
+use App\Enums\BankingConnectionStatus;
+use App\Enums\DripEmailType;
+use App\Jobs\Drip\SendConnectionExpiringEmailJob;
+use App\Mail\Drip\ConnectionExpiringEmail;
+use App\Models\BankingConnection;
+use App\Models\User;
+use App\Models\UserMailLog;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Mail;
+
+// Freeze time so a connection placed a fixed number of days from expiry cannot
+// drift across the edge of the warning window mid-test.
+beforeEach(fn () => $this->freezeTime());
+
+/**
+ * An active EnableBanking connection whose consent runs out in $inDays days.
+ *
+ * @param  array<string, mixed>  $attributes
+ */
+function expiringConnection(int $inDays = 3, array $attributes = []): BankingConnection
+{
+    return BankingConnection::factory()->create([
+        'valid_until' => now()->addDays($inDays),
+        ...$attributes,
+    ]);
+}
+
+it('queues the warning for a connection whose consent runs out inside the window', function () {
+    Bus::fake();
+
+    $connection = expiringConnection();
+
+    $this->artisan('email:connection-expiring')->assertSuccessful();
+
+    Bus::assertDispatched(
+        SendConnectionExpiringEmailJob::class,
+        fn (SendConnectionExpiringEmailJob $job): bool => $job->bankingConnection->is($connection)
+            && $job->user->is($connection->user),
+    );
+});
+
+it('leaves alone a consent with more than a week to run', function () {
+    Bus::fake();
+
+    expiringConnection(inDays: 8);
+
+    $this->artisan('email:connection-expiring')->assertSuccessful();
+
+    Bus::assertNotDispatched(SendConnectionExpiringEmailJob::class);
+});
+
+it('leaves the already-expired ones to the sync job, which emails them itself', function () {
+    Bus::fake();
+
+    BankingConnection::factory()->expired()->create();
+    expiringConnection(inDays: -1);
+
+    $this->artisan('email:connection-expiring')->assertSuccessful();
+
+    Bus::assertNotDispatched(SendConnectionExpiringEmailJob::class);
+});
+
+it('ignores connections that are not active', function (BankingConnectionStatus $status) {
+    Bus::fake();
+
+    expiringConnection(attributes: ['status' => $status]);
+
+    $this->artisan('email:connection-expiring')->assertSuccessful();
+
+    Bus::assertNotDispatched(SendConnectionExpiringEmailJob::class);
+})->with([
+    BankingConnectionStatus::Pending,
+    BankingConnectionStatus::AwaitingMapping,
+    BankingConnectionStatus::Revoked,
+    BankingConnectionStatus::Error,
+]);
+
+it('ignores providers that have no consent to renew', function () {
+    Bus::fake();
+
+    BankingConnection::factory()->indexaCapital()->create([
+        'valid_until' => now()->addDays(3),
+    ]);
+
+    $this->artisan('email:connection-expiring')->assertSuccessful();
+
+    Bus::assertNotDispatched(SendConnectionExpiringEmailJob::class);
+});
+
+it('leaves the shared demo account out of it', function () {
+    Bus::fake();
+
+    expiringConnection(attributes: [
+        'user_id' => User::factory()->create(['email' => config('app.demo.email')])->id,
+    ]);
+
+    $this->artisan('email:connection-expiring')->assertSuccessful();
+
+    Bus::assertNotDispatched(SendConnectionExpiringEmailJob::class);
+});
+
+it('does nothing when drip emails are disabled', function () {
+    config(['mail.drip_emails_enabled' => false]);
+    Bus::fake();
+
+    expiringConnection();
+
+    $this->artisan('email:connection-expiring')->assertSuccessful();
+
+    Bus::assertNotDispatched(SendConnectionExpiringEmailJob::class);
+});
+
+it('warns once per consent window however many days the command runs', function () {
+    Mail::fake();
+
+    $connection = expiringConnection(inDays: 6);
+
+    $this->artisan('email:connection-expiring')->assertSuccessful();
+    $this->travel(1)->days();
+    $this->artisan('email:connection-expiring')->assertSuccessful();
+
+    Mail::assertQueuedCount(1);
+    expect(UserMailLog::where('user_id', $connection->user_id)->count())->toBe(1);
+});
+
+it('sends the email and records a mail log keyed on the consent window', function () {
+    Mail::fake();
+
+    $connection = expiringConnection();
+
+    (new SendConnectionExpiringEmailJob($connection->user, $connection))->handle();
+
+    Mail::assertQueued(ConnectionExpiringEmail::class);
+
+    $log = UserMailLog::where('user_id', $connection->user_id)->sole();
+    expect($log->email_type)->toBe(DripEmailType::ConnectionExpiring);
+    expect($log->email_identifier)->toBe($connection->id.':'.$connection->valid_until->toDateString());
+});
+
+it('warns again once the next consent window is running out', function () {
+    Mail::fake();
+
+    $connection = expiringConnection();
+    (new SendConnectionExpiringEmailJob($connection->user, $connection))->handle();
+
+    // The user renewed, and months later that window is running out too.
+    $connection->update(['valid_until' => now()->addDays(3)->addMonths(3)]);
+    $this->travel(3)->months();
+
+    (new SendConnectionExpiringEmailJob($connection->user, $connection))->handle();
+
+    Mail::assertQueuedCount(2);
+    expect(UserMailLog::where('user_id', $connection->user_id)->count())->toBe(2);
+});
+
+it('does not send once the user has already renewed the consent', function () {
+    Mail::fake();
+
+    $connection = expiringConnection();
+
+    // Renewed between the command queueing the job and the queue running it.
+    $connection->update(['valid_until' => now()->addDays(90)]);
+
+    (new SendConnectionExpiringEmailJob($connection->user, $connection))->handle();
+
+    Mail::assertNothingQueued();
+    expect(UserMailLog::where('user_id', $connection->user_id)->count())->toBe(0);
+});
+
+it('does not send once the user has disconnected the bank', function () {
+    Mail::fake();
+
+    $connection = expiringConnection();
+    $connection->delete();
+
+    (new SendConnectionExpiringEmailJob($connection->user, $connection))->handle();
+
+    Mail::assertNothingQueued();
+});
+
+it('points its button at the reconnect route so the user can renew from the email', function () {
+    $connection = expiringConnection();
+
+    $html = (new ConnectionExpiringEmail($connection->user, $connection))->render();
+
+    expect($html)->toContain(route('open-banking.reconnect', $connection).'?utm_source=drip');
+});
+
+it('renders the email in the user locale', function () {
+    $connection = expiringConnection(attributes: ['aspsp_name' => 'Bankinter']);
+    $connection->user->update(['name' => 'Ada']);
+
+    app()->setLocale('es');
+
+    try {
+        $html = (new ConnectionExpiringEmail($connection->user->fresh(), $connection))->render();
+    } finally {
+        app()->setLocale('en');
+    }
+
+    expect($html)->toContain('Renueva tu conexión con Bankinter')
+        ->toContain('Renovar conexión');
+});

--- a/tests/Feature/OpenBanking/AuthorizationControllerTest.php
+++ b/tests/Feature/OpenBanking/AuthorizationControllerTest.php
@@ -451,17 +451,50 @@ test('reauthorize returns 422 for non-EnableBanking connections', function () {
     $response->assertJson(['error' => 'Only EnableBanking connections can be re-authorized.']);
 });
 
-test('reauthorize returns 422 for active connections', function () {
+test('reauthorize returns 422 for connections that are neither active, errored nor expired', function (BankingConnectionStatus $status) {
     $user = User::factory()->onboarded()->create();
     $connection = BankingConnection::factory()->create([
         'user_id' => $user->id,
-        'status' => BankingConnectionStatus::Active,
+        'status' => $status,
+        'valid_until' => now()->addDays(90),
     ]);
 
     $response = $this->actingAs($user)->postJson("/open-banking/connections/{$connection->id}/reauthorize");
 
     $response->assertUnprocessable();
-    $response->assertJson(['error' => 'Only connections with an error or expired status can be re-authorized.']);
+    $response->assertJson(['error' => 'Only active, error or expired connections can be re-authorized.']);
+})->with([
+    BankingConnectionStatus::Pending,
+    BankingConnectionStatus::AwaitingMapping,
+    BankingConnectionStatus::Revoked,
+]);
+
+test('reauthorize renews a healthy active connection so the consent never lapses', function () {
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->create([
+        'user_id' => $user->id,
+        'status' => BankingConnectionStatus::Active,
+        'valid_until' => now()->addDays(3),
+    ]);
+
+    $mockProvider = Mockery::mock(BankingProviderInterface::class);
+    $mockProvider->shouldReceive('startAuthorization')
+        ->once()
+        ->andReturn([
+            'url' => 'https://bank.example.com/reauthorize',
+            'authorization_id' => 'renewed-auth-id',
+        ]);
+
+    $this->app->instance(BankingProviderInterface::class, $mockProvider);
+
+    $response = $this->actingAs($user)->postJson("/open-banking/connections/{$connection->id}/reauthorize");
+
+    $response->assertOk();
+    $response->assertJson(['redirect_url' => 'https://bank.example.com/reauthorize']);
+
+    $connection->refresh();
+    expect($connection->status)->toBe(BankingConnectionStatus::Pending);
+    expect($connection->authorization_id)->toBe('renewed-auth-id');
 });
 
 test('reauthorize starts new authorization and sets connection to pending for error connections', function () {

--- a/tests/Feature/OpenBanking/AuthorizationControllerTest.php
+++ b/tests/Feature/OpenBanking/AuthorizationControllerTest.php
@@ -192,6 +192,33 @@ test('callback with error during reconnect preserves existing connection', funct
     expect($connection->error_message)->toBe('User denied access');
 });
 
+test('callback with error during an early renewal leaves the working connection alone', function () {
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->create([
+        'user_id' => $user->id,
+        'status' => BankingConnectionStatus::Active,
+        'valid_until' => now()->addDays(3),
+        'state_token' => 'state-token-renewal-abandoned',
+    ]);
+
+    Account::factory()->create([
+        'user_id' => $user->id,
+        'banking_connection_id' => $connection->id,
+    ]);
+
+    $response = $this->actingAs($user)
+        ->get('/open-banking/callback?error=access_denied&error_description=User+denied+access&state=state-token-renewal-abandoned');
+
+    $response->assertSessionHas('error', 'User denied access');
+
+    // The consent it already holds is untouched, so backing out of the bank's
+    // screen must not cost the user a connection that syncs fine.
+    $connection->refresh();
+    expect($connection->trashed())->toBeFalse();
+    expect($connection->status)->toBe(BankingConnectionStatus::Active);
+    expect($connection->error_message)->toBeNull();
+});
+
 test('callback with error and nothing pending still reports the error', function () {
     $user = User::factory()->onboarded()->create();
 
@@ -492,8 +519,10 @@ test('reauthorize renews a healthy active connection so the consent never lapses
     $response->assertOk();
     $response->assertJson(['redirect_url' => 'https://bank.example.com/reauthorize']);
 
+    // Active throughout, so syncing carries on with the consent it still has
+    // while the user is off at their bank.
     $connection->refresh();
-    expect($connection->status)->toBe(BankingConnectionStatus::Pending);
+    expect($connection->status)->toBe(BankingConnectionStatus::Active);
     expect($connection->authorization_id)->toBe('renewed-auth-id');
 });
 
@@ -657,6 +686,56 @@ test('callback with existing accounts updates session without creating new accou
 
     // No duplicate accounts should have been created
     $this->assertDatabaseCount('accounts', 1);
+
+    Queue::assertPushed(SyncBankingConnectionJob::class);
+});
+
+test('an early renewal pushes the consent window out without the connection ever breaking', function () {
+    Queue::fake();
+
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->create([
+        'user_id' => $user->id,
+        'status' => BankingConnectionStatus::Active,
+        'valid_until' => now()->addDays(3),
+        'state_token' => 'state-token-early-renewal',
+    ]);
+
+    Account::factory()->create([
+        'user_id' => $user->id,
+        'banking_connection_id' => $connection->id,
+        'external_account_id' => 'ext-account-renewed',
+    ]);
+
+    $mockProvider = Mockery::mock(BankingProviderInterface::class);
+    $mockProvider->shouldReceive('createSession')
+        ->with('test-code')
+        ->once()
+        ->andReturn([
+            'session_id' => 'renewed-session',
+            'accounts' => [
+                [
+                    'uid' => 'ext-account-renewed',
+                    'currency' => 'EUR',
+                    'name' => 'Renewed Account',
+                    'account_id' => ['iban' => 'ES1234567890123456789012'],
+                ],
+            ],
+            'access' => ['valid_until' => now()->addDays(90)->toIso8601String()],
+        ]);
+
+    $this->app->instance(BankingProviderInterface::class, $mockProvider);
+
+    $response = $this->actingAs($user)
+        ->get('/open-banking/callback?code=test-code&state=state-token-early-renewal');
+
+    $response->assertSessionHas('success', 'Bank account reconnected successfully.');
+
+    $connection->refresh();
+    expect($connection->status)->toBe(BankingConnectionStatus::Active);
+    expect($connection->session_id)->toBe('renewed-session');
+    expect($connection->valid_until->isAfter(now()->addDays(80)))->toBeTrue();
+    expect($connection->isExpiringSoon())->toBeFalse();
 
     Queue::assertPushed(SyncBankingConnectionJob::class);
 });


### PR DESCRIPTION
A consent window used to end with a few days of broken syncing: reconnecting was only possible once the connection had already expired or errored, so every user hit a gap between "your bank access ran out" and "you noticed and fixed it". From a week before `valid_until` they can now renew it in advance, and they get an email so they do not have to be in the app to find out.

## What changed

**The gate.** `startReauthorization()` accepts an Active EnableBanking connection too, not only an errored or expired one. The 7-day window drives the UI and the email; the gate itself stays a simple status check. The happy path needed nothing: `completeReconnect()` never assumed the old connection was broken.

**A healthy connection stays Active for the whole renewal.** It keeps the consent it already has, so syncing carries on while the user is off at their bank — and backing out of the bank's screen leaves the connection exactly as it was instead of flipping it to Error. Only a connection that was already unusable is recorded as failed. Without this, "I clicked Reconnect and changed my mind" would have cost the user a connection that was working fine.

**The window.** `BankingConnection::isExpiringSoon()` and `EXPIRY_WARNING_DAYS = 7`, mirrored by `isExpiringSoon()` in `resources/js/lib/banking-connections.ts` so the frontend computes it from `valid_until` rather than needing a new server-side flag. No new columns, no migration.

**Settings > Connections.** An amber "Expiring soon" badge and a notice under the card explaining that bank access is time-limited, with a Reconnect button in it — the same shape the "waiting for the bank" notice already used, now shared through one `AmberNotice`. The three Reconnect buttons on that page also became one `ReconnectButton`.

**The email.** `email:connection-expiring`, daily at 09:50 Europe/Madrid, over the existing drip infrastructure. The mail log is keyed on the consent window (`<connection id>:<valid_until date>`), so the user gets exactly one warning per window and a fresh one when the next window runs out — which is also what lets the command run every day of the window without sending twice. It is operational mail, so it is deliberately not in `DripEmailType::nudges()` and has no opt-out, exactly like the existing expired-connection email.

The already-expired path is untouched: `SyncBankingConnectionJob::markExpired()` still owns it and still sends `BankingConnectionExpiredEmail`.

## Tests

`SendConnectionExpiringEmailsCommandTest` covers the window edges, the statuses and providers that are skipped, the shared demo account, the drip kill switch, one-email-per-window across days, a fresh email for the next window, and the two ways the job stands down at send time (already renewed, bank disconnected). `AuthorizationControllerTest` covers the widened gate, the statuses still refused, an end-to-end early renewal pushing the window out, and an abandoned renewal leaving the connection Active. Vitest covers `isExpiringSoon()` at both edges and the page rendering the notice for one connection but not the other.

## Not in here

Hitting `open-banking.reconnect` when the provider itself errors still returns a raw 500 rather than a redirect with a flash message, because `startReauthorization()` does not guard the provider call. That is pre-existing behaviour on a pre-existing route — this branch does not change it — but the new email sends more traffic down that route, so it is worth a follow-up.

## Demo

<!-- PLACEHOLDER: drag the QA video here -->
