### PR TITLE
feat(achievements): put the Pro badge on the medal card too

### DIFF
--- a/app/Http/Controllers/AchievementController.php
+++ b/app/Http/Controllers/AchievementController.php
@@ -86,6 +86,7 @@ class AchievementController extends Controller
                 $format,
                 $theme,
                 $amount,
+                $request->user()->hasProPlan(),
             );
         } catch (Throwable $exception) {
             report($exception);

--- a/app/Mail/Drip/AchievementsEmail.php
+++ b/app/Mail/Drip/AchievementsEmail.php
@@ -138,6 +138,7 @@ class AchievementsEmail extends DripMail
                         CardFormat::default(),
                         CardTheme::default(),
                         amount: true,
+                        pro: $this->user->hasProPlan(),
                     )];
                 } catch (Throwable $exception) {
                     report($exception);

--- a/app/Services/Achievements/CardPresenter.php
+++ b/app/Services/Achievements/CardPresenter.php
@@ -33,6 +33,7 @@ class CardPresenter
      *                        Medals whose figure is a rate, a run of months or
      *                        a count ignore this: those are safe to post, and
      *                        the summary cards have shown them from the start.
+     * @param  bool  $pro  Whether the footer carries the Pro member badge.
      * @return array<string, mixed>
      */
     public function viewData(
@@ -42,6 +43,7 @@ class CardPresenter
         CardFormat $format,
         CardTheme $theme,
         bool $amount,
+        bool $pro,
     ): array {
         $locale = app()->getLocale();
         $metal = $definition->rarity->metal();
@@ -50,6 +52,7 @@ class CardPresenter
         return [
             'format' => $format,
             'theme' => $theme,
+            'pro' => $pro,
             'rarity' => $definition->rarity,
             'glyph' => $this->pictograms->path($definition->icon),
             'track' => $this->catalog->tracks()[$definition->track] ?? $definition->track,

--- a/app/Services/Achievements/CardRenderer.php
+++ b/app/Services/Achievements/CardRenderer.php
@@ -60,8 +60,9 @@ class CardRenderer
         CardFormat $format,
         CardTheme $theme,
         bool $amount,
+        bool $pro,
     ): string {
-        $path = $this->pathFor($achievement, $format, $theme, $amount);
+        $path = $this->pathFor($achievement, $format, $theme, $amount, $pro);
 
         if (! Storage::disk(self::DISK)->exists($path)) {
             [$width, $height] = $format->dimensions();
@@ -77,6 +78,7 @@ class CardRenderer
                         $format,
                         $theme,
                         $amount,
+                        $pro,
                     ))->render(),
                     $width,
                     $height,
@@ -93,14 +95,22 @@ class CardRenderer
      * language, read from the app exactly as {@see CardPresenter} reads it, so
      * the key and the copy inside the picture cannot disagree; and whether the
      * amount is on it, because that is the reader's choice and the two versions
-     * are different pictures. {@see DESIGN} sits above all of it, which is what
-     * a medal's own content never needing to be invalidated buys: a row is
-     * written once and never revoked, so only the design can go stale.
+     * are different pictures. And the Pro badge, so a reader who upgrades gets a
+     * new file rather than yesterday's unbadged one. {@see DESIGN} sits above
+     * all of it, which is what a medal's own content never needing to be
+     * invalidated buys: a row is written once and never revoked, so only the
+     * design can go stale.
+     *
+     * Adding the badge did NOT need a {@see DESIGN} bump: `-pro` is itself a
+     * complete invalidation. A Pro reader's file gains the suffix, so the old
+     * unbadged PNG is no longer named, and a free reader's card comes out
+     * byte-identical to before. Bumping would have redrawn every medal for
+     * everybody for nothing.
      */
-    private function pathFor(Achievement $achievement, CardFormat $format, CardTheme $theme, bool $amount): string
+    private function pathFor(Achievement $achievement, CardFormat $format, CardTheme $theme, bool $amount, bool $pro): string
     {
         $locale = app()->getLocale();
-        $suffix = $amount ? '' : '-plain';
+        $suffix = ($amount ? '' : '-plain').($pro ? '-pro' : '');
 
         return $this->directoryFor($achievement->user_id)."/{$achievement->key}-{$format->value}-{$theme->value}-{$locale}{$suffix}.png";
     }

--- a/resources/views/cards/achievement.blade.php
+++ b/resources/views/cards/achievement.blade.php
@@ -111,6 +111,19 @@
             padding-top: 40px;
             border-top: 2px solid {{ $rule }};
         }
+        .badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 12px;
+            background: {{ $dark ? '#fafafa' : '#18181b' }};
+            color: {{ $dark ? '#18181b' : '#ffffff' }};
+            border-radius: 999px;
+            padding: 13px 24px 13px 20px;
+            font-size: 23px;
+            font-weight: 600;
+            letter-spacing: 0.14em;
+            text-transform: uppercase;
+        }
         .lockup { display: flex; align-items: center; gap: 15px; }
         .lockup span { font-size: 38px; font-weight: 600; letter-spacing: -0.02em; }
         @if ($story)
@@ -143,7 +156,15 @@
     </div>
 
     <div class="foot">
-        <span></span>
+        @if ($pro)
+            <span class="badge mono">
+                @include('cards.partials.icon-sparkle', ['size' => 26, 'colour' => $dark ? '#18181b' : '#ffffff'])
+                {{ __('Pro member') }}
+            </span>
+        @else
+            <span></span>
+        @endif
+
         <span class="lockup">
             @include('cards.partials.icon-bird', ['size' => 42, 'colour' => $ink])
             <span class="mono">whisper.money</span>

--- a/tests/Feature/Achievements/AchievementCardTest.php
+++ b/tests/Feature/Achievements/AchievementCardTest.php
@@ -56,6 +56,25 @@ function earned(User $user, string $key, array $attributes = []): Achievement
     ]);
 }
 
+/**
+ * A reader on the paid plan.
+ *
+ * `subscriptions.enabled` is off for the whole suite and `hasProPlan()` reads
+ * true when it is, so every badge test has to turn billing on first —
+ * otherwise a free reader is indistinguishable from a paying one.
+ */
+function goPro(User $user): User
+{
+    $user->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => 'sub_test123',
+        'stripe_status' => 'active',
+        'stripe_price' => 'price_test123',
+    ]);
+
+    return $user->unsetRelation('subscriptions');
+}
+
 /** The HTML the one card in this test was drawn from. */
 function drawnCard(): string
 {
@@ -196,6 +215,55 @@ it('never writes the share of members on the card', function (): void {
         ->not->toContain('%');
 });
 
+it('badges the card of a reader on the paid plan', function (): void {
+    config()->set('subscriptions.enabled', true);
+    $user = goPro(medalOwner());
+    earned($user, 'streaks.2');
+
+    test()->actingAs($user)
+        ->get(route('achievements.card', ['medal' => 'streaks.2', 'format' => 'feed', 'theme' => 'light']))
+        ->assertOk();
+
+    expect(drawnCardText())->toContain('Pro member');
+});
+
+it('leaves the badge off a free reader\'s card', function (): void {
+    config()->set('subscriptions.enabled', true);
+    $user = medalOwner();
+    earned($user, 'streaks.2');
+
+    test()->actingAs($user)
+        ->get(route('achievements.card', ['medal' => 'streaks.2', 'format' => 'feed', 'theme' => 'light']))
+        ->assertOk();
+
+    expect(drawnCardText())->not->toContain('Pro member');
+});
+
+it('draws the badged and the unbadged cut as two different files', function (): void {
+    config()->set('subscriptions.enabled', true);
+    $user = medalOwner();
+    earned($user, 'streaks.2');
+
+    $ask = fn () => test()->actingAs($user)->get(route('achievements.card', [
+        'medal' => 'streaks.2', 'format' => 'feed', 'theme' => 'light',
+    ]))->assertOk();
+
+    $ask();
+
+    goPro($user);
+    $ask();
+
+    // Upgrading has to redraw: without the badge in the key the reader would be
+    // served the unbadged picture that is already sitting on the disk.
+    Process::assertRanTimes(fn (PendingProcess $process): bool => in_array(
+        base_path('scripts/render-card.mjs'), $process->command, true,
+    ), 2);
+
+    expect(collect(test()->drawnHtml)->keys()->filter(
+        fn (string $path): bool => str_ends_with($path, '-pro.png'),
+    ))->toHaveCount(1);
+});
+
 it('draws a fresh picture when the reader changes language', function (): void {
     $user = medalOwner();
     earned($user, 'streaks.2');
@@ -218,8 +286,8 @@ it('draws a fresh picture when the reader changes language', function (): void {
     // not know the difference.
     expect(Storage::disk(CardRenderer::DISK)->allFiles())->toHaveCount(2);
     expect(collect(test()->drawnHtml)->keys()->implode(' '))
-        ->toContain('-en.png')
-        ->toContain('-es.png');
+        ->toContain('-light-en')
+        ->toContain('-light-es');
 });
 
 it('draws each cut once and serves the rest off the disk', function (): void {

--- a/tests/Feature/Achievements/AchievementEmailTest.php
+++ b/tests/Feature/Achievements/AchievementEmailTest.php
@@ -37,9 +37,9 @@ beforeEach(function (): void {
 /**
  * @param  list<string>  $keys
  */
-function announcement(array $keys): AchievementsEmail
+function announcement(array $keys, ?User $user = null): AchievementsEmail
 {
-    $user = User::factory()->onboarded()->create(['currency_code' => 'EUR', 'locale' => 'en']);
+    $user ??= User::factory()->onboarded()->create(['currency_code' => 'EUR', 'locale' => 'en']);
 
     $medals = collect($keys)->map(fn (string $key): Achievement => Achievement::factory()->create([
         'user_id' => $user->id,
@@ -60,6 +60,35 @@ it('carries a picture of every medal it announces', function (): void {
     expect(Storage::disk(CardRenderer::DISK)->allFiles())
         ->toHaveCount(2)
         ->each->toContain('-feed-light-en');
+});
+
+it('warms the very file the share dialog will serve a Pro reader', function (): void {
+    config()->set('subscriptions.enabled', true);
+
+    $user = User::factory()->onboarded()->create(['currency_code' => 'EUR', 'locale' => 'en']);
+    $user->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => 'sub_test123',
+        'stripe_status' => 'active',
+        'stripe_price' => 'price_test123',
+    ]);
+
+    $assertDrawn = fn (int $times) => Process::assertRanTimes(fn (PendingProcess $process): bool => in_array(
+        base_path('scripts/render-card.mjs'), $process->command, true,
+    ), $times);
+
+    announcement(['streaks.2'], $user)->render();
+
+    $assertDrawn(1);
+
+    test()->actingAs($user->unsetRelation('subscriptions'))
+        ->get(route('achievements.card', ['medal' => 'streaks.2', 'format' => 'feed', 'theme' => 'light']))
+        ->assertOk();
+
+    // Still one: the email and the dialog read the badge off the same flag, so
+    // they name the same file and the dialog gets the picture the email already
+    // drew. Disagree on it and the medal is drawn twice, once wrong.
+    $assertDrawn(1);
 });
 
 it('links to the progress screen', function (): void {


### PR DESCRIPTION
The monthly summary card has carried a "Pro member" badge in its footer since it
shipped. The medal card was built with the empty `<span></span>` placeholder
where that badge goes and never got one. This fills the slot.

## Which flag it reads

`$user->hasProPlan()`, not the flag the summary card uses.

The summary takes its `$pro` from `AnalysisWriter::eligible()`, which is
`canUseFeature(AiSuggestions) && hasActiveAiConsent()` — really "is the AI
analysis on" rather than "is this person Pro". The badge says *Pro member*, so
here it asks the question it claims to answer. The summary's own flag is left
alone; that inconsistency is a separate call, not this PR.

## Cache key

The flag joins the render cache key as a `-pro` suffix, the same suffix
`MonthlySummary/CardRenderer` already uses, so a reader who upgrades gets a
fresh picture instead of yesterday's unbadged one.

`CardRenderer::DESIGN` is deliberately **not** bumped. The suffix is itself a
complete invalidation: a Pro reader's file gains it, so the old PNG stops being
named, and a free reader's card comes out byte-identical to today's — the
`@else` branch is the same empty span that is already there. Bumping DESIGN
would redraw every medal for everybody for nothing. The reasoning is in the
`pathFor()` docblock, which already explains the rest of the key.

## Both callers pass the same flag

This matters more than it looks. `AchievementsEmail::cards()` deliberately warms
the very file the share dialog serves later, so a disagreement between the two
would warm a wrong-keyed file and draw the medal twice — once wrong. There is a
test on exactly that (`warms the very file the share dialog will serve a Pro
reader`), and it was verified to fail when the two are made to disagree.

## Layout

The `.badge` CSS is duplicated into the card rather than extracted, following how
`.lockup` already lives in both card files — only the SVG icons are partials.
`resources/views` is outside `bun run dry`'s scan path, so it costs nothing at
the gate. This card has no `$s` scale factor, so the sizes are the summary's
values at scale 1.

## Verification

Rendered through the real `scripts/render-card.mjs` with actual headless Chromium
— not the faked-Chromium path the Pest suite uses, so these are the pictures a
reader would get:

| cut | result |
| --- | --- |
| feed 1080×1350, light | dark pill, white mono caps, sparkle icon, opposite the lockup |
| feed 1080×1350, dark | inverts correctly — light pill, dark text |
| story 1080×1920, light + dark | badge holds the tall format, no clipping, no collision |
| feed, light, `es` | "MIEMBRO PRO" widens the pill without reaching the lockup |
| feed, light, free reader | no badge, footer identical to before |
| feed, dark, money medal | figure and badge coexist |

Also confirmed end to end that the Pro path writes
`achievements/v1/<user-id>/streaks.2-feed-light-en-pro.png` to the private
`local` disk and that the free path is a different file.

`resources/js/components/share-medal-dialog.tsx` needs no change — the badge is
baked into the PNG and the dialog just points at the controller URL.

`__('Pro member')` already had `es` and `fr` translations. No new copy, no new keys.

## Out of scope, noted while here

Rendering a Spanish card surfaced a pre-existing gap unrelated to this change
(identical on `main`): `CardPresenter::figure()` calls
`trans_choice(':count month|:count months', …)`, and that pipe key has no entry
in `lang/es.json` or `lang/fr.json` — only `":count months"` on its own, which
`trans_choice` does not find. So a months/weeks/days figure falls back to English
on a Spanish or French card. Not introduced or touched here.
