### PR TITLE
fix(pwa): drop the Android status bar instead of trying to colour it

### DIFF
--- a/public/favicon/site.webmanifest
+++ b/public/favicon/site.webmanifest
@@ -5,7 +5,7 @@
   "start_url": "/dashboard",
   "scope": "/",
   "id": "/",
-  "display": "standalone",
+  "display": "fullscreen",
   "orientation": "portrait-primary",
   "theme_color": "#ffffff",
   "background_color": "#ffffff",

--- a/resources/js/pages/welcome.tsx
+++ b/resources/js/pages/welcome.tsx
@@ -2767,7 +2767,10 @@ export default function Welcome({
         }
 
         return (
-            window.matchMedia('(display-mode: standalone)').matches ||
+            // Android applies fullscreen, iOS falls back to standalone.
+            window.matchMedia(
+                '(display-mode: fullscreen), (display-mode: standalone)',
+            ).matches ||
             ('standalone' in navigator &&
                 (navigator as Navigator & { standalone: boolean }).standalone)
         );

--- a/tests/Feature/PwaTest.php
+++ b/tests/Feature/PwaTest.php
@@ -4,11 +4,25 @@ test('service worker exists', function () {
     expect(file_exists(public_path('sw.js')))->toBeTrue();
 });
 
-test('web manifest starts at dashboard with standalone display', function () {
+test('web manifest starts at dashboard with fullscreen display', function () {
     $manifest = json_decode(file_get_contents(public_path('favicon/site.webmanifest')), true);
 
+    // Fullscreen so Android hides the status bar instead of painting it with the
+    // manifest theme_color, which is baked at install time and cannot follow the
+    // app theme. iOS does not support fullscreen and falls back to standalone.
     expect($manifest['start_url'])->toBe('/dashboard')
-        ->and($manifest['display'])->toBe('standalone');
+        ->and($manifest['display'])->toBe('fullscreen');
+});
+
+test('the landing page detects an installed app in the display mode the manifest asks for', function () {
+    $manifest = json_decode(file_get_contents(public_path('favicon/site.webmanifest')), true);
+
+    // The landing page redirects installed users to the dashboard, and the
+    // display-mode media feature only matches the mode that was actually applied,
+    // so it has to cover both what we ask for and the standalone iOS falls back to.
+    expect(file_get_contents(resource_path('js/pages/welcome.tsx')))
+        ->toContain('(display-mode: '.$manifest['display'].')')
+        ->toContain('(display-mode: standalone)');
 });
 
 test('app template includes pwa meta tags and service worker registration', function () {


### PR DESCRIPTION
On an installed Android PWA the status bar never matches the app. Every route to
*colouring* it is closed, so this removes the bar instead.

## The diagnosis, so nobody re-derives it

Established empirically on device across three observations:

| When | manifest `theme_color` baked into the WebAPK | User was in | Bar shown |
| --- | --- | --- | --- |
| ~1 month ago | `#1b1b18` (near-black) | dark | black — looked right by coincidence |
| today, 1st report | `#1b1b18` | light | black — wrong |
| today, after forcing a WebAPK update | `#ffffff` | dark | white — wrong |

The bar tracked the baked manifest `theme_color` in all three and the
`<meta name="theme-color">` in none. `applyThemeColor()` in
`resources/js/hooks/use-appearance.tsx` (#933) removes every theme-color meta and
injects a single unscoped one with the right colour, so the DOM was provably
correct while the bar stayed wrong: **an installed WebAPK ignores the meta for the
status bar.**

Why the alternatives are dead ends:

- `dark_theme_color` / `user_preferences` — the manifest member that would fix
  this — is Chrome Platform Status feature 5714780426862592: "Origin trial", no
  desktop or Android milestone, no spec, created 2021-10-28, last touched
  2022-11-06. Firefox closed without a position, Safari no signal.
- Installed PWAs drawing behind the status bar ("short-edges cutout mode") is In
  Progress in Chromium as of July 2026, not in Stable.
- A single baked colour is wrong in one theme or the other by construction.

## The change

`"display": "standalone"` → `"display": "fullscreen"` in
`public/favicon/site.webmanifest`. On Android the status bar is then hidden
outright, so there is nothing left to mismatch.

**No `display_override`.** The spec's implicit fallback chain is already
`fullscreen → standalone → minimal-ui → browser`, which is exactly the chain we
want, and `display_override` is Chromium-only (MDN BCD: `safari: false`,
`firefox: false`; zero occurrences in the WebKit tree). It would add a line and
change nothing.

## iOS is unaffected — and I checked rather than assumed

`display: fullscreen` behaves differently per platform, and on iOS it is
documented in several places as *overlaying* the status bar on your content —
which is exactly the bug 80b66683 (#281) and ea9956f2 (#282) fixed with
`<meta name="apple-mobile-web-app-status-bar-style" content="default">`. That
turns out not to apply here:

- MDN browser-compat-data, `manifests/webapp/display.json`: `standalone` and
  `browser` are `safari_ios: 11.3`, but **`fullscreen` is `safari: false`** (and
  `safari_ios: "mirror"`). Safari does not support it.
- WebKit's `ApplicationManifestParser::parseDisplay` does parse `"fullscreen"`
  into `Display::Fullscreen` rather than rejecting it to `Display::Browser`, so
  there is no risk of the iOS app suddenly launching with browser chrome; the
  unsupported mode falls through the spec chain to `standalone`, which is what
  iOS does today.
- Inside open-source WebKit, `Display::Fullscreen` only reaches the `display-mode`
  media feature and the `_WKApplicationManifest` API — nothing that moves the
  status bar.

So iOS keeps `standalone` plus the opaque, non-overlaying `content="default"`
bar. **`apple-mobile-web-app-status-bar-style` is untouched and the `PwaTest`
assertions that pin it (`content="default"`, no `black-translucent`) are
untouched.** The advice you find online that pairs `display: fullscreen` with
`black-translucent` is conflating the two: the overlay comes from
`black-translucent`, not from the display mode.

## One thing this actually broke

`resources/js/pages/welcome.tsx` redirects an installed user who lands on `/`
through to `/dashboard`, and it detected "installed" with
`matchMedia('(display-mode: standalone)')`. The `display-mode` media feature
matches **only the mode that was actually applied** — no cross-matching, no
fallback-chain matching (w3c/manifest: "A user agent MUST reflect the applied
display mode … not necessarily the one declared in the manifest"). So on Android,
once the WebAPK regenerates, that query stops matching and an installed user
would get the marketing landing page instead of the dashboard.

`start_url` is `/dashboard`, so this doesn't bite when you tap the icon — it bites
when you reach `/` from inside the app, e.g. via the logo in `auth-simple-layout`,
which links to `home()`. Fixed by matching both modes:

```
'(display-mode: fullscreen), (display-mode: standalone)'
```

fullscreen for Android, standalone for the iOS fallback and desktop. A new test in
`PwaTest.php` builds the expected query from the manifest's own `display` value, so
the manifest and the landing page can't drift apart again — same idea as the
existing `--background` mirror-drift test in that file.

## Safe-area plumbing: checked, nothing to change

- `layouts/app/app-sidebar-layout.tsx` already carries `.pt-safe`, and
  `layouts/app-layout.tsx` delegates to it, so neither needs anything. It works
  under both outcomes by construction: `.pt-safe` is `env(safe-area-inset-top)`,
  so it collapses to `0` where there is no inset and pads where there is one.
- `layouts/auth-layout.tsx` → `auth/auth-simple-layout.tsx` is
  `min-h-svh … items-center justify-center p-6` — vertically centred with 24px of
  padding, nothing pinned to the top edge. No `.pt-safe` needed.
- The hardcoded `pb-[90px]` in `app-sidebar-layout.tsx` and the `bottom-6` on the
  floating mobile nav pill in `components/app-sidebar.tsx` are **not** made wrong
  by this. Both are measured from the viewport bottom, and fullscreen *removes*
  system UI at the bottom on Android rather than adding any — the pill ends up with
  more clearance, not less. Left alone deliberately.
  <br>Separately and pre-existing: `bottom-6` ignores `--safe-area-bottom`, so on an
  iPhone the pill can sit over the home indicator. iOS behaviour doesn't change in
  this PR, so that's not fixed here.
- `components/ui/popover.tsx` and `components/onboarding/step-screen.tsx` read the
  safe-area variables at runtime, so they adapt either way.
- `viewport-fit=cover` stays on the viewport meta, as `PwaTest` requires.

## Tradeoff accepted

Inside the app on Android there is **no clock, no battery indicator and no
notification icons**. Nothing in the app depends on the system clock being visible
(checked), so the cost is purely that: you leave the app to see the time.

## You won't see this on device yet

`display` is baked into the WebAPK at install time exactly like the colours are, so
nothing changes on an already-installed app until Chrome regenerates the WebAPK.
Force it via `chrome://webapks` → Whisper Money → **Update**; otherwise it's roughly
a day.

## Overlap with #934

#934 (`fix-pwa-system-bar-colors`) is already merged — it's the commit this branch
is based on — so there's nothing to rebase or coordinate. Worth flagging that its
stated rationale mostly evaporates here: it added `<meta name="color-scheme">` to
tint the Android **navigation** bar, and in fullscreen there is no navigation bar to
tint. It isn't wrong — declaring `color-scheme` at first paint is still the correct
thing for the UA canvas, form controls and scrollbars — just differently motivated
now. Whether its description wants reframing is your call, not mine; I haven't
touched that branch.

## Worth an eyeball on device

One thing I could not verify without a notched Android phone in fullscreen: the
onboarding progress hairline in `layouts/onboarding-layout.tsx` is deliberately
placed "at the very top edge" (its own comment) *above* the header that carries
`.pt-safe`. If Chrome reports a non-zero top inset in fullscreen on a device with a
cutout, that 2px line ends up in the cutout region. I left it as-is rather than
contradict the explicit design intent on a guess — it's a one-line move of
`.pt-safe` onto the outer wrapper if it turns out to look wrong. Screen readers are
unaffected either way (`role="progressbar"` + `aria-label` are on the element).

## QA

Browser QA against the dev server, mobile viewport 393×852:

| Emulated `display-mode` | `/` renders |
| --- | --- |
| `fullscreen` | redirects away from the landing page — `/dashboard` logged in, `/register` as a guest |
| `standalone` | same, unchanged |
| `browser` | the marketing landing page, no redirect |

Also checked: the manifest is served as `application/manifest+json`, parses, carries
`display: fullscreen` with every other member intact, and Chrome logs no
manifest-parse warning; the dashboard, transactions list and settings render with no
clipping at the top edge; `apple-mobile-web-app-status-bar-style="default"`,
`apple-mobile-web-app-capable="yes"`, `viewport-fit=cover` and the manifest `<link>`
are all still in the served HTML. `tests/Feature/PwaTest.php` is 6/6.

Two caveats, stated rather than papered over:

- CDP `Emulation.setEmulatedMedia` cannot override `display-mode` in this Chromium
  build (it silently stays `browser`, while the same API does flip
  `prefers-color-scheme`), so the matrix above was driven by stubbing `matchMedia`
  with the exact query string the app calls. Same code path, but not a real OS-level
  window-mode change.
- `env(safe-area-inset-*)` is `0` in desktop Chrome, so none of this is device-level
  proof about notches or insets. The Android status bar actually disappearing needs a
  phone and a regenerated WebAPK.

## Demo

<!-- PLACEHOLDER: drag the video in here -->
**📎 TODO: attach `~/Downloads/pwa-fullscreen-qa.mp4`** (27s — the three display-mode
cases logged out, then login and the logged-in fullscreen redirect, then the mobile
dashboard/transactions/settings walkthrough).
