### PR TITLE
feat(achievements): tell an earned medal from one in progress at a glance

### DIFF
--- a/lang/es.json
+++ b/lang/es.json
@@ -2936,5 +2936,6 @@
     ":name, :milestone. :remaining to go.": ":name, :milestone. A :remaining de conseguirlo.",
     "See all your medals": "Ver todas tus medallas",
     "{1}1 day|[2,*]:count days": "{1}1 día|[2,*]:count días",
-    "{1}1 week|[2,*]:count weeks": "{1}1 semana|[2,*]:count semanas"
+    "{1}1 week|[2,*]:count weeks": "{1}1 semana|[2,*]:count semanas",
+    "+:count to come": "+:count por llegar"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2489,5 +2489,6 @@
     ":name, :milestone. :remaining to go.": ":name, :milestone. Il vous reste :remaining.",
     "See all your medals": "Voir toutes vos médailles",
     "{1}1 day|[2,*]:count days": "{1}1 jour|[2,*]:count jours",
-    "{1}1 week|[2,*]:count weeks": "{1}1 semaine|[2,*]:count semaines"
+    "{1}1 week|[2,*]:count weeks": "{1}1 semaine|[2,*]:count semaines",
+    "+:count to come": "+:count à venir"
 }

--- a/resources/js/components/achievements/achievement-cell.test.tsx
+++ b/resources/js/components/achievements/achievement-cell.test.tsx
@@ -10,7 +10,8 @@ import { AchievementCell } from './achievement-cell';
  * send its name, so the cell has nothing to leak. The next one of its track is
  * the exception: named, with the figure to reach and, where the server can say
  * cheaply, how far along the reader is. What separates it from an earned medal
- * is that there is nothing to share yet and nothing to date.
+ * is that there is nothing to share yet, nothing to date, no fill under it and
+ * no check on its medal.
  */
 
 vi.mock('@inertiajs/react', () => ({
@@ -56,6 +57,31 @@ describe('AchievementCell', () => {
         expect(screen.queryByText('???')).toBeNull();
         // Nothing has happened yet, so there is nothing to post.
         expect(screen.queryByLabelText('Share this medal')).toBeNull();
+    });
+
+    it('fills an earned cell and strikes a check on its medal', () => {
+        const { container } = render(
+            <AchievementCell
+                medal={medal({
+                    state: 'earned',
+                    name: 'Visit streak',
+                    achieved_on: '2024-03',
+                })}
+            />,
+        );
+
+        // The one signal a reader cannot miss at arm's length: white on white
+        // is what the fill and the check are here to fix.
+        expect(container.firstElementChild).toHaveClass('bg-muted');
+        expect(container.querySelector('.bg-foreground')).toBeInTheDocument();
+    });
+
+    it('leaves the next cell unfilled and unchecked', () => {
+        const { container } = render(<AchievementCell medal={medal(next)} />);
+
+        expect(container.firstElementChild).not.toHaveClass('bg-muted');
+        expect(container.firstElementChild).toHaveClass('border-dashed');
+        expect(container.querySelector('.bg-foreground')).toBeNull();
     });
 
     it('fills the bar to how far along the reader is', () => {

--- a/resources/js/components/achievements/achievement-cell.tsx
+++ b/resources/js/components/achievements/achievement-cell.tsx
@@ -7,7 +7,7 @@ import { useLocale } from '@/hooks/use-locale';
 import { cn } from '@/lib/utils';
 import { type AchievementMedal, type AchievementProgress } from '@/types';
 import { __ } from '@/utils/i18n';
-import { Share2Icon } from 'lucide-react';
+import { CheckIcon, Share2Icon } from 'lucide-react';
 
 /**
  * One medal in a track.
@@ -20,13 +20,20 @@ import { Share2Icon } from 'lucide-react';
  * figure to reach — a ladder of identical question marks says nothing about
  * what there is to chase. It is drawn as a medal turned down rather than as one
  * won: the same dashed, transparent slot, with the real medallion dimmed inside
- * it. Nothing labels it "next", because in every track there is exactly one
- * cell with something in it between the earned ones and the question marks, and
- * the position already says so.
+ * it. Nothing labels it "next", because it is the one named cell of its track
+ * that no check and no date has caught up with, sitting where the earned ones
+ * stop, and the position already says so.
  *
- * The states read apart without colour: an earned cell is filled and bordered,
- * the other two are dashed and transparent. The epic tier alone gets a border
- * of its own, struck in the gold of the crown its medal wears.
+ * The states read apart without colour, and none of the three leans on a label
+ * to say which it is. An earned cell is filled, solidly bordered, and its medal
+ * wears a struck check; the other two sit transparent on the page inside a
+ * dashed edge, told apart by whether there is anything written in them. The
+ * epic tier alone gets a border of its own, struck in the gold of the crown its
+ * medal wears.
+ *
+ * The fill has to be `bg-muted` rather than `bg-card`: `--card` and
+ * `--background` are the same colour in both themes, so a "filled" cell drawn
+ * in card white is white on white.
  */
 export function monthLabel(date: string, locale: string): string {
     const [year, month] = date.split('-').map(Number);
@@ -103,10 +110,10 @@ export function AchievementCell({ medal }: { medal: AchievementMedal }) {
     return (
         <div
             className={cn(
-                'flex w-32 shrink-0 flex-col gap-2 rounded-lg border p-2.5',
-                earned && 'min-h-31 bg-card',
-                next && 'min-h-31 border-dashed',
-                locked && 'min-h-24 border-dashed',
+                'flex w-37 shrink-0 flex-col gap-2 rounded-lg border p-3',
+                earned && 'min-h-40 bg-muted',
+                next && 'min-h-40 border-dashed border-ring',
+                locked && 'min-h-32 border-dashed border-ring',
             )}
             style={
                 earned && medal.rarity === 'epic'
@@ -115,15 +122,32 @@ export function AchievementCell({ medal }: { medal: AchievementMedal }) {
             }
         >
             <div className="flex items-start justify-between gap-1">
-                <Medal
-                    rarity={medal.rarity}
-                    icon={medal.icon}
-                    locked={locked}
-                    // Struck but not yet won: the real medal, turned down, so
-                    // its shape and pictogram still read as "not yet" rather
-                    // than as a failure.
-                    className={next ? 'opacity-50 grayscale-[0.7]' : undefined}
-                />
+                <span className="relative inline-flex">
+                    <Medal
+                        rarity={medal.rarity}
+                        icon={medal.icon}
+                        locked={locked}
+                        size={56}
+                        // Struck but not yet won: the real medal, turned down,
+                        // so its shape and pictogram still read as "not yet"
+                        // rather than as a failure.
+                        className={
+                            next ? 'opacity-50 grayscale-[0.7]' : undefined
+                        }
+                    />
+
+                    {/* The ring is the cell's own fill, not a colour of its
+                        own, so the badge reads as punched out of the card and
+                        never as a dot floating over the metal. */}
+                    {earned && (
+                        <span className="absolute -right-0.5 -bottom-0.5 inline-flex size-[17px] items-center justify-center rounded-full bg-foreground ring-2 ring-muted">
+                            <CheckIcon
+                                className="size-2.5 text-background"
+                                strokeWidth={3.5}
+                            />
+                        </span>
+                    )}
+                </span>
 
                 {/* Always drawn rather than revealed on hover: the phone is
                     where a medal actually gets posted, and there is no hover

--- a/resources/js/components/achievements/track-medals.test.tsx
+++ b/resources/js/components/achievements/track-medals.test.tsx
@@ -1,0 +1,75 @@
+import { type AchievementMedal } from '@/types';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TrackMedals } from './track-medals';
+
+/*
+ * The locked tail.
+ *
+ * A track is a ladder, and the far end of it is a run of question marks that
+ * says nothing. Only what has been earned and the next rung are drawn; the rest
+ * is one slot carrying the count, which opens the ladder in place.
+ */
+
+vi.mock('@inertiajs/react', () => ({
+    usePage: () => ({ props: { locale: 'en-US' } }),
+}));
+
+function track(states: AchievementMedal['state'][]): AchievementMedal[] {
+    return states.map((state, index) => ({
+        key: `transactions.${index}`,
+        rarity: 'common',
+        share: null,
+        state,
+        name: state === 'locked' ? null : `Rung ${index}`,
+        icon: null,
+        figure: null,
+        reached: null,
+        achieved_on: state === 'earned' ? '2024-03' : null,
+        progress: null,
+    })) as AchievementMedal[];
+}
+
+describe('TrackMedals', () => {
+    it('draws what has been earned and the next rung, and folds the rest away', () => {
+        render(
+            <TrackMedals
+                medals={track(['earned', 'next', 'locked', 'locked', 'locked'])}
+            />,
+        );
+
+        expect(screen.getByText('Rung 0')).toBeInTheDocument();
+        expect(screen.getByText('Rung 1')).toBeInTheDocument();
+        expect(screen.queryByText('???')).toBeNull();
+        expect(screen.getByText('+3 to come')).toBeInTheDocument();
+    });
+
+    it('opens the rest of the ladder in place, and folds it back', () => {
+        render(<TrackMedals medals={track(['earned', 'next', 'locked'])} />);
+
+        fireEvent.click(screen.getByRole('button', { name: /to come/ }));
+
+        expect(screen.getByText('???')).toBeInTheDocument();
+        expect(screen.queryByText('+1 to come')).toBeNull();
+
+        fireEvent.click(screen.getByRole('button', { name: /Show less/ }));
+
+        expect(screen.queryByText('???')).toBeNull();
+        expect(screen.getByText('+1 to come')).toBeInTheDocument();
+    });
+
+    it('says nothing about a tail a completed track does not have', () => {
+        render(<TrackMedals medals={track(['earned', 'earned'])} />);
+
+        expect(screen.queryByRole('button', { name: /to come/ })).toBeNull();
+    });
+
+    // The tail folds for everyone, newcomer and veteran alike: a ladder with
+    // nothing earned yet is the case the collapse was drawn for.
+    it('folds the tail on day one too, leaving only the next rung', () => {
+        render(<TrackMedals medals={track(['next', 'locked', 'locked'])} />);
+
+        expect(screen.getByText('Rung 0')).toBeInTheDocument();
+        expect(screen.getByText('+2 to come')).toBeInTheDocument();
+    });
+});

--- a/resources/js/components/achievements/track-medals.tsx
+++ b/resources/js/components/achievements/track-medals.tsx
@@ -1,0 +1,67 @@
+import { AchievementCell } from '@/components/achievements/achievement-cell';
+import { Medal } from '@/components/achievements/medal';
+import { cn } from '@/lib/utils';
+import { type AchievementMedal } from '@/types';
+import { __ } from '@/utils/i18n';
+import { ChevronRightIcon } from 'lucide-react';
+import { useState } from 'react';
+
+/**
+ * The rungs of one track: what has been earned, what is next, and one slot
+ * standing for everything still to come.
+ *
+ * The catalogue is fifty-nine medals across thirteen tracks, so on day one the
+ * ladders were fifty-nine question marks — the wall of failure they were drawn
+ * to avoid, just laid out sideways. The locked tail is folded into a single
+ * slot instead, and it folds for every reader rather than only for newcomers:
+ * a veteran loses nothing, because the rest of their ladder is one click away
+ * and no round trip to the server is needed to open it.
+ */
+export function TrackMedals({ medals }: { medals: AchievementMedal[] }) {
+    const [expanded, setExpanded] = useState(false);
+    const locked = medals.filter((medal) => medal.state === 'locked');
+    const shown = expanded
+        ? medals
+        : medals.filter((medal) => medal.state !== 'locked');
+
+    return (
+        <div className="flex gap-2 sm:flex-wrap">
+            {shown.map((medal) => (
+                <AchievementCell key={medal.key} medal={medal} />
+            ))}
+
+            {locked.length > 0 && (
+                <button
+                    type="button"
+                    onClick={() => setExpanded(!expanded)}
+                    className="flex w-26 shrink-0 cursor-pointer flex-col items-center justify-center gap-2 self-stretch rounded-lg border border-dashed border-ring p-3"
+                >
+                    {/* Three rings rather than N: a stack says "more of these"
+                        at any count, and the count is written underneath. */}
+                    <span className="flex items-center">
+                        {[0, 1, 2].map((index) => (
+                            <Medal
+                                key={index}
+                                // The locked ring is the same silhouette in
+                                // every tier, so nothing here reads the rarity.
+                                rarity="common"
+                                locked
+                                size={26}
+                                className={index > 0 ? '-ml-2.5' : undefined}
+                            />
+                        ))}
+                    </span>
+
+                    <span className="flex items-center gap-0.5 text-[11px] leading-[14px] font-medium text-muted-foreground tabular-nums">
+                        {expanded
+                            ? __('Show less')
+                            : __('+:count to come', { count: locked.length })}
+                        <ChevronRightIcon
+                            className={cn('size-3.5', expanded && 'rotate-180')}
+                        />
+                    </span>
+                </button>
+            )}
+        </div>
+    );
+}

--- a/resources/js/pages/achievements/index.tsx
+++ b/resources/js/pages/achievements/index.tsx
@@ -1,5 +1,4 @@
 import {
-    AchievementCell,
     monthLabel,
     ProgressBar,
 } from '@/components/achievements/achievement-cell';
@@ -10,6 +9,7 @@ import {
 import { Medal } from '@/components/achievements/medal';
 import { RarityTag } from '@/components/achievements/rarity-tag';
 import { ShareMedalDialog } from '@/components/achievements/share-medal-dialog';
+import { TrackMedals } from '@/components/achievements/track-medals';
 import { Button } from '@/components/ui/button';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { useLocale } from '@/hooks/use-locale';
@@ -29,11 +29,12 @@ import { useState } from 'react';
  * Progress: every milestone the reader's money has crossed, and the months we
  * have closed.
  *
- * Forty-six medals, most of them still to come for most people, is a wall of
- * failure if it is drawn as a grid. So it is drawn as eleven ladders instead:
+ * Fifty-nine medals, most of them still to come for most people, is a wall of
+ * failure if it is drawn as a grid. So it is drawn as thirteen ladders instead:
  * each track runs from its smallest rung to its largest, what has been earned
- * sits on the left and what is still to come trails off to the right. The empty
- * slots read as the road ahead, which is what they are.
+ * sits on the left and the next rung follows it. What is further out than that
+ * is folded into one slot at the end of the row, which reads as the road ahead
+ * rather than as a list of everything not done yet.
  *
  * Two ways in. Tracks is the ladder; Timeline is the same medals dated by when
  * they really happened, which is the point of reconstructing the history at all:
@@ -138,14 +139,7 @@ function Tracks({ tracks }: { tracks: AchievementTrack[] }) {
                     {/* Sideways on a phone: the ladder keeps its direction
                         rather than wrapping into an unreadable block. */}
                     <div className="-mx-4 overflow-x-auto px-4 sm:mx-0 sm:overflow-visible sm:px-0">
-                        <div className="flex gap-2 sm:flex-wrap">
-                            {track.medals.map((medal) => (
-                                <AchievementCell
-                                    key={medal.key}
-                                    medal={medal}
-                                />
-                            ))}
-                        </div>
+                        <TrackMedals medals={track.medals} />
                     </div>
                 </div>
             ))}
@@ -207,7 +201,7 @@ function Timeline({ tracks }: { tracks: AchievementTrack[] }) {
                                     <Medal
                                         rarity={medal.rarity}
                                         icon={medal.icon}
-                                        size={32}
+                                        size={44}
                                     />
                                     <div className="flex min-w-0 flex-1 flex-col gap-0.5">
                                         <span className="flex flex-wrap items-baseline gap-x-1.5 text-sm font-medium">


### PR DESCRIPTION
Three changes to the Progress screen, all client-side. Design canvas (four
artboards — cell states today vs proposed, the full screen at 11/59, day one at
0/59, and the phone)

## 1. Earned vs in progress now reads at a glance

The states differed by a solid border versus a dashed one and nothing else. That
was invisible, because `--card` and `--background` are the same colour in both
themes: a "filled" earned cell was white on white.

- **earned** — `bg-muted` instead of `bg-card`, solid border kept (gold
  `EPIC_EDGE` still kept for epic), and a 17px check badge struck on the medal.
  The badge is ringed in the cell's own fill (`ring-2 ring-muted`) so it reads
  as punched out of the card rather than as a dot floating over the metal.
- **next** — still transparent and dashed with the medal turned down
  (`opacity-50 grayscale-[0.7]`), but the dashed edge darkens from
  `border-border` to `border-ring` so the outline is actually visible.
- **locked** — content unchanged (`???`), same darkened dashed edge, bigger
  silhouette.

No cell gets a text label. Fill, the colour of the medal, and the date versus
the progress bar are three independent signals already, and the component's doc
comment argues deliberately against labelling the next one — that comment was
updated to match what the code now does rather than left to drift.

Both themes verified rather than assumed: in dark, `--muted` (`oklch(0.269)`) is
lighter than `--background` (`oklch(0.225)`), so the fill separates in both
directions, and the badge (`bg-foreground` + `text-background`) inverts
correctly.

## 2. Bigger medal

`Medal size={56}` in the cell, up from 36 — **one value, no responsive branch**.
The phone artboard drew 52px; 56 everywhere renders the same in practice and
saves a breakpoint, so that's what shipped. The cell grows with it: `w-32` →
`w-37` (148px), `p-2.5` → `p-3`, and the height floors move up to `min-h-40` /
`min-h-32`. The Timeline row medal follows at 44px (was 32).

`medal.tsx` is untouched — it already took a `size` prop.

## 3. The locked tail folds

Fifty-nine medals across thirteen tracks meant fifty-nine question marks on day
one: the wall of failure the ladders were drawn to avoid, just laid out
sideways.

Each track now draws what has been earned and the next rung, then one 104px slot
standing for the rest — three overlapping locked rings and `+N to come`.
Clicking opens that track in place (local `useState`, no server round trip) and
the same slot flips to `Show less` with the chevron reversed, so a reader can
fold it back. One component, two labels.

**It folds for every reader**, with no "unlocked >= N" threshold: a veteran
loses nothing, because the rest of their ladder is one click away.

## Notes

- **No backend change.** `Progress.php` already sends every medal with
  `state: earned | next | locked` and already nulls out a locked medal's
  `name`/`icon`/`figure`. The collapse is purely a client-side slice of
  `track.medals`, so nothing leaks that wasn't already being sent.
  `Progress.php`, `Standing.php`, `Catalog.php` and `AchievementController.php`
  are untouched, and `tests/Feature/Achievements` passes unchanged (79 tests).
- `ProgressBar` is still shared with `Overview` — not forked.
- One new string, `+:count to come`, added to `lang/es.json` and `lang/fr.json`
  (`Show less` was already translated in both).
- `:unlocked of :total` in the track header still counts the whole catalogue for
  that track, including the folded medals. That's deliberate — it's the size of
  the ladder, not the number of cells on screen.

## Tests

`track-medals.test.tsx` is new: locked cells hidden by default, the slot carries
the right count, clicking reveals exactly those cells and folding puts them
back, a completed track shows no slot at all, and the day-one case (nothing
earned) still shows the next rung plus the fold. `achievement-cell.test.tsx`
gains two cases pinning the earned fill and the check badge, and the absence of
both on the next cell.

## QA

Browser-tested against the running app as `victoor89@gmail.com` (36 of 59
earned): all three states distinct in light and dark; epic gold border present
on earned epics and correctly absent on epic `next` cells; medal measured at
56px in the DOM on desktop and at 390px, Timeline at 44px; every track's
`+N to come` cross-checked against `total − earned − next`, and expanding one
revealed exactly that many `???` cells; expand touches only its own track and
issues no network request; a completed track shows no slot; at 390px the track
row scrolls internally while the page body does not scroll horizontally
(`documentElement.scrollWidth === clientWidth`); zero console errors or
warnings.

## Demo

https://github.com/user-attachments/assets/274238ab-dc7c-4ecd-ac2d-d16b549a17fa

