### PR TITLE
fix(pwa): follow the app theme in the status bar, not the OS one

### DIFF
--- a/public/favicon/site.webmanifest
+++ b/public/favicon/site.webmanifest
@@ -7,7 +7,7 @@
   "id": "/",
   "display": "standalone",
   "orientation": "portrait-primary",
-  "theme_color": "#1b1b18",
+  "theme_color": "#ffffff",
   "background_color": "#ffffff",
   "categories": ["finance", "productivity"],
   "icons": [

--- a/resources/js/hooks/use-appearance.test.ts
+++ b/resources/js/hooks/use-appearance.test.ts
@@ -1,0 +1,46 @@
+import { initializeTheme } from '@/hooks/use-appearance';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+const themeColor = () =>
+    [...document.querySelectorAll('meta[name="theme-color"]')].map((meta) => ({
+        content: meta.getAttribute('content'),
+        media: meta.getAttribute('media'),
+    }));
+
+describe('initializeTheme', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        document.head.innerHTML = '';
+
+        // jsdom ships no matchMedia; the boot path needs one to get this far.
+        window.matchMedia = ((query: string) => ({
+            matches: false,
+            media: query,
+            addEventListener: () => {},
+            removeEventListener: () => {},
+        })) as unknown as typeof window.matchMedia;
+    });
+
+    it.each([
+        ['light', '#ffffff'],
+        ['dark', '#1c1c1c'],
+    ])('points the status bar at the %s background', (appearance, expected) => {
+        localStorage.setItem('appearance', appearance);
+
+        initializeTheme();
+
+        expect(themeColor()).toEqual([{ content: expected, media: null }]);
+    });
+
+    it('collapses the server-rendered media pair once the theme is resolved', () => {
+        document.head.innerHTML = `
+            <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
+            <meta name="theme-color" content="#1c1c1c" media="(prefers-color-scheme: dark)">
+        `;
+        localStorage.setItem('appearance', 'light');
+
+        initializeTheme();
+
+        expect(themeColor()).toEqual([{ content: '#ffffff', media: null }]);
+    });
+});

--- a/resources/js/hooks/use-appearance.tsx
+++ b/resources/js/hooks/use-appearance.tsx
@@ -40,6 +40,25 @@ const setCookie = (name: string, value: string, days = 365) => {
     document.cookie = `${name}=${value};path=/;max-age=${maxAge};SameSite=Lax`;
 };
 
+/** Hex mirrors of --background in resources/css/app.css. */
+const THEME_COLORS = { light: '#ffffff', dark: '#1c1c1c' } as const;
+
+/**
+ * Keeps the PWA status bar on the app's theme. The server renders a
+ * prefers-color-scheme pair only for "system"; once the theme is resolved here a
+ * single unscoped meta is what the browser should read.
+ */
+const applyThemeColor = (isDark: boolean) => {
+    document
+        .querySelectorAll('meta[name="theme-color"]')
+        .forEach((meta) => meta.remove());
+
+    const meta = document.createElement('meta');
+    meta.name = 'theme-color';
+    meta.content = isDark ? THEME_COLORS.dark : THEME_COLORS.light;
+    document.head.appendChild(meta);
+};
+
 const applyTheme = (appearance: Appearance) => {
     if (typeof document === 'undefined') return;
 
@@ -48,6 +67,7 @@ const applyTheme = (appearance: Appearance) => {
 
     document.documentElement.classList.toggle('dark', isDark);
     document.documentElement.style.colorScheme = isDark ? 'dark' : 'light';
+    applyThemeColor(isDark);
 };
 
 const mediaQuery = () => {

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -1,16 +1,28 @@
+@php
+    // The status bar colour follows the app's own appearance preference, not the
+    // OS one: a user on a dark phone with the app set to light gets a light bar.
+    // Hex mirrors of --background in resources/css/app.css.
+    $appearance = $appearance ?? 'system';
+    $lightBackground = '#ffffff';
+    $darkBackground = '#1c1c1c';
+@endphp
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" translate="no" @class(['notranslate', 'dark' => ($appearance ?? 'system') == 'dark'])>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" translate="no" @class(['notranslate', 'dark' => $appearance === 'dark'])>
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-        <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
-        <meta name="theme-color" content="#383838" media="(prefers-color-scheme: dark)">
+        @if ($appearance === 'system')
+            <meta name="theme-color" content="{{ $lightBackground }}" media="(prefers-color-scheme: light)">
+            <meta name="theme-color" content="{{ $darkBackground }}" media="(prefers-color-scheme: dark)">
+        @else
+            <meta name="theme-color" content="{{ $appearance === 'dark' ? $darkBackground : $lightBackground }}">
+        @endif
         <meta name="google" content="notranslate">
 
         {{-- Inline script to detect system dark mode preference and apply it immediately --}}
         <script>
             (function() {
-                const appearance = @json($appearance ?? 'system');
+                const appearance = @json($appearance);
 
                 if (appearance === 'system') {
                     const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -35,11 +47,11 @@
         {{-- Inline style to set the HTML background color based on our theme in app.css --}}
         <style>
             html {
-                background-color: oklch(1 0 0);
+                background-color: {{ $lightBackground }};
             }
 
             html.dark {
-                background-color: oklch(0.145 0 0);
+                background-color: {{ $darkBackground }};
             }
         </style>
 

--- a/tests/Feature/ThemeColorMetaTest.php
+++ b/tests/Feature/ThemeColorMetaTest.php
@@ -1,0 +1,20 @@
+<?php
+
+test('the status bar colour follows the appearance preference, not the OS one', function (string $appearance, string $expected) {
+    $this->withUnencryptedCookie('appearance', $appearance)
+        ->get(route('login'))
+        ->assertOk()
+        ->assertSee('<meta name="theme-color" content="'.$expected.'">', false);
+})->with([
+    'light' => ['light', '#ffffff'],
+    'dark' => ['dark', '#1c1c1c'],
+]);
+
+test('the OS preference still drives the status bar when the appearance is system', function () {
+    $response = $this->withUnencryptedCookie('appearance', 'system')
+        ->get(route('login'))
+        ->assertOk();
+
+    $response->assertSee('<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">', false)
+        ->assertSee('<meta name="theme-color" content="#1c1c1c" media="(prefers-color-scheme: dark)">', false);
+});


### PR DESCRIPTION
## The problem

On the installed Android PWA the system status bar did not match the app. With the app on **light**, the app rendered white and the status bar rendered black.

Nothing regressed in the repo — the metas hadn't changed since #22. The cause is a mismatch between two different notions of "theme":

```blade
<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
<meta name="theme-color" content="#383838" media="(prefers-color-scheme: dark)">
```

`prefers-color-scheme` is **the OS setting**. But the app's theme is not driven by the OS — it is driven by the `appearance` preference (`light` | `dark` | `system`), shared into the blade by `HandleAppearance` and applied at runtime by `use-appearance.tsx`. A user with the phone in dark mode and the app set to `light` therefore got a white app under a dark status bar. The two only agreed by coincidence, whenever the OS and the app happened to be on the same theme.

## The fix

**`theme-color` now follows the app's own preference.** Rendered server-side from `$appearance`: a single unscoped colour for `light` and `dark`, and the `prefers-color-scheme` pair only for `system`, where the OS genuinely is the source of truth.

**It stays in sync at runtime.** `applyTheme()` in `use-appearance.tsx` — the single place the theme is applied — now also rewrites the meta, so switching the theme in settings moves the status bar without a reload. It collapses the media pair into one resolved meta; for `system`, the existing `matchMedia` listener already re-runs `applyTheme` when the OS scheme changes, so live OS switching keeps working.

**One dark background instead of three.** The meta said `#383838`, the inline critical style said `oklch(0.145 0 0)`, and the real `--background` in `app.css` is `oklch(0.225 0 0)`. The last one is the truth; the other two are now `#1c1c1c`, its hex mirror. `oklch(0.145 0 0)` was in fact `--foreground`, so the first-paint background was wrong too.

**Manifest aligned.** `theme_color` was `#1b1b18` (near-black), which Android uses for the launch/splash chrome before the page's meta applies — a second source of the same black. It is now `#ffffff`, matching `background_color`.

### Known trade-off

A web manifest is static and cannot be templated per user, so its single `theme_color` governs the cold-launch chrome before any page code runs. Pointing it at white fixes the reported bug for light and system-light users (the large majority, and the default), at the cost of a brief white flash on cold launch for users who have chosen **dark** — where the mismatch used to be small, since `#1b1b18` ≈ `#1c1c1c`. This is inherent to static manifests, not something this change can fully solve; flagging it so a future "white flash in dark mode" report isn't read as a surprise regression.

## Tests

- `tests/Feature/ThemeColorMetaTest.php` — the blade renders the right `theme-color` for each `appearance` cookie value, and still emits the media pair for `system`.
- `resources/js/hooks/use-appearance.test.ts` — `initializeTheme()` points the meta at the right background and collapses the server-rendered media pair.

## QA

Android's status bar can't be reproduced in a desktop browser, so this was verified against the artefact the OS actually reads — the rendered `<meta name="theme-color">`.

| Case | Result |
| --- | --- |
| `appearance=light` | one unscoped meta, `#ffffff` |
| `appearance=dark` | one unscoped meta, `#1c1c1c` |
| `appearance=system`, OS light | media pair from the server, collapsed to `#ffffff` after hydration |
| `appearance=system`, OS dark | media pair from the server, collapsed to `#1c1c1c` after hydration |
| Light → Dark → System in settings | meta updates on each click, 0 navigations, never more than one meta in the head |

No console errors; no visual regression on the settings and dashboard pages in either theme.

## Demo

<!-- PLACEHOLDER: drag the QA video here -->
