### PR TITLE
fix(pwa): let Android tint the bottom navigation bar from the app's theme

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -5,12 +5,19 @@
     $appearance = $appearance ?? 'system';
     $lightBackground = '#ffffff';
     $darkBackground = '#1c1c1c';
+
+    // Android tints the system bars — the bottom navigation bar included — from
+    // the page's colour scheme, so it has to be declared for the theme the app
+    // renders, not the one the phone is on.
+    $colorScheme = in_array($appearance, ['light', 'dark'], true) ? $appearance : 'light dark';
 @endphp
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}" translate="no" @class(['notranslate', 'dark' => $appearance === 'dark'])>
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+        {{-- Before any stylesheet, so the system bars are already right at first paint. --}}
+        <meta name="color-scheme" content="{{ $colorScheme }}">
         @if ($appearance === 'system')
             <meta name="theme-color" content="{{ $lightBackground }}" media="(prefers-color-scheme: light)">
             <meta name="theme-color" content="{{ $darkBackground }}" media="(prefers-color-scheme: dark)">

--- a/tests/Feature/PwaTest.php
+++ b/tests/Feature/PwaTest.php
@@ -24,3 +24,26 @@ test('app template includes pwa meta tags and service worker registration', func
         ->assertSee('viewport-fit=cover', false)
         ->assertSee("try {\n                    chartScheme = localStorage.getItem('chart-color-scheme')", false);
 });
+
+test('the manifest paints the splash and the system bars with the light background', function () {
+    $manifest = json_decode(file_get_contents(public_path('favicon/site.webmanifest')), true);
+
+    // A manifest is baked into the WebAPK at install time and cannot react to the
+    // theme, so it carries the light background — the default — for both.
+    $this->withUnencryptedCookie('appearance', 'light')
+        ->get(route('login'))
+        ->assertOk()
+        ->assertSee('<meta name="theme-color" content="'.$manifest['theme_color'].'">', false);
+
+    expect($manifest['background_color'])->toBe($manifest['theme_color']);
+});
+
+test('the --background tokens every hard-coded mirror was derived from have not drifted', function () {
+    // The blade, the manifest and use-appearance.tsx carry hex mirrors of these
+    // tokens, because neither a manifest nor a meta tag parses oklch. When this
+    // fails, re-derive every mirror: oklch(1 0 0) is #ffffff, oklch(0.225 0 0)
+    // is #1c1c1c.
+    expect(file_get_contents(resource_path('css/app.css')))
+        ->toContain('--background: oklch(1 0 0);')
+        ->toContain('--background: oklch(0.225 0 0);');
+});

--- a/tests/Feature/ThemeColorMetaTest.php
+++ b/tests/Feature/ThemeColorMetaTest.php
@@ -18,3 +18,14 @@ test('the OS preference still drives the status bar when the appearance is syste
     $response->assertSee('<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">', false)
         ->assertSee('<meta name="theme-color" content="#1c1c1c" media="(prefers-color-scheme: dark)">', false);
 });
+
+test('the colour scheme follows the appearance preference, so Android tints both system bars', function (string $appearance, string $expected) {
+    $this->withUnencryptedCookie('appearance', $appearance)
+        ->get(route('login'))
+        ->assertOk()
+        ->assertSee('<meta name="color-scheme" content="'.$expected.'">', false);
+})->with([
+    'light' => ['light', 'light'],
+    'dark' => ['dark', 'dark'],
+    'system' => ['system', 'light dark'],
+]);


### PR DESCRIPTION
## Scope

The bug came in as two symptoms on an installed Android PWA:

1. app on light, OS on light → **status bar black**
2. app on dark → **bottom navigation bar stays white**

**This PR fixes (2) only.** (1) turned out to be a platform limitation — see the status bar section
below. It is not something this repo can close.

## Why the navigation bar was white

`color-scheme` was only ever set from `applyTheme()` in `resources/js/hooks/use-appearance.tsx`,
i.e. after the JS bundle had loaded. Until then the page declared **no colour scheme at all**, so
Chrome treated it as light and tinted the system chrome it owns accordingly — including the
navigation bar, which Android 15's forced edge-to-edge made the browser's job rather than the
page's.

So: render it in the head, from the same `$appearance` the `theme-color` meta already uses, before
any stylesheet.

```html
<meta name="color-scheme" content="light">        {{-- appearance = light  --}}
<meta name="color-scheme" content="dark">         {{-- appearance = dark   --}}
<meta name="color-scheme" content="light dark">   {{-- appearance = system --}}
```

`applyTheme()` still sets `documentElement.style.colorScheme` on every theme toggle; it now
reinforces the meta at runtime instead of being the first declaration.

## What each colour actually drives

| Value | What it drives | Why it is what it is |
| --- | --- | --- |
| `theme_color` (manifest) | The **status bar** on mobile — and in an installed WebAPK it is the *only* thing that does. | Baked into the WebAPK at install time, so it cannot be theme-aware. Holds the light background. |
| `<meta name="theme-color">` | Overrides `theme_color` **in a browser tab**. An **installed WebAPK ignores it for the status bar** and keeps using the baked manifest colour. | Confirmed on device (see below) and tracked upstream: [crbug 40634649](https://issues.chromium.org/issues/40634649) "Theme-color isn't applied when in dark mode for PWA's" and [crbug 40759522](https://issues.chromium.org/issues/40759522) "Installed PWA doesn't respect theme color (as specified)". |
| `background_color` (manifest) | **Only** the splash screen and the window background *before stylesheets load*. MDN: "used only as a temporary measure during the initial loading phase and for generating splash screens." | It does **not** drive the navigation bar. Left light: baked at install, can't react to the theme, and light is the app's default. |
| `color-scheme` | The colour of the UA canvas and **browser-provided UI** — the lever over the navigation bar. | Now declared at first paint, per the app's own theme. **This is what this PR changes.** |

Worth stating plainly: **no web API colours Android's navigation bar directly.** The page's colour
scheme is the only influence available, so this is the fix that exists rather than a guaranteed one.

## The status bar: a static baked colour, not a theme-following one

An earlier draft of this description blamed a stale WebAPK cache. **Device evidence falsified that.**
On one phone, in sequence:

| manifest `theme_color` | device state | status bar |
| --- | --- | --- |
| `#1b1b18` | light OS, light app | **black** |
| `#ffffff` | dark OS, dark app | **white** |

The bar tracked the *manifest* across both and matched the *meta* in neither. The black→white flip
is the WebAPK update landing — so the cache did refresh, and the bar still didn't follow the theme.
At the same time `applyThemeColor()` had removed every other theme-color meta and injected a single
unscoped `<meta name="theme-color" content="#1c1c1c">`, so the DOM was correct and the bar was
white anyway.

**Conclusion: an installed WebAPK ignores `<meta name="theme-color">` for the status bar and uses
the baked manifest `theme_color`.** #933's status-bar fix works in a browser tab and is inert in the
installed app. The status bar is therefore **one static colour** — currently `#ffffff`, the light
background — and on Android today it **cannot follow the app's theme**. Installed PWAs also still
cannot draw behind it; the "short-edges cutout mode" work that would allow it is In Progress in
Chromium as of July 2026, not in Stable.

Follow-up worth its own ticket: the baked colour *is* ours to choose even though theme-following
isn't. Whether `#ffffff` is the least-bad single value for dark-mode users is a product call this PR
doesn't make.

### Forcing a manifest refresh

Manifest changes still reach a device only when Chrome regenerates the WebAPK, roughly a day or
more. To force it:

> `chrome://webapks` → **Whisper Money** → **Update**

That applies to the navigation-bar fix in this PR too — nobody sees it the moment this merges.

## Drift guard

`--background` lives in `resources/css/app.css` as `oklch()`, but neither a manifest nor a meta tag
parses `oklch`, so the blade, the manifest and `use-appearance.tsx` each carry a hex mirror. That is
how this drifted into four different darks in the first place. `PwaTest` now pins the tokens those
mirrors were derived from, so moving `--background` fails the build with a note to re-derive them.

## Tests

- `PwaTest` — the manifest's `theme_color` is what the light app actually renders, and the
  `--background` tokens behind every hex mirror have not moved.
- `ThemeColorMetaTest` — `color-scheme` follows the appearance preference across light / dark / system.

## QA

Browser pass over light / dark / system, including the OS-dark-but-app-light conflict case. The
meta, `documentElement.style.colorScheme` and the computed style agree in all three.

The one that matters: with the cache disabled and the network throttled to ~8KB/s, navigating with
`waitUntil: 'commit'` and confirming via `document.readyState === 'loading'` and an empty
`style.colorScheme` that neither the stylesheet nor the JS had run — the page painted solid
`#1c1c1c` with **no light flash**. That is the fix working before anything else on the page does.

No regressions in dark mode: native text/password inputs, custom comboboxes and the transactions
scrollbar all render dark.

Unrelated pre-existing quirk found along the way, not caused by this diff: the **native
`<input type="date">` calendar popup** renders light-on-white in dark mode even though the input's
computed `color-scheme` is correctly `dark`. It behaves the same with or without this change
(`applyTheme()` already set `colorScheme` long before a user could open that modal). Worth its own
ticket.

## Demo

<!-- PLACEHOLDER: drag the QA video in here -->

