### PR TITLE
feat(achievements): lay the medal cards out as a bordered 2-column grid

### DIFF
--- a/resources/views/mail/drip/achievements.blade.php
+++ b/resources/views/mail/drip/achievements.blade.php
@@ -14,11 +14,7 @@
 
 {{ trans_choice('{1}Your money crossed a line worth marking.|[2,*]Your money crossed a few lines worth marking.', count($lines)) }}
 
-@foreach ($lines as $line)
-@if ($line['card'] !== null)
-<x-mail::medal :cid="$line['card']" :alt="$line['name']" />
-@endif
-@endforeach
+<x-mail::medal :lines="$lines" />
 
 @foreach ($lines as $line)
 - **{{ $line['name'] }}{{ $line['milestone'] ? ' '.$line['milestone'] : '' }}** — {{ $line['rarity'] }}

--- a/resources/views/vendor/mail/html/layout.blade.php
+++ b/resources/views/vendor/mail/html/layout.blade.php
@@ -15,6 +15,17 @@ width: 100% !important;
 .footer {
 width: 100% !important;
 }
+
+/* One medal per row, and the gutter that separated the columns becomes the
+   gap under each card. */
+.medals, .medals > tbody, .medals > tbody > tr, .medals > tbody > tr > td {
+display: block !important;
+width: 100% !important;
+}
+
+.medal-cell {
+padding: 0 0 16px !important;
+}
 }
 
 @media only screen and (max-width: 500px) {

--- a/resources/views/vendor/mail/html/medal.blade.php
+++ b/resources/views/vendor/mail/html/medal.blade.php
@@ -1,12 +1,30 @@
 @props([
-    'cid',
-    'alt' => '',
-    'width' => 240,
+    'lines' => [],
 ])
-<table class="medal" align="center" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+@php
+    // Two per row. The cells split the content cell evenly and each one gives
+    // half the gutter back as padding, so both cards come out the same width
+    // whatever the client makes of the table: a column asked for 240px and a
+    // neighbour asked for 240px plus a gutter are not the same column, and the
+    // card that loses the argument is the one that gets scaled down.
+    //
+    // A third medal starts a second row at that same width rather than
+    // stretching across: a card wider than its neighbours reads as a mistake,
+    // a short row reads as a grid.
+    $cards = array_values(array_filter($lines, fn (array $line): bool => $line['card'] !== null));
+    $rows = array_chunk($cards, 2);
+    $alone = count($cards) === 1;
+@endphp
+@if ($rows !== [])
+<table class="medals" align="center" width="100%" cellpadding="0" cellspacing="0" role="presentation" style="margin: 8px 0 4px;">
+@foreach ($rows as $row)
 <tr>
-<td align="center" style="padding: 8px 0 4px;">
-<img src="cid:{{ $cid }}" alt="{{ $alt }}" width="{{ $width }}" style="display: block; width: {{ $width }}px; max-width: 100%; height: auto; border-radius: 12px;">
+@foreach ($row as $card)
+<td class="medal-cell" valign="top" align="{{ $alone ? 'center' : 'left' }}" width="{{ $alone ? '100%' : '50%' }}" style="width: {{ $alone ? '100%' : '50%' }};{{ $alone ? '' : ($loop->first ? ' padding-right: 13px;' : ' padding-left: 13px;') }}{{ $loop->parent->last ? '' : ' padding-bottom: 20px;' }}">
+<img src="cid:{{ $card['card'] }}" alt="{{ $card['name'] }}" width="240" style="display: block; width: 240px; max-width: 100%; height: auto; border: 1px solid #e4e4e7; border-radius: 4px;{{ $alone ? ' margin: 0 auto;' : '' }}">
 </td>
+@endforeach
 </tr>
+@endforeach
 </table>
+@endif

--- a/tests/Feature/Achievements/AchievementEmailTest.php
+++ b/tests/Feature/Achievements/AchievementEmailTest.php
@@ -91,6 +91,35 @@ it('warms the very file the share dialog will serve a Pro reader', function (): 
     $assertDrawn(1);
 });
 
+/**
+ * The medal grid on its own, so a count of rows or cells is a count of medals
+ * rather than of the layout the Markdown mail wraps them in.
+ */
+function medalGrid(string $html): string
+{
+    preg_match('/<table class="medals".*?<\/table>/s', $html, $matches);
+
+    return $matches[0] ?? '';
+}
+
+it('lays the medals out two to a row, every card the same width', function (): void {
+    $grid = medalGrid(announcement(['visits.1', 'visits.2', 'visits.3'])->render());
+
+    // Every card in a cell of the same width: a column that has to hold a
+    // gutter as well as a card is a narrower column, and the card inside it is
+    // the one the client scales down. The third medal starts a second row at
+    // that same width rather than stretching across.
+    expect(substr_count($grid, 'width: 50%'))->toBe(3)
+        ->and(substr_count($grid, '<tr>'))->toBe(2);
+});
+
+it('centres a lone medal rather than leaving half a row empty', function (): void {
+    $grid = medalGrid(announcement(['visits.1'])->render());
+
+    expect($grid)->toContain('align="center"')
+        ->and($grid)->not->toContain('width: 50%');
+});
+
 it('links to the progress screen', function (): void {
     announcement(['streaks.2'])->assertSeeInHtml('utm_content=progress', escape: false);
 });
@@ -134,6 +163,10 @@ it('goes out without the pictures when the browser cannot draw them', function (
 
     $mail->assertDontSeeInHtml('cid:', escape: false);
     $mail->assertSeeInText('Saving streak');
+
+    // And no grid where the pictures would have gone: an empty table is a
+    // pocket of air the reader has to scroll past for nothing.
+    expect(medalGrid($mail->render()))->toBe('');
 
     Exceptions::assertReported(RuntimeException::class);
 });


### PR DESCRIPTION
Three medals used to arrive as three 240px cards stacked down the page. The
card PNG's background is white and the email's `.inner-body` is white too, so
the cards had no edges at all: three floating blobs separated by big pockets of
dead air, and a screen and a half of near-empty white before the list of names.

Now the medals are a 2-column grid and every card has an edge.

## Before / after
<img width="375" height="1724" alt="medal-grid-after-mobile" src="https://github.com/user-attachments/assets/c52ab6f9-f9fa-4b31-9275-22decc73f99d" />
<img width="900" height="1200" alt="medal-grid-after-1" src="https://github.com/user-attachments/assets/fa644017-fc08-497b-a3f5-47850fb9a853" />
<img width="900" height="1200" alt="medal-grid-after-2" src="https://github.com/user-attachments/assets/7e6cbd8e-e62c-450e-9d26-430c6fb88a40" />
<img width="900" height="1326" alt="medal-grid-after-3" src="https://github.com/user-attachments/assets/f2b45630-f1ac-4409-8fff-71b1be0af5e5" />
<img width="900" height="1692" alt="medal-grid-before" src="https://github.com/user-attachments/assets/10c460a6-7832-4f60-b6b2-a35c8707d4eb" />

## What changed

`x-mail::medal` now draws the whole grid rather than one card, so the template
calls it once with `$lines` instead of looping. The component drops the medals
whose picture failed to render and lays out what is left:

- **Two per row.** The cells split the content cell evenly (`width: 50%`) and
  each one gives half the gutter back as padding, so both cards come out at
  exactly 240px whatever the client makes of the table. Asking for `240px` on
  one cell and `240px + gutter` on its neighbour is asking for two different
  columns, and the card that loses the argument is the one that gets scaled
  down — which is exactly what the first attempt did, 227px next to 240px.
- **A border**, `1px solid #e4e4e7` with a 4px radius, the rule colour and the
  panel radius `mail/summary/share.blade.php` already frames its card with.
- **A third medal starts a second row** at that same width instead of
  stretching across: a card wider than its neighbours reads as a mistake, a
  short row reads as a grid.
- **A lone medal is centred**, rather than sitting in half a row with an empty
  cell beside it.
- **Under 600px the row breaks** and the gutter that separated the columns
  becomes the gap under each card. The rules go in the shared mail layout's
  existing `<style>` block, following the idiom `mail/monthly-summary.blade.php`
  already uses.

The card PNG itself is untouched — `CardRenderer::DESIGN` is not bumped and the
share dialog and public page still serve the same file. The bullet list of
names stays below the grid: it is what a reader whose client blocks images
gets.

## Verified

Sent through MailHog and measured in the browser, all three counts:

| Count | Layout | Card boxes |
| --- | --- | --- |
| 3 | row of 2 + 1 left-aligned below | 240×300 each, 26px gutter, third flush with the first |
| 2 | one full row | 240×300 each, flush to both outer edges |
| 1 | centred | 240×300 |

At 375px and 320px the cards stack full-width at 240px with no horizontal
overflow. A medal whose render failed drops out of the grid without leaving a
hole; when every render fails no table is emitted at all, so there is no empty
pocket to scroll past.

`AchievementEmailTest` covers the two-to-a-row widths, the centred lone medal
and the absent grid. Tests, pint, format, lint, dry and crap all pass.