### PR TITLE
fix(transactions): clear the labels on screen when the bulk action removes them

### DIFF
--- a/resources/js/components/transactions/bulk-label-select.test.tsx
+++ b/resources/js/components/transactions/bulk-label-select.test.tsx
@@ -1,0 +1,31 @@
+import { type Label } from '@/types/label';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { BulkLabelSelect } from './bulk-label-select';
+
+const labels: Label[] = [
+    {
+        id: 'label-1',
+        user_id: 'user-1',
+        name: 'Work',
+        color: 'blue',
+        created_at: '2026-05-11T00:00:00.000000Z',
+        updated_at: '2026-05-11T00:00:00.000000Z',
+        deleted_at: null,
+    },
+];
+
+describe('BulkLabelSelect', () => {
+    it('asks for an empty label set when removing all labels', async () => {
+        const onLabelsChange = vi.fn();
+
+        render(
+            <BulkLabelSelect labels={labels} onLabelsChange={onLabelsChange} />,
+        );
+
+        fireEvent.click(screen.getByRole('combobox'));
+        fireEvent.click(await screen.findByText('Remove all labels'));
+
+        expect(onLabelsChange).toHaveBeenCalledWith([]);
+    });
+});

--- a/resources/js/components/transactions/transaction-list.tsx
+++ b/resources/js/components/transactions/transaction-list.tsx
@@ -73,6 +73,7 @@ import { Spinner } from '@/components/ui/spinner';
 import { TableCell, TableRow } from '@/components/ui/table';
 import { consoleDebug } from '@/lib/debug';
 import { captureEvent } from '@/lib/posthog';
+import { applyBulkLabels } from '@/lib/transaction-bulk-labels';
 import { mergeReEvaluatedTransaction } from '@/lib/transaction-re-evaluation';
 import { transactionSyncService } from '@/services/transaction-sync';
 import { type SharedData } from '@/types';
@@ -940,22 +941,8 @@ export function TransactionList({
                 label_ids: labelIds,
             });
 
-            const selectedLabels = labels.filter((label) =>
-                labelIds.includes(label.id),
-            );
-
             setTransactions((previous) =>
-                previous.map((transaction) => {
-                    if (!selectedIds.includes(transaction.id.toString())) {
-                        return transaction;
-                    }
-
-                    return {
-                        ...transaction,
-                        label_ids: labelIds,
-                        labels: selectedLabels,
-                    };
-                }),
+                applyBulkLabels(previous, selectedIds, labelIds, labels),
             );
 
             setRowSelection({});

--- a/resources/js/lib/transaction-bulk-labels.test.ts
+++ b/resources/js/lib/transaction-bulk-labels.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+
+import { type Label } from '@/types/label';
+import { type DecryptedTransaction } from '@/types/transaction';
+import { applyBulkLabels } from './transaction-bulk-labels';
+
+function label(id: string, name: string): Label {
+    return {
+        id,
+        user_id: 'user-1',
+        name,
+        color: 'blue',
+        created_at: '2026-05-11T00:00:00.000000Z',
+        updated_at: '2026-05-11T00:00:00.000000Z',
+        deleted_at: null,
+    };
+}
+
+function transaction(
+    overrides: Partial<DecryptedTransaction> = {},
+): DecryptedTransaction {
+    return {
+        id: 'transaction-1',
+        user_id: 'user-1',
+        account_id: 'account-1',
+        category_id: null,
+        description: 'Coffee',
+        description_iv: null,
+        transaction_date: '2026-05-11',
+        amount: -450,
+        currency_code: 'EUR',
+        notes: null,
+        notes_iv: null,
+        source: 'imported',
+        label_ids: [],
+        created_at: '2026-05-11T00:00:00.000000Z',
+        updated_at: '2026-05-11T00:00:00.000000Z',
+        decryptedDescription: 'Coffee',
+        decryptedNotes: null,
+        ...overrides,
+    };
+}
+
+const work = label('label-1', 'Work');
+const travel = label('label-2', 'Travel');
+const allLabels = [work, travel];
+
+describe('applyBulkLabels', () => {
+    it('empties both label_ids and labels when clearing', () => {
+        const labelled = transaction({
+            label_ids: [work.id],
+            labels: [work],
+        });
+
+        const [updated] = applyBulkLabels(
+            [labelled],
+            [labelled.id],
+            [],
+            allLabels,
+        );
+
+        expect(updated.label_ids).toEqual([]);
+        expect(updated.labels).toEqual([]);
+    });
+
+    it('replaces the existing labels instead of merging them', () => {
+        const labelled = transaction({
+            label_ids: [work.id],
+            labels: [work],
+        });
+
+        const [updated] = applyBulkLabels(
+            [labelled],
+            [labelled.id],
+            [travel.id],
+            allLabels,
+        );
+
+        expect(updated.label_ids).toEqual([travel.id]);
+        expect(updated.labels).toEqual([travel]);
+    });
+
+    it('leaves unselected transactions untouched', () => {
+        const selected = transaction({ id: 'transaction-1' });
+        const untouched = transaction({
+            id: 'transaction-2',
+            label_ids: [work.id],
+            labels: [work],
+        });
+
+        const [, result] = applyBulkLabels(
+            [selected, untouched],
+            [selected.id],
+            [travel.id],
+            allLabels,
+        );
+
+        expect(result).toBe(untouched);
+    });
+
+    it('ignores label ids that are not in the known labels', () => {
+        const [updated] = applyBulkLabels(
+            [transaction()],
+            ['transaction-1'],
+            [work.id, 'label-gone'],
+            allLabels,
+        );
+
+        expect(updated.labels).toEqual([work]);
+    });
+});

--- a/resources/js/lib/transaction-bulk-labels.ts
+++ b/resources/js/lib/transaction-bulk-labels.ts
@@ -1,0 +1,30 @@
+import { type Label } from '@/types/label';
+import { type DecryptedTransaction } from '@/types/transaction';
+
+/**
+ * Optimistic state for a bulk label change.
+ *
+ * Two things the callers kept getting wrong. The table renders labels from
+ * `label_ids`, not `labels`, so both have to move together or the badges stay
+ * on screen after the server already detached them. And `bulkUpdate` syncs the
+ * labels, so the new set *replaces* the old one — merging here made the UI
+ * disagree with the row that comes back on the next load.
+ *
+ * Rows outside `selectedIds` are returned by reference so memoised rows do not
+ * re-render.
+ */
+export function applyBulkLabels(
+    transactions: DecryptedTransaction[],
+    selectedIds: string[],
+    labelIds: string[],
+    allLabels: Label[],
+): DecryptedTransaction[] {
+    const selected = new Set(selectedIds);
+    const labels = allLabels.filter((label) => labelIds.includes(label.id));
+
+    return transactions.map((transaction) =>
+        selected.has(transaction.id.toString())
+            ? { ...transaction, label_ids: labelIds, labels }
+            : transaction,
+    );
+}

--- a/resources/js/pages/transactions/index.tsx
+++ b/resources/js/pages/transactions/index.tsx
@@ -91,6 +91,7 @@ import { consoleDebug } from '@/lib/debug';
 import { reloadPage } from '@/lib/leave-page';
 import { isNewSince } from '@/lib/new-transactions';
 import { captureEvent } from '@/lib/posthog';
+import { applyBulkLabels } from '@/lib/transaction-bulk-labels';
 import { getBulkDeleteConfirmationText } from '@/lib/transaction-delete-confirmation';
 import { mergeReEvaluatedTransaction } from '@/lib/transaction-re-evaluation';
 import { getTransactionRowActions } from '@/lib/transaction-row-actions';
@@ -1330,42 +1331,12 @@ export default function Transactions({
                 setIsSelectingAll(false);
                 refreshTransactions();
             } else {
-                const selectedLabels = labels.filter((l) =>
-                    labelIds.includes(l.id),
-                );
-
                 await transactionSyncService.updateMany(selectedIds, {
                     label_ids: labelIds,
                 });
 
                 setAllTransactions((previous) =>
-                    previous.map((transaction) => {
-                        if (selectedIds.includes(transaction.id.toString())) {
-                            if (labelIds.length === 0) {
-                                return {
-                                    ...transaction,
-                                    labels: [],
-                                };
-                            }
-
-                            const existingLabels = transaction.labels || [];
-                            const mergedLabels = [
-                                ...existingLabels,
-                                ...selectedLabels.filter(
-                                    (l) =>
-                                        !existingLabels.some(
-                                            (el) => el.id === l.id,
-                                        ),
-                                ),
-                            ];
-
-                            return {
-                                ...transaction,
-                                labels: mergedLabels,
-                            };
-                        }
-                        return transaction;
-                    }),
+                    applyBulkLabels(previous, selectedIds, labelIds, labels),
                 );
 
                 toast.success(

--- a/tests/Feature/BulkUpdateTransactionsTest.php
+++ b/tests/Feature/BulkUpdateTransactionsTest.php
@@ -271,6 +271,29 @@ it('bulk update replaces labels instead of merging them', function () {
     }
 });
 
+it('bulk update with an empty label list detaches every label', function () {
+    $label = Label::factory()->create(['user_id' => $this->user->id]);
+
+    $transaction = Transaction::factory()->create([
+        'user_id' => $this->user->id,
+        'account_id' => $this->account->id,
+    ]);
+
+    $transaction->labels()->attach($label->id);
+
+    // An empty `label_ids` is the "Remove all labels" bulk action, so it has to
+    // reach `sync([])` instead of being skipped as an empty value.
+    $response = $this->actingAs($this->user)->patchJson('/transactions/bulk', [
+        'transaction_ids' => [$transaction->id],
+        'label_ids' => [],
+    ]);
+
+    $response->assertSuccessful();
+    $response->assertJson(['count' => 1]);
+
+    expect($transaction->fresh()->labels)->toBeEmpty();
+});
+
 it('can update all transactions when no filters or IDs are provided', function () {
     Transaction::factory()
         ->count(3)

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -34,6 +34,22 @@ if (typeof window !== 'undefined') {
     if (!('PointerEvent' in window)) {
         window.PointerEvent = MouseEvent as unknown as typeof window.PointerEvent;
     }
+
+    /**
+     * Same story for the two APIs cmdk needs: jsdom implements neither, so any
+     * `Command` list (the label combobox, the command palette) throws when it
+     * mounts on `ResizeObserver`, then again on `scrollIntoView` as soon as it
+     * moves the selection.
+     */
+    if (!('ResizeObserver' in window)) {
+        globalThis.ResizeObserver = class {
+            observe() {}
+            unobserve() {}
+            disconnect() {}
+        };
+    }
+
+    Element.prototype.scrollIntoView ??= () => {};
 }
 
 beforeEach(() => {


### PR DESCRIPTION
## What

"Remove all labels" in the transactions bulk-actions bar did nothing, as far as the user could tell.

The server was right all along: `PATCH /transactions/bulk` with `label_ids: []` reaches
`syncLabels()` → `labels()->sync([])` and detaches them. The lie was in the optimistic update.
`handleBulkLabelsChange()` on `/transactions` wrote only `labels`:

```js
return { ...transaction, labels: [] };   // label_ids untouched
```

but the labels column renders from `label_ids`, not `labels`
(`transaction-columns.tsx:227`). So the labels were gone server-side and every badge stayed on
screen until a reload.

The same handler had a second version of the same bug: adding labels **merged** them into the
existing ones optimistically, while `bulkUpdate` **replaces** them
(`BulkUpdateTransactionsTest` pins that on purpose). So a bulk add showed old + new, then
collapsed to just the new set on the next load.

## How

`resources/js/components/transactions/transaction-list.tsx` (the account- and budget-detail
pages) already did it right. Rather than copy those five lines into `index.tsx` and hand
`bun run dry` a fresh clone, both call sites now go through one helper:

```ts
applyBulkLabels(transactions, selectedIds, labelIds, allLabels)
```

It replaces `label_ids` and `labels` together on the selected rows and returns everything else by
reference, so memoised rows don't re-render. `transaction-list.tsx`'s behaviour is unchanged —
it just calls the shared function now.

Per `.ai/rules/transactions-table.md` the transactions table exists twice on purpose, so this is
wired in both places.

## Tests

- **Unit** (`transaction-bulk-labels.test.ts`) — clearing empties both `label_ids` and `labels`;
  applying replaces rather than merges; unselected rows come back by reference; unknown label ids
  are ignored.
- **Component** (`bulk-label-select.test.tsx`) — clicking "Remove all labels" fires
  `onLabelsChange([])`, pinning the wiring the fix depends on.
- **Feature** (`BulkUpdateTransactionsTest`) — `label_ids: []` detaches every label and returns
  200. It passed before this PR; it's a guard so nobody folds the `$request->has('label_ids')`
  branch into a `!empty()` and silently breaks clearing.

`vitest.setup.ts` gains two jsdom shims cmdk needs (`ResizeObserver`, `scrollIntoView`),
alongside the existing `PointerEvent` one. Both are load-bearing — I verified the combobox test
fails without each.

## QA

Verified in the browser on the real `/transactions` page, since that's where the bug lived and
unit tests would not have caught it:

- Selected 3 labelled rows → "Remove all labels" → all badges cleared immediately, no reload.
  Unselected rows kept their labels. DB confirmed 0 labels on all three.
- Selected 2 rows carrying `Essential` / `Essential + Review Later` → added `Recurring` → both
  showed **only** `Recurring` (replace, not merge). DB agreed.
- Reloaded: the page matched what the optimistic UI had shown, so the optimistic state is
  truthful in both directions. No console errors.

## Note for a follow-up (not in this PR)

`BulkLabelSelect` always starts from `useState<string[]>([])`, so it never seeds from the selected
rows' current labels. Because the server does a full `sync()`, a bulk add drops any label the user
didn't re-pick — including a savings-goal label, which is hidden from the column. The old merging
optimistic update masked that until a reload; now the UI shows it honestly. Worth its own look.
