### PR TITLE
fix(dashboard): drop empty accounts from the net worth tooltip (WM-5D8C)

### DIFF
--- a/resources/js/components/dashboard/net-worth-chart.tsx
+++ b/resources/js/components/dashboard/net-worth-chart.tsx
@@ -639,6 +639,7 @@ export function NetWorthChart({
                                       }
                                     : undefined
                             }
+                            hideZeroValues
                         />
                     ) : (
                         <StackedBarChart
@@ -662,6 +663,7 @@ export function NetWorthChart({
                                       }
                                     : undefined
                             }
+                            hideZeroValues
                         />
                     ))}
                 {chartViews.currentView === 'mom' && (

--- a/resources/js/components/ui/chart-tooltip-content.test.tsx
+++ b/resources/js/components/ui/chart-tooltip-content.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ChartContainer, ChartTooltipContent } from './chart';
+import type { ChartConfig } from './chart';
+
+// ResponsiveContainer measures its DOM parent, which is 0x0 in jsdom, so it
+// would render nothing. The tooltip needs the chart config context around it,
+// not a laid-out chart.
+vi.mock('recharts', async (importOriginal) => {
+    const actual = (await importOriginal()) as typeof import('recharts');
+    return {
+        ...actual,
+        ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+            <>{children}</>
+        ),
+    };
+});
+
+vi.mock('@/contexts/privacy-mode-context', () => ({
+    usePrivacyMode: () => ({
+        isPrivacyModeEnabled: false,
+        togglePrivacyMode: vi.fn(),
+        setPrivacyMode: vi.fn(),
+    }),
+}));
+
+vi.mock('@/hooks/use-locale', () => ({
+    useLocale: () => 'en',
+}));
+
+const config: ChartConfig = {
+    checking: { label: 'Checking' },
+    savings: { label: 'Savings' },
+    cash: { label: 'Cash' },
+};
+
+/** Amounts are in minor units, like the chart data itself. */
+function item(id: string, value: number, display?: number) {
+    return {
+        dataKey: id,
+        name: id,
+        value,
+        payload: display === undefined ? {} : { [`${id}_display`]: display },
+    };
+}
+
+function renderTooltip(props: Partial<
+    React.ComponentProps<typeof ChartTooltipContent>
+>) {
+    return render(
+        <ChartContainer config={config}>
+            <ChartTooltipContent
+                active
+                hideLabel
+                displayCurrency="EUR"
+                payload={[
+                    item('checking', 150000),
+                    item('savings', 0),
+                    item('cash', 20000),
+                ]}
+                {...props}
+            />
+        </ChartContainer>,
+    );
+}
+
+function totalRow(): string {
+    return screen.getByText('Total').parentElement?.textContent ?? '';
+}
+
+describe('ChartTooltipContent zero rows', () => {
+    it('drops the accounts worth nothing at the hovered point', () => {
+        renderTooltip({ hideZeroValues: true });
+
+        expect(screen.getByText('Checking')).toBeInTheDocument();
+        expect(screen.getByText('Cash')).toBeInTheDocument();
+        expect(screen.queryByText('Savings')).not.toBeInTheDocument();
+    });
+
+    it('keeps the same account at a point where it holds something', () => {
+        renderTooltip({
+            hideZeroValues: true,
+            payload: [
+                item('checking', 150000),
+                item('savings', 90000),
+                item('cash', 20000),
+            ],
+        });
+
+        expect(screen.getByText('Savings')).toBeInTheDocument();
+    });
+
+    it('leaves zero rows alone for the charts that do not opt in', () => {
+        renderTooltip({});
+
+        expect(screen.getByText('Savings')).toBeInTheDocument();
+    });
+
+    it('reads the same total either way', () => {
+        const { unmount } = renderTooltip({});
+        const before = totalRow();
+
+        unmount();
+        renderTooltip({ hideZeroValues: true });
+
+        expect(totalRow()).toBe(before);
+    });
+
+    // Net worth mode scales the asset series to fit the bar, and a month with a
+    // negative net worth scales every one of them to 0. The rows must survive:
+    // the balance they show is the unscaled `_display` value.
+    it('judges a scaled net-worth series by the value it displays', () => {
+        renderTooltip({
+            hideZeroValues: true,
+            netWorthMode: { liabilityTypeLabel: 'Loan' },
+            payload: [
+                item('checking', 0, 150000),
+                item('savings', 0, 0),
+                item('cash', 0, 20000),
+            ],
+        });
+
+        expect(screen.getByText('Checking')).toBeInTheDocument();
+        expect(screen.getByText('Cash')).toBeInTheDocument();
+        expect(screen.queryByText('Savings')).not.toBeInTheDocument();
+    });
+});

--- a/resources/js/components/ui/chart-tooltip-content.test.tsx
+++ b/resources/js/components/ui/chart-tooltip-content.test.tsx
@@ -108,6 +108,17 @@ describe('ChartTooltipContent zero rows', () => {
         expect(totalRow()).toBe(before);
     });
 
+    it('draws no tooltip at all when nothing is left to show', () => {
+        const { baseElement } = renderTooltip({
+            hideZeroValues: true,
+            payload: [item('checking', 0), item('savings', 0)],
+        });
+
+        expect(screen.queryByText('Checking')).not.toBeInTheDocument();
+        expect(screen.queryByText('Total')).not.toBeInTheDocument();
+        expect(baseElement.textContent).toBe('');
+    });
+
     // Net worth mode scales the asset series to fit the bar, and a month with a
     // negative net worth scales every one of them to 0. The rows must survive:
     // the balance they show is the unscaled `_display` value.

--- a/resources/js/components/ui/chart.tsx
+++ b/resources/js/components/ui/chart.tsx
@@ -420,6 +420,18 @@ const ChartTooltipContent = React.forwardRef<
               )
             : seriesPayload;
 
+        const liabilitiesTotal = netWorthMode
+            ? (payload[0]?.payload?.__liabilities_total as number | undefined)
+            : undefined;
+        const hasLiabilities =
+            typeof liabilitiesTotal === 'number' && liabilitiesTotal > 0;
+
+        // Every row filtered out and no liability row to fall back on: an empty
+        // box reads as broken, so draw nothing at all.
+        if (itemPayload.length === 0 && !hasLiabilities) {
+            return null;
+        }
+
         const nestLabel = itemPayload.length === 1 && indicator !== 'dot';
         const hasMultipleCurrencies =
             currencyTotals && currencyTotals.length > 1;
@@ -525,16 +537,12 @@ const ChartTooltipContent = React.forwardRef<
                         },
                     )}
                     {(() => {
-                        const liabilitiesTotal = netWorthMode
-                            ? (payload[0]?.payload?.__liabilities_total as number | undefined)
-                            : undefined;
                         const liabilitiesJson = netWorthMode
                             ? (payload[0]?.payload?.__liabilities as string | undefined)
                             : undefined;
                         const liabilities: Array<{ name: string; amount: number }> = liabilitiesJson
                             ? (JSON.parse(liabilitiesJson) as Array<{ name: string; amount: number }>)
                             : [];
-                        const hasLiabilities = typeof liabilitiesTotal === 'number' && liabilitiesTotal > 0;
                         const showTotalSection = itemPayload.length > 1 || hasLiabilities;
 
                         if (!showTotalSection) return null;

--- a/resources/js/components/ui/chart.tsx
+++ b/resources/js/components/ui/chart.tsx
@@ -426,9 +426,10 @@ const ChartTooltipContent = React.forwardRef<
         const hasLiabilities =
             typeof liabilitiesTotal === 'number' && liabilitiesTotal > 0;
 
-        // Every row filtered out and no liability row to fall back on: an empty
-        // box reads as broken, so draw nothing at all.
-        if (itemPayload.length === 0 && !hasLiabilities) {
+        // The filter left no rows and there is no liability row to fall back
+        // on: an empty box reads as broken, so draw nothing at all. Gated on
+        // the same opt-in, so no other chart can reach it.
+        if (hideZeroValues && itemPayload.length === 0 && !hasLiabilities) {
             return null;
         }
 

--- a/resources/js/components/ui/chart.tsx
+++ b/resources/js/components/ui/chart.tsx
@@ -259,6 +259,32 @@ interface ChartTooltipContentProps {
     displayCurrency?: string;
     /** When set, tooltip shows liability rows and net-worth total instead of simple sum. */
     netWorthMode?: NetWorthMode;
+    /**
+     * Drops the rows whose value at the hovered point is exactly zero. Off by
+     * default, so every other chart keeps listing them.
+     */
+    hideZeroValues?: boolean;
+}
+
+/**
+ * The value a tooltip row shows. In net-worth mode the rendered series is
+ * scaled to fit the bar, so the row reads the unscaled original stored
+ * alongside it in the data point.
+ */
+function getTooltipItemValue(
+    item: TooltipPayloadItem,
+    netWorthMode?: NetWorthMode,
+): number | string | undefined {
+    if (!netWorthMode) {
+        return item.value;
+    }
+
+    const accountId = String(item.dataKey || item.name || '');
+
+    return (
+        (item.payload?.[`${accountId}_display`] as number | undefined) ??
+        item.value
+    );
 }
 
 function formatCurrencyWithCode(
@@ -290,6 +316,7 @@ const ChartTooltipContent = React.forwardRef<
             accountCurrencies,
             displayCurrency,
             netWorthMode,
+            hideZeroValues,
             coordinate,
         },
         ref,
@@ -381,9 +408,17 @@ const ChartTooltipContent = React.forwardRef<
 
         // The synthetic deficit series is rendering-only; the negative net
         // worth already shows in the total row, so drop it from the item list.
-        const itemPayload = netWorthMode?.deficitKey
+        const seriesPayload = netWorthMode?.deficitKey
             ? payload.filter((item) => item.dataKey !== netWorthMode.deficitKey)
             : payload;
+
+        // An account holding nothing at the hovered point carries no
+        // information; its row only pushes the ones that do out of sight.
+        const itemPayload = hideZeroValues
+            ? seriesPayload.filter(
+                  (item) => getTooltipItemValue(item, netWorthMode) !== 0,
+              )
+            : seriesPayload;
 
         const nestLabel = itemPayload.length === 1 && indicator !== 'dot';
         const hasMultipleCurrencies =
@@ -412,11 +447,10 @@ const ChartTooltipContent = React.forwardRef<
                                 item.dataKey || item.name || '',
                             );
 
-                            // In net worth mode, use the original unscaled
-                            // value stored in the data point for display.
-                            const displayValue = netWorthMode
-                                ? ((item.payload?.[`${accountId}_display`] as number | undefined) ?? item.value)
-                                : item.value;
+                            const displayValue = getTooltipItemValue(
+                                item,
+                                netWorthMode,
+                            );
 
                             return (
                                 <div

--- a/resources/js/components/ui/stacked-area-chart.tsx
+++ b/resources/js/components/ui/stacked-area-chart.tsx
@@ -38,6 +38,8 @@ export interface StackedAreaChartProps<T extends Record<string, unknown>> {
     showLegend?: boolean;
     minBarWidth?: number;
     netWorthMode?: NetWorthMode;
+    /** Hides the tooltip rows worth exactly zero at the hovered point. */
+    hideZeroValues?: boolean;
 }
 
 export function StackedAreaChart<T extends Record<string, unknown>>({
@@ -53,6 +55,7 @@ export function StackedAreaChart<T extends Record<string, unknown>>({
     showLegend = true,
     minBarWidth = 20,
     netWorthMode,
+    hideZeroValues,
 }: StackedAreaChartProps<T>) {
     const scrollContainerRef = useRef<HTMLDivElement>(null);
 
@@ -135,6 +138,7 @@ export function StackedAreaChart<T extends Record<string, unknown>>({
                                 accountCurrencies={accountCurrencies}
                                 displayCurrency={displayCurrency}
                                 netWorthMode={netWorthMode}
+                                hideZeroValues={hideZeroValues}
                             />
                         }
                     />

--- a/resources/js/components/ui/stacked-bar-chart.tsx
+++ b/resources/js/components/ui/stacked-bar-chart.tsx
@@ -147,6 +147,8 @@ export interface StackedBarChartProps<T extends Record<string, unknown>> {
     showLegend?: boolean;
     minBarWidth?: number;
     netWorthMode?: NetWorthMode;
+    /** Hides the tooltip rows worth exactly zero at the hovered point. */
+    hideZeroValues?: boolean;
 }
 
 export function StackedBarChart<T extends Record<string, unknown>>({
@@ -162,6 +164,7 @@ export function StackedBarChart<T extends Record<string, unknown>>({
     showLegend = true,
     minBarWidth = 50,
     netWorthMode,
+    hideZeroValues,
 }: StackedBarChartProps<T>) {
     const scrollContainerRef = useRef<HTMLDivElement>(null);
 
@@ -246,6 +249,7 @@ export function StackedBarChart<T extends Record<string, unknown>>({
                                 accountCurrencies={accountCurrencies}
                                 displayCurrency={displayCurrency}
                                 netWorthMode={netWorthMode}
+                                hideZeroValues={hideZeroValues}
                             />
                         }
                     />


### PR DESCRIPTION
## The bug

The net worth chart's tooltip listed one row per asset account, including the
accounts holding nothing at the hovered point. With a handful of empty accounts,
the rows that carry information got pushed off the top of the reader's eye.

The asymmetry was already half-fixed in the codebase: the branch that builds the
**liability** rows skips its zeros (`Math.abs(value) > 0`), the **asset** branch
never did. An empty loan stayed out of the tooltip; an empty current account did
not.

## The fix

- `ChartTooltipContent` takes a new opt-in `hideZeroValues` prop, off by default,
  that drops the payload rows whose value at the hovered point is exactly zero.
- Threaded `net-worth-chart.tsx` → `StackedBarChart` / `StackedAreaChart` →
  `ChartTooltipContent`, and turned on for both granularities of the net worth
  chart (monthly bars and daily area). Nothing else passes it, so the other
  consumers — the category analysis drawer and the account balance chart — render
  exactly as they do today.
- The filter reads the value each row *displays*, through a new
  `getTooltipItemValue` helper it shares with the row rendering. Net worth mode
  scales the asset series to fit the bar, and a month with a negative net worth
  scales every asset to zero, so filtering the *plotted* value would have emptied
  the tooltip in exactly those months.
- The chart data is untouched. Dropping a key would leave a hole in the stacked
  area's continuity instead of a flat zero.
- When the filter leaves no rows at all and there is no liability row to fall back
  on, the tooltip is not drawn — an empty bordered box reads as broken. That guard
  is gated on the same opt-in, so no other chart can reach it.

## Deliberate calls

- **Per point, not per account.** An account with nothing in April and a balance in
  May still appears in May. A pleasant consequence: an archived account contributes
  zero from its archive date, so it drops out of the months after it and stays in
  the months it was live — no archived-specific code needed.
- **Exact zero only**, no epsilon. A threshold would hide real money.
- **The total row is unchanged**: zeros contribute nothing to it, so it reads the
  same value as before. Its *visibility* follows the visible rows (shown from two
  rows up), the rule a single-account chart already followed.
- **The legend code is untouched** — and the dashboard's net worth chart renders
  without one anyway (`showLegend` defaults to `false`). The Accounts card below
  the chart still lists every account.

## Tests

`resources/js/components/ui/chart-tooltip-content.test.tsx` (new): a zero row
dropped; the same account kept at a point where it holds money; zero rows left
alone for the charts that don't opt in; the total identical either way; no tooltip
when nothing is left to show; and a scaled net-worth series judged by the value it
displays.

## QA

Browser QA against the demo account, both granularities:

- An asset account holding nothing never appears in any tooltip.
- After giving that account a balance today, it appears in the current month's
  tooltip and is still absent from the previous months' — and in the daily view,
  present today and absent a couple of weeks back.
- The funded rows, the Total and the bars/areas read exactly as before.
- The all-zero point (no tooltip at all) is covered by the unit test; reproducing
  it live would have meant emptying every account.

## Demo

https://github.com/user-attachments/assets/cab0bbef-5fbe-4a81-9faa-6d5755f0a45a

