### PR TITLE
feat(navigation): open the documentation from the user menu

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -696,6 +696,7 @@
     "Do not show": "Ne pas montrer",
     "Do not show in Sankey": "Ne pas se présenter à Sankey",
     "Do not show in cashflow chart": "Ne pas apparaître sur le graphique des flux de trésorerie",
+    "Documentation": "Documentation",
     "Don't have an account?": "Vous n'avez pas de compte ?",
     "Don't want these emails? Manage notifications in [notification settings](:url).": "Vous ne souhaitez pas recevoir ces e-mails ? Gérez les notifications dans [les paramètres de notifications](:url).",
     "Don't want these emails? You can manage your notifications in your [account settings](:url).": "Vous ne souhaitez pas recevoir ces e-mails ? Vous pouvez gérer vos notifications dans [les paramètres de votre compte](:url).",

--- a/resources/js/components/user-menu-content.test.tsx
+++ b/resources/js/components/user-menu-content.test.tsx
@@ -92,6 +92,23 @@ const user: User = {
 };
 
 describe('UserMenuContent', () => {
+    it('opens the documentation in a new tab', () => {
+        render(
+            <UserMenuContent
+                user={user}
+                onOpenSupport={vi.fn()}
+                onOpenIntegrationRequests={vi.fn()}
+            />,
+        );
+
+        const documentation = screen.getByRole('link', {
+            name: /documentation/i,
+        });
+
+        expect(documentation.getAttribute('href')).toBe('/documentation');
+        expect(documentation.getAttribute('target')).toBe('_blank');
+    });
+
     it('shows community above feedback in the user dropdown', () => {
         render(
             <UserMenuContent

--- a/resources/js/components/user-menu-content.tsx
+++ b/resources/js/components/user-menu-content.tsx
@@ -14,12 +14,14 @@ import { logout } from '@/routes';
 import accounts from '@/routes/accounts';
 import { index as progress } from '@/routes/achievements';
 import { edit as editAppearance } from '@/routes/appearance';
+import documentation from '@/routes/documentation';
 import { index as monthlySummaries } from '@/routes/monthly-summaries';
 import { type SharedData, type User } from '@/types';
 import { __ } from '@/utils/i18n';
 import { Link, router, usePage } from '@inertiajs/react';
 import {
     Award,
+    BookOpen,
     Eye,
     EyeOff,
     FileText,
@@ -159,6 +161,18 @@ export function UserMenuContent({
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
+                <DropdownMenuItem asChild>
+                    <a
+                        className="block w-full cursor-pointer"
+                        href={documentation.index.url()}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={cleanup}
+                    >
+                        <BookOpen className="mr-2" />
+                        {__('Documentation')}
+                    </a>
+                </DropdownMenuItem>
                 <DropdownMenuItem asChild>
                     <a
                         className="block w-full cursor-pointer"


### PR DESCRIPTION
## What

Adds a **Documentation** item to the user dropdown menu, opening `/documentation` in a new tab.

Until now the docs were only linked from the landing page footer, so anyone already inside the app had no way to reach them. The new entry sits at the head of the resources group, next to Community, Feedback and Roadmap.

## How

- `resources/js/components/user-menu-content.tsx`: new item as the first entry of the resources group, with the `BookOpen` icon and the same `<a target="_blank" rel="noopener noreferrer">` shape its neighbours already use. The URL comes from the Wayfinder route (`documentation.index.url()`), not a hardcoded string.
- A plain `<a>` rather than an Inertia `<Link>`: `target="_blank"` on a client-side visit does nothing, so the new tab needs a real anchor.
- `lang/fr.json`: adds the missing `Documentation` key (`es` already had it; `en` is the source text).
- `resources/js/components/user-menu-content.test.tsx`: one test asserting the item points at `/documentation` and carries `target="_blank"`.

## QA

Browser QA on the running app, logged in, desktop and mobile (390x844), light and dark:

- The item shows first in the resources group, above Community, with the book icon.
- `href="/documentation"`, `target="_blank"`, `rel="noopener noreferrer"`.
- Clicking opens a new tab on the real documentation page; the original tab stays put.
- No console errors or warnings.

Checks: `bun run format`, `bun run lint`, `bun run dry` (3.66% vs 5.4% threshold), the full vitest suite (732 tests) and `tests/Feature/LocalizationTest.php` all pass locally.

## Demo

https://github.com/user-attachments/assets/09d344e2-d4fd-495e-b3db-8ed4824341ce


