### PR TITLE
fix(sidebar): give the collapsed bell and avatar room to breathe

### DIFF
--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -86,7 +86,7 @@ export function AppSidebar() {
                     )}
                     {/* The bell sits beside the account; on the icon rail it
                         stacks above the avatar and its panel opens sideways. */}
-                    <div className="flex items-center gap-1 group-data-[collapsible=icon]:flex-col-reverse">
+                    <div className="flex items-center gap-1 group-data-[collapsible=icon]:flex-col-reverse group-data-[collapsible=icon]:gap-2">
                         <NavUser className="min-w-0 flex-1" />
                         <NotificationBell
                             side={collapsed ? 'right' : 'top'}


### PR DESCRIPTION
## What

On the collapsed sidebar (icon rail) the notification bell and the user menu avatar stack vertically and shared the same `gap-1` (4px) as the expanded horizontal row, which left them visually touching. The collapsed state now gets `gap-2` (8px).

One class:

```diff
-<div className="flex items-center gap-1 group-data-[collapsible=icon]:flex-col-reverse">
+<div className="flex items-center gap-1 group-data-[collapsible=icon]:flex-col-reverse group-data-[collapsible=icon]:gap-2">
```

The expanded (horizontal) spacing is untouched, and so is the `NotificationBell` instance in the mobile header (`app-sidebar-header.tsx`), which is not inside the collapsible group.

## QA

Verified in the browser at 1440x900 and 390x844:

- Expanded footer: computed gap `4px` — unchanged, pixel-identical before/after.
- Collapsed rail: computed gap `8px`, bell above the avatar with clear separation, neither clipped by the 48px rail.
- Bell panel and user menu still open correctly to the right of the rail while collapsed.
- Toggling back to expanded returns to `4px`.
- Dark mode: same behaviour.
- Mobile header bell: renders normally, unaffected.

`gap-3` was considered as a fallback if 8px still looked cramped; it doesn't — 8px reads as one account cluster, 12px would start to separate them into unrelated sections.

## Demo

<!-- PLACEHOLDER: drag the QA video here -->
**⬆️ Attach video here** — generated at `~/Downloads/sidebar-collapsed-bell-spacing-qa.mp4`

## Tests

No test added: this is a single Tailwind spacing class with no logic, and there are no existing tests for `app-sidebar.tsx`.
