### PR TITLE
fix(banking): rebuild a balance history the bank left holes in (WM-2E7B)

### DIFF
--- a/app/Http/Controllers/AccountBalanceController.php
+++ b/app/Http/Controllers/AccountBalanceController.php
@@ -43,6 +43,9 @@ class AccountBalanceController extends Controller
             ],
             [
                 'balance' => $validated['balance'],
+                // The user's own figure, so the backwards balance walk stops
+                // treating this day as its own to recalculate.
+                'derived' => false,
                 ...array_key_exists('invested_amount', $validated)
                     ? ['invested_amount' => $validated['invested_amount']]
                     : [],
@@ -71,6 +74,9 @@ class AccountBalanceController extends Controller
             ],
             [
                 'balance' => $validated['balance'],
+                // The user's own figure, so the backwards balance walk stops
+                // treating this day as its own to recalculate.
+                'derived' => false,
                 ...array_key_exists('invested_amount', $validated)
                     ? ['invested_amount' => $validated['invested_amount']]
                     : [],

--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -8,6 +8,7 @@ use App\Http\Requests\IndexTransactionRequest;
 use App\Http\Requests\StoreTransactionRequest;
 use App\Http\Requests\UpdateTransactionRequest;
 use App\Jobs\ReassignTransactionsToBudgets;
+use App\Jobs\RecalculateHistoricalBalancesJob;
 use App\Models\Account;
 use App\Models\AutomationRule;
 use App\Models\Bank;
@@ -213,9 +214,39 @@ class TransactionController extends Controller
             $balanceAdjuster->applyCreatedTransaction($transaction);
         }
 
+        $this->recalculateBalanceHistoryIfBackdated($transaction);
+
         return response()->json([
             'data' => $transaction->load('labels'),
         ], 201);
+    }
+
+    /**
+     * Queue a rebuild of a connected account's derived balance history when a
+     * transaction lands on a day that history already covers.
+     *
+     * Those balances are walked backwards from the bank's latest figure, so a
+     * row dated inside the walked range changes every earlier day. The import
+     * flow posts one row at a time; the job is unique per account, so an import
+     * of several months collapses into a single run.
+     */
+    private function recalculateBalanceHistoryIfBackdated(Transaction $transaction): void
+    {
+        $account = $transaction->account;
+
+        if ($account === null || ! $account->isConnected()) {
+            return;
+        }
+
+        $newestBalance = $account->balances()
+            ->orderByDesc('balance_date')
+            ->first();
+
+        if ($newestBalance === null || ! $transaction->transaction_date->lt($newestBalance->balance_date)) {
+            return;
+        }
+
+        RecalculateHistoricalBalancesJob::dispatch($account);
     }
 
     public function update(UpdateTransactionRequest $request, Transaction $transaction, ManualBalanceAdjuster $balanceAdjuster): JsonResponse

--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -16,6 +16,7 @@ use App\Models\Category;
 use App\Models\Label;
 use App\Models\Transaction;
 use App\Services\Ai\CategoryOverrideHandler;
+use App\Services\Banking\BalanceSyncService;
 use App\Services\ManualBalanceAdjuster;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -226,15 +227,19 @@ class TransactionController extends Controller
      * transaction lands on a day that history already covers.
      *
      * Those balances are walked backwards from the bank's latest figure, so a
-     * row dated inside the walked range changes every earlier day. The import
-     * flow posts one row at a time; the job is unique per account, so an import
-     * of several months collapses into a single run.
+     * row dated inside the walked range changes every earlier day. In practice
+     * that means an import: the flow posts one row at a time, and the job is
+     * unique per account, so months of rows collapse into a single run.
      */
     private function recalculateBalanceHistoryIfBackdated(Transaction $transaction): void
     {
         $account = $transaction->account;
 
         if ($account === null || ! $account->isConnected()) {
+            return;
+        }
+
+        if (! in_array($transaction->source, BalanceSyncService::WALKED_SOURCES, true)) {
             return;
         }
 

--- a/app/Jobs/RecalculateHistoricalBalancesJob.php
+++ b/app/Jobs/RecalculateHistoricalBalancesJob.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Account;
+use App\Services\Banking\BalanceSyncService;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+/**
+ * Rebuild a connected account's derived balance history after transactions land
+ * on days that history already covers.
+ *
+ * The bank's own sync recalculates as it goes, but an import does not: it is
+ * client-side and POSTs one transaction at a time, so filling in months the bank
+ * never reported would otherwise leave the history untouched. Dispatching this
+ * per row is fine because it is {@see ShouldBeUnique} keyed by account, which
+ * collapses a whole import's worth of dispatches into a single queued run.
+ *
+ * The condition is re-checked on execution and the walk itself is idempotent, so
+ * a dispatch that no longer applies - the account gone, or disconnected since -
+ * is a no-op rather than a failure.
+ */
+class RecalculateHistoricalBalancesJob implements ShouldBeUnique, ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public Account $account) {}
+
+    public function uniqueId(): string
+    {
+        return $this->account->id;
+    }
+
+    public function handle(BalanceSyncService $balanceSync): void
+    {
+        $account = $this->account->fresh();
+
+        if ($account === null || ! $account->isConnected()) {
+            return;
+        }
+
+        $balanceSync->calculateHistoricalBalances($account);
+    }
+}

--- a/app/Models/AccountBalance.php
+++ b/app/Models/AccountBalance.php
@@ -22,6 +22,7 @@ class AccountBalance extends Model
         'balance_date',
         'balance',
         'invested_amount',
+        'derived',
     ];
 
     protected function casts(): array
@@ -30,6 +31,7 @@ class AccountBalance extends Model
             'balance_date' => 'date',
             'balance' => 'integer',
             'invested_amount' => 'integer',
+            'derived' => 'boolean',
         ];
     }
 

--- a/app/Services/Banking/BalanceSyncService.php
+++ b/app/Services/Banking/BalanceSyncService.php
@@ -47,7 +47,7 @@ class BalanceSyncService
 
         $account->balances()->updateOrCreate(
             ['balance_date' => $date],
-            ['balance' => $amount],
+            ['balance' => $amount, 'derived' => false],
         );
 
         Log::info('Synced balance', [
@@ -72,21 +72,32 @@ class BalanceSyncService
             return;
         }
 
-        $existingDates = $account->balances()
+        // Only the rows this walk wrote itself are its to correct. Everything
+        // else is somebody's word on what the balance was that day - the bank's,
+        // or the user's through the balance editor - and stays put. Rows written
+        // before the `derived` column existed carry its false default, so they
+        // count as somebody's too: their author is unknowable and overwriting
+        // one on a guess is worse than leaving a stale figure alone.
+        $protectedDates = $account->balances()
+            ->where('derived', false)
             ->pluck('balance_date')
             ->map(fn (mixed $date) => $date instanceof Carbon ? $date->toDateString() : (string) $date)
             ->flip()
             ->all();
 
-        // The reference balance comes from the bank, so it only reflects rows the
-        // bank itself reported. Walking back through a hand-entered or imported
-        // row would subtract money the bank never counted. A row the user moved
-        // to another day counts on the day the bank gave it, for the same reason:
-        // the bank's balance was reached on the bank's timeline.
+        // The reference balance comes from the bank, so the walk may only subtract
+        // movements that balance already counted. Rows the bank sent are in, and so
+        // are rows the user imported: when the bank's transaction list has a hole
+        // but its balance does not, the imported rows are the only thing that
+        // explains how the balance moved across those days, and subtracting them
+        // makes the walk more correct rather than less. Hand-entered rows stay out
+        // - nothing says the bank ever counted one. A row the user moved to another
+        // day counts on the day the bank gave it, for the same reason: the bank's
+        // balance was reached on the bank's timeline.
         $bankDate = 'COALESCE(source_date, transaction_date)';
 
         $dailyTotals = $account->transactions()
-            ->where('source', TransactionSource::EnableBanking)
+            ->whereIn('source', [TransactionSource::EnableBanking, TransactionSource::Imported])
             ->whereRaw("{$bankDate} <= ?", [$referenceBalance->balance_date->toDateString()])
             ->selectRaw("{$bankDate} as bank_date, SUM(amount) as daily_total")
             ->groupByRaw($bankDate)
@@ -103,12 +114,13 @@ class BalanceSyncService
         $rows = [];
 
         foreach ($dailyTotals as $date => $sum) {
-            if ($date < $referenceDate && ! isset($existingDates[$date])) {
+            if ($date < $referenceDate && ! isset($protectedDates[$date])) {
                 $rows[] = [
                     'id' => (string) Str::uuid(),
                     'account_id' => $account->id,
                     'balance_date' => $date,
                     'balance' => $runningBalance,
+                    'derived' => true,
                     'created_at' => $now,
                     'updated_at' => $now,
                 ];

--- a/app/Services/Banking/BalanceSyncService.php
+++ b/app/Services/Banking/BalanceSyncService.php
@@ -16,6 +16,15 @@ class BalanceSyncService
     /** Balance types in preference order */
     private const PREFERRED_BALANCE_TYPES = ['CLBD', 'ITAV', 'ITBD', 'OPBD', 'XPCD'];
 
+    /**
+     * The transaction sources the backwards walk in
+     * {@see self::calculateHistoricalBalances()} subtracts. A row of any other
+     * source cannot move what that walk produces.
+     *
+     * @var list<TransactionSource>
+     */
+    public const WALKED_SOURCES = [TransactionSource::EnableBanking, TransactionSource::Imported];
+
     public function __construct(
         private BankingProviderInterface $provider,
     ) {}
@@ -97,7 +106,7 @@ class BalanceSyncService
         $bankDate = 'COALESCE(source_date, transaction_date)';
 
         $dailyTotals = $account->transactions()
-            ->whereIn('source', [TransactionSource::EnableBanking, TransactionSource::Imported])
+            ->whereIn('source', self::WALKED_SOURCES)
             ->whereRaw("{$bankDate} <= ?", [$referenceBalance->balance_date->toDateString()])
             ->selectRaw("{$bankDate} as bank_date, SUM(amount) as daily_total")
             ->groupByRaw($bankDate)
@@ -130,6 +139,8 @@ class BalanceSyncService
         }
 
         if ($rows !== []) {
+            // `derived` is left out of the update list on purpose: every row this
+            // can collide with was skipped above unless the walk already owned it.
             AccountBalance::upsert($rows, ['account_id', 'balance_date'], ['balance', 'updated_at']);
         }
 

--- a/database/factories/AccountBalanceFactory.php
+++ b/database/factories/AccountBalanceFactory.php
@@ -26,6 +26,17 @@ class AccountBalanceFactory extends Factory
     }
 
     /**
+     * Indicate that the balance was produced by the backwards balance walk,
+     * which makes it the walk's to overwrite on a later run.
+     */
+    public function derived(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'derived' => true,
+        ]);
+    }
+
+    /**
      * Indicate that the balance has an invested amount.
      */
     public function withInvestedAmount(?int $investedAmount = null): static

--- a/database/migrations/2026_09_07_073934_add_derived_to_account_balances_table.php
+++ b/database/migrations/2026_09_07_073934_add_derived_to_account_balances_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Marks the rows the backwards balance walk produced itself, so a later run
+     * may correct them while leaving every other row alone.
+     *
+     * Rows that predate this column default to false on purpose: their author is
+     * unknowable, and guessing wrong would overwrite a figure the bank or the
+     * user gave us. No backfill.
+     */
+    public function up(): void
+    {
+        Schema::table('account_balances', function (Blueprint $table) {
+            $table->boolean('derived')->default(false)->after('invested_amount');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('account_balances', function (Blueprint $table) {
+            $table->dropColumn('derived');
+        });
+    }
+};

--- a/resources/js/types/account.ts
+++ b/resources/js/types/account.ts
@@ -63,6 +63,7 @@ export interface AccountBalance {
     balance_date: string;
     balance: number;
     invested_amount: number | null;
+    derived: boolean;
     created_at: string;
     updated_at: string;
 }

--- a/tests/Feature/OpenBanking/BalanceSyncServiceTest.php
+++ b/tests/Feature/OpenBanking/BalanceSyncServiceTest.php
@@ -1,12 +1,15 @@
 <?php
 
 use App\Contracts\BankingProviderInterface;
+use App\Enums\TransactionSource;
 use App\Models\Account;
 use App\Models\AccountBalance;
 use App\Models\BankingConnection;
 use App\Models\Transaction;
 use App\Models\User;
 use App\Services\Banking\BalanceSyncService;
+
+use function Pest\Laravel\actingAs;
 
 test('calculateHistoricalBalances derives balances from transactions', function () {
     $user = User::factory()->onboarded()->create();
@@ -178,7 +181,7 @@ test('calculateHistoricalBalances handles multiple transactions per day', functi
     expect($feb8->balance)->toBe(100000);
 });
 
-test('calculateHistoricalBalances skips dates with existing balances', function () {
+test('calculateHistoricalBalances leaves a balance of unknown authorship alone', function () {
     $user = User::factory()->onboarded()->create();
     $connection = BankingConnection::factory()->create(['user_id' => $user->id]);
     $account = Account::factory()->connected()->create([
@@ -193,7 +196,8 @@ test('calculateHistoricalBalances skips dates with existing balances', function 
         'balance' => 100000,
     ]);
 
-    // Existing balance from balance_after_transaction (more accurate)
+    // Not flagged as derived, so as far as the walk can tell somebody else put
+    // it there - the bank, the user, or a run that predates the flag entirely.
     AccountBalance::factory()->create([
         'account_id' => $account->id,
         'balance_date' => '2026-02-05',
@@ -258,4 +262,230 @@ test('calculateHistoricalBalances does nothing without transactions', function (
     $service->calculateHistoricalBalances($account);
 
     expect($account->balances()->count())->toBe(1);
+});
+
+test('sync marks the balance it stores as reported, not derived', function () {
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->create(['user_id' => $user->id]);
+    $account = Account::factory()->connected()->create([
+        'user_id' => $user->id,
+        'banking_connection_id' => $connection->id,
+        'external_account_id' => 'ext-123',
+        'currency_code' => 'EUR',
+    ]);
+
+    // A day the walk had already filled in for itself.
+    AccountBalance::factory()->derived()->create([
+        'account_id' => $account->id,
+        'balance_date' => '2026-03-10',
+        'balance' => 100000,
+    ]);
+
+    $provider = Mockery::mock(BankingProviderInterface::class);
+    $provider->shouldReceive('getBalances')->once()->andReturn([
+        'balances' => [[
+            'balance_type' => 'CLBD',
+            'balance_amount' => ['amount' => '1234.56'],
+            'reference_date' => '2026-03-10',
+        ]],
+    ]);
+
+    (new BalanceSyncService($provider))->sync($account);
+
+    $march10 = $account->balances()->where('balance_date', '2026-03-10')->first();
+
+    expect($march10->balance)->toBe(123456)
+        ->and($march10->derived)->toBeFalse();
+});
+
+/**
+ * An account whose bank reported March and January but never February, with the
+ * missing month present as imported transactions.
+ *
+ * Reference balance: end of Mar 10 = 100000.
+ * Bank movements:     Mar 10 -5000, Mar 5 +2000, Jan 25 -1000.
+ * Imported movements: Feb 20 -30000, Feb 10 +8000 (the hole).
+ *
+ * @return array{0: User, 1: Account}
+ */
+function accountWithAGapInItsBankHistory(bool $withImportedGap = true): array
+{
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->create(['user_id' => $user->id]);
+    $account = Account::factory()->connected()->create([
+        'user_id' => $user->id,
+        'banking_connection_id' => $connection->id,
+        'external_account_id' => 'ext-123',
+    ]);
+
+    AccountBalance::factory()->create([
+        'account_id' => $account->id,
+        'balance_date' => '2026-03-10',
+        'balance' => 100000,
+    ]);
+
+    $movements = [
+        ['2026-03-10', -5000, 'enableBanking'],
+        ['2026-03-05', 2000, 'enableBanking'],
+        ['2026-02-20', -30000, 'imported'],
+        ['2026-02-10', 8000, 'imported'],
+        ['2026-01-25', -1000, 'enableBanking'],
+    ];
+
+    foreach ($movements as [$date, $amount, $source]) {
+        if ($source === 'imported' && ! $withImportedGap) {
+            continue;
+        }
+
+        Transaction::factory()->{$source}()->create([
+            'user_id' => $user->id,
+            'account_id' => $account->id,
+            'transaction_date' => $date,
+            'amount' => $amount,
+        ]);
+    }
+
+    return [$user, $account];
+}
+
+test('calculateHistoricalBalances subtracts imported movements the bank left out of its history', function () {
+    [, $account] = accountWithAGapInItsBankHistory();
+
+    $service = new BalanceSyncService(Mockery::mock(BankingProviderInterface::class));
+    $service->calculateHistoricalBalances($account);
+
+    $balanceOn = fn (string $date): ?int => $account->balances()->where('balance_date', $date)->value('balance');
+
+    // Mar 10 is the reference: 100000. Strip its own -5000 to reach Mar 9: 105000.
+    expect($balanceOn('2026-03-05'))->toBe(105000)
+        // Strip Mar 5's +2000 to reach Mar 4, which is still where Feb 20 ends.
+        ->and($balanceOn('2026-02-20'))->toBe(103000)
+        // Strip Feb 20's -30000: the imported month is what moves the walk here.
+        ->and($balanceOn('2026-02-10'))->toBe(133000)
+        // Strip Feb 10's +8000.
+        ->and($balanceOn('2026-01-25'))->toBe(125000);
+});
+
+test('calculateHistoricalBalances corrects a balance it derived before the gap was filled', function () {
+    [$user, $account] = accountWithAGapInItsBankHistory(withImportedGap: false);
+
+    $service = new BalanceSyncService(Mockery::mock(BankingProviderInterface::class));
+    $service->calculateHistoricalBalances($account);
+
+    // With February missing, the walk steps straight over it and plants Mar 4's
+    // balance on Jan 25.
+    expect($account->balances()->where('balance_date', '2026-01-25')->value('balance'))->toBe(103000);
+
+    // The user imports the months the bank never sent.
+    Transaction::factory()->imported()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'transaction_date' => '2026-02-20',
+        'amount' => -30000,
+    ]);
+    Transaction::factory()->imported()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'transaction_date' => '2026-02-10',
+        'amount' => 8000,
+    ]);
+
+    $service->calculateHistoricalBalances($account);
+
+    expect($account->balances()->where('balance_date', '2026-01-25')->value('balance'))->toBe(125000)
+        ->and($account->balances()->where('balance_date', '2026-02-20')->value('balance'))->toBe(103000)
+        ->and($account->balances()->where('balance_date', '2026-02-10')->value('balance'))->toBe(133000);
+});
+
+test('calculateHistoricalBalances leaves a bank-reported balance alone on a re-run', function () {
+    [$user, $account] = accountWithAGapInItsBankHistory(withImportedGap: false);
+
+    // What a daily sync left behind on Mar 5 back when that was the current day.
+    AccountBalance::factory()->create([
+        'account_id' => $account->id,
+        'balance_date' => '2026-03-05',
+        'balance' => 99999,
+    ]);
+
+    $service = new BalanceSyncService(Mockery::mock(BankingProviderInterface::class));
+    $service->calculateHistoricalBalances($account);
+
+    Transaction::factory()->imported()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'transaction_date' => '2026-02-20',
+        'amount' => -30000,
+    ]);
+
+    $service->calculateHistoricalBalances($account);
+
+    // The walk corrects its own Jan 25 but never touches the bank's Mar 5.
+    expect($account->balances()->where('balance_date', '2026-03-05')->value('balance'))->toBe(99999)
+        ->and($account->balances()->where('balance_date', '2026-01-25')->value('balance'))->toBe(133000);
+});
+
+test('calculateHistoricalBalances leaves a balance the user set alone on a re-run', function () {
+    [$user, $account] = accountWithAGapInItsBankHistory();
+
+    $service = new BalanceSyncService(Mockery::mock(BankingProviderInterface::class));
+    $service->calculateHistoricalBalances($account);
+
+    expect($account->balances()->where('balance_date', '2026-02-20')->value('balance'))->toBe(103000);
+
+    // The user corrects that day by hand, through the balance editor.
+    actingAs($user)->postJson(route('api.accounts.balances.store', $account), [
+        'balance_date' => '2026-02-20',
+        'balance' => 55555,
+    ])->assertCreated();
+
+    $service->calculateHistoricalBalances($account);
+
+    expect($account->balances()->where('balance_date', '2026-02-20')->value('balance'))->toBe(55555)
+        // The days the walk does own are still rebuilt around it.
+        ->and($account->balances()->where('balance_date', '2026-01-25')->value('balance'))->toBe(125000);
+});
+
+test('calculateHistoricalBalances ignores hand-entered transactions on a connected account', function () {
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->create(['user_id' => $user->id]);
+    $account = Account::factory()->connected()->create([
+        'user_id' => $user->id,
+        'banking_connection_id' => $connection->id,
+        'external_account_id' => 'ext-123',
+    ]);
+
+    AccountBalance::factory()->create([
+        'account_id' => $account->id,
+        'balance_date' => '2026-03-10',
+        'balance' => 100000,
+    ]);
+
+    Transaction::factory()->enableBanking()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'transaction_date' => '2026-03-10',
+        'amount' => -5000,
+    ]);
+
+    // Nothing says the bank's figure ever counted this one.
+    Transaction::factory()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'transaction_date' => '2026-03-05',
+        'amount' => -50000,
+        'source' => TransactionSource::ManuallyCreated,
+    ]);
+
+    Transaction::factory()->enableBanking()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'transaction_date' => '2026-03-01',
+        'amount' => 1000,
+    ]);
+
+    $service = new BalanceSyncService(Mockery::mock(BankingProviderInterface::class));
+    $service->calculateHistoricalBalances($account);
+
+    expect($account->balances()->where('balance_date', '2026-03-05')->exists())->toBeFalse()
+        ->and($account->balances()->where('balance_date', '2026-03-01')->value('balance'))->toBe(105000);
 });

--- a/tests/Feature/OpenBanking/RecalculateHistoricalBalancesJobTest.php
+++ b/tests/Feature/OpenBanking/RecalculateHistoricalBalancesJobTest.php
@@ -1,0 +1,160 @@
+<?php
+
+use App\Jobs\RecalculateHistoricalBalancesJob;
+use App\Models\Account;
+use App\Models\AccountBalance;
+use App\Models\BankingConnection;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Services\Banking\BalanceSyncService;
+use Illuminate\Support\Facades\Queue;
+
+use function Pest\Laravel\actingAs;
+
+/**
+ * A connected account holding one bank balance on Mar 10 and the movement that
+ * produced it, so the walk has something to rebuild.
+ *
+ * @return array{0: User, 1: Account}
+ */
+function connectedAccountWithBalanceHistory(): array
+{
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->create(['user_id' => $user->id]);
+    $account = Account::factory()->connected()->create([
+        'user_id' => $user->id,
+        'banking_connection_id' => $connection->id,
+        'external_account_id' => 'ext-123',
+        'currency_code' => 'EUR',
+    ]);
+
+    AccountBalance::factory()->create([
+        'account_id' => $account->id,
+        'balance_date' => '2026-03-10',
+        'balance' => 100000,
+    ]);
+
+    Transaction::factory()->enableBanking()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'transaction_date' => '2026-03-01',
+        'amount' => -5000,
+    ]);
+
+    return [$user, $account];
+}
+
+/**
+ * @param  array<string, mixed>  $overrides
+ */
+function postTransaction(User $user, Account $account, array $overrides = []): void
+{
+    actingAs($user)->postJson(route('transactions.store'), [
+        'account_id' => $account->id,
+        'description' => 'Imported row',
+        'transaction_date' => '2026-02-20',
+        'amount' => -30000,
+        'currency_code' => 'EUR',
+        'source' => 'imported',
+        ...$overrides,
+    ])->assertCreated();
+}
+
+test('storing a transaction dated inside the balance history queues a rebuild', function () {
+    Queue::fake();
+
+    [$user, $account] = connectedAccountWithBalanceHistory();
+
+    postTransaction($user, $account);
+
+    Queue::assertPushed(
+        RecalculateHistoricalBalancesJob::class,
+        fn (RecalculateHistoricalBalancesJob $job): bool => $job->account->is($account),
+    );
+});
+
+test('storing a transaction dated past the newest balance queues nothing', function () {
+    Queue::fake();
+
+    [$user, $account] = connectedAccountWithBalanceHistory();
+
+    postTransaction($user, $account, ['transaction_date' => '2026-03-20']);
+
+    Queue::assertNotPushed(RecalculateHistoricalBalancesJob::class);
+});
+
+test('storing a transaction on an account with no balance history queues nothing', function () {
+    Queue::fake();
+
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->create(['user_id' => $user->id]);
+    $account = Account::factory()->connected()->create([
+        'user_id' => $user->id,
+        'banking_connection_id' => $connection->id,
+        'external_account_id' => 'ext-123',
+        'currency_code' => 'EUR',
+    ]);
+
+    postTransaction($user, $account);
+
+    Queue::assertNotPushed(RecalculateHistoricalBalancesJob::class);
+});
+
+test('storing a transaction on a manual account queues nothing', function () {
+    Queue::fake();
+
+    $user = User::factory()->onboarded()->create();
+    $account = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'EUR']);
+
+    AccountBalance::factory()->create([
+        'account_id' => $account->id,
+        'balance_date' => '2026-03-10',
+        'balance' => 100000,
+    ]);
+
+    postTransaction($user, $account);
+
+    Queue::assertNotPushed(RecalculateHistoricalBalancesJob::class);
+});
+
+test('an import of many rows collapses into a single queued rebuild', function () {
+    Queue::fake();
+
+    [$user, $account] = connectedAccountWithBalanceHistory();
+
+    foreach (range(1, 5) as $day) {
+        postTransaction($user, $account, ['transaction_date' => sprintf('2026-02-%02d', $day)]);
+    }
+
+    // ShouldBeUnique is what does the collapsing, and the fake honours it.
+    Queue::assertPushed(RecalculateHistoricalBalancesJob::class, 1);
+});
+
+test('the job rebuilds the history the import just made answerable', function () {
+    [$user, $account] = connectedAccountWithBalanceHistory();
+
+    Transaction::factory()->imported()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'transaction_date' => '2026-02-20',
+        'amount' => -30000,
+    ]);
+
+    (new RecalculateHistoricalBalancesJob($account))->handle(app(BalanceSyncService::class));
+
+    // Mar 10 is the reference at 100000; Mar 1's -5000 lands the walk on 105000,
+    // and Feb 20's -30000 carries it back to 135000 before that.
+    expect($account->balances()->where('balance_date', '2026-03-01')->value('balance'))->toBe(100000)
+        ->and($account->balances()->where('balance_date', '2026-02-20')->value('balance'))->toBe(105000);
+});
+
+test('the job does nothing for an account disconnected since it was queued', function () {
+    [, $account] = connectedAccountWithBalanceHistory();
+
+    $job = new RecalculateHistoricalBalancesJob($account);
+    $account->update(['banking_connection_id' => null]);
+
+    $job->handle(app(BalanceSyncService::class));
+
+    expect($account->balances()->count())->toBe(1);
+});

--- a/tests/Feature/OpenBanking/RecalculateHistoricalBalancesJobTest.php
+++ b/tests/Feature/OpenBanking/RecalculateHistoricalBalancesJobTest.php
@@ -100,6 +100,18 @@ test('storing a transaction on an account with no balance history queues nothing
     Queue::assertNotPushed(RecalculateHistoricalBalancesJob::class);
 });
 
+test('storing a hand-entered transaction queues nothing', function () {
+    Queue::fake();
+
+    [$user, $account] = connectedAccountWithBalanceHistory();
+
+    // The walk never subtracts a hand-entered row, so it cannot change what the
+    // walk would produce.
+    postTransaction($user, $account, ['source' => 'manually_created']);
+
+    Queue::assertNotPushed(RecalculateHistoricalBalancesJob::class);
+});
+
 test('storing a transaction on a manual account queues nothing', function () {
     Queue::fake();
 


### PR DESCRIPTION
`BalanceSyncService::calculateHistoricalBalances()` reconstructs a connected account's daily balance history by walking backwards from the bank's latest reported balance, subtracting each day's movements. Two things made that walk wrong, and nothing re-ran it once it was.

## The bug

**The walk counted only `enablebanking` rows.** The reasoning was sound: the bank's reference balance reflects only what the bank itself counted, so subtracting a row the bank never saw moves the walk by money that balance never included.

What it missed is the case where the bank's *transaction list* is incomplete but its *balance* is not. Banks do leave holes — a stretch of days they never report. The balance moved across those days; the rows explaining it just never arrived. With no rows to subtract, the walk stepped straight over the hole and planted a much later balance on the day before it, and every earlier date inherited the error.

**The walk skipped any date that already had a row.** That guard is what stopped a re-run from ever correcting a value the walk itself had got wrong.

**Nothing re-ran it after an import.** The only caller was the bank sync, and it backfills on a first sync only. So a user who imported the missing months fixed their income and expense totals while the balance history never noticed.

## The fix

**Count imported rows in the walk.** When the bank's list has a hole its balance does not, the imported rows are the only thing that explains how the balance moved across those days; subtracting them makes the walk more correct, not less. Hand-entered rows stay out — nothing says the bank's figure ever counted one. The two sources the walk subtracts are now a single constant on the service, so the walk and its trigger cannot drift apart.

**Mark the rows the walk writes.** A new `account_balances.derived` column records a row as the walk's own output, and the walk overwrites only rows it owns. That replaces the blanket "skip any existing date" guard: a bank-reported daily balance and a balance the user set by hand or imported stay untouchable, while the walk's own output becomes correctable.

**Re-run it when transactions arrive that change the answer.** `RecalculateHistoricalBalancesJob` is dispatched from `TransactionController@store` when the account is connected, the transaction is dated before the account's newest balance, and its source is one the walk counts. The import flow is client-side and posts one row at a time, so this fires once per row; `ShouldBeUnique` keyed by account collapses an import's hundreds of dispatches into a single queued run, and the job re-checks the condition on execution. Same pattern as `PurgeResidualEncryptionArtifactsJob`.

## What this does not fix

**Accounts that already carry a wrong history are not repaired.** Rows already in the table predate the `derived` column and their authorship is unknowable — the walk's own bad output is indistinguishable from a figure the bank or the user gave us. Guessing wrong would overwrite real data, so the migration adds the column with a `false` default and backfills nothing. Those rows stay protected and stay stale. They heal on the next gap-free recalculation, or the user corrects them through the balance import. A one-off repair command is a follow-up, not this PR.

**Only `store()` triggers a rebuild.** Editing an imported transaction's amount, or deleting it, leaves the derived history stale until the next recalculation. Deliberate, and called out here so it doesn't read as an oversight: editing a *date* is already safe, because `source_date` pins the row to the day the bank or the import gave it.

## Tests

The walk is arithmetic over real money, so the tests carry the weight:

- a hole in the middle of the history, with real movements inside it, derived correctly once imported rows explain it
- a re-run correcting a balance the walk itself derived before the gap was filled
- a bank-reported row surviving a re-run
- a balance the user set surviving a re-run, with the walk's own days still rebuilt around it
- hand-entered transactions still ignored on a connected account
- `sync()` marking the bank's figure as reported, not derived
- the dispatch firing, and not firing, on each arm of its condition — and five posts collapsing into one queued rebuild

Also QA'd end to end outside the test suite: five POSTs to `/transactions` against a real database queue produced exactly one rebuild job, a real worker ran it, and the history came back with the gap filled and the user's own row untouched.
