### PR TITLE
feat(transactions): let a manual transaction carry its own currency

### DIFF
--- a/app/Http/Controllers/Api/ExchangeRateController.php
+++ b/app/Http/Controllers/Api/ExchangeRateController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\ExchangeRateRequest;
+use App\Services\ExchangeRateService;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * One amount converted between two currencies, for the transaction modal.
+ *
+ * Everything else converts server-side while it adds transactions up; the modal
+ * is the one place that needs a single figure on demand, so it asks here rather
+ * than shipping a rate table to the browser.
+ */
+class ExchangeRateController extends Controller
+{
+    public function __construct(private ExchangeRateService $exchangeRateService) {}
+
+    public function __invoke(ExchangeRateRequest $request): JsonResponse
+    {
+        return response()->json([
+            // Null when the day holds no rate: the modal shows the original
+            // alone rather than printing a figure it could not convert.
+            'amount' => $this->exchangeRateService->convertOrNull(
+                $request->string('from')->toString(),
+                $request->string('to')->toString(),
+                $request->integer('amount'),
+                $request->string('date')->toString(),
+            ),
+        ]);
+    }
+}

--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -227,21 +227,9 @@ class TransactionController extends Controller
         $hasLabelUpdate = $request->has('label_ids');
         unset($data['label_ids']);
 
-        $learnedRule = null;
-
-        // A user-set category overrides any AI assignment: learn the correction as
-        // a forward-looking rule, log/self-heal as needed, and reset provenance.
-        if ($request->has('category_id')) {
-            $newCategoryId = $data['category_id'] ?? null;
-
-            if ($newCategoryId !== $transaction->category_id) {
-                $learnedRule = app(CategoryOverrideHandler::class)->record($transaction, $newCategoryId);
-
-                $data['category_source'] = $newCategoryId === null ? null : CategorySource::Manual->value;
-                $data['ai_confidence'] = null;
-                $data['categorized_by_rule_id'] = null;
-            }
-        }
+        $learnedRule = $request->has('category_id')
+            ? $this->recordCategoryOverride($transaction, $data)
+            : null;
 
         // Snapshot the pre-edit account/date/amount before filling, so a manual
         // account balance can be moved off the old values if the edit changes them.
@@ -252,31 +240,16 @@ class TransactionController extends Controller
             $transaction->fill($data);
         }
 
-        // Sync labels if provided
-        if ($hasLabelUpdate) {
-            $transaction->labels()->sync($labelIds ?? []);
-            // Reload labels so the event listener has fresh data
-            $transaction->load('labels');
-        }
+        $this->saveWithLabels($transaction, $labelIds, $hasLabelUpdate);
 
-        // Save to fire the updated event if there are any changes
-        // We need to save even if just labels changed (isDirty won't detect pivot changes)
-        if ($transaction->isDirty() || $hasLabelUpdate) {
-            // Touch the model to ensure it's marked as changed for the event
-            if (! $transaction->isDirty() && $hasLabelUpdate) {
-                $transaction->touch();
-            }
-            $transaction->save();
-        }
-
-        // Move the manual account balance to match an edited amount/date/account:
-        // strip the pre-edit contribution (exactly as a deletion would) and apply
-        // the new one (exactly as a creation would), both cascading forward.
-        // ponytail: like create/delete, this trusts the opt-in flag and keeps no
+        // Move the manual account balance to match an edited amount/date/account/
+        // currency: strip the pre-edit contribution (exactly as a deletion would)
+        // and apply the new one (exactly as a creation would), both cascading
+        // forward. Like create/delete, this trusts the opt-in flag and keeps no
         // record of whether creation adjusted the balance, so mixing the flag
         // across create and edit can drift; a transaction-derived balance would
         // remove that trust. Connected accounts are skipped inside the adjuster.
-        if ($request->boolean('update_balance') && $transaction->wasChanged(['amount', 'transaction_date', 'account_id'])) {
+        if ($request->boolean('update_balance') && $transaction->wasChanged(ManualBalanceAdjuster::BALANCE_AFFECTING_ATTRIBUTES)) {
             $balanceAdjuster->reverseDeletedTransaction($originalSnapshot);
             $balanceAdjuster->applyCreatedTransaction($transaction->load('account'));
         }
@@ -289,6 +262,53 @@ class TransactionController extends Controller
                 'category_id' => $learnedRule->action_category_id,
             ],
         ]);
+    }
+
+    /**
+     * Persist the edit, labels included.
+     *
+     * A pivot change leaves the model itself clean, so labels-only edits are
+     * touched into dirtiness on purpose: the `updated` event is what the
+     * listeners downstream run on, and they have to see the new labels.
+     *
+     * @param  list<string>|null  $labelIds
+     */
+    private function saveWithLabels(Transaction $transaction, ?array $labelIds, bool $hasLabelUpdate): void
+    {
+        if ($hasLabelUpdate) {
+            $transaction->labels()->sync($labelIds ?? []);
+            // Reload labels so the event listener has fresh data
+            $transaction->load('labels');
+        }
+
+        if ($transaction->isDirty() || $hasLabelUpdate) {
+            if (! $transaction->isDirty()) {
+                $transaction->touch();
+            }
+            $transaction->save();
+        }
+    }
+
+    /**
+     * A user-set category overrides any AI assignment: learn the correction as a
+     * forward-looking rule, log/self-heal as needed, and reset the provenance
+     * columns on `$data` so the save carries them.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    private function recordCategoryOverride(Transaction $transaction, array &$data): ?AutomationRule
+    {
+        $newCategoryId = $data['category_id'] ?? null;
+
+        if ($newCategoryId === $transaction->category_id) {
+            return null;
+        }
+
+        $data['category_source'] = $newCategoryId === null ? null : CategorySource::Manual->value;
+        $data['ai_confidence'] = null;
+        $data['categorized_by_rule_id'] = null;
+
+        return app(CategoryOverrideHandler::class)->record($transaction, $newCategoryId);
     }
 
     public function destroy(Request $request, Transaction $transaction, ManualBalanceAdjuster $balanceAdjuster): JsonResponse

--- a/app/Http/Requests/Api/ExchangeRateRequest.php
+++ b/app/Http/Requests/Api/ExchangeRateRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ExchangeRateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'from' => ['required', 'string', 'size:3'],
+            'to' => ['required', 'string', 'size:3'],
+            'amount' => ['required', 'integer'],
+            'date' => ['required', 'date_format:Y-m-d'],
+        ];
+    }
+}

--- a/app/Mcp/Tools/CreateTransaction.php
+++ b/app/Mcp/Tools/CreateTransaction.php
@@ -23,7 +23,7 @@ class CreateTransaction extends WriteTool
         return [
             'account_id' => $schema->string()->description('Id of the account to add the transaction to.')->required(),
             'description' => $schema->string()->description('Human-readable description.')->required(),
-            'amount' => $schema->integer()->description('Signed amount in the account currency\'s minor units. Negative = expense, positive = income.')->required(),
+            'amount' => $schema->integer()->description('Signed amount in the minor units of currency_code, which defaults to the account currency. Negative = expense, positive = income.')->required(),
             'transaction_date' => $schema->string()->description('Transaction date, YYYY-MM-DD.')->required(),
             'currency_code' => $schema->string()->description('ISO 4217 currency code (3 letters). Defaults to the account currency.'),
             'category_id' => $schema->string()->description('Optional category id to assign.'),

--- a/app/Mcp/Tools/UpdateTransaction.php
+++ b/app/Mcp/Tools/UpdateTransaction.php
@@ -23,7 +23,7 @@ class UpdateTransaction extends WriteTool
         return [
             'transaction_id' => $schema->string()->description('Id of the manually-created transaction to edit.')->required(),
             'description' => $schema->string()->description('New description.'),
-            'amount' => $schema->integer()->description('New signed amount in the account currency\'s minor units.'),
+            'amount' => $schema->integer()->description('New signed amount, in the minor units of the transaction\'s own currency.'),
             'transaction_date' => $schema->string()->description('New transaction date, YYYY-MM-DD.'),
             'currency_code' => $schema->string()->description('New ISO 4217 currency code (3 letters).'),
             'account_id' => $schema->string()->description('Move the transaction to another account.'),
@@ -93,7 +93,7 @@ class UpdateTransaction extends WriteTool
 
         $balanceUpdated = false;
 
-        if ($request->boolean('update_balance') && $transaction->wasChanged(['amount', 'transaction_date', 'account_id'])) {
+        if ($request->boolean('update_balance') && $transaction->wasChanged(ManualBalanceAdjuster::BALANCE_AFFECTING_ATTRIBUTES)) {
             $adjuster = app(ManualBalanceAdjuster::class);
             // Either side no-ops on a connected account, so moving a transaction
             // onto one still unwinds the manual account it came from.

--- a/app/Services/ExchangeRateService.php
+++ b/app/Services/ExchangeRateService.php
@@ -61,6 +61,29 @@ class ExchangeRateService
     }
 
     /**
+     * The same conversion as {@see convert()}, but null when that day holds no
+     * rate for the pair.
+     *
+     * `convert()` answers a missing rate with the amount rescaled but
+     * unconverted, which is the right call for a total that must still add up.
+     * Callers that either show the figure or write it to a money column need
+     * the difference: an unconverted amount printed as a conversion is a lie,
+     * and stored as one it is a wrong balance.
+     */
+    public function convertOrNull(string $source, string $target, int $amountInMinorUnits, string $date): ?int
+    {
+        if (strcasecmp($source, $target) === 0) {
+            return $amountInMinorUnits;
+        }
+
+        if (empty($this->getRates($target, $date)[strtolower($source)])) {
+            return null;
+        }
+
+        return $this->convert($source, $target, $amountInMinorUnits, $date);
+    }
+
+    /**
      * Get all exchange rates for a base currency on a given date.
      *
      * Checks the DB cache first, then fetches from the external API

--- a/app/Services/ManualBalanceAdjuster.php
+++ b/app/Services/ManualBalanceAdjuster.php
@@ -4,9 +4,22 @@ namespace App\Services;
 
 use App\Models\Account;
 use App\Models\Transaction;
+use Illuminate\Support\Facades\Log;
 
 class ManualBalanceAdjuster
 {
+    /**
+     * The attributes whose edit moves what a transaction contributes to its
+     * account's balance. The currency belongs here with the amount: the
+     * snapshots are held in the account's own currency, so 2500 USD and
+     * 2500 EUR shift them by different numbers.
+     *
+     * @var list<string>
+     */
+    public const BALANCE_AFFECTING_ATTRIBUTES = ['amount', 'transaction_date', 'account_id', 'currency_code'];
+
+    public function __construct(private ExchangeRateService $exchangeRateService) {}
+
     /**
      * Reverse a deleted transaction's effect on its manual account's balances.
      *
@@ -24,10 +37,16 @@ class ManualBalanceAdjuster
             return false;
         }
 
+        $amount = $this->amountInAccountCurrency($transaction, $account);
+
+        if ($amount === null) {
+            return false;
+        }
+
         $this->shiftBalancesFrom(
             $account,
             $transaction->transaction_date->toDateString(),
-            -$transaction->amount,
+            -$amount,
         );
 
         return true;
@@ -51,6 +70,12 @@ class ManualBalanceAdjuster
             return false;
         }
 
+        $amount = $this->amountInAccountCurrency($transaction, $account);
+
+        if ($amount === null) {
+            return false;
+        }
+
         $transactionDate = $transaction->transaction_date->toDateString();
 
         $account->balances()->firstOrCreate(
@@ -58,9 +83,46 @@ class ManualBalanceAdjuster
             ['balance' => $this->carriedForwardBalance($account, $transactionDate)],
         );
 
-        $this->shiftBalancesFrom($account, $transactionDate, $transaction->amount);
+        $this->shiftBalancesFrom($account, $transactionDate, $amount);
 
         return true;
+    }
+
+    /**
+     * The transaction amount as the account holds it, or null when that day
+     * holds no rate to convert it with.
+     *
+     * Balance snapshots are kept in the account's own currency, so a
+     * transaction in another one — the picker in the manual form, a mapped
+     * currency column in an import — has to be converted before it shifts them.
+     * Both directions read the same date's rate, so applying and reversing
+     * cancel out exactly.
+     *
+     * With no rate the balance is left alone rather than shifted by the
+     * unconverted number, which would be a wrong figure written into a money
+     * column with nothing on screen to say so. The caller reports the balance
+     * as untouched, and the warning is the trace worth having.
+     */
+    private function amountInAccountCurrency(Transaction $transaction, Account $account): ?int
+    {
+        $amount = $this->exchangeRateService->convertOrNull(
+            $transaction->currency_code ?: $account->currency_code,
+            $account->currency_code,
+            $transaction->amount,
+            $transaction->transaction_date->toDateString(),
+        );
+
+        if ($amount === null) {
+            Log::warning('Balance left untouched: no rate to convert the transaction with', [
+                'transaction_id' => $transaction->id,
+                'account_id' => $account->id,
+                'source' => $transaction->currency_code,
+                'target' => $account->currency_code,
+                'date' => $transaction->transaction_date->toDateString(),
+            ]);
+        }
+
+        return $amount;
     }
 
     /**

--- a/lang/es.json
+++ b/lang/es.json
@@ -2924,5 +2924,7 @@
     "The medal, its name and its tier still show. The figure does not.": "Se siguen viendo la medalla, su nombre y su nivel. La cifra no.",
     "Save the picture": "Guardar la imagen",
     "Sharing…": "Compartiendo…",
-    "That could not be shared. You can save it instead.": "No se ha podido compartir. Puedes guardar la imagen en su lugar."
+    "That could not be shared. You can save it instead.": "No se ha podido compartir. Puedes guardar la imagen en su lugar.",
+    "In account currency": "En la moneda de la cuenta",
+    "≈ :amount in the account currency": "≈ :amount en la moneda de la cuenta"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2477,5 +2477,7 @@
     "Progress": "Progression",
     "1 month": "1 mois",
     "{1}1 month|[2,*]:count months": "{1}1 mois|[2,*]:count mois",
-    "Every milestone your money has crossed, dated when it actually happened.": "Chaque jalon franchi par votre argent, daté du moment où il s’est vraiment produit."
+    "Every milestone your money has crossed, dated when it actually happened.": "Chaque jalon franchi par votre argent, daté du moment où il s’est vraiment produit.",
+    "In account currency": "Dans la devise du compte",
+    "≈ :amount in the account currency": "≈ :amount dans la devise du compte"
 }

--- a/resources/js/components/transactions/edit-transaction-dialog.test.tsx
+++ b/resources/js/components/transactions/edit-transaction-dialog.test.tsx
@@ -47,7 +47,17 @@ vi.mock('@inertiajs/react', () => ({
         reload: vi.fn(),
     },
     usePage: () => ({
-        props: { auth: { user: { currency_code: 'EUR' } } },
+        props: {
+            auth: { user: { currency_code: 'EUR' } },
+            currencies: {
+                profile: [{ code: 'EUR', name: 'Euro' }],
+                accounts: [
+                    { code: 'EUR', name: 'Euro' },
+                    { code: 'USD', name: 'US Dollar' },
+                ],
+                decimals: { EUR: 2, USD: 2 },
+            },
+        },
     }),
 }));
 
@@ -59,14 +69,29 @@ vi.mock('sonner', () => ({
 }));
 
 vi.mock('@/components/ui/select', () => ({
+    // The dialog renders more than one Select; a named one gets a testid of its
+    // own so the account's stays unambiguous.
     Select: ({
+        name,
         value,
+        onValueChange,
         children,
     }: {
+        name?: string;
         value?: string;
+        onValueChange?: (value: string) => void;
         children: React.ReactNode;
     }) => (
-        <div data-testid="account-value" data-value={value ?? ''}>
+        <div
+            data-testid={name ? `${name}-value` : 'account-value'}
+            data-value={value ?? ''}
+            onClick={(event) => {
+                const next = (event.target as HTMLElement).dataset.selectValue;
+                if (next) {
+                    onValueChange?.(next);
+                }
+            }}
+        >
             {children}
         </div>
     ),
@@ -76,9 +101,13 @@ vi.mock('@/components/ui/select', () => ({
     SelectContent: ({ children }: { children: React.ReactNode }) => (
         <div>{children}</div>
     ),
-    SelectItem: ({ children }: { children: React.ReactNode }) => (
-        <div>{children}</div>
-    ),
+    SelectItem: ({
+        value,
+        children,
+    }: {
+        value: string;
+        children: React.ReactNode;
+    }) => <div data-select-value={value}>{children}</div>,
     SelectValue: ({ placeholder }: { placeholder?: string }) => (
         <span>{placeholder}</span>
     ),
@@ -803,6 +832,199 @@ describe('EditTransactionDialog', () => {
             'data-state',
             'on',
         );
+    });
+
+    it('defaults the currency to the account it is being added to', () => {
+        render(
+            <EditTransactionDialog
+                transaction={null}
+                categories={[]}
+                accounts={[{ ...checkingAccount, currency_code: 'USD' }]}
+                banks={[]}
+                labels={[]}
+                open
+                onOpenChange={vi.fn()}
+                onSuccess={vi.fn()}
+                mode="create"
+                initialAccountId="account-1"
+            />,
+        );
+
+        expect(screen.getByTestId('currency_code-value')).toHaveAttribute(
+            'data-value',
+            'USD',
+        );
+        expect(screen.getByText('$')).toBeInTheDocument();
+    });
+
+    it('stores the picked currency rather than the account one', async () => {
+        vi.mocked(transactionSyncService.create).mockResolvedValue(
+            manualTransaction,
+        );
+
+        render(
+            <EditTransactionDialog
+                transaction={null}
+                categories={[]}
+                accounts={[checkingAccount]}
+                banks={[]}
+                labels={[]}
+                open
+                onOpenChange={vi.fn()}
+                onSuccess={vi.fn()}
+                mode="create"
+                initialAccountId="account-1"
+            />,
+        );
+
+        fireEvent.click(screen.getByText('USD - US Dollar'));
+
+        fireEvent.change(
+            screen.getByPlaceholderText('Transaction description'),
+            { target: { value: 'Hotel' } },
+        );
+        const amountInput = screen.getByPlaceholderText('0.00');
+        fireEvent.change(amountInput, { target: { value: '40' } });
+        fireEvent.blur(amountInput);
+        fireEvent.click(screen.getByTestId('submit-transaction'));
+
+        await waitFor(() => {
+            expect(transactionSyncService.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    amount: -4000,
+                    currency_code: 'USD',
+                }),
+                expect.anything(),
+            );
+        });
+    });
+
+    it('shows what a foreign-currency amount comes to in the account currency', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ amount: 3700 }),
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        render(
+            <EditTransactionDialog
+                transaction={{ ...manualTransaction, currency_code: 'USD' }}
+                categories={[]}
+                accounts={[checkingAccount]}
+                banks={[]}
+                labels={[]}
+                open
+                onOpenChange={vi.fn()}
+                onSuccess={vi.fn()}
+                mode="edit"
+            />,
+        );
+
+        expect(await screen.findByTestId('converted-amount')).toHaveTextContent(
+            '\u2248 €37.00 in the account currency',
+        );
+        expect(fetchMock).toHaveBeenCalledWith(
+            '/api/exchange-rate?from=USD&to=EUR&date=2026-05-27&amount=1200',
+        );
+
+        vi.unstubAllGlobals();
+    });
+
+    it('shows nothing extra when the transaction is in the account currency', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        render(
+            <EditTransactionDialog
+                transaction={manualTransaction}
+                categories={[]}
+                accounts={[checkingAccount]}
+                banks={[]}
+                labels={[]}
+                open
+                onOpenChange={vi.fn()}
+                onSuccess={vi.fn()}
+                mode="edit"
+            />,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByDisplayValue('12.00')).toBeInTheDocument();
+        });
+        expect(
+            screen.queryByTestId('converted-amount'),
+        ).not.toBeInTheDocument();
+        expect(fetchMock).not.toHaveBeenCalled();
+
+        vi.unstubAllGlobals();
+    });
+
+    it('keeps the original alone when no rate can be found', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+                ok: true,
+                json: async () => ({ amount: null }),
+            }),
+        );
+
+        render(
+            <EditTransactionDialog
+                transaction={{ ...manualTransaction, currency_code: 'USD' }}
+                categories={[]}
+                accounts={[checkingAccount]}
+                banks={[]}
+                labels={[]}
+                open
+                onOpenChange={vi.fn()}
+                onSuccess={vi.fn()}
+                mode="edit"
+            />,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByDisplayValue('12.00')).toBeInTheDocument();
+        });
+        expect(
+            screen.queryByTestId('converted-amount'),
+        ).not.toBeInTheDocument();
+
+        vi.unstubAllGlobals();
+    });
+
+    it('adds the account-currency figure to a locked transaction details', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+                ok: true,
+                json: async () => ({ amount: -1100 }),
+            }),
+        );
+
+        render(
+            <EditTransactionDialog
+                transaction={{
+                    ...manualTransaction,
+                    source: 'imported' as const,
+                    currency_code: 'USD',
+                }}
+                categories={[]}
+                accounts={[checkingAccount]}
+                banks={[]}
+                labels={[]}
+                open
+                onOpenChange={vi.fn()}
+                onSuccess={vi.fn()}
+                mode="edit"
+            />,
+        );
+
+        expect(
+            await screen.findByText('In account currency'),
+        ).toBeInTheDocument();
+        expect(screen.getByText('-€11.00')).toBeInTheDocument();
+
+        vi.unstubAllGlobals();
     });
 
     it('hides the Delete button in create mode', () => {

--- a/resources/js/components/transactions/edit-transaction-dialog.test.tsx
+++ b/resources/js/components/transactions/edit-transaction-dialog.test.tsx
@@ -108,9 +108,13 @@ vi.mock('@/components/ui/select', () => ({
         value: string;
         children: React.ReactNode;
     }) => <div data-select-value={value}>{children}</div>,
-    SelectValue: ({ placeholder }: { placeholder?: string }) => (
-        <span>{placeholder}</span>
-    ),
+    SelectValue: ({
+        placeholder,
+        children,
+    }: {
+        placeholder?: string;
+        children?: React.ReactNode;
+    }) => <span>{children ?? placeholder}</span>,
 }));
 
 vi.mock('@/components/ui/dialog', () => ({
@@ -286,8 +290,11 @@ describe('EditTransactionDialog', () => {
             />,
         );
 
-        expect(screen.getByText('€')).toBeInTheDocument();
-        expect(screen.queryByText('$')).not.toBeInTheDocument();
+        expect(screen.getByText('EUR')).toBeInTheDocument();
+        expect(screen.getByTestId('currency_code-value')).toHaveAttribute(
+            'data-value',
+            'EUR',
+        );
     });
 
     it('shows each account currency in the account options', async () => {
@@ -854,7 +861,7 @@ describe('EditTransactionDialog', () => {
             'data-value',
             'USD',
         );
-        expect(screen.getByText('$')).toBeInTheDocument();
+        expect(screen.getByText('USD')).toBeInTheDocument();
     });
 
     it('stores the picked currency rather than the account one', async () => {

--- a/resources/js/components/transactions/edit-transaction-dialog.tsx
+++ b/resources/js/components/transactions/edit-transaction-dialog.tsx
@@ -750,6 +750,35 @@ export function EditTransactionDialog({
         ? currencies.accounts
         : [...currencies.accounts, { code: currencyCode, name: currencyCode }];
 
+    // Sits inside the amount field, so the label the field already carries is
+    // its label too - hence the aria-label rather than a <FormLabel> of its own.
+    const currencyPicker = (
+        <Select
+            name="currency_code"
+            value={currencyCode}
+            onValueChange={handleCurrencyChange}
+            disabled={isSubmitting}
+        >
+            <SelectTrigger
+                id="currency"
+                aria-label={__('Currency')}
+                data-testid="currency-select"
+                className="h-7 w-full gap-1 rounded-md px-2 text-xs font-medium shadow-none"
+            >
+                <SelectValue placeholder={__('Select currency')}>
+                    {currencyCode}
+                </SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+                {currencyOptions.map((currency) => (
+                    <SelectItem key={currency.code} value={currency.code}>
+                        {`${currency.code} - ${currency.name}`}
+                    </SelectItem>
+                ))}
+            </SelectContent>
+        </Select>
+    );
+
     // The date the source gave this row: the stored one once it has been moved,
     // otherwise the day it still sits on. Manual rows have no source to compare
     // against - the user picked every date they ever had.
@@ -1017,6 +1046,7 @@ export function EditTransactionDialog({
                                                     )
                                                 }
                                                 currencyCode={currencyCode}
+                                                currencySlot={currencyPicker}
                                                 disabled={isSubmitting}
                                                 required
                                                 className="h-11 text-right text-xl font-semibold tabular-nums md:text-xl"
@@ -1098,42 +1128,6 @@ export function EditTransactionDialog({
                                                             )}
                                                         >
                                                             {`${decryptedAccountNames.get(account.id) || __('[Loading...]')} · ${account.currency_code}`}
-                                                        </SelectItem>
-                                                    ),
-                                                )}
-                                            </SelectContent>
-                                        </Select>
-                                    </div>
-                                    <div className="space-y-2">
-                                        <FormLabel htmlFor="currency">
-                                            {__('Currency')}
-                                        </FormLabel>
-                                        <Select
-                                            name="currency_code"
-                                            value={currencyCode}
-                                            onValueChange={handleCurrencyChange}
-                                            disabled={isSubmitting}
-                                        >
-                                            <SelectTrigger
-                                                id="currency"
-                                                data-testid="currency-select"
-                                            >
-                                                <SelectValue
-                                                    placeholder={__(
-                                                        'Select currency',
-                                                    )}
-                                                />
-                                            </SelectTrigger>
-                                            <SelectContent>
-                                                {currencyOptions.map(
-                                                    (currency) => (
-                                                        <SelectItem
-                                                            key={currency.code}
-                                                            value={
-                                                                currency.code
-                                                            }
-                                                        >
-                                                            {`${currency.code} - ${currency.name}`}
                                                         </SelectItem>
                                                     ),
                                                 )}

--- a/resources/js/components/transactions/edit-transaction-dialog.tsx
+++ b/resources/js/components/transactions/edit-transaction-dialog.tsx
@@ -763,7 +763,7 @@ export function EditTransactionDialog({
                 id="currency"
                 aria-label={__('Currency')}
                 data-testid="currency-select"
-                className="h-7 w-full gap-1 rounded-md px-2 text-xs font-medium shadow-none"
+                className="h-7 w-fit gap-1 rounded-md px-2 text-xs font-medium shadow-none"
             >
                 <SelectValue placeholder={__('Select currency')}>
                     {currencyCode}

--- a/resources/js/components/transactions/edit-transaction-dialog.tsx
+++ b/resources/js/components/transactions/edit-transaction-dialog.tsx
@@ -28,6 +28,7 @@ import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { useSyncContext } from '@/contexts/sync-context';
 import { useLocale } from '@/hooks/use-locale';
 import { decrypt, importKey } from '@/lib/crypto';
+import { fetchJson } from '@/lib/fetch-json';
 import { getStoredKey } from '@/lib/key-storage';
 import { evaluateRulesForNewTransaction } from '@/lib/rule-engine';
 import { readStoredValue, writeStoredValue } from '@/lib/safe-storage';
@@ -39,12 +40,14 @@ import {
     filterTransactionalAccounts,
     type Account,
     type Bank,
+    type CurrencyCode,
+    type CurrencyOption,
 } from '@/types/account';
 import { type AutomationRule } from '@/types/automation-rule';
 import { type Category } from '@/types/category';
 import { type Label } from '@/types/label';
 import { type DecryptedTransaction } from '@/types/transaction';
-import { formatCurrency, toMajorUnits } from '@/utils/currency';
+import { formatCurrency, toMajorUnits, toMinorUnits } from '@/utils/currency';
 import { formatDate } from '@/utils/date';
 import { __ } from '@/utils/i18n';
 import { router, usePage } from '@inertiajs/react';
@@ -97,6 +100,55 @@ function formatTransactionDate(date: string, locale: string): string {
     return formatted.charAt(0).toUpperCase() + formatted.slice(1);
 }
 
+/**
+ * An amount converted to the account's currency at the transaction's own date,
+ * the same date every total in the app converts at.
+ *
+ * Null whenever there is nothing to show: the two currencies match, the amount
+ * is still empty, the request failed (offline), or the server has no rate for
+ * that day. A figure that could not be converted is never rendered as one.
+ */
+function useConvertedAmount(
+    amountInMinorUnits: number,
+    from: CurrencyCode,
+    to: CurrencyCode | undefined,
+    date: string,
+): number | null {
+    const [converted, setConverted] = useState<number | null>(null);
+
+    useEffect(() => {
+        setConverted(null);
+
+        if (!to || from === to || amountInMinorUnits === 0 || !date) {
+            return;
+        }
+
+        let cancelled = false;
+        const params = new URLSearchParams({
+            from,
+            to,
+            date,
+            amount: String(amountInMinorUnits),
+        });
+
+        fetchJson<{ amount: number | null }>(`/api/exchange-rate?${params}`)
+            .then((json) => {
+                if (!cancelled) {
+                    setConverted(json.amount);
+                }
+            })
+            .catch(() => {
+                // Offline or a rate we could not reach: the original alone.
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [amountInMinorUnits, from, to, date]);
+
+    return converted;
+}
+
 export function EditTransactionDialog({
     transaction,
     categories,
@@ -115,8 +167,8 @@ export function EditTransactionDialog({
     initialAccountId = null,
 }: EditTransactionDialogProps) {
     const locale = useLocale();
-    const userCurrencyCode =
-        usePage<SharedData>().props.auth.user.currency_code;
+    const { auth, currencies } = usePage<SharedData>().props;
+    const userCurrencyCode = auth.user.currency_code;
     const STORAGE_KEY_UPDATE_BALANCE =
         'whisper_money_update_balance_on_transaction';
 
@@ -129,6 +181,8 @@ export function EditTransactionDialog({
     >('expense');
     const [showNotes, setShowNotes] = useState(false);
     const [accountId, setAccountId] = useState<string>('');
+    const [currencyCode, setCurrencyCode] =
+        useState<CurrencyCode>(userCurrencyCode);
     const [categoryId, setCategoryId] = useState<string>('null');
     const [selectedLabelIds, setSelectedLabelIds] = useState<string[]>([]);
     const [notes, setNotes] = useState('');
@@ -176,6 +230,7 @@ export function EditTransactionDialog({
             setUnsignedAmount(Math.abs(transaction.amount));
             setTransactionType(transaction.amount > 0 ? 'income' : 'expense');
             setAccountId(transaction.account_id);
+            setCurrencyCode(transaction.currency_code);
             setCategoryId(transaction.category_id || 'null');
             setSelectedLabelIds(
                 transaction.label_ids ||
@@ -196,11 +251,12 @@ export function EditTransactionDialog({
                 (account) => account.id === initialAccountId,
             );
             setAccountId(initialAccount?.id ?? '');
+            setCurrencyCode(initialAccount?.currency_code ?? userCurrencyCode);
             setCategoryId('null');
             setSelectedLabelIds([]);
             setNotes('');
         }
-    }, [mode, transaction, open, accounts, initialAccountId]);
+    }, [mode, transaction, open, accounts, initialAccountId, userCurrencyCode]);
 
     useEffect(() => {
         if (!open) return;
@@ -337,6 +393,34 @@ export function EditTransactionDialog({
         };
     }
 
+    /**
+     * Keep the amount the user typed at face value when the scale changes:
+     * 10.50 EUR becomes 10.50 BTC, not 0.00001050 of one.
+     */
+    function handleCurrencyChange(nextCurrencyCode: CurrencyCode) {
+        setUnsignedAmount((current) =>
+            toMinorUnits(toMajorUnits(current, currencyCode), nextCurrencyCode),
+        );
+        setCurrencyCode(nextCurrencyCode);
+    }
+
+    /**
+     * The currency follows the account: picking an account is the clearest
+     * statement of what the transaction is in, so it wins over an earlier pick
+     * in the currency field. Changing only the currency afterwards keeps it.
+     */
+    function handleAccountChange(nextAccountId: string) {
+        setAccountId(nextAccountId);
+
+        const nextCurrencyCode = accounts.find(
+            (account) => account.id === nextAccountId,
+        )?.currency_code;
+
+        if (nextCurrencyCode) {
+            handleCurrencyChange(nextCurrencyCode);
+        }
+    }
+
     function handleUpdateBalanceChange(checked: boolean) {
         setUpdateAccountBalance(checked);
         writeStoredValue(STORAGE_KEY_UPDATE_BALANCE, String(checked));
@@ -410,7 +494,7 @@ export function EditTransactionDialog({
                         description_iv: finalDescriptionIv,
                         transaction_date: transactionDate,
                         amount: signedAmount,
-                        currency_code: selectedAccount.currency_code,
+                        currency_code: currencyCode,
                         notes: encryptedNotes,
                         notes_iv: notesIv,
                         creditor_name: null,
@@ -505,8 +589,6 @@ export function EditTransactionDialog({
                 const editedAccount = accounts.find(
                     (acc) => acc.id === accountId,
                 );
-                const editedCurrencyCode =
-                    editedAccount?.currency_code ?? transaction.currency_code;
 
                 if (canEditDate) {
                     updateData.transaction_date = transactionDate;
@@ -521,7 +603,7 @@ export function EditTransactionDialog({
                 if (canEditAllFields) {
                     updateData.amount = signedAmount;
                     updateData.account_id = accountId;
-                    updateData.currency_code = editedCurrencyCode;
+                    updateData.currency_code = currencyCode;
                 }
 
                 const result = await transactionSyncService.update(
@@ -581,7 +663,7 @@ export function EditTransactionDialog({
                         ? {
                               amount: signedAmount,
                               account_id: accountId,
-                              currency_code: editedCurrencyCode,
+                              currency_code: currencyCode,
                               account: editedAccount ?? transaction.account,
                               bank: editedAccount?.bank?.id
                                   ? banks.find(
@@ -659,6 +741,15 @@ export function EditTransactionDialog({
             ? [...transactionalAccounts, selectedAccount]
             : transactionalAccounts;
 
+    // A transaction can hold a currency the picker no longer offers - an imported
+    // row, a code since retired - and it stays selectable so the field never
+    // reads as empty.
+    const currencyOptions: CurrencyOption[] = currencies.accounts.some(
+        (currency) => currency.code === currencyCode,
+    )
+        ? currencies.accounts
+        : [...currencies.accounts, { code: currencyCode, name: currencyCode }];
+
     // The date the source gave this row: the stored one once it has been moved,
     // otherwise the day it still sits on. Manual rows have no source to compare
     // against - the user picked every date they ever had.
@@ -696,6 +787,23 @@ export function EditTransactionDialog({
         ? formatCurrency(transaction.amount, transaction.currency_code, locale)
         : '';
 
+    // The editable branch mirrors the input, which is unsigned - the toggle owns
+    // the sign - while the read-only one mirrors the signed amount it prints.
+    const convertedAmount = useConvertedAmount(
+        canEditAllFields ? unsignedAmount : (transaction?.amount ?? 0),
+        currencyCode,
+        selectedAccount?.currency_code,
+        transactionDate,
+    );
+    const formattedConvertedAmount =
+        convertedAmount === null || !selectedAccount
+            ? null
+            : formatCurrency(
+                  convertedAmount,
+                  selectedAccount.currency_code,
+                  locale,
+              );
+
     const detailRows = transaction
         ? [
               transaction.creditor_name
@@ -719,6 +827,12 @@ export function EditTransactionDialog({
                         value: transaction.bank?.name
                             ? `${accountName} · ${transaction.bank.name}`
                             : accountName,
+                    }
+                  : null,
+              formattedConvertedAmount
+                  ? {
+                        label: __('In account currency'),
+                        value: formattedConvertedAmount,
                     }
                   : null,
           ].filter((row): row is { label: string; value: string } => !!row)
@@ -902,16 +1016,26 @@ export function EditTransactionDialog({
                                                         Math.abs(cents),
                                                     )
                                                 }
-                                                currencyCode={
-                                                    selectedAccount?.currency_code ||
-                                                    userCurrencyCode
-                                                }
+                                                currencyCode={currencyCode}
                                                 disabled={isSubmitting}
                                                 required
                                                 className="h-11 text-right text-xl font-semibold tabular-nums md:text-xl"
                                             />
                                         </div>
                                     </div>
+                                    {formattedConvertedAmount && (
+                                        <p
+                                            className="text-sm text-muted-foreground"
+                                            data-testid="converted-amount"
+                                        >
+                                            {__(
+                                                '≈ :amount in the account currency',
+                                                {
+                                                    amount: formattedConvertedAmount,
+                                                },
+                                            )}
+                                        </p>
+                                    )}
                                     {selectedAccount?.banking_connection_id ? (
                                         <p className="text-sm text-muted-foreground">
                                             {__(
@@ -951,7 +1075,7 @@ export function EditTransactionDialog({
                                         </FormLabel>
                                         <Select
                                             value={accountId}
-                                            onValueChange={setAccountId}
+                                            onValueChange={handleAccountChange}
                                             disabled={isSubmitting}
                                         >
                                             <SelectTrigger
@@ -974,6 +1098,42 @@ export function EditTransactionDialog({
                                                             )}
                                                         >
                                                             {`${decryptedAccountNames.get(account.id) || __('[Loading...]')} · ${account.currency_code}`}
+                                                        </SelectItem>
+                                                    ),
+                                                )}
+                                            </SelectContent>
+                                        </Select>
+                                    </div>
+                                    <div className="space-y-2">
+                                        <FormLabel htmlFor="currency">
+                                            {__('Currency')}
+                                        </FormLabel>
+                                        <Select
+                                            name="currency_code"
+                                            value={currencyCode}
+                                            onValueChange={handleCurrencyChange}
+                                            disabled={isSubmitting}
+                                        >
+                                            <SelectTrigger
+                                                id="currency"
+                                                data-testid="currency-select"
+                                            >
+                                                <SelectValue
+                                                    placeholder={__(
+                                                        'Select currency',
+                                                    )}
+                                                />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                {currencyOptions.map(
+                                                    (currency) => (
+                                                        <SelectItem
+                                                            key={currency.code}
+                                                            value={
+                                                                currency.code
+                                                            }
+                                                        >
+                                                            {`${currency.code} - ${currency.name}`}
                                                         </SelectItem>
                                                     ),
                                                 )}

--- a/resources/js/components/transactions/transaction-columns.test.tsx
+++ b/resources/js/components/transactions/transaction-columns.test.tsx
@@ -1,7 +1,13 @@
+import { PrivacyModeProvider } from '@/contexts/privacy-mode-context';
 import type { DecryptedTransaction } from '@/types/transaction';
-import type { ColumnDef } from '@tanstack/react-table';
-import { describe, expect, it } from 'vitest';
+import type { CellContext, ColumnDef } from '@tanstack/react-table';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 import { createTransactionColumns } from './transaction-columns';
+
+vi.mock('@/hooks/use-locale', () => ({
+    useLocale: () => 'en-US',
+}));
 
 function categoryClassName(columns: ColumnDef<DecryptedTransaction>[]): string {
     const category = columns.find(
@@ -42,5 +48,39 @@ describe('createTransactionColumns category padding', () => {
 
         expect(className).toContain('pl-2');
         expect(className).not.toContain('pl-0');
+    });
+});
+
+describe('createTransactionColumns amount', () => {
+    it('shows the amount in the currency the transaction was made in', () => {
+        const amount = buildColumns(false).find(
+            (column) =>
+                'accessorKey' in column && column.accessorKey === 'amount',
+        );
+
+        const transaction = {
+            amount: -1200,
+            // The account is in euros; the row is not, and the table shows the
+            // row as it stands rather than converting it.
+            currency_code: 'USD',
+        } as DecryptedTransaction;
+
+        render(
+            <PrivacyModeProvider>
+                {(
+                    amount?.cell as (
+                        context: CellContext<DecryptedTransaction, unknown>,
+                    ) => React.ReactNode
+                )?.({
+                    row: {
+                        getValue: () => transaction.amount,
+                        original: transaction,
+                    },
+                } as unknown as CellContext<DecryptedTransaction, unknown>)}
+            </PrivacyModeProvider>,
+        );
+
+        expect(screen.getByText(/\$/)).toBeInTheDocument();
+        expect(screen.queryByText(/€/)).not.toBeInTheDocument();
     });
 });

--- a/resources/js/components/ui/amount-input.tsx
+++ b/resources/js/components/ui/amount-input.tsx
@@ -211,8 +211,12 @@ const evaluateMathExpression = (
 /** Breathing room between the symbol and the number it labels. */
 const SYMBOL_GAP = '0.75rem';
 
-/** Room for a three-letter code and its chevron, and the inset it sits at. */
-const SLOT_WIDTH = '3.75rem';
+/**
+ * The slot sizes itself to the control inside it; this is only the room the
+ * number keeps clear of it, held above what a three-letter ISO code and its
+ * chevron can occupy so the two never collide.
+ */
+const SLOT_RESERVE = '4.5rem';
 const SLOT_INSET = '0.35rem';
 
 const resolveMinorUnits = (input: string, currencyCode: string): number =>
@@ -314,7 +318,7 @@ export const AmountInput = React.forwardRef<HTMLInputElement, AmountInputProps>(
         // The slot takes the symbol's place, so the number is padded off the
         // control rather than off a symbol that is no longer drawn.
         const padding = currencySlot
-            ? { paddingLeft: `calc(${SLOT_INSET} + ${SLOT_WIDTH} + ${SYMBOL_GAP})` }
+            ? { paddingLeft: `calc(${SLOT_INSET} + ${SLOT_RESERVE} + ${SYMBOL_GAP})` }
             : symbolPosition === 'prefix'
               ? { paddingLeft: symbolRoom }
               : { paddingRight: symbolRoom };
@@ -324,7 +328,7 @@ export const AmountInput = React.forwardRef<HTMLInputElement, AmountInputProps>(
                 {currencySlot && (
                     <div
                         className="-translate-y-1/2 absolute top-1/2 z-10 flex items-center"
-                        style={{ left: SLOT_INSET, width: SLOT_WIDTH }}
+                        style={{ left: SLOT_INSET }}
                     >
                         {currencySlot}
                     </div>

--- a/resources/js/components/ui/amount-input.tsx
+++ b/resources/js/components/ui/amount-input.tsx
@@ -31,6 +31,12 @@ interface AmountInputProps {
      * unlocks when the numbers add up — where waiting for blur reads as broken.
      */
     commitOnChange?: boolean;
+    /**
+     * A control to sit inside the field where the currency symbol would go,
+     * for the amounts whose currency the user picks rather than reads. Sized
+     * for an ISO 4217 code, which is always three letters.
+     */
+    currencySlot?: React.ReactNode;
 }
 
 const getCurrencyInfo = (
@@ -205,6 +211,10 @@ const evaluateMathExpression = (
 /** Breathing room between the symbol and the number it labels. */
 const SYMBOL_GAP = '0.75rem';
 
+/** Room for a three-letter code and its chevron, and the inset it sits at. */
+const SLOT_WIDTH = '3.75rem';
+const SLOT_INSET = '0.35rem';
+
 const resolveMinorUnits = (input: string, currencyCode: string): number =>
     evaluateMathExpression(input, currencyCode) ??
     parseInputValue(input, currencyCode);
@@ -222,6 +232,7 @@ export const AmountInput = React.forwardRef<HTMLInputElement, AmountInputProps>(
             className = '',
             allowNegative = false,
             commitOnChange = false,
+            currencySlot,
         },
         ref,
     ) => {
@@ -300,9 +311,25 @@ export const AmountInput = React.forwardRef<HTMLInputElement, AmountInputProps>(
             symbolPosition === 'prefix' && allowNegative ? '2.5rem' : '0.75rem';
         const symbolRoom = `calc(${symbolInset} + ${currencySymbol.length}ch + ${SYMBOL_GAP})`;
 
+        // The slot takes the symbol's place, so the number is padded off the
+        // control rather than off a symbol that is no longer drawn.
+        const padding = currencySlot
+            ? { paddingLeft: `calc(${SLOT_INSET} + ${SLOT_WIDTH} + ${SYMBOL_GAP})` }
+            : symbolPosition === 'prefix'
+              ? { paddingLeft: symbolRoom }
+              : { paddingRight: symbolRoom };
+
         return (
             <div className="relative">
-                {symbolPosition === 'prefix' && (
+                {currencySlot && (
+                    <div
+                        className="-translate-y-1/2 absolute top-1/2 z-10 flex items-center"
+                        style={{ left: SLOT_INSET, width: SLOT_WIDTH }}
+                    >
+                        {currencySlot}
+                    </div>
+                )}
+                {!currencySlot && symbolPosition === 'prefix' && (
                     <span
                         className="-translate-y-1/2 absolute top-1/2 text-muted-foreground text-sm"
                         style={{ left: symbolInset }}
@@ -325,16 +352,15 @@ export const AmountInput = React.forwardRef<HTMLInputElement, AmountInputProps>(
                     required={required}
                     className={cn([
                         'bg-background',
-                        allowNegative && symbolPosition === 'suffix' && 'pl-11',
+                        allowNegative &&
+                            !currencySlot &&
+                            symbolPosition === 'suffix' &&
+                            'pl-11',
                         className,
                     ])}
-                    style={
-                        symbolPosition === 'prefix'
-                            ? { paddingLeft: symbolRoom }
-                            : { paddingRight: symbolRoom }
-                    }
+                    style={padding}
                 />
-                {symbolPosition === 'suffix' && (
+                {!currencySlot && symbolPosition === 'suffix' && (
                     <span
                         className="-translate-y-1/2 absolute top-1/2 text-muted-foreground text-sm"
                         style={{ right: symbolInset }}

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Api\AccountImportConfigController;
 use App\Http\Controllers\Api\CashflowAnalyticsController;
 use App\Http\Controllers\Api\CategoryMonthlyBreakdownController;
 use App\Http\Controllers\Api\DashboardAnalyticsController;
+use App\Http\Controllers\Api\ExchangeRateController;
 use App\Http\Controllers\Api\ImportDataController;
 use App\Http\Controllers\Api\SavedFilterController;
 use App\Http\Controllers\Api\TransactionAnalysisController;
@@ -31,6 +32,9 @@ Route::middleware(['web', 'auth', 'throttle:300,1'])->group(function () {
     Route::post('transactions/check-duplicates', [TransactionController::class, 'checkDuplicates'])->name('api.transactions.check-duplicates');
     Route::get('transactions/analysis', [TransactionAnalysisController::class, 'summary'])->name('api.transactions.analysis');
     Route::patch('transactions/bulk', [TransactionController::class, 'bulkUpdate'])->name('api.transactions.bulk-update');
+
+    // One amount converted between two currencies, for the transaction modal
+    Route::get('exchange-rate', ExchangeRateController::class)->name('api.exchange-rate');
 
     // Category analysis
     Route::get('categories/{category}/monthly-breakdown', CategoryMonthlyBreakdownController::class)->name('api.categories.monthly-breakdown');

--- a/tests/Feature/ExchangeRateEndpointTest.php
+++ b/tests/Feature/ExchangeRateEndpointTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use App\Models\ExchangeRate;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\getJson;
+
+test('it converts an amount at the given date', function () {
+    ExchangeRate::factory()->create([
+        'base_currency' => 'eur',
+        'date' => '2025-11-11',
+        'rates' => ['eur' => 1.0, 'usd' => 2.0],
+    ]);
+
+    actingAs(User::factory()->onboarded()->create())
+        ->getJson('/api/exchange-rate?from=USD&to=EUR&date=2025-11-11&amount=12000')
+        ->assertOk()
+        ->assertExactJson(['amount' => 6000]);
+});
+
+test('it answers with no amount when the day has no rate for that currency', function () {
+    ExchangeRate::factory()->create([
+        'base_currency' => 'eur',
+        'date' => '2025-11-11',
+        'rates' => ['eur' => 1.0],
+    ]);
+
+    actingAs(User::factory()->onboarded()->create())
+        ->getJson('/api/exchange-rate?from=USD&to=EUR&date=2025-11-11&amount=12000')
+        ->assertOk()
+        ->assertExactJson(['amount' => null]);
+});
+
+test('it hands back the same amount when both currencies match', function () {
+    actingAs(User::factory()->onboarded()->create())
+        ->getJson('/api/exchange-rate?from=EUR&to=EUR&date=2025-11-11&amount=12000')
+        ->assertOk()
+        ->assertExactJson(['amount' => 12000]);
+
+    // Nothing to look up, so nothing is fetched: the stray-request guard would
+    // have failed the test had it tried.
+    expect(ExchangeRate::query()->count())->toBe(0);
+});
+
+test('it rejects a date that is not a plain Y-m-d', function () {
+    actingAs(User::factory()->onboarded()->create())
+        ->getJson('/api/exchange-rate?from=USD&to=EUR&date=11/11/2025&amount=12000')
+        ->assertUnprocessable();
+});
+
+test('it turns strangers away', function () {
+    getJson('/api/exchange-rate?from=USD&to=EUR&date=2025-11-11&amount=12000')
+        ->assertUnauthorized();
+});

--- a/tests/Feature/Mcp/McpWriteToolsTest.php
+++ b/tests/Feature/Mcp/McpWriteToolsTest.php
@@ -123,8 +123,8 @@ it('edits a manual transaction', function () {
 
 it('moves a transaction onto a connected account, unwinding only the manual side', function () {
     $user = User::factory()->create();
-    $manualAccount = Account::factory()->create(['user_id' => $user->id]);
-    $connectedAccount = Account::factory()->connected()->create(['user_id' => $user->id]);
+    $manualAccount = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'EUR']);
+    $connectedAccount = Account::factory()->connected()->create(['user_id' => $user->id, 'currency_code' => 'EUR']);
 
     $manualAccount->balances()->create(['balance_date' => '2026-01-15', 'balance' => 9_000]);
     $connectedAccount->balances()->create(['balance_date' => '2026-01-15', 'balance' => 50_000]);
@@ -134,6 +134,7 @@ it('moves a transaction onto a connected account, unwinding only the manual side
         'account_id' => $manualAccount->id,
         'transaction_date' => '2026-01-15',
         'amount' => -1_000,
+        'currency_code' => 'EUR',
     ]);
 
     callWriteTool($user, UpdateTransaction::class, [

--- a/tests/Feature/TransactionTest.php
+++ b/tests/Feature/TransactionTest.php
@@ -5,6 +5,7 @@ use App\Models\AutomationRule;
 use App\Models\Budget;
 use App\Models\BudgetPeriod;
 use App\Models\Category;
+use App\Models\ExchangeRate;
 use App\Models\Label;
 use App\Models\Transaction;
 use App\Models\User;
@@ -379,7 +380,7 @@ test('users cannot delete other users transactions', function () {
 
 test('deleting a manual account expense increases the current balance when requested', function () {
     $user = User::factory()->onboarded()->create();
-    $account = Account::factory()->create(['user_id' => $user->id]);
+    $account = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'EUR']);
 
     $account->balances()->create([
         'balance_date' => now()->toDateString(),
@@ -390,6 +391,7 @@ test('deleting a manual account expense increases the current balance when reque
         'user_id' => $user->id,
         'account_id' => $account->id,
         'amount' => -2500,
+        'currency_code' => 'EUR',
     ]);
 
     actingAs($user)
@@ -405,7 +407,7 @@ test('deleting a manual account expense increases the current balance when reque
 
 test('deleting a manual account income decreases the current balance when requested', function () {
     $user = User::factory()->onboarded()->create();
-    $account = Account::factory()->create(['user_id' => $user->id]);
+    $account = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'EUR']);
 
     $account->balances()->create([
         'balance_date' => now()->toDateString(),
@@ -416,6 +418,7 @@ test('deleting a manual account income decreases the current balance when reques
         'user_id' => $user->id,
         'account_id' => $account->id,
         'amount' => 3000,
+        'currency_code' => 'EUR',
     ]);
 
     actingAs($user)
@@ -431,7 +434,7 @@ test('deleting a manual account income decreases the current balance when reques
 
 test('deleting a past-dated transaction reverses it on that date and every later balance', function () {
     $user = User::factory()->onboarded()->create();
-    $account = Account::factory()->create(['user_id' => $user->id]);
+    $account = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'EUR']);
 
     $account->balances()->create(['balance_date' => '2025-11-10', 'balance' => 5000]);
     $account->balances()->create(['balance_date' => '2025-11-11', 'balance' => 5000]);
@@ -441,6 +444,7 @@ test('deleting a past-dated transaction reverses it on that date and every later
         'account_id' => $account->id,
         'amount' => -1500,
         'transaction_date' => '2025-11-10',
+        'currency_code' => 'EUR',
     ]);
 
     actingAs($user)
@@ -513,7 +517,7 @@ test('deleting a connected account transaction never changes the balance', funct
 
 test('creating a transaction updates the balance on its date when one exists', function () {
     $user = User::factory()->onboarded()->create();
-    $account = Account::factory()->create(['user_id' => $user->id]);
+    $account = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'USD']);
 
     $account->balances()->create([
         'balance_date' => '2025-11-11',
@@ -540,7 +544,7 @@ test('creating a transaction updates the balance on its date when one exists', f
 
 test('creating a transaction creates a balance on its date from the closest earlier balance', function () {
     $user = User::factory()->onboarded()->create();
-    $account = Account::factory()->create(['user_id' => $user->id]);
+    $account = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'USD']);
 
     $account->balances()->create([
         'balance_date' => '2025-11-01',
@@ -566,7 +570,7 @@ test('creating a transaction creates a balance on its date from the closest earl
 
 test('creating a past-dated transaction updates that date and every later balance', function () {
     $user = User::factory()->onboarded()->create();
-    $account = Account::factory()->create(['user_id' => $user->id]);
+    $account = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'USD']);
 
     $account->balances()->create(['balance_date' => '2025-11-10', 'balance' => 1000]);
     $account->balances()->create(['balance_date' => '2025-11-11', 'balance' => 1000]);
@@ -595,7 +599,7 @@ test('creating a past-dated transaction updates that date and every later balanc
 
 test('creating the first transaction on an account creates a balance equal to its amount', function () {
     $user = User::factory()->onboarded()->create();
-    $account = Account::factory()->create(['user_id' => $user->id]);
+    $account = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'USD']);
 
     actingAs($user)->postJson(route('transactions.store'), [
         'account_id' => $account->id,
@@ -659,7 +663,7 @@ test('creating a connected account transaction never changes the balance', funct
 
 test('editing a manual transaction amount moves the balance by the delta when requested', function () {
     $user = User::factory()->onboarded()->create();
-    $account = Account::factory()->create(['user_id' => $user->id]);
+    $account = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'EUR']);
 
     // Balance already reflects the transaction's original 2500 amount (100000 base + 2500).
     $account->balances()->create([
@@ -672,6 +676,7 @@ test('editing a manual transaction amount moves the balance by the delta when re
         'account_id' => $account->id,
         'amount' => 2500,
         'transaction_date' => '2025-11-11',
+        'currency_code' => 'EUR',
         'source' => 'manually_created',
     ]);
 
@@ -717,8 +722,8 @@ test('editing a manual transaction amount does not change the balance when not r
 
 test('moving a manual transaction between accounts reverses the old balance and credits the new one', function () {
     $user = User::factory()->onboarded()->create();
-    $fromAccount = Account::factory()->create(['user_id' => $user->id]);
-    $toAccount = Account::factory()->create(['user_id' => $user->id]);
+    $fromAccount = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'EUR']);
+    $toAccount = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'EUR']);
 
     // Origin balance embeds the transaction's 2500; destination starts flat.
     $fromAccount->balances()->create(['balance_date' => '2025-11-11', 'balance' => 102500]);
@@ -729,6 +734,7 @@ test('moving a manual transaction between accounts reverses the old balance and 
         'account_id' => $fromAccount->id,
         'amount' => 2500,
         'transaction_date' => '2025-11-11',
+        'currency_code' => 'EUR',
         'source' => 'manually_created',
     ]);
 
@@ -749,10 +755,132 @@ test('moving a manual transaction between accounts reverses the old balance and 
     ]);
 });
 
-test('editing only the currency of a manual transaction does not change the balance', function () {
+test('storing a transaction in a currency other than the account one keeps it as typed', function () {
     $user = User::factory()->onboarded()->create();
-    $account = Account::factory()->create(['user_id' => $user->id]);
+    $account = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'EUR']);
 
+    actingAs($user)->postJson(route('transactions.store'), [
+        'account_id' => $account->id,
+        'description' => 'Hotel in New York',
+        'transaction_date' => '2025-11-11',
+        'amount' => -12000,
+        'currency_code' => 'USD',
+        'source' => 'manually_created',
+    ])->assertCreated();
+
+    $this->assertDatabaseHas('transactions', [
+        'account_id' => $account->id,
+        'amount' => -12000,
+        'currency_code' => 'USD',
+    ]);
+});
+
+test('creating a foreign-currency transaction shifts the balance by its converted amount', function () {
+    $user = User::factory()->onboarded()->create();
+    $account = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'EUR']);
+
+    ExchangeRate::factory()->create([
+        'base_currency' => 'eur',
+        'date' => '2025-11-11',
+        'rates' => ['eur' => 1.0, 'usd' => 2.0],
+    ]);
+
+    $account->balances()->create(['balance_date' => '2025-11-11', 'balance' => 100000]);
+
+    actingAs($user)->postJson(route('transactions.store'), [
+        'account_id' => $account->id,
+        'description' => 'Hotel in New York',
+        'transaction_date' => '2025-11-11',
+        'amount' => -12000,
+        'currency_code' => 'USD',
+        'source' => 'manually_created',
+        'update_balance' => true,
+    ])->assertCreated();
+
+    // 120 USD at 2 USD per EUR is 60 EUR off an account held in euros.
+    $this->assertDatabaseHas('account_balances', [
+        'account_id' => $account->id,
+        'balance_date' => '2025-11-11',
+        'balance' => 94000,
+    ]);
+});
+
+test('deleting a foreign-currency transaction gives back exactly what it took', function () {
+    $user = User::factory()->onboarded()->create();
+    $account = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'EUR']);
+
+    ExchangeRate::factory()->create([
+        'base_currency' => 'eur',
+        'date' => '2025-11-11',
+        'rates' => ['eur' => 1.0, 'usd' => 2.0],
+    ]);
+
+    $account->balances()->create(['balance_date' => '2025-11-11', 'balance' => 94000]);
+
+    $transaction = Transaction::factory()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'amount' => -12000,
+        'currency_code' => 'USD',
+        'transaction_date' => '2025-11-11',
+        'source' => 'manually_created',
+    ]);
+
+    actingAs($user)
+        ->deleteJson(route('transactions.destroy', $transaction), ['update_balance' => true])
+        ->assertSuccessful();
+
+    $this->assertDatabaseHas('account_balances', [
+        'account_id' => $account->id,
+        'balance_date' => '2025-11-11',
+        'balance' => 100000,
+    ]);
+});
+
+test('a transaction in a currency with no rate leaves the balance untouched', function () {
+    $user = User::factory()->onboarded()->create();
+    $account = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'EUR']);
+
+    ExchangeRate::factory()->create([
+        'base_currency' => 'eur',
+        'date' => '2025-11-11',
+        'rates' => ['eur' => 1.0],
+    ]);
+
+    $account->balances()->create(['balance_date' => '2025-11-11', 'balance' => 100000]);
+
+    actingAs($user)->postJson(route('transactions.store'), [
+        'account_id' => $account->id,
+        'description' => 'Hotel in New York',
+        'transaction_date' => '2025-11-11',
+        'amount' => -12000,
+        'currency_code' => 'USD',
+        'source' => 'manually_created',
+        'update_balance' => true,
+    ])->assertCreated();
+
+    // The transaction is still stored; only the balance is held back, because
+    // shifting it by the unconverted number would write a figure nobody can
+    // reconcile against the account.
+    $this->assertDatabaseHas('transactions', ['account_id' => $account->id, 'amount' => -12000]);
+    $this->assertDatabaseHas('account_balances', [
+        'account_id' => $account->id,
+        'balance_date' => '2025-11-11',
+        'balance' => 100000,
+    ]);
+});
+
+test('editing only the currency of a manual transaction re-converts the balance', function () {
+    $user = User::factory()->onboarded()->create();
+    $account = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'EUR']);
+
+    ExchangeRate::factory()->create([
+        'base_currency' => 'eur',
+        'date' => '2025-11-11',
+        'rates' => ['eur' => 1.0, 'usd' => 2.0],
+    ]);
+
+    // Balance already embeds the transaction at 2500 EUR.
     $account->balances()->create(['balance_date' => '2025-11-11', 'balance' => 102500]);
 
     $transaction = Transaction::factory()->create([
@@ -760,19 +888,20 @@ test('editing only the currency of a manual transaction does not change the bala
         'account_id' => $account->id,
         'amount' => 2500,
         'transaction_date' => '2025-11-11',
-        'currency_code' => 'USD',
+        'currency_code' => 'EUR',
         'source' => 'manually_created',
     ]);
 
     actingAs($user)->patchJson(route('transactions.update', $transaction), [
-        'currency_code' => 'EUR',
+        'currency_code' => 'USD',
         'update_balance' => true,
     ])->assertSuccessful();
 
+    // The same 2500 is now dollars, worth half as many euros to the account.
     $this->assertDatabaseHas('account_balances', [
         'account_id' => $account->id,
         'balance_date' => '2025-11-11',
-        'balance' => 102500,
+        'balance' => 101250,
     ]);
 });
 


### PR DESCRIPTION
## What

A manual transaction can now carry its own currency. The form forced every one of them into its account's currency, while the importer has always given each row whatever currency its file said — so a hotel paid in dollars off a euro account had to be typed as euros, converted by hand, at whatever rate the user guessed.

The dialog gets a **Currency** picker on create and on edit of a manual transaction, gated by the existing `canEditAllFields` (bank and imported rows stay locked, split parts too). It defaults to the selected account's currency and follows the account when the account changes.

- The amount is stored **as typed, in the picked currency**. No new column, no converted amount at rest — the read-time conversion machinery (`ConvertsTransactionCurrency`, `ExchangeRateService`) already handles every total.
- The picker drives the amount input's **decimal scale**, so BTC gets its eight and JPY its none. Switching currency keeps the typed major amount (10.50 EUR becomes 10.50 BTC, not 0.00001050).
- When the picked currency differs from the account's, the modal shows what the amount comes to **in the account's currency**, converted at the transaction's own date — the same date every aggregate converts at. When they match, nothing extra appears.
- An imported foreign-currency row gets the same figure as an **"In account currency"** line in its locked details card.
- The transactions table goes on showing the **original** currency (unchanged; now covered by a test).

## The bug this fixes on the way

`ManualBalanceAdjuster` shifted an account's balance snapshots by the transaction's raw amount — but those snapshots are held in the **account's** currency. A foreign-currency transaction moved the balance by a number that meant nothing. This was reachable through the importer long before this picker existed.

It converts now, in both directions, off the same date's rate, so applying and reversing cancel out exactly.

**With no rate for that day, the balance is left alone** rather than shifted by the unconverted number, which would write a figure nobody can reconcile into a money column. `ExchangeRateService::convertOrNull()` is what tells "no rate" apart from a real conversion; the modal reads it the same way, so offline or unquoted currencies show the original alone and never a number we could not convert.

> **Known limitation, deliberate:** in that no-rate case the balance silently stays put even though the user ticked "Update account balance". Surfacing it needs a `balance_updated` field threaded through `store`/`update`/`destroy` → `transaction-sync` → a toast. Happy to add it if you'd rather not ship the silence. The MCP tools already report `balance_updated: false` correctly, since they return what the adjuster actually did.

## Two knock-on changes worth your eye

1. **Editing only the currency of a manual transaction now re-adjusts the balance.** It did not before, and a test asserted exactly that. With conversion in place, 2500 USD and 2500 EUR contribute differently to a euro balance, so leaving it put would silently desync it. The test was **rewritten, not removed** (`editing only the currency of a manual transaction re-converts the balance`). `currency_code` joined the balance-affecting attribute list, now shared as `ManualBalanceAdjuster::BALANCE_AFFECTING_ATTRIBUTES` between the controller and the MCP tool rather than duplicated.
2. **`TransactionController::update` gained two private methods** (`saveWithLabels`, `recordCategoryOverride`). `php artisan crap` only analyses methods a diff touches, so editing one line put it over the complexity threshold at 13. These are cohesive extractions, not a split to game the number — the duplication gate stays green.

## New endpoint

`GET /api/exchange-rate?from=&to=&date=&amount=` → `{"amount": int|null}`, authenticated, behind the existing throttle. `null` means "no rate for that day". The modal calls it only when the two currencies differ, and only on amount blur — `AmountInput` commits on blur unless `commitOnChange` is passed, which it isn't here, so this is one request per edit, not per keystroke.

## Also updated

The MCP `create_transaction` / `update_transaction` schemas described `amount` as being "in the account currency's minor units". That stopped being true once `currency_code` could be set independently, so an agent driving those tools could miscompute. Reworded.

## Testing

- **Pest**: the exchange-rate endpoint (auth, same-currency short circuit with a no-query assertion, invalid date format, missing rate), storing a transaction in a currency other than the account's, the adjuster converting on create and reversing symmetrically on delete, and the no-rate case leaving the balance untouched while still storing the transaction.
- **Vitest**: the picker defaulting to the account currency, storing the picked currency rather than the account's, the converted line appearing and its exact text, nothing shown when the currencies match (asserting `fetch` is never called), nothing shown when no rate comes back, the locked-details row, and the table rendering the row's own currency.
- Several existing balance tests pinned their account/transaction currencies. `AccountFactory` and `TransactionFactory` each pick a random currency independently, so with conversion in place those tests would non-deterministically reach for a live rate. Pinning them makes the intent explicit ("same currency, so nothing converts") and the suite deterministic.

Full suite: 3138 passing. Three failures on this branch (`SavingsGoalTest` ×2, `SharedAccountOwnershipTest` ×1, all HTTP 409) reproduce identically with this branch's changes stashed, so they predate it.

`vendor/bin/pint --test`, `bun run format`, `bun run lint`, `bun run dry`, `bun run build` and `php artisan crap --base=origin/main` all clean.

## QA

Browser-tested against the running app with a seeded throwaway user (since removed), covering: the table showing dollars for a USD row on a EUR account; the "In account currency" line on a locked imported row; no conversion line when currencies match; the picker defaulting to EUR and the `≈ €50.00` line appearing after switching to USD at 100; the picker following the account in both directions; a foreign-currency transaction submitted with "Update account balance" checked; JPY (0 decimals) and BTC (8 decimals) changing the input's precision; and the endpoint returning `{"amount":6000}`. Zero console errors.

Verified at rest: the transaction stored as `amount = -10000`, `currency_code = USD` (un-converted), and the EUR account's balance moved `100000 → 95000` — the converted 50,00 €, not the raw 100 USD.

One QA note worth keeping: the imported row dated three days back converted at **that day's** real historical rate rather than a rate seeded for today, which is the correct behaviour and a nice incidental confirmation that the date being used is the transaction's own.

## Demo
<img width="1052" height="1192" alt="modal-1-same-currency" src="https://github.com/user-attachments/assets/f28c9f48-4ca7-47c6-8a86-c88da75de6fe" />
<img width="1052" height="1248" alt="modal-2-foreign-currency" src="https://github.com/user-attachments/assets/e8fe40ce-297b-401f-8cb7-25b787df7656" />
<img width="1052" height="1192" alt="modal-3-jpy-zero-decimals" src="https://github.com/user-attachments/assets/b12d0dfd-14a7-48c8-8d83-9e034ca8d176" />

