### PR TITLE
feat(achievements): put the medal in the email that announces it

### DIFF
--- a/app/Mail/Drip/AchievementsEmail.php
+++ b/app/Mail/Drip/AchievementsEmail.php
@@ -2,13 +2,19 @@
 
 namespace App\Mail\Drip;
 
+use App\Enums\CardFormat;
+use App\Enums\CardTheme;
 use App\Models\Achievement;
 use App\Models\User;
+use App\Services\Achievements\CardRenderer;
 use App\Services\Achievements\Catalog;
+use App\Services\Achievements\Ladders;
 use App\Services\Achievements\Presenter;
+use Illuminate\Mail\Attachment;
 use Illuminate\Mail\Mailables\Headers;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\URL;
+use Throwable;
 
 /**
  * The day's medals, in one message.
@@ -23,6 +29,16 @@ use Illuminate\Support\Facades\URL;
  */
 class AchievementsEmail extends DripMail
 {
+    /**
+     * How many medals the message carries a picture of. Past a handful an email
+     * is a download rather than a note, and a sweep that unlocks ten at once is
+     * a reader whose history just arrived, not a Tuesday.
+     */
+    private const MAX_CARDS = 3;
+
+    /** @var array<string, string>|null medal key => its card on the private disk */
+    private ?array $cards = null;
+
     /**
      * @param  Collection<int, Achievement>  $achievements
      */
@@ -68,6 +84,79 @@ class AchievementsEmail extends DripMail
         ];
     }
 
+    /**
+     * The cards ride inside the message rather than behind a URL: they are
+     * drawn on the private disk on purpose — see {@see CardRenderer} — and an
+     * inbox has no session to prove it may read one.
+     *
+     * @return list<Attachment>
+     */
+    public function attachments(): array
+    {
+        return collect($this->cards())
+            ->map(fn (string $path, string $key): Attachment => Attachment::fromStorageDisk(CardRenderer::DISK, $path)
+                ->as($this->cid($key))
+                ->withMime('image/png'))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * The medals as pictures, drawn here rather than in the job so they come
+     * out in the language the mailer switched to. Light and 4:5, the shape a
+     * card is drawn in everywhere it is not being posted to a story, which is
+     * also the file the share dialog serves later: the email warms it.
+     *
+     * A render that fails costs the picture, not the message.
+     *
+     * @return array<string, string> medal key => path on {@see CardRenderer::DISK}
+     */
+    private function cards(): array
+    {
+        if ($this->cards !== null) {
+            return $this->cards;
+        }
+
+        $renderer = app(CardRenderer::class);
+        $catalog = app(Catalog::class);
+        $currency = app(Ladders::class)->currencyFor($this->user->currency_code);
+
+        return $this->cards = $this->achievements
+            ->take(self::MAX_CARDS)
+            ->mapWithKeys(function (Achievement $achievement) use ($renderer, $catalog, $currency): array {
+                $definition = $catalog->find($achievement->key);
+
+                if ($definition === null) {
+                    return [];
+                }
+
+                try {
+                    return [$achievement->key => $renderer->path(
+                        $achievement,
+                        $definition,
+                        $currency,
+                        CardFormat::default(),
+                        CardTheme::default(),
+                        amount: true,
+                    )];
+                } catch (Throwable $exception) {
+                    report($exception);
+
+                    return [];
+                }
+            })
+            ->all();
+    }
+
+    /**
+     * Symfony turns an attachment into an inline part when the HTML asks for it
+     * by name, so the attachment's name is the reference the template writes.
+     */
+    private function cid(string $key): string
+    {
+        return $key.'.png';
+    }
+
     private function unsubscribeUrl(): string
     {
         return URL::signedRoute('achievements.unsubscribe', ['user' => $this->user->id]);
@@ -77,16 +166,17 @@ class AchievementsEmail extends DripMail
      * One line per medal: what it is called, the milestone it stands for and
      * the tier it belongs to, all written out for the inbox.
      *
-     * @return list<array{name: string, milestone: ?string, rarity: string}>
+     * @return list<array{name: string, milestone: ?string, rarity: string, card: ?string}>
      */
     private function lines(): array
     {
         $catalog = app(Catalog::class);
         $presenter = app(Presenter::class);
         $locale = app()->getLocale();
+        $cards = $this->cards();
 
         return $this->achievements
-            ->map(function (Achievement $achievement) use ($catalog, $presenter, $locale): ?array {
+            ->map(function (Achievement $achievement) use ($catalog, $presenter, $locale, $cards): ?array {
                 $definition = $catalog->find($achievement->key);
 
                 if ($definition === null) {
@@ -97,6 +187,7 @@ class AchievementsEmail extends DripMail
                     'name' => $definition->name,
                     'milestone' => $presenter->write($presenter->milestone($definition, $this->user->currency_code), $locale),
                     'rarity' => $definition->rarity->label(),
+                    'card' => isset($cards[$achievement->key]) ? $this->cid($achievement->key) : null,
                 ];
             })
             ->filter()

--- a/resources/views/mail/drip/achievements.blade.php
+++ b/resources/views/mail/drip/achievements.blade.php
@@ -1,6 +1,12 @@
-{{-- What the sweep found, in one message. Prose and a short list, so the
-     standard Markdown mail is the right shape: the designed artefact here is
-     the medal itself, and it lives on the progress screen. --}}
+{{-- What the sweep found, in one message. Prose, the medals as pictures and a
+     short list, so the standard Markdown mail is still the right shape: the
+     designed artefact here is the medal itself, and the card the share dialog
+     draws is the same picture that rides in here.
+
+     The pictures come first and the list after, rather than one line under each
+     card: a list broken up by HTML blocks stops being a list. The list is also
+     what a reader whose client blocks images gets, so it stays whatever the
+     cards did. --}}
 <x-mail::message>
 # {{ trans_choice('{1}You unlocked an achievement|[2,*]You unlocked :count achievements', count($lines), ['count' => count($lines)]) }}
 
@@ -9,10 +15,16 @@
 {{ trans_choice('{1}Your money crossed a line worth marking.|[2,*]Your money crossed a few lines worth marking.', count($lines)) }}
 
 @foreach ($lines as $line)
+@if ($line['card'] !== null)
+<x-mail::medal :cid="$line['card']" :alt="$line['name']" />
+@endif
+@endforeach
+
+@foreach ($lines as $line)
 - **{{ $line['name'] }}{{ $line['milestone'] ? ' '.$line['milestone'] : '' }}** — {{ $line['rarity'] }}
 @endforeach
 
-<x-mail::button :url="route('achievements.index')">
+<x-mail::button :url="route('achievements.index', $emailUtm + ['utm_content' => 'progress'])">
 {{ __('See your progress') }}
 </x-mail::button>
 

--- a/resources/views/vendor/mail/html/medal.blade.php
+++ b/resources/views/vendor/mail/html/medal.blade.php
@@ -1,0 +1,12 @@
+@props([
+    'cid',
+    'alt' => '',
+    'width' => 240,
+])
+<table class="medal" align="center" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+<tr>
+<td align="center" style="padding: 8px 0 4px;">
+<img src="cid:{{ $cid }}" alt="{{ $alt }}" width="{{ $width }}" style="display: block; width: {{ $width }}px; max-width: 100%; height: auto; border-radius: 12px;">
+</td>
+</tr>
+</table>

--- a/resources/views/vendor/mail/text/medal.blade.php
+++ b/resources/views/vendor/mail/text/medal.blade.php
@@ -1,0 +1,1 @@
+{{-- The medal is a picture. Plain text already names it in the list below. --}}

--- a/tests/Feature/Achievements/AchievementEmailTest.php
+++ b/tests/Feature/Achievements/AchievementEmailTest.php
@@ -1,0 +1,110 @@
+<?php
+
+use App\Mail\Drip\AchievementsEmail;
+use App\Models\Achievement;
+use App\Models\User;
+use App\Services\Achievements\CardRenderer;
+use Illuminate\Process\PendingProcess;
+use Illuminate\Support\Facades\Exceptions;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Facades\Storage;
+
+/*
+ * The message a sweep sends.
+ *
+ * Chromium is faked the way `AchievementCardTest` fakes it — a file written
+ * where each job asked for its PNG — because what is under test is which
+ * pictures the email carries and how it carries them, not that a screenshot can
+ * be taken.
+ */
+
+beforeEach(function (): void {
+    Storage::fake(CardRenderer::DISK);
+    config()->set('achievements.enabled', true);
+
+    Process::fake(function (PendingProcess $process) {
+        $manifest = json_decode((string) file_get_contents((string) last($process->command)), true);
+
+        foreach ($manifest as $job) {
+            file_put_contents($job['png'], 'png');
+        }
+
+        return Process::result('');
+    });
+});
+
+/**
+ * @param  list<string>  $keys
+ */
+function announcement(array $keys): AchievementsEmail
+{
+    $user = User::factory()->onboarded()->create(['currency_code' => 'EUR', 'locale' => 'en']);
+
+    $medals = collect($keys)->map(fn (string $key): Achievement => Achievement::factory()->create([
+        'user_id' => $user->id,
+        'space_id' => $user->activeSpace()->id,
+        'key' => $key,
+    ]));
+
+    return new AchievementsEmail($user, $medals);
+}
+
+it('carries a picture of every medal it announces', function (): void {
+    $mail = announcement(['streaks.2', 'transactions.1']);
+
+    $mail->assertSeeInHtml('cid:streaks.2.png', escape: false);
+    $mail->assertSeeInHtml('cid:transactions.1.png', escape: false);
+
+    // Light and 4:5, the shape the share dialog and the public page already use.
+    expect(Storage::disk(CardRenderer::DISK)->allFiles())
+        ->toHaveCount(2)
+        ->each->toContain('-feed-light-en');
+});
+
+it('links to the progress screen', function (): void {
+    announcement(['streaks.2'])->assertSeeInHtml('utm_content=progress', escape: false);
+});
+
+it('still names every medal for a reader whose client blocks images', function (): void {
+    $mail = announcement(['streaks.2']);
+
+    $mail->assertSeeInText('Saving streak');
+    $mail->assertDontSeeInText('cid:');
+});
+
+it('stops short of mailing a whole history as pictures', function (): void {
+    $mail = announcement(['visits.1', 'visits.2', 'visits.3', 'visits.4', 'visits.5']);
+
+    $mail->assertSeeInHtml('cid:visits.3.png', escape: false);
+    $mail->assertDontSeeInHtml('cid:visits.4.png', escape: false);
+
+    expect(Storage::disk(CardRenderer::DISK)->allFiles())->toHaveCount(3)
+        // The list is the message, so it keeps the medals the pictures dropped.
+        ->and(substr_count($mail->render(), '<li'))->toBe(5);
+});
+
+it('shows the card inside the message rather than attaching a file', function (): void {
+    $mail = announcement(['streaks.2']);
+
+    Mail::to('reader@example.test')->send($mail);
+
+    $sent = (string) Mail::mailer()->getSymfonyTransport()->messages()->first()->getOriginalMessage()->toString();
+
+    // Symfony turns the attachment into a related inline part because the HTML
+    // asks for it by name, which is the whole reason it is named after the medal.
+    expect($sent)->toContain('Content-Disposition: inline')
+        ->and($sent)->not->toContain('Content-Disposition: attachment');
+});
+
+it('goes out without the pictures when the browser cannot draw them', function (): void {
+    Exceptions::fake();
+    Process::fake(fn () => Process::result(exitCode: 1, errorOutput: 'no browser'));
+
+    $mail = announcement(['streaks.2']);
+
+    $mail->assertDontSeeInHtml('cid:', escape: false);
+    $mail->assertSeeInText('Saving streak');
+
+    Exceptions::assertReported(RuntimeException::class);
+});


### PR DESCRIPTION
## Why

The email a sweep sends was prose and a bullet list. The medal itself — the drawn
artefact the reader just earned, the one they might post — only existed on the
progress screen, so the message announcing it was the one place it could not be
seen.

## What changed

**Every medal the email announces rides in it as a picture.** The same 4:5 light
card the share dialog draws (`CardFormat::default()` + `CardTheme::default()`,
1080×1350), centred at 240px above the list. It is the same cached file the share
route serves, so the email warms it: the first time the reader opens the share
dialog the PNG is already drawn.

**Three at most.** A sweep that unlocks ten medals is a reader whose history just
arrived, not a Tuesday, and ten PNGs make an email a download. The list underneath
keeps naming all of them — it is also what a reader whose client blocks images
gets, so it stays whatever the cards did.

**The button now carries the campaign's UTM**, `utm_content=progress`, like every
other drip link. The button itself was already there.

## How

The cards are **inline parts, not URLs**. These land on the private disk on purpose
(see `Achievements\CardRenderer`): a medal card writes the reader's amount, and a
file under `/storage` would be obscurity rather than authorisation. An inbox has no
session to prove it may read one, so the picture travels with the message. The
attachment is named after the medal (`streaks.2.png`) and the template asks for it
by that name, which is what makes Symfony move it into a related inline part —
verified in a test, because the failure mode is a file dangling off the email.

Drawn inside the mailable rather than in the job, so the copy on the card comes out
in the language the mailer switched to — the same trap `SendMonthlySummaryEmailJob`
documents. Memoised, because `lines()` and `attachments()` both need it and
`dripSubject()` asks first.

A render that dies costs the picture, not the message: reported and skipped.

## Tests

`tests/Feature/Achievements/AchievementEmailTest.php`, Chromium faked the way
`AchievementCardTest` fakes it: a card per medal, feed + light, inline and not
attached, the cap at three with all five still in the list, the plain-text
fallback, and a browser that cannot draw.

Worth knowing: three cards base64'd is a heavier email than this used to be. If it
becomes a problem the cheap fix is an email-sized `CardFormat`, at the cost of the
cache shared with the share dialog.