### PR TITLE
fix(achievements): measure the transactions bar in closed months, like the medal

### DIFF
--- a/app/Services/Achievements/Standing.php
+++ b/app/Services/Achievements/Standing.php
@@ -5,6 +5,7 @@ namespace App\Services\Achievements;
 use App\Models\MonthlySummary;
 use App\Models\Transaction;
 use App\Models\User;
+use Illuminate\Support\Collection;
 
 /**
  * Where a reader stands right now, per track.
@@ -27,14 +28,18 @@ class Standing
      */
     public function for(User $user, ?MonthlySummary $report): array
     {
+        // One grouped query answers both transaction tracks, so the count and
+        // the run can never disagree about which months they read.
+        $months = $this->closedMonths($user);
+
         return [
             // The longest run rather than the current one, because that is what
             // the medal is awarded on: a bar reading the live streak would fall
             // back on a broken run without the medal moving any further away.
             'visits' => (int) $user->longest_visit_streak,
             'visit_weeks' => (int) $user->longest_visit_week_streak,
-            'transactions' => $user->transactions()->count(),
-            'categorized' => $this->categorizedRun($user),
+            'transactions' => (int) $months->sum('total'),
+            'categorized' => $this->categorizedRun($months),
             // Read off the last report rather than recomputed, like the live
             // streak in the overview, so the two cannot disagree.
             'streaks' => (int) ($report?->figure('streak_months') ?? 0),
@@ -42,17 +47,20 @@ class Standing
     }
 
     /**
-     * Closed months in a row, ending with the last one, in which everything
-     * recorded got a category.
+     * What a reader recorded in each closed month, and how much of it was left
+     * without a category, keyed by month.
      *
-     * Counted backwards from the last closed month rather than forwards from
-     * the first: the run the next medal needs is the one still going, and a
-     * broken run has to be rebuilt from scratch to earn anything. A month with
-     * nothing recorded in it breaks the run, exactly as it does for the sweep.
+     * The month in progress is left out, for the same reason the visit bar
+     * reads the longest run: the medal is awarded on what the nightly sweep
+     * sees, and {@see HistoryBuilder} stops at the last closed month. Counting
+     * today's transactions would fill the bar, and promise the medal tonight,
+     * up to a month before either is true.
+     *
+     * @return Collection<string, object>
      */
-    private function categorizedRun(User $user): int
+    private function closedMonths(User $user): Collection
     {
-        $months = Transaction::query()
+        return Transaction::query()
             ->where('user_id', $user->id)
             ->where('transaction_date', '<', now()->startOfMonth())
             ->selectRaw("date_format(transaction_date, '%Y-%m') as period")
@@ -64,7 +72,21 @@ class Standing
             ->toBase()
             ->get()
             ->keyBy('period');
+    }
 
+    /**
+     * Closed months in a row, ending with the last one, in which everything
+     * recorded got a category.
+     *
+     * Counted backwards from the last closed month rather than forwards from
+     * the first: the run the next medal needs is the one still going, and a
+     * broken run has to be rebuilt from scratch to earn anything. A month with
+     * nothing recorded in it breaks the run, exactly as it does for the sweep.
+     *
+     * @param  Collection<string, object>  $months
+     */
+    private function categorizedRun(Collection $months): int
+    {
         $month = now()->subMonth()->startOfMonth();
         $run = 0;
 

--- a/app/Services/Achievements/Standing.php
+++ b/app/Services/Achievements/Standing.php
@@ -6,6 +6,7 @@ use App\Models\MonthlySummary;
 use App\Models\Transaction;
 use App\Models\User;
 use Illuminate\Support\Collection;
+use stdClass;
 
 /**
  * Where a reader stands right now, per track.
@@ -56,7 +57,7 @@ class Standing
      * today's transactions would fill the bar, and promise the medal tonight,
      * up to a month before either is true.
      *
-     * @return Collection<string, object>
+     * @return Collection<int|string, stdClass>
      */
     private function closedMonths(User $user): Collection
     {
@@ -83,7 +84,7 @@ class Standing
      * broken run has to be rebuilt from scratch to earn anything. A month with
      * nothing recorded in it breaks the run, exactly as it does for the sweep.
      *
-     * @param  Collection<string, object>  $months
+     * @param  Collection<int|string, stdClass>  $months
      */
     private function categorizedRun(Collection $months): int
     {

--- a/tests/Feature/Achievements/AchievementScreenTest.php
+++ b/tests/Feature/Achievements/AchievementScreenTest.php
@@ -204,12 +204,13 @@ it('says nothing about medals to a reader the feature is off for', function (): 
 });
 
 /**
- * One transaction in a closed month, with or without a category on it.
+ * Transactions in one month, with or without a category on them. Month zero is
+ * the one in progress.
  *
  * Reuses one account and one category per reader, so a run of months is a run
  * of rows rather than a tree of factories.
  */
-function recordIn(User $user, int $monthsAgo, bool $categorized = true): void
+function recordIn(User $user, int $monthsAgo, bool $categorized = true, int $count = 1): void
 {
     $space = $user->activeSpace();
 
@@ -224,7 +225,7 @@ function recordIn(User $user, int $monthsAgo, bool $categorized = true): void
         ['space_id' => $space->id, 'type' => CategoryType::Expense],
     );
 
-    Transaction::factory()->create([
+    Transaction::factory()->count($count)->create([
         'user_id' => $user->id,
         'space_id' => $space->id,
         'account_id' => $account->id,
@@ -327,7 +328,7 @@ it('says a medal unlocks tonight once the reader is already past it', function (
     expect($medal['progress'])->toBe(['now' => 35, 'goal' => 30, 'unlocking' => true]);
 });
 
-it('counts the transactions a reader has recorded', function (): void {
+it('counts the transactions a reader recorded in closed months', function (): void {
     $user = readerWithMedals();
     recordIn($user, 1);
     recordIn($user, 2);
@@ -335,6 +336,35 @@ it('counts the transactions a reader has recorded', function (): void {
     $medal = medalsIn(progressProps($user))->firstWhere('key', 'transactions.2');
 
     expect($medal['progress'])->toBe(['now' => 2, 'goal' => 50, 'unlocking' => false]);
+});
+
+it('leaves the bar at nothing while a reader has only recorded in the month in progress', function (): void {
+    $user = readerWithMedals();
+    recordIn($user, 0, count: 3);
+
+    $medal = medalsIn(progressProps($user))->firstWhere('key', 'transactions.2');
+
+    // The sweep reads up to the last closed month, so nothing recorded this
+    // month is anywhere near the medal yet. The bar says so.
+    expect($medal['progress'])->toBe(['now' => 0, 'goal' => 50, 'unlocking' => false]);
+});
+
+it('waits for the closed months to cross the threshold before promising the medal tonight', function (): void {
+    $user = readerWithMedals();
+    recordIn($user, 1, count: 49);
+    // Enough this month to carry a live count well past fifty, which is
+    // exactly the promise that would be a lie until the month closes.
+    recordIn($user, 0, count: 10);
+
+    $medal = medalsIn(progressProps($user))->firstWhere('key', 'transactions.2');
+
+    expect($medal['progress'])->toBe(['now' => 49, 'goal' => 50, 'unlocking' => false]);
+
+    recordIn($user, 1);
+
+    $medal = medalsIn(progressProps($user))->firstWhere('key', 'transactions.2');
+
+    expect($medal['progress'])->toBe(['now' => 50, 'goal' => 50, 'unlocking' => true]);
 });
 
 it('counts the closed months in a row that were left fully categorized', function (): void {


### PR DESCRIPTION
## The bug

`Standing::for()` read the `transactions` figure as a live count of everything the reader had recorded:

```php
'transactions' => $user->transactions()->count(),
```

The medal is not awarded on that. `Evaluator::transactions()` accumulates `$history->transactions`, and `HistoryBuilder::for()` builds that history up to `now()->subMonth()` — the last **closed** month.

So the bar under the next `transactions` medal could fill, and the cell could say **"Unlocks tonight"**, up to a month before it was true. Somebody who records 60 transactions this month saw the promise this afternoon; the medal did not arrive until the 1st.

Caught by the QA of #936 and written into that PR's description rather than fixed, because it was a product call.

## The fix

Count closed months, so the bar measures exactly what the medal measures. This is the criterion the rest of the design already follows — two fields up, `visits` reads `longest_visit_streak` rather than `visit_streak` for the same reason.

The cut is `transaction_date < now()->startOfMonth()`, the same one `categorizedRun()` was already applying, and equivalent to `HistoryBuilder`'s `now()->subMonth()->endOfMonth()`.

Rather than add a `where` to the `count()`, the grouped query `categorizedRun()` already ran over exactly that range now answers both tracks: the sum of its `total` **is** the closed-month count. `Standing` makes **one query fewer** than before, and the two figures cannot disagree about which months they read.

`transactions.1` (First transaction) is an event with no threshold and still has no bar.

Nothing about awarding medals changes — `Evaluator`, `Awarder`, `HistoryBuilder` and `Catalog` are untouched. This is only how the not-yet-awarded is measured. No frontend change.

## The tradeoff, accepted

During the month in progress the bar does not move, and it jumps on the 1st. That is preferable to a notice that lies. A live bar with the notice gated separately was considered and dropped — it is a second number and extra logic for a worse promise.

One transitional effect worth naming: on deploy, a reader who has recorded this month sees the bar step **back** to the last closed month's total, rather than merely stall. Same tradeoff, just visible once.

## Tests

`tests/Feature/Achievements/AchievementScreenTest.php`:

- `leaves the bar at nothing while a reader has only recorded in the month in progress` — 3 transactions this month, `now => 0`.
- `waits for the closed months to cross the threshold before promising the medal tonight` — 49 closed + 10 this month (a live count of 59, well past the goal of 50) stays `unlocking => false`; the 50th closed transaction flips it.

Both fail against the old live count, on exactly the bug: `now => 59, unlocking => true` where the medal is still a month off.

`counts the transactions a reader has recorded` was renamed to `…recorded in closed months`; it already only used closed months, so its assertions stand.

## QA

Backend change with no new visual surface, so this is the real path rather than a browser video: readers built in the dev database (rolled back afterwards) and the props `AchievementController::index()` hands to Inertia read back.

| Reader | Live count | `transactions.2` props |
| --- | --- | --- |
| 60 transactions, all this month | 60 | `now: 0, unlocking: false` |
| 60 in the last closed month, 5 this month | 65 | `now: 60, unlocking: true` |
| 49 in the last closed month, 20 this month | 69 | `now: 49, unlocking: false` |

The third row is the bug: 69 recorded, and the screen correctly refuses to promise a medal it will not get tonight. `Standing::for()` issued **1** query.