### PR TITLE
feat(achievements): reveal the next medal of every track, with progress where it is cheap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ yarn-error.log
 .pint.cache
 /.playwright-mcp
 /build
+
+# Written by DocumentationImagesTest and deleted again when it finishes: on
+# disk only while the suite runs, so an interrupted run cannot leave it behind
+# for the next `git add` to sweep up.
+/tests/.documentation-images/

--- a/app/Services/Achievements/Progress.php
+++ b/app/Services/Achievements/Progress.php
@@ -135,7 +135,7 @@ class Progress
                     'key' => $track,
                     'label' => $label,
                     'note' => $this->note($track),
-                    'unlocked' => count(array_filter($medals, fn (array $medal): bool => $medal['state'] === 'earned')),
+                    'unlocked' => $definitions->filter(fn (Definition $definition): bool => $earned->has($definition->key))->count(),
                     'medals' => $medals,
                 ];
             })

--- a/app/Services/Achievements/Progress.php
+++ b/app/Services/Achievements/Progress.php
@@ -3,6 +3,7 @@
 namespace App\Services\Achievements;
 
 use App\Models\Achievement;
+use App\Models\MonthlySummary;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
@@ -14,6 +15,12 @@ use Illuminate\Support\Collection;
  * the road ahead rather than a list of failures, and the screen draws them as
  * empty slots to the right of what has been earned. What a locked medal is
  * called stays here — the frontend gets a tier and nothing else for it.
+ *
+ * The one exception is the next medal of each track, the first rung nobody has
+ * earned yet. A wall of thirteen identical silhouettes says nothing about what
+ * there is to chase, so that one arrives named, with its pictogram and the
+ * figure to reach, and — where {@see Standing} can read the figure cheaply —
+ * how far along the reader already is.
  */
 class Progress
 {
@@ -22,6 +29,7 @@ class Progress
         private Ladders $ladders,
         private Presenter $presenter,
         private Rarity $rarity,
+        private Standing $standing,
     ) {}
 
     /**
@@ -32,26 +40,37 @@ class Progress
         $earned = $user->achievements()->get()->keyBy('key');
         $currency = $this->ladders->currencyFor($user->currency_code);
         $shares = $this->rarity->shares();
+        // Read once: the overview wants the month it started, the saving track
+        // wants the number, and both are the same row.
+        $report = $this->lastReport($user);
 
         return [
             'currency' => $currency,
-            'overview' => $this->overview($earned, $user),
-            'tracks' => $this->tracks($earned, $currency, $shares),
+            'overview' => $this->overview($earned, $report),
+            'tracks' => $this->tracks($earned, $currency, $shares, $this->standing->for($user, $report)),
         ];
+    }
+
+    private function lastReport(User $user): ?MonthlySummary
+    {
+        return $user->monthlySummaries()
+            ->whereNotNull('sent_at')
+            ->orderByDesc('period')
+            ->first();
     }
 
     /**
      * @param  Collection<string, Achievement>  $earned
      * @return array<string, mixed>
      */
-    private function overview(Collection $earned, User $user): array
+    private function overview(Collection $earned, ?MonthlySummary $report): array
     {
         $latest = $earned->sortByDesc('achieved_on')->first();
 
         return [
             'unlocked' => $earned->count(),
             'total' => $this->catalog->all()->count(),
-            'streak' => $this->activeStreak($user),
+            'streak' => $this->activeStreak($report),
             'latest' => $latest === null ? null : [
                 'name' => $this->catalog->find($latest->key)?->name,
                 'achieved_on' => $latest->achieved_on->toDateString(),
@@ -67,38 +86,48 @@ class Progress
      *
      * @return array{months: int, since: ?string}|null
      */
-    private function activeStreak(User $user): ?array
+    private function activeStreak(?MonthlySummary $report): ?array
     {
-        $summary = $user->monthlySummaries()
-            ->whereNotNull('sent_at')
-            ->orderByDesc('period')
-            ->first();
+        $months = (int) ($report?->figure('streak_months') ?? 0);
 
-        $months = (int) ($summary?->figure('streak_months') ?? 0);
-
-        if ($summary === null || $months < 1) {
+        if ($report === null || $months < 1) {
             return null;
         }
 
         return [
             'months' => $months,
-            'since' => $summary->periodStart()->copy()->subMonths($months - 1)->toDateString(),
+            'since' => $report->periodStart()->copy()->subMonths($months - 1)->toDateString(),
         ];
     }
 
     /**
      * @param  Collection<string, Achievement>  $earned
      * @param  array<string, float>  $shares
+     * @param  array<string, int>  $standing
      * @return list<array<string, mixed>>
      */
-    private function tracks(Collection $earned, string $currency, array $shares): array
+    private function tracks(Collection $earned, string $currency, array $shares, array $standing): array
     {
         $byTrack = $this->catalog->all()->groupBy(fn (Definition $definition): string => $definition->track);
 
         return collect($this->catalog->tracks())
-            ->map(function (string $label, string $track) use ($byTrack, $earned, $currency, $shares): array {
-                $medals = $byTrack->get($track, collect())
-                    ->map(fn (Definition $definition): array => $this->medal($definition, $earned->get($definition->key), $currency, $shares))
+            ->map(function (string $label, string $track) use ($byTrack, $earned, $currency, $shares, $standing): array {
+                /** @var Collection<int, Definition> $definitions */
+                $definitions = $byTrack->get($track, collect());
+
+                // The catalog is already in tier order, so the first rung that
+                // is not earned is the one to aim at. A finished track has none.
+                $next = $definitions->first(fn (Definition $definition): bool => ! $earned->has($definition->key))?->key;
+
+                $medals = $definitions
+                    ->map(fn (Definition $definition): array => $this->medal(
+                        $definition,
+                        $earned->get($definition->key),
+                        $definition->key === $next,
+                        $currency,
+                        $shares,
+                        $standing,
+                    ))
                     ->values()
                     ->all();
 
@@ -106,7 +135,7 @@ class Progress
                     'key' => $track,
                     'label' => $label,
                     'note' => $this->note($track),
-                    'unlocked' => count(array_filter($medals, fn (array $medal): bool => ! $medal['locked'])),
+                    'unlocked' => count(array_filter($medals, fn (array $medal): bool => $medal['state'] === 'earned')),
                     'medals' => $medals,
                 ];
             })
@@ -116,22 +145,58 @@ class Progress
 
     /**
      * @param  array<string, float>  $shares
+     * @param  array<string, int>  $standing
      * @return array<string, mixed>
      */
-    private function medal(Definition $definition, ?Achievement $earned, string $currency, array $shares): array
+    private function medal(Definition $definition, ?Achievement $earned, bool $next, string $currency, array $shares, array $standing): array
     {
+        // A medal still to come is a silhouette: no name, no pictogram, no
+        // figure. The exception is the next one on its track, which is the
+        // thing the reader is working towards and says nothing at all as three
+        // question marks. Nothing has happened for it yet, so it carries no
+        // date and nothing reached.
+        $shown = $earned !== null || $next;
+        $figure = $shown ? $this->presenter->milestone($definition, $currency) : null;
+
         return [
             'key' => $definition->key,
             'rarity' => $definition->rarity->value,
             'share' => $shares[$definition->key] ?? null,
-            'locked' => $earned === null,
-            // A medal still to come is a silhouette: no name, no pictogram, no
-            // figure. Only the tier, so the shape of what is left is readable.
-            'name' => $earned === null ? null : $definition->name,
-            'icon' => $earned === null ? null : $definition->icon,
-            'figure' => $earned === null ? null : $this->presenter->milestone($definition, $currency),
+            'state' => $earned !== null ? 'earned' : ($next ? 'next' : 'locked'),
+            'name' => $shown ? $definition->name : null,
+            'icon' => $shown ? $definition->icon : null,
+            'figure' => $figure,
             'reached' => $earned === null ? null : $this->presenter->reached($earned),
             'achieved_on' => $earned?->achieved_on->toDateString(),
+            'progress' => $next ? $this->progress($definition, $figure, $standing) : null,
+        ];
+    }
+
+    /**
+     * How far along the reader is towards the next medal, for the tracks whose
+     * figure {@see Standing} can read without building a history.
+     *
+     * @param  array{type: string, value: int|float, currency: ?string}|null  $figure
+     * @param  array<string, int>  $standing
+     * @return array{now: int, goal: int|float, unlocking: bool}|null
+     */
+    private function progress(Definition $definition, ?array $figure, array $standing): ?array
+    {
+        $now = $standing[$definition->track] ?? null;
+
+        // No figure means no number to reach — the first transaction is an
+        // event, not a count — and so nothing to draw a bar against.
+        if ($now === null || $figure === null) {
+            return null;
+        }
+
+        return [
+            'now' => $now,
+            'goal' => $figure['value'],
+            // The sweep runs at night, so a reader crossing a threshold today
+            // stands past it with the medal still locked. Say that, rather than
+            // trim the figure back to the goal and call it done.
+            'unlocking' => $now >= $figure['value'],
         ];
     }
 

--- a/app/Services/Achievements/Standing.php
+++ b/app/Services/Achievements/Standing.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Services\Achievements;
+
+use App\Models\MonthlySummary;
+use App\Models\Transaction;
+use App\Models\User;
+
+/**
+ * Where a reader stands right now, per track.
+ *
+ * Only five of the thirteen tracks are here, and that is the whole point: each
+ * of these is a column, a count or a figure somebody already wrote down, so the
+ * progress screen can put a number under the next medal without paying for one.
+ * The other eight are money, and their current value only exists inside the
+ * {@see History} the nightly sweep builds — a balance walk per account and a
+ * month of exchange rates, which is not something a page render can afford.
+ *
+ * The figures are live while the medals are awarded overnight, so a reader can
+ * already stand past a threshold with the medal still locked. The screen says
+ * so rather than pretending the number is smaller.
+ */
+class Standing
+{
+    /**
+     * @return array<string, int> the current figure, keyed by track
+     */
+    public function for(User $user, ?MonthlySummary $report): array
+    {
+        return [
+            // The longest run rather than the current one, because that is what
+            // the medal is awarded on: a bar reading the live streak would fall
+            // back on a broken run without the medal moving any further away.
+            'visits' => (int) $user->longest_visit_streak,
+            'visit_weeks' => (int) $user->longest_visit_week_streak,
+            'transactions' => $user->transactions()->count(),
+            'categorized' => $this->categorizedRun($user),
+            // Read off the last report rather than recomputed, like the live
+            // streak in the overview, so the two cannot disagree.
+            'streaks' => (int) ($report?->figure('streak_months') ?? 0),
+        ];
+    }
+
+    /**
+     * Closed months in a row, ending with the last one, in which everything
+     * recorded got a category.
+     *
+     * Counted backwards from the last closed month rather than forwards from
+     * the first: the run the next medal needs is the one still going, and a
+     * broken run has to be rebuilt from scratch to earn anything. A month with
+     * nothing recorded in it breaks the run, exactly as it does for the sweep.
+     */
+    private function categorizedRun(User $user): int
+    {
+        $months = Transaction::query()
+            ->where('user_id', $user->id)
+            ->where('transaction_date', '<', now()->startOfMonth())
+            ->selectRaw("date_format(transaction_date, '%Y-%m') as period")
+            ->selectRaw('count(*) as total')
+            ->selectRaw('sum(case when category_id is null then 1 else 0 end) as uncategorized')
+            ->groupBy('period')
+            // Rows of aggregates, not models: read off the base query so they
+            // stay the plain objects they are.
+            ->toBase()
+            ->get()
+            ->keyBy('period');
+
+        $month = now()->subMonth()->startOfMonth();
+        $run = 0;
+
+        while (true) {
+            $row = $months->get($month->format('Y-m'));
+
+            if ($row === null || (int) $row->total === 0 || (int) $row->uncategorized > 0) {
+                return $run;
+            }
+
+            $run++;
+            $month->subMonth();
+        }
+    }
+}

--- a/lang/es.json
+++ b/lang/es.json
@@ -2926,5 +2926,7 @@
     "Sharing…": "Compartiendo…",
     "That could not be shared. You can save it instead.": "No se ha podido compartir. Puedes guardar la imagen en su lugar.",
     "In account currency": "En la moneda de la cuenta",
-    "≈ :amount in the account currency": "≈ :amount en la moneda de la cuenta"
+    "≈ :amount in the account currency": "≈ :amount en la moneda de la cuenta",
+    "Unlocks tonight": "Se desbloquea esta noche",
+    ":now of :goal": ":now de :goal"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2480,6 +2480,6 @@
     "Every milestone your money has crossed, dated when it actually happened.": "Chaque jalon franchi par votre argent, daté du moment où il s’est vraiment produit.",
     "In account currency": "Dans la devise du compte",
     "≈ :amount in the account currency": "≈ :amount dans la devise du compte",
-    "Unlocks tonight": "Débloqué cette nuit",
+    "Unlocks tonight": "Se débloque cette nuit",
     ":now of :goal": ":now sur :goal"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2479,5 +2479,7 @@
     "{1}1 month|[2,*]:count months": "{1}1 mois|[2,*]:count mois",
     "Every milestone your money has crossed, dated when it actually happened.": "Chaque jalon franchi par votre argent, daté du moment où il s’est vraiment produit.",
     "In account currency": "Dans la devise du compte",
-    "≈ :amount in the account currency": "≈ :amount dans la devise du compte"
+    "≈ :amount in the account currency": "≈ :amount dans la devise du compte",
+    "Unlocks tonight": "Débloqué cette nuit",
+    ":now of :goal": ":now sur :goal"
 }

--- a/resources/js/components/achievements/achievement-cell.test.tsx
+++ b/resources/js/components/achievements/achievement-cell.test.tsx
@@ -1,0 +1,93 @@
+import { type AchievementMedal } from '@/types';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AchievementCell } from './achievement-cell';
+
+/*
+ * The three states of a cell.
+ *
+ * A locked one is three question marks and nothing else — the server does not
+ * send its name, so the cell has nothing to leak. The next one of its track is
+ * the exception: named, with the figure to reach and, where the server can say
+ * cheaply, how far along the reader is. What separates it from an earned medal
+ * is that there is nothing to share yet and nothing to date.
+ */
+
+vi.mock('@inertiajs/react', () => ({
+    usePage: () => ({ props: { locale: 'en-US' } }),
+}));
+
+function medal(overrides: Partial<AchievementMedal> = {}): AchievementMedal {
+    return {
+        key: 'visits.3',
+        rarity: 'uncommon',
+        share: 12,
+        state: 'locked',
+        name: null,
+        icon: null,
+        figure: null,
+        reached: null,
+        achieved_on: null,
+        progress: null,
+        ...overrides,
+    } as AchievementMedal;
+}
+
+const next = {
+    state: 'next',
+    name: 'Visit streak',
+    icon: 'calendar-days',
+    figure: { type: 'days', value: 30, currency: null },
+} as const;
+
+describe('AchievementCell', () => {
+    it('says nothing at all about a locked medal', () => {
+        render(<AchievementCell medal={medal()} />);
+
+        expect(screen.getByText('???')).toBeInTheDocument();
+        expect(screen.queryByLabelText('Share this medal')).toBeNull();
+    });
+
+    it('names the next medal and the figure to reach, without a way to share it', () => {
+        render(<AchievementCell medal={medal(next)} />);
+
+        expect(screen.getByText('Visit streak')).toBeInTheDocument();
+        expect(screen.getByText('30 days')).toBeInTheDocument();
+        expect(screen.queryByText('???')).toBeNull();
+        // Nothing has happened yet, so there is nothing to post.
+        expect(screen.queryByLabelText('Share this medal')).toBeNull();
+    });
+
+    it('fills the bar to how far along the reader is', () => {
+        const { container } = render(
+            <AchievementCell
+                medal={medal({
+                    ...next,
+                    progress: { now: 12, goal: 30, unlocking: false },
+                })}
+            />,
+        );
+
+        expect(screen.getByText('12 of 30')).toBeInTheDocument();
+        expect(container.querySelector('.bg-primary')).toHaveStyle({
+            width: '40%',
+        });
+    });
+
+    it('fills the bar and names the sweep once the reader is already past the goal', () => {
+        const { container } = render(
+            <AchievementCell
+                medal={medal({
+                    ...next,
+                    progress: { now: 35, goal: 30, unlocking: true },
+                })}
+            />,
+        );
+
+        // Never "35 of 30", and never trimmed back to "30 of 30" either.
+        expect(screen.getByText('Unlocks tonight')).toBeInTheDocument();
+        expect(container.querySelector('.bg-primary')).toHaveStyle({
+            width: '100%',
+        });
+    });
+});

--- a/resources/js/components/achievements/achievement-cell.test.tsx
+++ b/resources/js/components/achievements/achievement-cell.test.tsx
@@ -74,6 +74,20 @@ describe('AchievementCell', () => {
         });
     });
 
+    it('writes a count the way the figure above it is written', () => {
+        render(
+            <AchievementCell
+                medal={medal({
+                    ...next,
+                    figure: { type: 'count', value: 10000, currency: null },
+                    progress: { now: 4321, goal: 10000, unlocking: false },
+                })}
+            />,
+        );
+
+        expect(screen.getByText('4,321 of 10,000')).toBeInTheDocument();
+    });
+
     it('fills the bar and names the sweep once the reader is already past the goal', () => {
         const { container } = render(
             <AchievementCell

--- a/resources/js/components/achievements/achievement-cell.tsx
+++ b/resources/js/components/achievements/achievement-cell.tsx
@@ -84,8 +84,10 @@ function MedalProgress({ progress }: { progress: AchievementProgress }) {
                 {progress.unlocking
                     ? __('Unlocks tonight')
                     : __(':now of :goal', {
-                          now: progress.now,
-                          goal: progress.goal,
+                          // Written like the figure above it rather than as a
+                          // bare integer: "4,321 of 10,000", not "4321 of 10000".
+                          now: progress.now.toLocaleString(),
+                          goal: progress.goal.toLocaleString(),
                       })}
             </span>
         </div>
@@ -95,14 +97,16 @@ function MedalProgress({ progress }: { progress: AchievementProgress }) {
 export function AchievementCell({ medal }: { medal: AchievementMedal }) {
     const locale = useLocale();
     const earned = medal.state === 'earned';
+    const next = medal.state === 'next';
+    const locked = medal.state === 'locked';
 
     return (
         <div
             className={cn(
                 'flex w-32 shrink-0 flex-col gap-2 rounded-lg border p-2.5',
                 earned && 'min-h-31 bg-card',
-                medal.state === 'next' && 'min-h-31 border-dashed',
-                medal.state === 'locked' && 'min-h-24 border-dashed',
+                next && 'min-h-31 border-dashed',
+                locked && 'min-h-24 border-dashed',
             )}
             style={
                 earned && medal.rarity === 'epic'
@@ -114,15 +118,11 @@ export function AchievementCell({ medal }: { medal: AchievementMedal }) {
                 <Medal
                     rarity={medal.rarity}
                     icon={medal.icon}
-                    locked={medal.state === 'locked'}
+                    locked={locked}
                     // Struck but not yet won: the real medal, turned down, so
                     // its shape and pictogram still read as "not yet" rather
                     // than as a failure.
-                    className={
-                        medal.state === 'next'
-                            ? 'opacity-50 grayscale-[0.7]'
-                            : undefined
-                    }
+                    className={next ? 'opacity-50 grayscale-[0.7]' : undefined}
                 />
 
                 {/* Always drawn rather than revealed on hover: the phone is
@@ -143,7 +143,7 @@ export function AchievementCell({ medal }: { medal: AchievementMedal }) {
             </div>
 
             <div className="flex flex-1 flex-col gap-px">
-                {medal.state === 'locked' ? (
+                {locked ? (
                     <span className="font-mono text-sm font-semibold tracking-widest text-muted-foreground">
                         ???
                     </span>

--- a/resources/js/components/achievements/achievement-cell.tsx
+++ b/resources/js/components/achievements/achievement-cell.tsx
@@ -5,7 +5,7 @@ import { ShareMedalDialog } from '@/components/achievements/share-medal-dialog';
 import { Button } from '@/components/ui/button';
 import { useLocale } from '@/hooks/use-locale';
 import { cn } from '@/lib/utils';
-import { type AchievementMedal } from '@/types';
+import { type AchievementMedal, type AchievementProgress } from '@/types';
 import { __ } from '@/utils/i18n';
 import { Share2Icon } from 'lucide-react';
 
@@ -16,9 +16,17 @@ import { Share2Icon } from 'lucide-react';
  * happened. Still to come, it is a silhouette with three question marks: the
  * server does not send its name, so there is nothing here to read ahead.
  *
- * The two read apart without colour: an earned cell is filled and bordered, an
- * empty one is dashed and transparent. The epic tier alone gets a border of its
- * own, struck in the gold of the crown its medal wears.
+ * The exception is the next one of its track, which arrives named and with the
+ * figure to reach — a ladder of identical question marks says nothing about
+ * what there is to chase. It is drawn as a medal turned down rather than as one
+ * won: the same dashed, transparent slot, with the real medallion dimmed inside
+ * it. Nothing labels it "next", because in every track there is exactly one
+ * cell with something in it between the earned ones and the question marks, and
+ * the position already says so.
+ *
+ * The states read apart without colour: an earned cell is filled and bordered,
+ * the other two are dashed and transparent. The epic tier alone gets a border
+ * of its own, struck in the gold of the crown its medal wears.
  */
 export function monthLabel(date: string, locale: string): string {
     const [year, month] = date.split('-').map(Number);
@@ -29,17 +37,75 @@ export function monthLabel(date: string, locale: string): string {
     });
 }
 
+/**
+ * The one progress bar in the app, shared with the overview at the top of the
+ * screen so the two cannot drift apart.
+ */
+export function ProgressBar({
+    percent,
+    className,
+}: {
+    percent: number;
+    className?: string;
+}) {
+    return (
+        <div
+            className={cn(
+                'h-1.5 overflow-hidden rounded-full bg-muted',
+                className,
+            )}
+        >
+            <div
+                className="h-full rounded-full bg-primary"
+                style={{ width: `${percent}%` }}
+            />
+        </div>
+    );
+}
+
+/**
+ * How far along the next medal is, for the tracks that can say.
+ *
+ * Past the goal with the medal still locked is the everyday case rather than an
+ * edge one — crossing day 30 of a visit streak happens by opening the app, and
+ * the sweep that awards it runs at night — so the bar fills and says when it
+ * lands instead of showing a count that reads as wrong either way it is
+ * written.
+ */
+function MedalProgress({ progress }: { progress: AchievementProgress }) {
+    const percent = progress.unlocking
+        ? 100
+        : Math.round((progress.now / progress.goal) * 100);
+
+    return (
+        <div className="mt-1.5 flex flex-col gap-[3px]">
+            <ProgressBar percent={percent} />
+            <span className="text-[11px] leading-[14px] text-muted-foreground tabular-nums">
+                {progress.unlocking
+                    ? __('Unlocks tonight')
+                    : __(':now of :goal', {
+                          now: progress.now,
+                          goal: progress.goal,
+                      })}
+            </span>
+        </div>
+    );
+}
+
 export function AchievementCell({ medal }: { medal: AchievementMedal }) {
     const locale = useLocale();
+    const earned = medal.state === 'earned';
 
     return (
         <div
             className={cn(
                 'flex w-32 shrink-0 flex-col gap-2 rounded-lg border p-2.5',
-                medal.locked ? 'min-h-24 border-dashed' : 'min-h-31 bg-card',
+                earned && 'min-h-31 bg-card',
+                medal.state === 'next' && 'min-h-31 border-dashed',
+                medal.state === 'locked' && 'min-h-24 border-dashed',
             )}
             style={
-                !medal.locked && medal.rarity === 'epic'
+                earned && medal.rarity === 'epic'
                     ? { borderColor: EPIC_EDGE }
                     : undefined
             }
@@ -48,13 +114,21 @@ export function AchievementCell({ medal }: { medal: AchievementMedal }) {
                 <Medal
                     rarity={medal.rarity}
                     icon={medal.icon}
-                    locked={medal.locked}
+                    locked={medal.state === 'locked'}
+                    // Struck but not yet won: the real medal, turned down, so
+                    // its shape and pictogram still read as "not yet" rather
+                    // than as a failure.
+                    className={
+                        medal.state === 'next'
+                            ? 'opacity-50 grayscale-[0.7]'
+                            : undefined
+                    }
                 />
 
                 {/* Always drawn rather than revealed on hover: the phone is
                     where a medal actually gets posted, and there is no hover
                     there to reveal it with. */}
-                {!medal.locked && (
+                {earned && (
                     <ShareMedalDialog medal={medal}>
                         <Button
                             variant="ghost"
@@ -69,7 +143,7 @@ export function AchievementCell({ medal }: { medal: AchievementMedal }) {
             </div>
 
             <div className="flex flex-1 flex-col gap-px">
-                {medal.locked ? (
+                {medal.state === 'locked' ? (
                     <span className="font-mono text-sm font-semibold tracking-widest text-muted-foreground">
                         ???
                     </span>
@@ -96,20 +170,23 @@ export function AchievementCell({ medal }: { medal: AchievementMedal }) {
                                 {monthLabel(medal.achieved_on, locale)}
                             </span>
                         )}
+                        {medal.progress && (
+                            <MedalProgress progress={medal.progress} />
+                        )}
                     </>
                 )}
             </div>
 
             <RarityTag
                 rarity={medal.rarity}
-                share={medal.locked ? null : medal.share}
-                muted={medal.locked}
+                share={earned ? medal.share : null}
+                muted={!earned}
                 title={
-                    medal.share === null
-                        ? undefined
-                        : __(':share% of members have this one', {
+                    earned && medal.share !== null
+                        ? __(':share% of members have this one', {
                               share: medal.share,
                           })
+                        : undefined
                 }
             />
         </div>

--- a/resources/js/components/achievements/share-medal-dialog.test.tsx
+++ b/resources/js/components/achievements/share-medal-dialog.test.tsx
@@ -22,12 +22,13 @@ function medal(overrides: Partial<AchievementMedal> = {}): AchievementMedal {
         key: 'monthly_saving.4',
         rarity: 'epic',
         share: 4,
-        locked: false,
+        state: 'earned',
         name: 'Saved in a month',
         icon: 'piggy-bank',
         figure: { type: 'money', value: 500000, currency: 'EUR' },
         reached: null,
         achieved_on: '2025-03-01',
+        progress: null,
         ...overrides,
     } as AchievementMedal;
 }

--- a/resources/js/pages/achievements/index.tsx
+++ b/resources/js/pages/achievements/index.tsx
@@ -1,6 +1,7 @@
 import {
     AchievementCell,
     monthLabel,
+    ProgressBar,
 } from '@/components/achievements/achievement-cell';
 import {
     AchievementFigure,
@@ -69,12 +70,7 @@ function Overview({ overview }: Pick<Props, 'overview'>) {
                         {__('of :total', { total: overview.total })}
                     </span>
                 </span>
-                <div className="mt-0.5 h-1.5 overflow-hidden rounded-full bg-muted">
-                    <div
-                        className="h-full rounded-full bg-primary"
-                        style={{ width: `${percent}%` }}
-                    />
-                </div>
+                <ProgressBar percent={percent} className="mt-0.5" />
             </div>
 
             <div className="flex flex-col gap-1.5 border-b p-4 sm:border-r sm:border-b-0">

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -82,20 +82,39 @@ export interface AchievementFigureValue {
     currency: string | null;
 }
 
+/**
+ * Where a medal stands: earned, the next rung of its track — named, so there is
+ * something to aim at — or still a silhouette carrying only its tier.
+ */
+export type AchievementState = 'earned' | 'next' | 'locked';
+
+/**
+ * How far along the next medal of a track is. Only the tracks whose current
+ * figure is cheap to read get one; the money ones arrive without.
+ */
+export interface AchievementProgress {
+    now: number;
+    goal: number;
+    /** Already past the goal, waiting on the nightly sweep. */
+    unlocking: boolean;
+}
+
 /** One medal on the progress screen. A locked one carries only its tier. */
 export interface AchievementMedal {
     key: string;
     rarity: AchievementRarity;
     /** Share of evaluated members holding it, or null below the floor. */
     share: number | null;
-    locked: boolean;
+    state: AchievementState;
     name: string | null;
     icon: string | null;
     /** The milestone it stands for. */
     figure: AchievementFigureValue | null;
-    /** What was actually reached on the day. */
+    /** What was actually reached on the day. Never set on the next one. */
     reached: AchievementFigureValue | null;
     achieved_on: string | null;
+    /** Only ever set on the next medal of a track, and not on all of those. */
+    progress: AchievementProgress | null;
 }
 
 export interface AchievementTrack {

--- a/tests/.documentation-images/only-light-en.md
+++ b/tests/.documentation-images/only-light-en.md
@@ -1,5 +1,0 @@
-# Only light
-
-A page whose screenshot has no dark copy.
-
-![A screenshot with no dark copy taken yet](/docs/documentation/does-not-exist.png)

--- a/tests/.documentation-images/only-light-en.md
+++ b/tests/.documentation-images/only-light-en.md
@@ -1,0 +1,5 @@
+# Only light
+
+A page whose screenshot has no dark copy.
+
+![A screenshot with no dark copy taken yet](/docs/documentation/does-not-exist.png)

--- a/tests/Feature/Achievements/AchievementScreenTest.php
+++ b/tests/Feature/Achievements/AchievementScreenTest.php
@@ -370,3 +370,24 @@ it('reads the saving streak off the last report, like the overview does', functi
     // already behind the reader and waiting on tonight's sweep.
     expect($medal['progress'])->toBe(['now' => 5, 'goal' => 3, 'unlocking' => true]);
 });
+
+it('reveals one medal on a track whose rungs are events rather than a ladder', function (): void {
+    $user = readerWithMedals(0);
+
+    // Data hygiene is not really a ladder: connecting a bank, writing a rule
+    // and setting a budget happen in whatever order a reader does them, so a
+    // later rung can be earned while an earlier one is not. The track still
+    // reveals exactly one, and every rung keeps the state it has earned —
+    // which is how the screen already drew this before anything was revealed.
+    collect(['hygiene.1', 'hygiene.4', 'hygiene.5'])
+        ->each(fn (string $key) => Achievement::factory()->key($key)->create([
+            'user_id' => $user->id,
+            'space_id' => $user->activeSpace()->id,
+        ]));
+
+    $track = collect(progressProps($user)['tracks'])->firstWhere('key', 'hygiene');
+
+    expect(collect($track['medals'])->pluck('state')->all())
+        ->toBe(['earned', 'next', 'locked', 'earned', 'earned', 'locked'])
+        ->and($track['unlocked'])->toBe(3);
+});

--- a/tests/Feature/Achievements/AchievementScreenTest.php
+++ b/tests/Feature/Achievements/AchievementScreenTest.php
@@ -1,7 +1,12 @@
 <?php
 
+use App\Enums\CategoryType;
 use App\Features\Achievements;
+use App\Models\Account;
 use App\Models\Achievement;
+use App\Models\Category;
+use App\Models\MonthlySummary;
+use App\Models\Transaction;
 use App\Models\User;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
@@ -12,8 +17,14 @@ use Laravel\Pennant\Feature;
  * The progress screen.
  *
  * Every medal is sent, earned or not, because the empty slots are the road
- * ahead. What a locked one is called is not sent: a silhouette that leaks its
- * own name through the network tab is not a silhouette.
+ * ahead. What a locked one is called is still not sent: a silhouette that leaks
+ * its own name through the network tab is not a silhouette.
+ *
+ * The next rung of each track is the deliberate exception. Thirteen identical
+ * silhouettes say nothing about what there is to chase, so exactly one medal
+ * per ladder — the first nobody has earned — arrives named, with the figure to
+ * reach and, where the current figure is cheap to read, how far along the reader
+ * already is. Everything past it stays three question marks.
  */
 
 beforeEach(function (): void {
@@ -86,10 +97,10 @@ it('sends every medal in the catalog, earned or not', function (): void {
         });
 });
 
-it('keeps the name of a medal still to come to itself', function (): void {
+it('keeps the name of a medal past the next one to itself', function (): void {
     $user = readerWithMedals(1);
 
-    $locked = medalsIn(progressProps($user))->filter(fn (array $medal): bool => $medal['locked']);
+    $locked = medalsIn(progressProps($user))->where('state', 'locked');
 
     expect($locked)->not->toBeEmpty();
 
@@ -190,4 +201,172 @@ it('says nothing about medals to a reader the feature is off for', function (): 
         ->get(route('dashboard'))
         ->assertOk()
         ->assertInertia(fn (AssertableInertia $page) => $page->where('achievements', null));
+});
+
+/**
+ * One transaction in a closed month, with or without a category on it.
+ *
+ * Reuses one account and one category per reader, so a run of months is a run
+ * of rows rather than a tree of factories.
+ */
+function recordIn(User $user, int $monthsAgo, bool $categorized = true): void
+{
+    $space = $user->activeSpace();
+
+    $account = $user->accounts()->first() ?? Account::factory()->create([
+        'user_id' => $user->id,
+        'space_id' => $space->id,
+        'currency_code' => 'EUR',
+    ]);
+
+    $category = Category::query()->firstOrCreate(
+        ['user_id' => $user->id, 'name' => 'Groceries'],
+        ['space_id' => $space->id, 'type' => CategoryType::Expense],
+    );
+
+    Transaction::factory()->create([
+        'user_id' => $user->id,
+        'space_id' => $space->id,
+        'account_id' => $account->id,
+        'category_id' => $categorized ? $category->id : null,
+        // The first of the month, then four days in: subtracting whole months
+        // from a 31st slides into the wrong one.
+        'transaction_date' => now()->startOfMonth()->subMonths($monthsAgo)->addDays(4),
+        'currency_code' => 'EUR',
+    ]);
+}
+
+it('reveals the next medal of a track, and nothing past it', function (): void {
+    $user = readerWithMedals();
+
+    $medals = medalsIn(progressProps($user))->keyBy('key');
+
+    expect($medals['net_worth.2']['state'])->toBe('next')
+        ->and($medals['net_worth.2']['name'])->toBe('Net worth')
+        ->and($medals['net_worth.2']['icon'])->toBe('landmark')
+        ->and($medals['net_worth.2']['figure'])->toBe(['type' => 'money', 'value' => 2500000, 'currency' => 'EUR'])
+        // Nothing has happened for it yet: no figure reached, no date.
+        ->and($medals['net_worth.2']['reached'])->toBeNull()
+        ->and($medals['net_worth.2']['achieved_on'])->toBeNull()
+        // The rung after it is still a silhouette.
+        ->and($medals['net_worth.3']['state'])->toBe('locked')
+        ->and($medals['net_worth.3']['name'])->toBeNull()
+        ->and($medals['net_worth.3']['figure'])->toBeNull();
+});
+
+it('opens with the first rung of all thirteen tracks for a reader who has nothing', function (): void {
+    $user = User::factory()->onboarded()->create(['currency_code' => 'EUR', 'locale' => 'en']);
+
+    $next = medalsIn(progressProps($user))->where('state', 'next');
+
+    expect($next->pluck('key')->all())->toBe([
+        'visits.1', 'visit_weeks.1', 'transactions.1', 'categorized.1', 'hygiene.1',
+        'monthly_saving.1', 'monthly_investing.1', 'yearly_saving.1', 'net_worth.1',
+        'safety.1', 'streaks.1', 'savings_rate.1', 'momentum.1',
+    ]);
+
+    $next->each(fn (array $medal) => expect($medal['name'])->toBeString());
+});
+
+it('has nothing left to reveal on a track that is finished', function (): void {
+    $user = readerWithMedals(0);
+
+    collect(['visit_weeks.1', 'visit_weeks.2', 'visit_weeks.3', 'visit_weeks.4'])
+        ->each(fn (string $key) => Achievement::factory()->key($key)->create([
+            'user_id' => $user->id,
+            'space_id' => $user->activeSpace()->id,
+        ]));
+
+    $track = collect(progressProps($user)['tracks'])->firstWhere('key', 'visit_weeks');
+
+    expect(collect($track['medals'])->pluck('state')->unique()->all())->toBe(['earned']);
+});
+
+it('puts a figure under the next medal only where reading it is cheap', function (): void {
+    $user = readerWithMedals();
+
+    $next = medalsIn(progressProps($user))->where('state', 'next');
+
+    // The five tracks a column, a count or the last report can answer. The
+    // eight money ones would need the whole history built on every render.
+    expect($next->filter(fn (array $medal): bool => $medal['progress'] !== null)->pluck('key')->all())
+        ->toBe(['visits.1', 'visit_weeks.1', 'transactions.2', 'categorized.1', 'streaks.1']);
+});
+
+it('leaves the first transaction without a bar, because it is an event and not a count', function (): void {
+    $user = User::factory()->onboarded()->create(['currency_code' => 'EUR', 'locale' => 'en']);
+
+    $medal = medalsIn(progressProps($user))->firstWhere('key', 'transactions.1');
+
+    expect($medal['state'])->toBe('next')
+        ->and($medal['figure'])->toBeNull()
+        ->and($medal['progress'])->toBeNull();
+});
+
+it('measures a visit streak by the longest run, which is what the medal is awarded on', function (): void {
+    $user = readerWithMedals(0);
+    $user->forceFill(['visit_streak' => 1, 'longest_visit_streak' => 2])->saveQuietly();
+
+    $medal = medalsIn(progressProps($user))->firstWhere('key', 'visits.1');
+
+    expect($medal['progress'])->toBe(['now' => 2, 'goal' => 3, 'unlocking' => false]);
+});
+
+it('says a medal unlocks tonight once the reader is already past it', function (): void {
+    $user = readerWithMedals(0);
+    $user->forceFill(['longest_visit_streak' => 35])->saveQuietly();
+
+    collect(['visits.1', 'visits.2'])->each(fn (string $key) => Achievement::factory()->key($key)->create([
+        'user_id' => $user->id,
+        'space_id' => $user->activeSpace()->id,
+    ]));
+
+    // Thirty days crossed today, with the sweep that awards it still hours off.
+    $medal = medalsIn(progressProps($user))->firstWhere('key', 'visits.3');
+
+    expect($medal['progress'])->toBe(['now' => 35, 'goal' => 30, 'unlocking' => true]);
+});
+
+it('counts the transactions a reader has recorded', function (): void {
+    $user = readerWithMedals();
+    recordIn($user, 1);
+    recordIn($user, 2);
+
+    $medal = medalsIn(progressProps($user))->firstWhere('key', 'transactions.2');
+
+    expect($medal['progress'])->toBe(['now' => 2, 'goal' => 50, 'unlocking' => false]);
+});
+
+it('counts the closed months in a row that were left fully categorized', function (): void {
+    $user = readerWithMedals(0);
+    Achievement::factory()->key('categorized.1')->create([
+        'user_id' => $user->id,
+        'space_id' => $user->activeSpace()->id,
+    ]);
+
+    // Two closed months in a row, and one before them with something left
+    // uncategorized: the run the next medal needs is the one still going, and a
+    // broken one has to be rebuilt from scratch, so the earlier months do not
+    // count towards it.
+    recordIn($user, 3, categorized: false);
+    collect([2, 1])->each(fn (int $ago) => recordIn($user, $ago));
+
+    $medal = medalsIn(progressProps($user))->firstWhere('key', 'categorized.2');
+
+    expect($medal['state'])->toBe('next')
+        ->and($medal['progress'])->toBe(['now' => 2, 'goal' => 3, 'unlocking' => false]);
+});
+
+it('reads the saving streak off the last report, like the overview does', function (): void {
+    $user = readerWithMedals(0);
+    MonthlySummary::factory()->sent()->create([
+        'user_id' => $user->id,
+        'space_id' => $user->activeSpace()->id,
+    ]);
+
+    $medal = medalsIn(progressProps($user))->firstWhere('key', 'streaks.1');
+
+    // The factory's payload reports a five-month streak, so the first rung is
+    // already behind the reader and waiting on tonight's sweep.
+    expect($medal['progress'])->toBe(['now' => 5, 'goal' => 3, 'unlocking' => true]);
 });


### PR DESCRIPTION
## Why

Fifty-nine medals across thirteen tracks, and every one a reader has not earned is
the same dashed silhouette with `???` on it. A new reader opens Progress and sees a
wall of question marks: nothing on the screen says what any of them are for, so
there is nothing to aim at and no reason to come back.

## What changed

**The next medal of each track is revealed.** For each of the thirteen ladders, the
first rung nobody has earned now arrives with its real name, its pictogram and the
figure to reach. Everything past it stays a silhouette, so the screen still does not
read out the whole catalog — one medal per track, thirty-nine of the fifty-nine
still say nothing.

It is drawn as a medal turned down rather than as one won: the same dashed border
and transparent background as a locked slot, with the real medallion at
`opacity .5` and `grayscale(.7)` inside it. No date, no share button, no "next"
label — in a ladder there is exactly one cell with something in it between the
earned ones and the question marks, and the position says so without a badge.

**Five of the thirteen tracks also say how far along the reader is.** A 6px bar
under the name and a caption like `12 of 30`:

| Track | Where the current figure comes from |
| --- | --- |
| Visit streaks | `users.longest_visit_streak` |
| Weekly visits | `users.longest_visit_week_streak` |
| Transactions | one `count()` |
| Fully categorized | one grouped query, walked backwards from the last closed month |
| Saving streaks | `streak_months` on the last monthly report |

The eight money tracks get a name and a figure but no bar. Their current value only
exists inside the `History` the nightly sweep builds — a balance walk per account
plus a month of exchange rates — which is fine once a night and not something a page
render can pay for. Those cells are simply shorter, and that is deliberate: where
there is a number there is a bar, where there is not there is not.

**Past the goal is the normal case, not an edge one.** The figures are live and the
medals are awarded overnight, so crossing day 30 of a visit streak happens by opening
the app and the medal lands hours later. The bar fills and the caption reads
"Unlocks tonight" rather than trimming the count back to `30 of 30` or showing a
nonsensical `35 of 30`.

## How

`Progress::medal()` was the only place hiding anything, and it still is. `locked: bool`
became `state: 'earned' | 'next' | 'locked'`, which describes what the screen actually
draws; `reached` and `achieved_on` stay null on the next one, because nothing has
happened for it yet.

A new `Standing` service answers the five cheap tracks in one pass. It reads the last
monthly report that `Progress` was already fetching for the overview, so that is one
query, not two, and the bar and the overview streak cannot disagree about the same
number — the same reason `activeStreak()` reads the report instead of recomputing.

The visit tracks use the *longest* run rather than the current one, because that is
what `Evaluator` awards the medal on. A bar reading the live streak would fall back
on a broken run without the medal having moved any further away.

The one progress bar the app already had, in the Overview at the top of this screen,
is now shared with the cell instead of copied into it.

## Known nuances

- **Transactions counts live; the sweep awards off closed months.** `HistoryBuilder`
  stops at the last closed month, so a reader whose 50th transaction is recorded this
  month can see "Unlocks tonight" up to a month before it actually unlocks. The
  alternative — counting only closed months — shows "0 of 50" to someone who recorded
  ten transactions today, which reads worse. Flagging rather than hiding it.
- **Data hygiene and Debt and safety are not really ladders.** Connecting a bank,
  writing an automation rule and setting a budget happen in whatever order a reader
  does them, so a later rung can be earned while an earlier one is not, and earned
  medals can sit to the right of a `???`. That is how the screen already drew those
  two tracks before this change — `locked` was per-medal on `main` too — and sorting
  earned-first would break the eleven tracks that *are* ladders, where `net_worth.3`
  sitting left of `net_worth.4` is the whole point. There is a test pinning it.

## Not touched

`HistoryBuilder`, `Evaluator`, `Awarder`, `Catalog`, `Ladders` — how a medal is won
does not change; this is only how the ones not yet won are presented. The PNG card
route still 404s for a medal the reader has not earned: the card is for showing off
what happened, not for previewing what has not. Timeline is unchanged, since it
orders by real dates and the next medal has none. The feature flag is unchanged.

## Tests

`AchievementScreenTest` covers the next medal being revealed and the ones past it not,
a finished track revealing nothing, progress arriving on the five tracks and never on
the eight money ones, `transactions.1` carrying no bar because it is an event and not
a count, the "unlocks tonight" case, the streak read off the last report, and the
non-monotonic track above. `achievement-cell.test.tsx` covers the three cell states
and both captions.

`vendor/bin/pint --test`, `bun run format`, `bun run lint`, `bun run dry` (3.67%
against a 5.4 threshold), `bun run build` and
`php artisan crap --base=origin/main --no-coverage` all pass.

## Demo

https://github.com/user-attachments/assets/b5bdc87f-0b2a-4574-af47-f112775abe7f


