### PR TITLE
fix(summaries): hold the report when a Pro reader's analysis cannot be written

### DIFF
--- a/app/Console/Commands/PreviewMonthlySummaryCommand.php
+++ b/app/Console/Commands/PreviewMonthlySummaryCommand.php
@@ -11,9 +11,11 @@ use App\Services\MonthlySummary\AnalysisWriter;
 use App\Services\MonthlySummary\Summaries;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Mail\Mailable;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Traits\Localizable;
+use Laravel\Ai\Exceptions\FailoverableException;
 use Throwable;
 
 /**
@@ -198,7 +200,15 @@ class PreviewMonthlySummaryCommand extends Command
         return function () use (&$drafted, &$text, $user, $summary, $writer): string {
             if (! $drafted) {
                 $drafted = true;
-                $text = $writer->draft($summary, $user);
+
+                try {
+                    $text = $writer->draft($summary, $user);
+                } catch (ConnectionException|FailoverableException) {
+                    // A real send holds itself back and comes back later; a
+                    // preview has nowhere to come back to, and a stack trace
+                    // would say less than the warning below.
+                    $text = null;
+                }
 
                 if ($text === null) {
                     $this->warn('The model wrote nothing: falling back to the sample text.');

--- a/app/Jobs/Drip/SendMonthlySummaryEmailJob.php
+++ b/app/Jobs/Drip/SendMonthlySummaryEmailJob.php
@@ -10,8 +10,10 @@ use App\Models\User;
 use App\Services\MonthlySummary\AnalysisWriter;
 use App\Services\MonthlySummary\Summaries;
 use Illuminate\Contracts\Translation\HasLocalePreference;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Mail\Mailable;
 use Illuminate\Support\Traits\Localizable;
+use Laravel\Ai\Exceptions\FailoverableException;
 
 /**
  * Sends one frozen monthly summary.
@@ -35,6 +37,19 @@ class SendMonthlySummaryEmailJob extends SendDripEmailJob
      */
     public int $timeout = 300;
 
+    /**
+     * Bounded here rather than left to the worker's own `--tries`, because the
+     * send holds itself back while the model is unreachable and every hold costs
+     * an attempt. Run out of them and the job lands in `failed_jobs`, which
+     * would cost the reader the whole report to save the analysis. Four holds is
+     * two hours of cover, and the fifth attempt sends whatever it has.
+     *
+     * It is one budget, not two: an attempt a failing mailer takes is an attempt
+     * the analysis cannot hold on to. That trade is the right way round — the
+     * mailer failing is what actually stops the reader being written to.
+     */
+    public int $tries = 5;
+
     public function __construct(User $user, public MonthlySummary $summary)
     {
         parent::__construct($user);
@@ -54,9 +69,59 @@ class SendMonthlySummaryEmailJob extends SendDripEmailJob
         return $this->summary->period.':'.$this->summary->space_id;
     }
 
+    /**
+     * Unlike its siblings this one has a side effect: {@see analysisIsSettled()}
+     * writes the analysis, and can put the job back on the queue instead of
+     * answering. It is here because it is the last thing the parent asks before
+     * it sends.
+     */
     protected function shouldSend(): bool
     {
-        return $this->user->wantsMonthlySummaryEmail();
+        return $this->user->wantsMonthlySummaryEmail() && $this->analysisIsSettled();
+    }
+
+    /**
+     * Writes the analysis, and says whether the report can go out yet.
+     *
+     * This is the last guard before the send, which is the only place the
+     * question fits: {@see buildMail()} is evaluated as the argument to
+     * `Mail::to()->send()`, so a job released from in there would deliver the
+     * email regardless. It is also the first place it fits — asking a model
+     * about a reader the earlier guards are going to turn away is paid for and
+     * thrown out.
+     *
+     * A reader entitled to an analysis whose model cannot be reached gets the
+     * report held rather than an analysis-less one: the analysis has to arrive
+     * in the email, not only on the screen. On the last permitted attempt it
+     * goes out with the honest "we could not write it" block instead, which is
+     * still a report. {@see AnalysisWriter::write()} stores what it writes, so
+     * a pass that succeeds is never paid for twice.
+     */
+    private function analysisIsSettled(): bool
+    {
+        $writer = app(AnalysisWriter::class);
+
+        if (! $writer->eligible($this->user)) {
+            return true;
+        }
+
+        try {
+            $writer->write($this->summary, $this->user);
+
+            return true;
+        } catch (ConnectionException|FailoverableException $exception) {
+            if ($this->attempts() >= $this->tries) {
+                // Reported here and only here: one Sentry event for a reader who
+                // really did lose the analysis, rather than one per pass.
+                report($exception);
+
+                return true;
+            }
+
+            $this->release(now()->addMinutes(30));
+
+            return false;
+        }
     }
 
     /**
@@ -79,7 +144,8 @@ class SendMonthlySummaryEmailJob extends SendDripEmailJob
         $mail = new MonthlySummaryEmail(
             $this->user,
             $this->summary,
-            app(AnalysisWriter::class)->write($this->summary, $this->user),
+            // Already written by shouldSend(), or given up on there.
+            $this->summary->ai_analysis,
             // The one card the message carries, drawn here because the message
             // cannot go out without it.
             app(Summaries::class)->primaryCardUrl($this->summary, $pro),

--- a/app/Services/MonthlySummary/AnalysisWriter.php
+++ b/app/Services/MonthlySummary/AnalysisWriter.php
@@ -45,8 +45,10 @@ class AnalysisWriter
 
     /**
      * Write the analysis onto the summary, unless it already has one or the user
-     * is not entitled to it. Returns the text, or null when there is none — the
-     * report goes out either way.
+     * is not entitled to it. Returns the text, or null when there is none.
+     *
+     * @throws ConnectionException|FailoverableException when the model could not
+     *                                                   be reached at all
      */
     public function write(MonthlySummary $summary, User $user): ?string
     {
@@ -71,13 +73,17 @@ class AnalysisWriter
 
     /**
      * A provider hiccup costs a paying user their analysis for a whole month, so
-     * it is worth a few attempts. What it is never worth is delaying the report:
-     * once the attempts are spent this returns null and the email goes without
-     * the section.
+     * it is worth a few attempts. Once they are spent the last failure is handed
+     * back rather than swallowed: only the caller knows whether there is another
+     * pass coming, and a send that comes back in half an hour would otherwise
+     * file one Sentry event per pass.
      *
      * Nothing is written here: the caller decides whether the text is kept. That
      * is what lets the preview command show a real analysis without leaving one
      * on the summary the real send will read later in the month.
+     *
+     * @throws ConnectionException|FailoverableException when the model could not
+     *                                                   be reached at all
      */
     public function draft(MonthlySummary $summary, User $user): ?string
     {
@@ -110,12 +116,10 @@ class AnalysisWriter
         }
 
         // One hiccup is expected and stays in the logs. Every attempt failing is
-        // an outage that just cost a paying reader their month, and a provider
-        // that is never reachable would otherwise be invisible here. Getting
-        // here means the last attempt was one of those failures.
-        report($lastTransient);
-
-        return null;
+        // an outage, and what that is worth is not this method's call: the send
+        // holds the report and comes back, and reports it only once it has run
+        // out of passes of its own.
+        throw $lastTransient;
     }
 
     private function promptOnce(MonthlySummary $summary, User $user): ?string

--- a/config/ai_monthly_summary.php
+++ b/config/ai_monthly_summary.php
@@ -26,8 +26,9 @@ return [
     |
     | Provider failures are almost always transient, and a paying user losing
     | their analysis to a 200 ms hiccup is a bad trade — so a few attempts with
-    | a growing pause. What never happens is the report waiting: once the
-    | attempts are spent, it goes out without the section.
+    | a growing pause. These are the attempts inside one send; a send that spends
+    | them all against an unreachable model holds the report and comes back
+    | later, and only gives up on the section once its own retries are spent.
     |
     */
 

--- a/tests/Feature/Console/PreviewMonthlySummaryCommandTest.php
+++ b/tests/Feature/Console/PreviewMonthlySummaryCommandTest.php
@@ -10,6 +10,7 @@ use App\Models\Transaction;
 use App\Models\User;
 use App\Services\MonthlySummary\AnalysisWriter;
 use App\Services\MonthlySummary\CardRenderer;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Mail;
 
 /*
@@ -178,6 +179,25 @@ it('never asks the model for a case that carries no analysis', function (): void
     ])->assertSuccessful();
 
     Mail::assertSentCount(1);
+});
+
+it('falls back to the sample text when the model cannot be reached', function (): void {
+    // A real send holds the report and comes back for an unreachable model, so
+    // `draft()` hands the failure back rather than returning null. A preview has
+    // nowhere to come back to: it says so and shows the sample.
+    Mail::fake();
+    $this->mock(AnalysisWriter::class, fn ($mock) => $mock->shouldReceive('draft')->andThrow(
+        new ConnectionException('cURL error 28: Operation timed out after 30002 milliseconds with 0 bytes received'),
+    ));
+
+    $this->artisan('email:monthly-summary-preview', [
+        'email' => 'look@whisper.test',
+        '--source' => previewSource()->email,
+        '--type' => 'pro',
+        '--ai' => true,
+    ])->assertSuccessful();
+
+    Mail::assertSent(MonthlySummaryEmail::class, fn (MonthlySummaryEmail $mail): bool => str_contains((string) $mail->analysis, '[TEXTO DE MUESTRA]'));
 });
 
 it('falls back to the sample text when the model gives up', function (): void {

--- a/tests/Feature/MonthlySummary/AnalysisWriterTest.php
+++ b/tests/Feature/MonthlySummary/AnalysisWriterTest.php
@@ -13,6 +13,10 @@ use Illuminate\Support\Sleep;
  * their whole month. The retry only ever covered a provider that answered badly,
  * so one that did not answer at all - a 30s timeout reaching Gemini - burned the
  * month on the first try and was filed as a bug (PHP-LARAVEL-5Q).
+ *
+ * Spending the attempts is all this does. Whether an unreachable model is worth
+ * holding the report back for belongs to the caller, so the failure is handed
+ * back rather than filed here.
  */
 
 beforeEach(function (): void {
@@ -32,31 +36,35 @@ function readerAwaitingAnalysis(): array
     return [$summary, $user];
 }
 
-it('spends every attempt on a transient provider failure before giving up', function (Closure $makeFailure): void {
+it('spends every attempt on a transient provider failure before handing it back', function (Closure $makeFailure): void {
     config()->set('ai_monthly_summary.attempts', 2);
 
     Exceptions::fake();
     Log::spy();
 
+    $failure = $makeFailure();
+
     $calls = 0;
-    MonthlySummaryAgent::fake(function () use (&$calls, $makeFailure) {
+    MonthlySummaryAgent::fake(function () use (&$calls, $failure) {
         $calls++;
 
-        throw $makeFailure();
+        throw $failure;
     });
 
     [$summary, $user] = readerAwaitingAnalysis();
 
-    expect(app(AnalysisWriter::class)->draft($summary, $user))->toBeNull()
-        ->and($calls)->toBe(2);
+    expect(fn (): ?string => app(AnalysisWriter::class)->draft($summary, $user))
+        ->toThrow($failure::class);
+
+    expect($calls)->toBe(2);
 
     Log::shouldHaveReceived('warning')
         ->withArgs(fn (string $message): bool => $message === 'Monthly summary analysis attempt failed.')
         ->twice();
 
-    // Quiet per attempt, but a run that never got through is an outage the logs
-    // alone would bury.
-    Exceptions::assertReportedCount(1);
+    // Not filed here: the send holds the report and comes back, and one outage
+    // would otherwise be one Sentry event per pass per reader.
+    Exceptions::assertNothingReported();
 })->with('transient provider failures');
 
 it('recovers when a later attempt gets through', function (Closure $makeFailure): void {

--- a/tests/Feature/MonthlySummary/MonthlySummaryEmailTest.php
+++ b/tests/Feature/MonthlySummary/MonthlySummaryEmailTest.php
@@ -13,11 +13,13 @@ use App\Services\MonthlySummary\CardPicker;
 use App\Services\MonthlySummary\CardRenderer;
 use App\Services\MonthlySummary\EmailPresenter;
 use App\Services\MonthlySummary\Summaries;
+use Illuminate\Contracts\Queue\Job;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Exceptions;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Sleep;
+use Mockery\MockInterface;
 
 /*
  * The report email itself: what it says, who sees the analysis, and how a reader
@@ -264,29 +266,84 @@ it('draws the screen\'s cards in the reader\'s language too', function (): void 
     expect($drawnIn)->toBe('es')->and(app()->getLocale())->toBe('en');
 });
 
-it('spends every attempt on a provider that never answers, and sends the report regardless', function (): void {
-    // The report has always gone out without the section - a read timeout was
-    // caught as an unexpected bug, reported, and the remaining attempts thrown
-    // away (PHP-LARAVEL-5Q). What the reader lost was the analysis itself, to a
-    // single blip that a second attempt would usually have got past.
+/**
+ * A reader entitled to an analysis, and a model that never answers: the 30s
+ * Gemini timeout that cost 13 of 97 Pro readers their analysis on the first real
+ * send (PHP-LARAVEL-5Q). Billing off makes everyone Pro, so consent is the only
+ * gate left to grant.
+ */
+function readerOwedAnAnalysis(): MonthlySummary
+{
     config(['subscriptions.enabled' => false, 'ai_monthly_summary.attempts' => 2]);
-    Mail::fake();
-    Queue::fake();
-    Exceptions::fake();
 
     $summary = sentSummaryFor();
     $summary->user->recordAiConsent();
 
-    $attempts = 0;
-    MonthlySummaryAgent::fake(function () use (&$attempts): never {
-        $attempts++;
+    MonthlySummaryAgent::fake(fn (): never => throw new ConnectionException(
+        'cURL error 28: Operation timed out after 30002 milliseconds with 0 bytes received',
+    ));
 
-        throw new ConnectionException(
-            'cURL error 28: Operation timed out after 30002 milliseconds with 0 bytes received',
-        );
-    });
+    return $summary;
+}
 
-    (new SendMonthlySummaryEmailJob($summary->user->fresh(), $summary))->handle();
+/**
+ * The job as the worker runs it. `attempts()` and `release()` mean nothing
+ * without a queue job attached, and the decision to hold the report reads both.
+ *
+ * @return array{0: SendMonthlySummaryEmailJob, 1: MockInterface}
+ */
+function summaryJobOnAttempt(MonthlySummary $summary, int $attempt): array
+{
+    $job = new SendMonthlySummaryEmailJob($summary->user->fresh(), $summary);
+
+    $queueJob = Mockery::mock(Job::class);
+    $queueJob->shouldReceive('attempts')->andReturn($attempt);
+    $job->setJob($queueJob);
+
+    return [$job, $queueJob];
+}
+
+it('holds the report rather than handing a paying reader an analysis-less one', function (): void {
+    // The analysis has to reach them in the email, not only on the screen, so a
+    // provider wobble postpones the send instead of spending the month's one
+    // report on a summary with the section missing.
+    Mail::fake();
+    Queue::fake();
+    Exceptions::fake();
+
+    $summary = readerOwedAnAnalysis();
+    [$job, $queueJob] = summaryJobOnAttempt($summary, 1);
+    $queueJob->shouldReceive('release')->once();
+
+    $job->handle();
+
+    Mail::assertNothingQueued();
+
+    expect($summary->fresh()->sent_at)->toBeNull()
+        ->and(UserMailLog::where('user_id', $summary->user_id)
+            ->where('email_type', DripEmailType::MonthlySummary)
+            ->exists())->toBeFalse();
+
+    // Nothing filed while there are passes left, or one outage would be five
+    // Sentry events per reader.
+    Exceptions::assertNothingReported();
+});
+
+it('sends the report without the analysis once the retries are spent', function (): void {
+    // The last permitted attempt must send: another release would exhaust the
+    // job and drop it in failed_jobs, and the reader would get no report at all
+    // - strictly worse than one carrying the honest "we could not write it".
+    Mail::fake();
+    Queue::fake();
+    Exceptions::fake();
+
+    $summary = readerOwedAnAnalysis();
+    [$job, $queueJob] = summaryJobOnAttempt($summary, 5);
+    $queueJob->shouldNotReceive('release');
+
+    expect($job->tries)->toBe(5);
+
+    $job->handle();
 
     // Sent, addressed to a reader the email knows is entitled - which is what
     // keeps the paywall block out of it - and with no analysis.
@@ -295,11 +352,13 @@ it('spends every attempt on a provider that never answers, and sends the report 
         fn (MonthlySummaryEmail $mail): bool => $mail->analysis === null && $mail->pro,
     );
 
-    expect($attempts)->toBe(2)
-        ->and($summary->fresh()->sent_at)->not->toBeNull()
+    expect($summary->fresh()->sent_at)->not->toBeNull()
         ->and(UserMailLog::where('user_id', $summary->user_id)
             ->where('email_type', DripEmailType::MonthlySummary)
             ->exists())->toBeTrue();
+
+    // One event for a reader who really did lose the analysis.
+    Exceptions::assertReportedCount(1);
 });
 
 it('does not send to a reader who turned the summary off', function (): void {


### PR DESCRIPTION
On the first real send, 3 September 2026, 97 of the 161 reports went to Pro readers
with an active AI consent. 84 carried an analysis; 13 did not. Sentry `PHP-LARAVEL-5Q`
has the reason: 14 × `ConnectionException`, cURL 28, "timed out after 30002 ms with 0
bytes received" against `gemini-flash-latest`, all between 06:00 and 07:33 UTC.

`AnalysisWriter::draft()` spent its three attempts, returned null, the report went out,
`sent_at` was stamped and `ai_analysis` stayed null. The reader got the honest "We could
not write your analysis this month" block from #918 — and never got the analysis, for
the whole month. The analysis is what they pay for, and it has to reach them in the
email, not only on the dashboard.

## The change

A reader who is entitled to an analysis and whose model cannot be reached no longer
gets an analysis-less report: the send is held and comes back half an hour later.

- `AnalysisWriter::draft()` hands the last transient failure back instead of reporting
  it. It never knew whether another pass was coming; the caller does. Reporting there
  meant one Sentry event per pass per reader once the send started retrying.
- `SendMonthlySummaryEmailJob::shouldSend()` — the last guard before the send — writes
  the analysis and decides. On a transient failure it releases the job for 30 minutes
  and answers no, so nothing is sent and no `UserMailLog` is written. On the last
  permitted attempt it reports once and answers yes: the report goes out with the
  fallback block, which is still a report.

It has to be `shouldSend()` rather than `buildMail()`: `buildMail()` is evaluated as the
*argument* to `Mail::to()->send(...)`, so by the time you are inside it the send is
already committed — a release from there would deliver the email anyway and still write
the mail log. It is also the earliest place it fits, so a reader the earlier guards turn
away is never paid for at the provider.

`$tries = 5` is set on the job rather than left to the worker's `--tries=5`, so the bound
lives in the code the release loop is written in. Four holds is two hours of cover, which
keeps the report same-day; the fifth attempt sends. A release loop without that bound
would exhaust the worker's attempts and land in `failed_jobs`, and the reader would get
nothing at all — strictly worse than today.

`reportEmail()` now reads `$this->summary->ai_analysis` instead of calling `write()` a
second time. Same value in every branch, and it matters now: on the last attempt a second
`write()` would spend another 90 seconds against the dead provider and then throw, from
inside `buildMail()`, failing the job.

Non-eligible readers are untouched: no AI call, no delay, the report goes out on the
first attempt as it does today.

## Notes

- `config/ai_monthly_summary.php` is comment-only. Its "what never happens is the report
  waiting" is no longer true; the 30 s timeout is left alone as a separate lever.
- `PreviewMonthlySummaryCommand` catches the new exception so a preview against a down
  provider warns and falls back to the sample text rather than throwing a stack trace.
- One attempt budget, not two: an attempt a failing mailer takes is one the analysis
  cannot hold on to. That trade is the right way round — the mailer failing is what
  actually stops the reader being written to.
- During a long provider outage every eligible reader now costs up to five ~90 s passes
  instead of one. Released jobs go to the back of the queue with a 30-minute delay, so
  readers who are not waiting on a model are not held up behind them.

## Tests

- `MonthlySummaryEmailTest`: the report is held rather than sent analysis-less, with
  nothing queued, no `sent_at`, no mail log and nothing reported; and the last permitted
  attempt sends the report, reporting exactly once.
- `AnalysisWriterTest`: `draft()` spends every attempt and then throws, reporting nothing.
- `PreviewMonthlySummaryCommandTest`: the preview falls back to the sample text when
  the model cannot be reached, which is the throw path the old null-return test never
  covered.

Readiness is untouched: a reader with no connection and nothing in the new month is
still not treated as settled, gets the reminder on the 3rd, and gets the report on the
last day whether or not they imported anything.
