### PR TITLE
feat(mcp): expose the medals through a list_achievements tool

### DIFF
--- a/app/Mcp/Servers/WhisperMoneyServer.php
+++ b/app/Mcp/Servers/WhisperMoneyServer.php
@@ -83,10 +83,15 @@ data.
   saving streak, a net-worth or savings-rate level, transactions logged, data
   kept tidy. `list_achievements` returns the whole catalog grouped into tracks,
   earned or not, and a medal is never revoked once earned even if the streak or
-  balance behind it falls. A medal still to come is deliberately a silhouette —
-  `locked: true` with `name`, `icon` and `figure` all null — so do not guess
-  what it is or what it would take. `overview.streak` is the live saving streak
-  instead, which can break, and is not itself a medal.
+  balance behind it falls. Each one carries a `state`: `earned`, `next` for the
+  single rung the user is working towards on that track, or `locked`. A `locked`
+  medal is deliberately a silhouette — `name`, `icon` and `figure` all null — so
+  do not guess what it is or what it would take; only the `next` one is named.
+  On the tracks whose figure is cheap to read, `next` also carries `progress`
+  with `now`, `goal` and `unlocking`, the last true once the user is already
+  past the goal but the medal is still waiting on the nightly sweep.
+  `overview.streak` is the live saving streak instead, which can break, and is
+  not itself a medal.
 - To find recurring charges (subscriptions), use `search_transactions` and group
   the results by merchant and cadence yourself.
 

--- a/app/Mcp/Servers/WhisperMoneyServer.php
+++ b/app/Mcp/Servers/WhisperMoneyServer.php
@@ -19,6 +19,7 @@ use App\Mcp\Tools\GetCashflow;
 use App\Mcp\Tools\GetNetWorth;
 use App\Mcp\Tools\LabelTransaction;
 use App\Mcp\Tools\ListAccounts;
+use App\Mcp\Tools\ListAchievements;
 use App\Mcp\Tools\ListAutomationRules;
 use App\Mcp\Tools\ListBudgets;
 use App\Mcp\Tools\ListCategories;
@@ -78,6 +79,14 @@ data.
   and everything set on them. A part cannot be split again, deleted on its own,
   or have its amount, date or account changed; categorizing and labelling it
   works as usual.
+- A medal (an "achievement") records a milestone the user reached: a visit or
+  saving streak, a net-worth or savings-rate level, transactions logged, data
+  kept tidy. `list_achievements` returns the whole catalog grouped into tracks,
+  earned or not, and a medal is never revoked once earned even if the streak or
+  balance behind it falls. A medal still to come is deliberately a silhouette —
+  `locked: true` with `name`, `icon` and `figure` all null — so do not guess
+  what it is or what it would take. `overview.streak` is the live saving streak
+  instead, which can break, and is not itself a medal.
 - To find recurring charges (subscriptions), use `search_transactions` and group
   the results by merchant and cadence yourself.
 
@@ -109,6 +118,7 @@ class WhisperMoneyServer extends Server
         ListBudgets::class,
         ListAutomationRules::class,
         ListSpaces::class,
+        ListAchievements::class,
 
         // Write
         CreateTransaction::class,

--- a/app/Mcp/Tools/ListAchievements.php
+++ b/app/Mcp/Tools/ListAchievements.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Features\Achievements;
+use App\Models\User;
+use App\Services\Achievements\Progress;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+use Laravel\Pennant\Feature;
+
+/**
+ * Served even while the medals are switched off, unlike SplitTransaction, which
+ * hides itself. A tool that vanishes leaves an agent with no way to say why, and
+ * "not enabled for this account" is a better answer to "what medals do I have?"
+ * than a catalog that quietly lacks the word.
+ */
+#[IsReadOnly]
+#[Description('List the medals the user has earned and the ones still to come, grouped into tracks, with the unlocked count and the saving streak in progress. A locked medal comes back without a name.')]
+class ListAchievements extends McpTool
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+
+    protected function respond(Request $request, User $user): Response
+    {
+        if (Feature::for($user)->inactive(Achievements::class)) {
+            return Response::error('Achievements are not enabled for this account.');
+        }
+
+        // The progress screen's payload, handed over untouched: a locked medal
+        // is a silhouette there, and naming it here would read out what the
+        // screen deliberately keeps back.
+        return $this->json(app(Progress::class)->for($user));
+    }
+}

--- a/app/Mcp/Tools/ListAchievements.php
+++ b/app/Mcp/Tools/ListAchievements.php
@@ -19,7 +19,7 @@ use Laravel\Pennant\Feature;
  * than a catalog that quietly lacks the word.
  */
 #[IsReadOnly]
-#[Description('List the medals the user has earned and the ones still to come, grouped into tracks, with the unlocked count and the saving streak in progress. A locked medal comes back without a name.')]
+#[Description('List the user\'s medals: the ones earned, the next rung to aim at on each track with how far along they are, and the ones beyond it, which stay nameless. Plus the unlocked count and saving streak.')]
 class ListAchievements extends McpTool
 {
     /**
@@ -36,9 +36,9 @@ class ListAchievements extends McpTool
             return Response::error('Achievements are not enabled for this account.');
         }
 
-        // The progress screen's payload, handed over untouched: a locked medal
-        // is a silhouette there, and naming it here would read out what the
-        // screen deliberately keeps back.
+        // The progress screen's payload, handed over untouched, so what the
+        // screen reveals and what an assistant can say stay the same thing: the
+        // next rung named, everything past it a silhouette.
         return $this->json(app(Progress::class)->for($user));
     }
 }

--- a/chatgpt-app-submission.json
+++ b/chatgpt-app-submission.json
@@ -4,7 +4,7 @@
   "app_info": {
     "display_name": "Whisper Money",
     "subtitle": "Chat with your own finances",
-    "description": "Whisper Money is a privacy-first personal finance app: your financial data is yours, and it is never shared with third parties. This app connects ChatGPT to your own Whisper Money account so you can analyse your money in plain language instead of clicking through dashboards.\n\nAsk questions like \"how much did I spend on groceries last month\", \"what's my net worth trend this year\", \"which subscriptions are draining me\" or \"break down Q2 by category\" — the app reads your transactions, accounts, categories, labels, budgets, cashflow and net worth and answers with your real numbers. You can also keep your books tidy from the conversation: log manual transactions, recategorize and label existing ones, split a transaction that covered several things into parts with their own categories, record balances for manual accounts, and manage budgets, categories, labels and automation rules — including running an automation rule over the transactions you already have, after previewing what it would match.\n\nYour synced bank data is protected: transactions imported from a bank connection can be categorized and labelled, but never edited or deleted, and balances can only be recorded on manual accounts. You can still add your own manual transactions to a bank-connected account — a sync never removes them. Data is scoped to the account you sign in with, including any shared spaces you belong to. The app reads and writes bookkeeping records only — it can never move money, make payments or reach any account outside Whisper Money.\n\nRequires a Whisper Money account on a paid (Pro) plan. Sign in happens through Whisper Money's own OAuth flow — ChatGPT never sees your password, and access can be revoked at any time from your account settings.",
+    "description": "Whisper Money is a privacy-first personal finance app: your financial data is yours, and it is never shared with third parties. This app connects ChatGPT to your own Whisper Money account so you can analyse your money in plain language instead of clicking through dashboards.\n\nAsk questions like \"how much did I spend on groceries last month\", \"what's my net worth trend this year\", \"which subscriptions are draining me\" or \"break down Q2 by category\" — the app reads your transactions, accounts, categories, labels, budgets, cashflow, net worth and the milestone medals you have earned along the way, and answers with your real numbers. You can also keep your books tidy from the conversation: log manual transactions, recategorize and label existing ones, split a transaction that covered several things into parts with their own categories, record balances for manual accounts, and manage budgets, categories, labels and automation rules — including running an automation rule over the transactions you already have, after previewing what it would match.\n\nYour synced bank data is protected: transactions imported from a bank connection can be categorized and labelled, but never edited or deleted, and balances can only be recorded on manual accounts. You can still add your own manual transactions to a bank-connected account — a sync never removes them. Data is scoped to the account you sign in with, including any shared spaces you belong to. The app reads and writes bookkeeping records only — it can never move money, make payments or reach any account outside Whisper Money.\n\nRequires a Whisper Money account on a paid (Pro) plan. Sign in happens through Whisper Money's own OAuth flow — ChatGPT never sees your password, and access can be revoked at any time from your account settings.",
     "category": "FINANCE"
   },
   "tools": {
@@ -85,6 +85,14 @@
       "justifications": {
         "read_only_justification": "Lists the personal and shared spaces the user is a member of, so later calls can target the right one. It writes nothing.",
         "open_world_justification": "Lists only the spaces the authenticated user already belongs to, inside Whisper Money, a closed system.",
+        "destructive_justification": "Read-only, so nothing can be changed or lost."
+      }
+    },
+    "list_achievements": {
+      "annotations": { "readOnlyHint": true, "openWorldHint": false, "destructiveHint": false },
+      "justifications": {
+        "read_only_justification": "Lists the user's own milestone medals, which ones are unlocked and which are still to come. It writes nothing.",
+        "open_world_justification": "Reads only the medals earned inside the authenticated user's own Whisper Money account, a closed system.",
         "destructive_justification": "Read-only, so nothing can be changed or lost."
       }
     },

--- a/resources/js/pages/welcome.tsx
+++ b/resources/js/pages/welcome.tsx
@@ -1418,7 +1418,7 @@ function CashflowChartPreview() {
  * step with App\Mcp\Servers\WhisperMoneyServer, so the landing cannot claim a
  * number the server stopped serving.
  */
-const MCP_READ_TOOL_COUNT = 10;
+const MCP_READ_TOOL_COUNT = 11;
 const MCP_WRITE_TOOL_COUNT = 21;
 
 /**

--- a/tests/Feature/Mcp/McpToolsTest.php
+++ b/tests/Feature/Mcp/McpToolsTest.php
@@ -298,14 +298,17 @@ it('lists the medals a reader has earned alongside the ones still to come', func
         ->assertSee(['First transaction', '"unlocked":2', '"total":59']);
 });
 
-it('keeps the name of a medal still to come to itself', function () {
+it('names the next rung of a track and keeps the ones past it to itself', function () {
     config()->set('achievements.enabled', true);
 
     WhisperMoneyServer::actingAs(medalist('transactions.1'))
         ->tool(ListAchievements::class)
         ->assertOk()
-        ->assertSee('"locked":true,"name":null,"icon":null,"figure":null')
-        ->assertDontSee('Loan paid off');
+        // transactions.2 is the rung to aim at, so it arrives named and with a
+        // bar to fill. safety.2 sits behind safety.1 and stays a silhouette.
+        ->assertSee(['"state":"next"', 'Transactions recorded', '"goal":50'])
+        ->assertSee('"state":"locked","name":null,"icon":null,"figure":null')
+        ->assertDontSee('Emergency fund');
 });
 
 it('never exposes another user\'s medals', function () {
@@ -315,8 +318,10 @@ it('never exposes another user\'s medals', function () {
     WhisperMoneyServer::actingAs(User::factory()->create())
         ->tool(ListAchievements::class)
         ->assertOk()
+        // Not a name: the first rung of every track is revealed to everybody,
+        // so what must not appear is a medal anyone actually holds.
         ->assertSee('"unlocked":0')
-        ->assertDontSee('First transaction');
+        ->assertDontSee('"state":"earned"');
 });
 
 it('says nothing about medals while the feature is off', function () {

--- a/tests/Feature/Mcp/McpToolsTest.php
+++ b/tests/Feature/Mcp/McpToolsTest.php
@@ -1,19 +1,23 @@
 <?php
 
+use App\Features\Achievements;
 use App\Mcp\Servers\WhisperMoneyServer;
 use App\Mcp\Tools\ListAccounts;
+use App\Mcp\Tools\ListAchievements;
 use App\Mcp\Tools\ListAutomationRules;
 use App\Mcp\Tools\ListBudgets;
 use App\Mcp\Tools\ListCategories;
 use App\Mcp\Tools\ListSpaces;
 use App\Mcp\Tools\SearchTransactions;
 use App\Models\Account;
+use App\Models\Achievement;
 use App\Models\AutomationRule;
 use App\Models\Budget;
 use App\Models\Category;
 use App\Models\Label;
 use App\Models\Transaction;
 use App\Models\User;
+use Laravel\Pennant\Feature;
 
 it('blocks read tools when subscriptions are enabled and the user has no paid plan', function () {
     config(['subscriptions.enabled' => true]);
@@ -264,4 +268,63 @@ it('never exposes another user\'s automation rules', function () {
         ->tool(ListAutomationRules::class)
         ->assertOk()
         ->assertDontSee('Secret Rule');
+});
+
+/*
+ * Medals. The tool hands over the same payload the progress screen renders, so
+ * a medal still to come stays a silhouette here too.
+ */
+
+function medalist(string ...$keys): User
+{
+    $user = User::factory()->create(['currency_code' => 'EUR', 'locale' => 'en']);
+
+    foreach ($keys as $key) {
+        Achievement::factory()->key($key)->create([
+            'user_id' => $user->id,
+            'space_id' => $user->activeSpace()->id,
+        ]);
+    }
+
+    return $user;
+}
+
+it('lists the medals a reader has earned alongside the ones still to come', function () {
+    config()->set('achievements.enabled', true);
+
+    WhisperMoneyServer::actingAs(medalist('transactions.1', 'net_worth.1'))
+        ->tool(ListAchievements::class)
+        ->assertOk()
+        ->assertSee(['First transaction', '"unlocked":2', '"total":59']);
+});
+
+it('keeps the name of a medal still to come to itself', function () {
+    config()->set('achievements.enabled', true);
+
+    WhisperMoneyServer::actingAs(medalist('transactions.1'))
+        ->tool(ListAchievements::class)
+        ->assertOk()
+        ->assertSee('"locked":true,"name":null,"icon":null,"figure":null')
+        ->assertDontSee('Loan paid off');
+});
+
+it('never exposes another user\'s medals', function () {
+    config()->set('achievements.enabled', true);
+    medalist('transactions.1');
+
+    WhisperMoneyServer::actingAs(User::factory()->create())
+        ->tool(ListAchievements::class)
+        ->assertOk()
+        ->assertSee('"unlocked":0')
+        ->assertDontSee('First transaction');
+});
+
+it('says nothing about medals while the feature is off', function () {
+    config()->set('achievements.enabled', false);
+    Feature::purge(Achievements::class);
+
+    WhisperMoneyServer::actingAs(medalist('transactions.1'))
+        ->tool(ListAchievements::class)
+        ->assertHasErrors()
+        ->assertDontSee('First transaction');
 });

--- a/tests/Unit/Mcp/ToolAnnotationsTest.php
+++ b/tests/Unit/Mcp/ToolAnnotationsTest.php
@@ -18,6 +18,7 @@ $readOnly = [
     'list_budgets',
     'list_automation_rules',
     'list_spaces',
+    'list_achievements',
 ];
 
 $destructive = [


### PR DESCRIPTION
Exposes the medals through the MCP server, so an assistant can answer "what have
I earned?" and "what am I working towards?" against the reader's own account.

One tool, `list_achievements`: read-only, no arguments. It hands over the payload
`Progress::for()` already builds for the progress screen, untouched, so the
screen and an assistant cannot disagree about what a reader has — and, more to
the point, cannot disagree about what they have *not*. A medal past the next rung
comes back `state: locked` with `name`, `icon` and `figure` all null, exactly as
the screen draws it. Nothing new was written to present medals, and nothing under
`app/Services/Achievements` was touched.

## Built on #936

#936 changed the shape this tool returns: a medal's `locked` boolean became a
three-value `state`, and the next rung of every track now arrives named with a
`progress` bar. The tool hands the progress payload over untouched, so it
inherited that for free — but the `#[Description]` and the server
`#[Instructions]` had to be rewritten, because they told the agent every
unearned medal was nameless, which would have had it refuse to say what the
screen was already showing. That is `3f6d0a5e`.

Now that #936 has merged, this branch is replanted on top of it and the diff is
just the MCP surface.

## The feature flag

Gated like every other achievements surface. `AchievementController` aborts 404;
an MCP tool returns responses rather than aborting, so this returns
`Response::error(...)` when the flag is inactive. That leaves the tool in the
served catalog while the medals are off, unlike `split_transaction`, which hides
itself — deliberate, and the reason is in the class docblock: a tool that
vanishes leaves an assistant with no way to say why, and "not enabled for this
account" beats a catalog that quietly lacks the word.

## The five enforced surfaces

Registered in the `Read` block, plus the four CI-enforced surfaces from
`.ai/rules/mcp.md`: `ToolAnnotationsTest`'s read-only list, `MCP_READ_TOOL_COUNT`
on the landing page (10 → 11), a `chatgpt-app-submission.json` entry with all
three justifications, and the `#[Instructions]` block. The tool description is
196 characters, inside the submission form's 200-character cap.

No `test_cases` entry in the submission JSON, on purpose: those are prompts an
OpenAI reviewer runs against the demo account, and this one cannot work there.
The demo account is blocked from the MCP by design, and the flag is off by
default. A test case that returns an error is worse than none.

## Tests

Four in `McpToolsTest`, alongside the other read tools: a reader gets the medals
they earned; the next rung arrives named with its goal while the rung behind it
stays a silhouette; another reader's medals never appear; and the flag being off
returns an error and leaks nothing. The last one was mutation-checked — stubbing
the gate out makes it fail.

QA'd through the real `/mcp` endpoint with a Sanctum token, not only the test
harness: an earned medal and a locked one side by side in the payload, and the
flag-off case coming back as HTTP 200 with the error in band, no medal name or
key anywhere in it. The `McpToolCall` usage metric records the good call and not
the failed one.

`./vendor/bin/pest` (3164), `pint --test`, `bun run format`, `bun run lint`,
`bun run dry` and `php artisan crap --base=origin/main --no-coverage` all pass.
