### PR TITLE
feat(monthly-summary): remember the month's medals and name the next ones

### DIFF
--- a/app/Http/Controllers/MonthlySummaryController.php
+++ b/app/Http/Controllers/MonthlySummaryController.php
@@ -6,6 +6,7 @@ use App\Enums\CardFormat;
 use App\Enums\CardTheme;
 use App\Enums\MonthlySummaryCard;
 use App\Models\MonthlySummary;
+use App\Services\MonthlySummary\AchievementsSection;
 use App\Services\MonthlySummary\AnalysisWriter;
 use App\Services\MonthlySummary\CardPicker;
 use App\Services\MonthlySummary\CardRenderer;
@@ -34,6 +35,7 @@ class MonthlySummaryController extends Controller
         private CardRenderer $renderer,
         private EmailPresenter $presenter,
         private AnalysisWriter $analysis,
+        private AchievementsSection $achievements,
         private NotificationFeed $notifications,
     ) {}
 
@@ -62,6 +64,7 @@ class MonthlySummaryController extends Controller
             'summary' => $this->listRow($summary),
             'report' => $this->presenter->present($summary, app()->getLocale(), $pro),
             'analysis' => $summary->ai_analysis,
+            'achievements' => $this->achievements->for($request->user(), $summary, app()->getLocale()),
             'cards' => $this->cardOptions($summary),
             'shareUrl' => $summary->share_token === null ? null : route('monthly-summaries.shared', $summary->share_token),
         ]);

--- a/app/Mail/Drip/AchievementsEmail.php
+++ b/app/Mail/Drip/AchievementsEmail.php
@@ -6,8 +6,6 @@ use App\Models\Achievement;
 use App\Models\User;
 use App\Services\Achievements\Catalog;
 use App\Services\Achievements\Presenter;
-use App\Support\Figures;
-use App\Support\Money;
 use Illuminate\Mail\Mailables\Headers;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\URL;
@@ -97,26 +95,12 @@ class AchievementsEmail extends DripMail
 
                 return [
                     'name' => $definition->name,
-                    'milestone' => $this->write($presenter->milestone($definition, $this->user->currency_code), $locale),
+                    'milestone' => $presenter->write($presenter->milestone($definition, $this->user->currency_code), $locale),
                     'rarity' => $definition->rarity->label(),
                 ];
             })
             ->filter()
             ->values()
             ->all();
-    }
-
-    /**
-     * @param  array{type: string, value: int|float, currency: ?string}|null  $figure
-     */
-    private function write(?array $figure, string $locale): ?string
-    {
-        return match (true) {
-            $figure === null => null,
-            $figure['currency'] !== null => Money::formatIn((int) $figure['value'], $figure['currency'], $locale),
-            $figure['type'] === 'percent' => Figures::percent((float) $figure['value'], $locale, decimals: 0),
-            $figure['type'] === 'months' => trans_choice('{1}1 month|[2,*]:count months', (int) $figure['value'], ['count' => (int) $figure['value']]),
-            default => Figures::count((int) $figure['value'], $locale),
-        };
     }
 }

--- a/app/Mail/Drip/MonthlySummaryEmail.php
+++ b/app/Mail/Drip/MonthlySummaryEmail.php
@@ -5,6 +5,7 @@ namespace App\Mail\Drip;
 use App\Enums\MonthlySummaryCard;
 use App\Models\MonthlySummary;
 use App\Models\User;
+use App\Services\MonthlySummary\AchievementsSection;
 use App\Services\MonthlySummary\CardPicker;
 use App\Services\MonthlySummary\EmailPresenter;
 use App\Support\Figures;
@@ -16,8 +17,13 @@ use Illuminate\Support\Facades\URL;
  * The monthly report.
  *
  * A view rather than a Markdown mail, because the design is a report and not a
- * letter. Everything it prints comes from the frozen summary, so re-sending or
- * previewing it can never produce different figures than the reader was given.
+ * letter. Every figure about the month comes from the frozen summary, so
+ * re-sending or previewing it can never produce different figures than the
+ * reader was given.
+ *
+ * The medals block is the one thing read live: how far off the next one is is a
+ * distance of today, and a resend a fortnight later should say today's. See
+ * {@see AchievementsSection}.
  */
 class MonthlySummaryEmail extends DripMail
 {
@@ -96,6 +102,8 @@ class MonthlySummaryEmail extends DripMail
                 'preferencesUrl' => $this->withUtm(route('notifications.index'), 'preferences'),
                 'unsubscribeUrl' => $this->unsubscribeUrl(),
                 'todos' => $this->todosWithUrls($report['todos']),
+                'achievements' => app(AchievementsSection::class)->for($this->user, $this->summary, app()->getLocale()),
+                'achievementsUrl' => $this->withUtm(route('achievements.index'), 'achievements'),
             ],
         );
     }

--- a/app/Services/Achievements/Catalog.php
+++ b/app/Services/Achievements/Catalog.php
@@ -48,6 +48,27 @@ class Catalog
     }
 
     /**
+     * The rung of each track that is next to fall: the first one nobody has
+     * earned. A finished track is absent.
+     *
+     * The catalog is written in tier order, so "first not earned" is the whole
+     * rule — and it is a rule two screens read, the progress page and the
+     * monthly report, which is why it is written down once here.
+     *
+     * @param  Collection<string, mixed>  $earned  anything keyed by medal key
+     * @return Collection<string, Definition> keyed by track
+     */
+    public function next(Collection $earned): Collection
+    {
+        return $this->all()
+            ->groupBy(fn (Definition $definition): string => $definition->track)
+            ->map(fn (Collection $definitions): ?Definition => $definitions->first(
+                fn (Definition $definition): bool => ! $earned->has($definition->key),
+            ))
+            ->filter();
+    }
+
+    /**
      * Track labels, in display order.
      *
      * @return array<string, string>

--- a/app/Services/Achievements/Presenter.php
+++ b/app/Services/Achievements/Presenter.php
@@ -4,6 +4,8 @@ namespace App\Services\Achievements;
 
 use App\Enums\AchievementFigure as Figure;
 use App\Models\Achievement;
+use App\Support\Figures;
+use App\Support\Money;
 
 /**
  * Turns a medal into what the frontend draws.
@@ -11,7 +13,8 @@ use App\Models\Achievement;
  * Figures leave here as numbers with a type rather than as sentences, because
  * an amount has to be written by `AmountDisplay` on the client: privacy mode
  * replaces its digits with asterisks, and a figure baked into a server-rendered
- * string would sit there in the clear.
+ * string would sit there in the clear. {@see write()} is the way out for the
+ * surfaces that have no client to defer to.
  */
 class Presenter
 {
@@ -59,6 +62,29 @@ class Presenter
         return $achievement->currency_code === null
             ? $this->figure(Figure::Count, $achievement->value, null)
             : $this->figure(Figure::Money, $achievement->value, $achievement->currency_code);
+    }
+
+    /**
+     * The same figure written out in the clear, for the places that cannot
+     * defer to `AmountDisplay`: the inbox, and the monthly report that prints
+     * its amounts server-side the way its other sentences do.
+     *
+     * Everything with a unit carries it, because these land inside a sentence
+     * where a bare number says nothing: "Visit streak, 30" is not a milestone.
+     *
+     * @param  array{type: string, value: int|float, currency: ?string}|null  $figure
+     */
+    public function write(?array $figure, string $locale): ?string
+    {
+        return match (true) {
+            $figure === null => null,
+            $figure['currency'] !== null => Money::formatIn((int) $figure['value'], $figure['currency'], $locale),
+            $figure['type'] === 'percent' => Figures::percent((float) $figure['value'], $locale, decimals: 0),
+            $figure['type'] === 'months' => trans_choice('{1}1 month|[2,*]:count months', (int) $figure['value'], ['count' => (int) $figure['value']]),
+            $figure['type'] === 'days' => trans_choice('{1}1 day|[2,*]:count days', (int) $figure['value'], ['count' => (int) $figure['value']]),
+            $figure['type'] === 'weeks' => trans_choice('{1}1 week|[2,*]:count weeks', (int) $figure['value'], ['count' => (int) $figure['value']]),
+            default => Figures::count((int) $figure['value'], $locale),
+        };
     }
 
     /**

--- a/app/Services/Achievements/Progress.php
+++ b/app/Services/Achievements/Progress.php
@@ -109,15 +109,15 @@ class Progress
     private function tracks(Collection $earned, string $currency, array $shares, array $standing): array
     {
         $byTrack = $this->catalog->all()->groupBy(fn (Definition $definition): string => $definition->track);
+        $nextByTrack = $this->catalog->next($earned);
 
         return collect($this->catalog->tracks())
-            ->map(function (string $label, string $track) use ($byTrack, $earned, $currency, $shares, $standing): array {
+            ->map(function (string $label, string $track) use ($byTrack, $nextByTrack, $earned, $currency, $shares, $standing): array {
                 /** @var Collection<int, Definition> $definitions */
                 $definitions = $byTrack->get($track, collect());
 
-                // The catalog is already in tier order, so the first rung that
-                // is not earned is the one to aim at. A finished track has none.
-                $next = $definitions->first(fn (Definition $definition): bool => ! $earned->has($definition->key))?->key;
+                // The rung to aim at, or none at all on a finished track.
+                $next = $nextByTrack->get($track)?->key;
 
                 $medals = $definitions
                     ->map(fn (Definition $definition): array => $this->medal(

--- a/app/Services/MonthlySummary/AchievementsSection.php
+++ b/app/Services/MonthlySummary/AchievementsSection.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace App\Services\MonthlySummary;
+
+use App\Features\Achievements;
+use App\Models\Achievement;
+use App\Models\MonthlySummary;
+use App\Models\User;
+use App\Services\Achievements\Catalog;
+use App\Services\Achievements\Definition;
+use App\Services\Achievements\Ladders;
+use App\Services\Achievements\Presenter;
+use App\Services\Achievements\Standing;
+use Illuminate\Support\Collection;
+use Laravel\Pennant\Feature;
+
+/**
+ * The medals half of the monthly report: what the month earned, and what is
+ * within reach now.
+ *
+ * Worked out at presentation time rather than frozen into the payload, for
+ * three reasons. The payload is handed whole to the model that writes the
+ * analysis, and a prompt told to use only the figures it is given would start
+ * writing about medals. Nothing here needs the summary's shape to change. And
+ * "how far off the next one is" is a figure of today, not of a month that
+ * closed weeks ago — the reader can act on it this afternoon.
+ *
+ * Both halves are optional and the whole section is dropped when neither has
+ * anything to say, the same way the report drops a row it has no figure for.
+ */
+class AchievementsSection
+{
+    /**
+     * Three at most: this is the tail of a report, not the progress screen.
+     */
+    private const SUGGESTIONS = 3;
+
+    public function __construct(
+        private Catalog $catalog,
+        private Ladders $ladders,
+        private Presenter $presenter,
+        private Standing $standing,
+    ) {}
+
+    /**
+     * @return list<array{title: string, lines: list<string>}>|null null when the
+     *                                                              feature is off for this reader, or when there is nothing to say
+     */
+    public function for(User $user, MonthlySummary $summary, string $locale): ?array
+    {
+        if (! Feature::for($user)->active(Achievements::class)) {
+            return null;
+        }
+
+        $earned = $user->achievements()->orderBy('key')->get()->keyBy('key');
+        $currency = $this->ladders->currencyFor($user->currency_code);
+
+        $groups = array_values(array_filter([
+            $this->unlocked($earned, $summary, $currency, $locale),
+            $this->next($user, $earned, $summary, $currency, $locale),
+        ]));
+
+        return $groups === [] ? null : $groups;
+    }
+
+    /**
+     * The medals the reported month earned.
+     *
+     * An exact match rather than a range: a medal is always dated to the first
+     * day of the month it really happened in, so the month that closed is the
+     * whole filter. The sweep runs nightly and the report goes out from the 3rd,
+     * so by the time this is read the month has long been swept.
+     *
+     * @param  Collection<string, Achievement>  $earned
+     * @return array{title: string, lines: list<string>}|null
+     */
+    private function unlocked(Collection $earned, MonthlySummary $summary, string $currency, string $locale): ?array
+    {
+        $month = $summary->periodStart();
+
+        $lines = $earned
+            ->filter(fn (Achievement $achievement): bool => $achievement->achieved_on->toDateString() === $month->toDateString())
+            ->map(fn (Achievement $achievement): ?Definition => $this->catalog->find($achievement->key))
+            ->filter()
+            ->map(fn (Definition $definition): string => $this->earnedLine($definition, $currency, $locale))
+            ->values()
+            ->all();
+
+        return $lines === [] ? null : [
+            'title' => __('What you unlocked in :month', ['month' => $month->locale($locale)->isoFormat('MMMM')]),
+            'lines' => $lines,
+        ];
+    }
+
+    /**
+     * The medals closest to falling, nearest first.
+     *
+     * Only the ones whose distance can be named. A suggestion without a "you
+     * are this far off" is a nudge towards nothing, and the tracks whose
+     * current figure only exists inside a balance walk cannot be given one.
+     *
+     * @param  Collection<string, Achievement>  $earned
+     * @return array{title: string, lines: list<string>}|null
+     */
+    private function next(User $user, Collection $earned, MonthlySummary $summary, string $currency, string $locale): ?array
+    {
+        $figures = $this->figures($user, $summary);
+        $candidates = [];
+
+        foreach ($this->catalog->next($earned) as $track => $definition) {
+            $goal = $this->presenter->milestone($definition, $currency);
+            $now = $figures[$track] ?? null;
+
+            // Nothing under way and nothing left to reach are both silence.
+            // Past the threshold, the medal lands on tonight's sweep and is an
+            // unlock waiting to happen rather than something to chase. At zero
+            // or below, there is no distance worth naming: a month that spent
+            // more than it earned is not "600 euros from saving 100", and the
+            // to-dos further down are the honest thing to say to it.
+            if ($goal === null || $now === null || $now <= 0 || $now >= $goal['value']) {
+                continue;
+            }
+
+            $candidates[] = [
+                'share' => $now / $goal['value'],
+                'line' => $this->nextLine($definition, $goal, $now, $locale),
+            ];
+        }
+
+        // Nearest first, measured as a share of the way there: the tracks count
+        // days, months, transactions and money, and a raw remainder cannot be
+        // compared across them.
+        usort($candidates, fn (array $a, array $b): int => $b['share'] <=> $a['share']);
+
+        $lines = array_column(array_slice($candidates, 0, self::SUGGESTIONS), 'line');
+
+        return $lines === [] ? null : [
+            'title' => __('What you can unlock next'),
+            'lines' => $lines,
+        ];
+    }
+
+    /**
+     * Where the reader stands, per track, without paying for a history.
+     *
+     * {@see Standing} covers the five tracks that are a column or a count. The
+     * money ones come off the frozen payload, which is something the progress
+     * screen cannot do: it has no month in hand, and these figures were worked
+     * out once when the month closed.
+     *
+     * @return array<string, int|float>
+     */
+    private function figures(User $user, MonthlySummary $summary): array
+    {
+        $figures = $this->standing->for($user, $summary);
+        $figures['savings_rate'] = (float) $summary->figure('cashflow.savings_rate', 0);
+
+        $currency = strtoupper((string) $summary->figure('currency', ''));
+
+        // Money ladders are read in the reader's own currency when one exists
+        // for it and in the fallback currency when it does not, while the frozen
+        // figures are always in their own. Across that gap the comparison would
+        // be pesos against euros, so it is not made at all.
+        if ($this->ladders->currencyFor($currency) === $currency) {
+            $figures['net_worth'] = (int) $summary->figure('net_worth.current', 0);
+            $figures['monthly_saving'] = (int) $summary->figure('cashflow.net', 0);
+        }
+
+        return $figures;
+    }
+
+    private function earnedLine(Definition $definition, string $currency, string $locale): string
+    {
+        $milestone = $this->presenter->write($this->presenter->milestone($definition, $currency), $locale);
+        $name = $this->strong($definition->name);
+
+        return $milestone === null
+            ? $name.'.'
+            : __(':name, :milestone.', ['name' => $name, 'milestone' => e($milestone)]);
+    }
+
+    /**
+     * @param  array{type: string, value: int|float, currency: ?string}  $goal
+     */
+    private function nextLine(Definition $definition, array $goal, int|float $now, string $locale): string
+    {
+        return __(':name, :milestone. :remaining to go.', [
+            'name' => $this->strong($definition->name),
+            'milestone' => e((string) $this->presenter->write($goal, $locale)),
+            'remaining' => $this->strong((string) $this->presenter->write([...$goal, 'value' => $goal['value'] - $now], $locale)),
+        ]);
+    }
+
+    /**
+     * Emphasis is applied here, like the rest of the report: the sentences are
+     * assembled from translated fragments and a translator should not have to
+     * carry markup through in every language.
+     */
+    private function strong(string $value): string
+    {
+        return '<strong>'.e($value).'</strong>';
+    }
+}

--- a/lang/es.json
+++ b/lang/es.json
@@ -2928,5 +2928,12 @@
     "In account currency": "En la moneda de la cuenta",
     "≈ :amount in the account currency": "≈ :amount en la moneda de la cuenta",
     "Unlocks tonight": "Se desbloquea esta noche",
-    ":now of :goal": ":now de :goal"
+    ":now of :goal": ":now de :goal",
+    "What you unlocked in :month": "Lo que desbloqueaste en :month",
+    "What you can unlock next": "Lo que puedes desbloquear a continuación",
+    ":name, :milestone.": ":name, :milestone.",
+    ":name, :milestone. :remaining to go.": ":name, :milestone. A :remaining de conseguirlo.",
+    "See all your medals": "Ver todas tus medallas",
+    "{1}1 day|[2,*]:count days": "{1}1 día|[2,*]:count días",
+    "{1}1 week|[2,*]:count weeks": "{1}1 semana|[2,*]:count semanas"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2481,5 +2481,12 @@
     "In account currency": "Dans la devise du compte",
     "≈ :amount in the account currency": "≈ :amount dans la devise du compte",
     "Unlocks tonight": "Se débloque cette nuit",
-    ":now of :goal": ":now sur :goal"
+    ":now of :goal": ":now sur :goal",
+    "What you unlocked in :month": "Ce que vous avez débloqué en :month",
+    "What you can unlock next": "Ce que vous pouvez débloquer ensuite",
+    ":name, :milestone.": ":name, :milestone.",
+    ":name, :milestone. :remaining to go.": ":name, :milestone. Il vous reste :remaining.",
+    "See all your medals": "Voir toutes vos médailles",
+    "{1}1 day|[2,*]:count days": "{1}1 jour|[2,*]:count jours",
+    "{1}1 week|[2,*]:count weeks": "{1}1 semaine|[2,*]:count semaines"
 }

--- a/resources/js/pages/monthly-summaries/show.tsx
+++ b/resources/js/pages/monthly-summaries/show.tsx
@@ -9,9 +9,10 @@ import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import AppLayout from '@/layouts/app-layout';
 import { cn } from '@/lib/utils';
+import { index as progress } from '@/routes/achievements';
 import { type BreadcrumbItem } from '@/types';
 import { __ } from '@/utils/i18n';
-import { Head, router } from '@inertiajs/react';
+import { Head, Link, router } from '@inertiajs/react';
 import { CheckIcon, CopyIcon, Share2Icon, SparklesIcon } from 'lucide-react';
 import { useState } from 'react';
 
@@ -26,6 +27,7 @@ import { useState } from 'react';
  */
 type Row = { text: string };
 type Todo = { text: string; action: string };
+type AchievementGroup = { title: string; lines: string[] };
 type CardOption = { card: string; chosen: boolean; preview: string };
 
 interface Props {
@@ -38,6 +40,9 @@ interface Props {
         todos: Todo[];
     };
     analysis: string | null;
+    // Null when the medals are off for this reader, or when the month earned
+    // nothing and nothing is close enough to name a distance to.
+    achievements: AchievementGroup[] | null;
     cards: CardOption[];
     shareUrl: string | null;
 }
@@ -114,6 +119,7 @@ export default function MonthlySummaryShow({
     summary,
     report,
     analysis,
+    achievements,
     cards,
     shareUrl,
 }: Props) {
@@ -284,6 +290,30 @@ export default function MonthlySummaryShow({
                         ))}
                     </ul>
                 </div>
+
+                {achievements?.map((group) => (
+                    <div key={group.title} className="flex flex-col gap-4">
+                        <h2 className="text-sm font-semibold">{group.title}</h2>
+                        <ul className="divide-y rounded-lg border">
+                            {group.lines.map((line, index) => (
+                                <li
+                                    key={index}
+                                    className="p-4 text-sm leading-relaxed text-muted-foreground [&_strong]:font-semibold [&_strong]:text-foreground"
+                                    dangerouslySetInnerHTML={{ __html: line }}
+                                />
+                            ))}
+                        </ul>
+                    </div>
+                ))}
+
+                {achievements !== null && (
+                    <Link
+                        href={progress().url}
+                        className="text-sm font-medium underline underline-offset-4"
+                    >
+                        {__('See all your medals')}
+                    </Link>
+                )}
 
                 {report.todos.length > 0 && (
                     <div className="flex flex-col gap-4">

--- a/resources/views/mail/monthly-summary.blade.php
+++ b/resources/views/mail/monthly-summary.blade.php
@@ -80,6 +80,10 @@
                 @endforeach
             </div>
 
+            @if ($achievements !== null)
+                @include('mail.summary.achievements')
+            @endif
+
             @if (count($todos) > 0)
                 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="margin:34px 0 14px;"><tr>
                     <td align="left" style="font-size:15px;font-weight:700;color:{{ $ink }};letter-spacing:-0.01em;">{{ trans_choice('One thing to close :month|:count things to close :month', count($todos), ['count' => count($todos), 'month' => $monthName]) }}</td>

--- a/resources/views/mail/summary/achievements.blade.php
+++ b/resources/views/mail/summary/achievements.blade.php
@@ -1,0 +1,20 @@
+{{-- The medals: what the month earned, and what is within reach now.
+
+     Sits between the figures and the to-dos on purpose. The unlocked ones close
+     the month off — they are the reward for what the rows above just described —
+     and the next ones open the following one, which is what the to-dos are
+     already about.
+
+     Same rule as everywhere else in this report: no block at all when there is
+     nothing to say. --}}
+@foreach ($achievements as $group)
+    <p style="margin:34px 0 8px;font-size:15px;font-weight:700;color:#18181b;letter-spacing:-0.01em;">{{ $group['title'] }}</p>
+
+    @foreach ($group['lines'] as $line)
+        <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="border-top:1px solid #e4e4e7;">
+            <tr><td style="padding:15px 0;font-size:15px;line-height:1.5;color:#52525b;">{!! $line !!}</td></tr>
+        </table>
+    @endforeach
+@endforeach
+
+<p style="margin:15px 0 0;"><a href="{{ $achievementsUrl }}" style="font-size:13px;font-weight:600;color:#18181b;text-decoration:none;border-bottom:1px solid #d4d4d8;">{{ __('See all your medals') }}</a></p>

--- a/tests/Feature/MonthlySummary/MonthlySummaryAchievementsTest.php
+++ b/tests/Feature/MonthlySummary/MonthlySummaryAchievementsTest.php
@@ -1,0 +1,164 @@
+<?php
+
+use App\Mail\Drip\MonthlySummaryEmail;
+use App\Models\Achievement;
+use App\Models\Category;
+use App\Models\MonthlySummary;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Services\MonthlySummary\CardRenderer;
+use Illuminate\Support\Facades\Cache;
+use Inertia\Testing\AssertableInertia;
+
+/*
+ * The medals block of the monthly report.
+ *
+ * Two halves, in both the email and on the screen: what the reported month
+ * earned, and what is close enough now to say how far off it is. Behind the
+ * same flag as everything else about medals, and gone entirely when neither
+ * half has anything to say.
+ */
+
+beforeEach(function (): void {
+    Cache::flush();
+    config()->set('achievements.enabled', true);
+    // These assertions are about props and rendered mail, never about the HTML
+    // an SSR pass would produce — see MonthlySummaryPagesTest.
+    config()->set('inertia.ssr.enabled', false);
+
+    $this->mock(CardRenderer::class, function ($mock): void {
+        $mock->shouldReceive('url')->andReturn('https://whisper.money/storage/card.png');
+        $mock->shouldReceive('forget')->andReturnNull();
+    });
+});
+
+function readerWithMedalReport(): User
+{
+    $user = User::factory()->onboarded()->create(['currency_code' => 'EUR', 'locale' => 'en']);
+
+    MonthlySummary::factory()->sent()->create([
+        'user_id' => $user->id,
+        'space_id' => $user->activeSpace()->id,
+    ]);
+
+    return $user;
+}
+
+/**
+ * @param  list<string>  $keys
+ */
+function awardMedals(User $user, array $keys, ?string $on = null): void
+{
+    foreach ($keys as $key) {
+        Achievement::factory()->key($key)->create([
+            'user_id' => $user->id,
+            'space_id' => $user->activeSpace()->id,
+            'achieved_on' => $on ?? now()->subMonths(6)->startOfMonth(),
+        ]);
+    }
+}
+
+function renderedMedalReport(User $user): string
+{
+    $summary = $user->monthlySummaries()->first();
+
+    return (new MonthlySummaryEmail($user, $summary))->render();
+}
+
+it('remembers the medals the reported month earned, and only those', function (): void {
+    $user = readerWithMedalReport();
+    $month = $user->monthlySummaries()->first()->periodStart();
+
+    awardMedals($user, ['streaks.1', 'hygiene.5', 'visits.1'], $month->toDateString());
+    awardMedals($user, ['safety.1'], $month->copy()->subMonth()->toDateString());
+
+    expect(renderedMedalReport($user))
+        ->toContain('What you unlocked in '.$month->isoFormat('MMMM'))
+        ->toContain('Saving streak')
+        ->toContain('3 months')
+        // Every figure carries its unit: "Visit streak, 3" is not a milestone.
+        ->toContain('3 days')
+        // A medal with no figure to it is still worth naming.
+        ->toContain('First budget')
+        // Earned the month before the one this report is about.
+        ->not->toContain('Loan paid off');
+});
+
+it('suggests the three nearest medals, nearest first, each with the distance left', function (): void {
+    $user = readerWithMedalReport();
+
+    // Everything below these rungs is already earned, so the next one on each
+    // track is the one the frozen month can measure a distance to.
+    awardMedals($user, [
+        'streaks.1',                                                  // next: 6 months, standing at 5
+        'savings_rate.1', 'savings_rate.2',                           // next: 50%, standing at 35.5%
+        'net_worth.1', 'net_worth.2', 'net_worth.3', 'net_worth.4',   // next: 250,000 €, standing at 160,223.05 €
+        'monthly_saving.1', 'monthly_saving.2',                       // next: 2,500 €, standing at 1,368.05 €
+    ]);
+
+    $rendered = renderedMedalReport($user);
+
+    expect($rendered)->toContain('What you can unlock next');
+
+    $order = collect(['Saving streak', 'Savings rate', 'Net worth', 'Monthly saving'])
+        ->mapWithKeys(fn (string $name): array => [$name => strpos($rendered, $name.'</strong>, ')])
+        ->filter(fn (int|bool $at): bool => $at !== false);
+
+    // Three at most, nearest first: 83% of the way there, then 71%, then 64%.
+    // The fourth, at 55%, does not make the cut.
+    expect($order->keys()->all())->toBe(['Saving streak', 'Savings rate', 'Net worth'])
+        ->and($order->values()->all())->toBe($order->values()->sort()->values()->all())
+        // A month of the streak left, and the amount left of the net worth rung.
+        ->and($rendered)->toContain('<strong>1 month</strong> to go')
+        ->and($rendered)->toContain('89,776.95');
+});
+
+it('says nothing at all when the medals are off for the reader', function (): void {
+    config()->set('achievements.enabled', false);
+
+    $user = readerWithMedalReport();
+    awardMedals($user, ['streaks.1'], $user->monthlySummaries()->first()->periodStart()->toDateString());
+
+    expect(renderedMedalReport($user))
+        ->not->toContain('What you unlocked')
+        ->not->toContain('What you can unlock next');
+
+    $this->actingAs($user)
+        ->get(route('monthly-summaries.show', $user->monthlySummaries()->first()))
+        ->assertInertia(fn (AssertableInertia $page) => $page->where('achievements', null));
+});
+
+it('drops the block when the month earned nothing and every next medal is already within reach', function (): void {
+    $user = readerWithMedalReport();
+
+    // Standing past every rung the report can measure: those medals land on
+    // tonight's sweep, so there is nothing to chase and nothing to remember.
+    $user->forceFill(['longest_visit_streak' => 400, 'longest_visit_week_streak' => 60])->save();
+
+    Transaction::factory()->create([
+        'user_id' => $user->id,
+        'space_id' => $user->activeSpace()->id,
+        'category_id' => Category::factory()->create(['user_id' => $user->id, 'space_id' => $user->activeSpace()->id])->id,
+        'transaction_date' => now()->subMonth()->startOfMonth()->addDays(3),
+    ]);
+
+    expect(renderedMedalReport($user))
+        ->not->toContain('What you unlocked')
+        ->not->toContain('What you can unlock next');
+});
+
+it('hands the screen the same block it puts in the email', function (): void {
+    $user = readerWithMedalReport();
+    $summary = $user->monthlySummaries()->first();
+
+    awardMedals($user, ['streaks.1'], $summary->periodStart()->toDateString());
+
+    $this->actingAs($user)
+        ->get(route('monthly-summaries.show', $summary))
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->has('achievements', 2)
+            ->where('achievements.0.title', 'What you unlocked in '.$summary->periodStart()->isoFormat('MMMM'))
+            ->has('achievements.0.lines', 1)
+            ->where('achievements.1.title', 'What you can unlock next'));
+});


### PR DESCRIPTION
The monthly report closed a month without ever mentioning the medals it earned,
and the progress screen was the only place that said what was coming next. Both
belong in the summary: the unlocked ones are the reward for the rows above them,
and the next ones are what the following month is for.

Two halves, in the email and on the screen, between "the figures" and the
to-dos, all of it behind `App\Features\Achievements`.

## What you unlocked in <month>

Every medal dated to the month the report is about. `achieved_on` is always the
first day of the month a medal really happened in, so the filter is exact rather
than a range, and the nightly sweep has long run by the time a report goes out
on the 3rd. A medal with no figure to it — "First budget" — is still named.

## What you can unlock next

Up to three, nearest first, each saying what is left to go.

Only the medals whose distance can be named; a suggestion with no "you are this
far off" is a nudge towards nothing. `Standing` reads five tracks cheaply, and
the frozen month supplies three more that the progress screen cannot: net worth,
savings rate, and the month's saving. Nearness is measured as a share of the way
there, because the tracks count days, months, transactions and money, and a raw
remainder cannot be compared across them.

Two things are deliberately never suggested:

- A track standing **past** its next threshold. That medal lands on tonight's
  sweep — it is an unlock waiting to happen, not something to chase.
- A track at zero or below. A month that spent more than it earned is not
  "600 euros away from saving 100", and the to-dos below are the honest thing
  to say to it.

`monthly_investing` is **not** wired up, unlike the rest of the money tracks:
the payload's `invested` is the portfolio's contributed-versus-value, while that
ladder is measured against money moved into investments *within the month*.
Comparing the two would put a confidently wrong number in front of the reader.
`yearly_saving`, `hygiene`, `safety` and `momentum` are out for the same reason —
no figure a report can read.

## Where it is worked out

In a small service at presentation time, not in the frozen payload.
`AnalysisWriter` hands the payload to the model whole and the prompt tells it to
use only the figures it is given, so medals in the payload would have had the AI
analysis writing about medals. Nothing here needs the frozen shape to change,
and "how far off the next one is" is a distance of today anyway.

Neither half has anything to say and the whole block goes, the way the report
already drops a row it has no figure for. Without the flag there is no block and
no query.

## Shared rather than copied

- `Presenter::write()` — the figure-to-sentence writer the daily medals email
  already had. It also learned to say "days" and "weeks" out loud: inside a
  sentence, a bare "Visit streak, 30" is not a milestone.
- `Catalog::next()` — "the first rung nobody has earned is the one to aim at".
  `Progress` now reads it from there instead of keeping its own copy; its tests
  pass unchanged.

## Tests

`tests/Feature/MonthlySummary/MonthlySummaryAchievementsTest.php`: medals of the
reported month and not of the month before, the three nearest in order with the
distance left, the block absent without the flag (email and screen), and the
block absent when there is nothing to say.

## Demo

https://github.com/user-attachments/assets/4244ab5e-3a5b-4003-a72f-1535e8d03272



## Known, not fixed here

17 of the 21 medal names have no French translation in `lang/fr.json`, so a
French reader sees "**Fully categorized**, 12 mois." This is pre-existing — the
progress screen and the daily medals email already read that way today — and
filling in a catalog's worth of French copy belongs in its own PR, not smuggled
into this one. Spanish is complete.
