### PR TITLE
fix(summaries): keep an archived account out of the summary payload (WM-9B2E)

### DIFF
--- a/app/Services/MonthlySummary/SummaryBuilder.php
+++ b/app/Services/MonthlySummary/SummaryBuilder.php
@@ -90,11 +90,15 @@ class SummaryBuilder
             'budgets' => $this->budgetsSection($user, $month),
             'goal' => $this->goalSection($user, $month),
             'todos' => $this->todosSection($user, $month),
-            'account_names' => $this->accountNames($accounts),
+            'account_names' => $this->accountNames($accounts, $month),
         ];
     }
 
     /**
+     * Every account, archived ones included. Each caller decides its own as-of
+     * date — scoping the query instead would erase an account from a month it
+     * legitimately belonged to.
+     *
      * @return Collection<int, Account>
      */
     private function accountsOf(User $user): Collection
@@ -588,12 +592,20 @@ class SummaryBuilder
      * Bank and account names, for the AI analysis only. Transaction descriptions
      * and merchants deliberately never leave the account.
      *
+     * An account archived by the end of the month is left out: the analysis is
+     * allowed to name anything in this list, and a reader who archived an
+     * account does not expect to read about it. As-of the month, not today, so
+     * a month the account was still live keeps naming it.
+     *
      * @param  Collection<int, Account>  $accounts
      * @return list<string>
      */
-    private function accountNames(Collection $accounts): array
+    private function accountNames(Collection $accounts, Carbon $month): array
     {
+        $end = $month->copy()->endOfMonth();
+
         return $accounts
+            ->reject(fn (Account $account): bool => $account->isArchivedOn($end))
             ->map(fn (Account $account): string => trim(($account->bank?->name ? $account->bank->name.' · ' : '').$account->name))
             ->values()
             ->all();

--- a/tests/Feature/MonthlySummary/SummaryBuilderTest.php
+++ b/tests/Feature/MonthlySummary/SummaryBuilderTest.php
@@ -183,6 +183,28 @@ it('carries bank and account names for the analysis but no transaction descripti
         ->and(json_encode($payload))->not->toContain('description');
 });
 
+it('leaves an archived account out of the names the analysis may use', function (): void {
+    // As-of the month, not today: a month that closed before the archiving
+    // still belonged to the account, so it keeps its name there.
+    $user = summaryUser();
+    $live = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'EUR', 'name' => 'Salary account', 'type' => AccountType::Checking]);
+    $archivedBefore = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'EUR', 'name' => 'Old savings', 'type' => AccountType::Savings, 'archived_at' => $this->month->copy()->subMonths(2)]);
+    $archivedDuring = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'EUR', 'name' => 'Closed mid month', 'type' => AccountType::Savings, 'archived_at' => $this->month->copy()->addDays(10)]);
+    $archivedAfter = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'EUR', 'name' => 'Archived later', 'type' => AccountType::Savings, 'archived_at' => $this->month->copy()->addMonths(1)]);
+    $archivedOnLastDay = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'EUR', 'name' => 'Closed on the last day', 'type' => AccountType::Savings, 'archived_at' => $this->month->copy()->endOfMonth()]);
+
+    monthlyTransaction($user, $live, -1000, CategoryType::Expense, 'Housing');
+
+    $payload = app(SummaryBuilder::class)->build($user, $this->month, complete: true);
+    $names = implode(' | ', $payload['account_names']);
+
+    expect($names)->toContain($live->name)
+        ->and($names)->toContain($archivedAfter->name)
+        ->and($names)->not->toContain($archivedBefore->name)
+        ->and($names)->not->toContain($archivedDuring->name)
+        ->and($names)->not->toContain($archivedOnLastDay->name);
+});
+
 it('hands the model amounts a person can read, not minor units', function (): void {
     // The payload stores 352000 for €3,520.00. A model has no way to know that
     // and will faithfully report a hundred times the amount, so what it receives


### PR DESCRIPTION
## The bug

`SummaryBuilder::accountNames()` mapped **every** account belonging to the user, with no archival filter. Its output is the monthly summary payload's `account_names` key, and `MonthlySummaryAgent`'s system prompt explicitly authorises the model to name a bank or an account *when the payload names it*.

So an account the user had archived could still be brought up by name in the AI analysis of a monthly summary.

`accountNames()` was the only leak. `netWorthSection()` (via `NetWorthCalculator::at()`) and `investedSection()` already apply their own archival check, and `lookupFor()` only prefetches balances by id.

## The fix

Reject accounts that are `isArchivedOn($month->endOfMonth())` before building the list — the same **as-of-date** rule `investedSection()` and `NetWorthCalculator` already use.

Deliberately *not* `whereNull('archived_at')`: that would erase an account from a historical month it legitimately belonged to. A summary for a month the account was still live keeps naming it; only months that had already closed after the archiving drop it.

`accountsOf()` is unchanged and still loads archived accounts — every section applies its own as-of date, and narrowing the query there would silently change net worth history. The docblock now says so, so the omission doesn't read like a bug to the next reader.

## Tests

`tests/Feature/MonthlySummary/SummaryBuilderTest.php` covers the four cases:

| Account archived… | In `account_names`? |
| --- | --- |
| before the summary month | no |
| during the month | no |
| on the month's last day (the `gte` boundary) | no |
| after the month | **yes** — that month it was live |
| never | yes |

The archived-after-the-month case is the one a careless fix breaks; it's asserted explicitly. Verified red before the change and green after.

## Scope

Payload only. The AI prompt is untouched — the fix is to stop feeding it archived names, not to ask it more nicely. `NetWorthCalculator`, `investedSection` and `BalanceLookup` are left alone; they were already correct.