### PR TITLE
fix(mcp): let the agent write notes on any transaction

### DIFF
--- a/app/Mcp/Servers/WhisperMoneyServer.php
+++ b/app/Mcp/Servers/WhisperMoneyServer.php
@@ -77,8 +77,8 @@ data.
   `split_parent_id` shared with its siblings; pass any one of them to
   `merge_transaction_splits` to put the original back, which deletes the parts
   and everything set on them. A part cannot be split again, deleted on its own,
-  or have its amount, date or account changed; categorizing and labelling it
-  works as usual.
+  or have its amount, date or account changed; categorizing, labelling and
+  editing its notes works as usual.
 - A medal (an "achievement") records a milestone the user reached: a visit or
   saving streak, a net-worth or savings-rate level, transactions logged, data
   kept tidy. `list_achievements` returns the whole catalog grouped into tracks,
@@ -102,9 +102,12 @@ budgets, categories, labels and automation rules) require a read & write token;
 a read-only token can analyse data but never change it.
 Manual transactions can be created on any account, bank-connected ones included
 — a sync never removes them.
-Bank/imported transactions themselves are protected: only manually-created ones
-can be edited or deleted, though you can categorize, label and split any
-transaction.
+Bank/imported transactions keep their core fields protected: only a
+manually-created one can change its description, amount, date, currency,
+account or counterparty names, and only a manually-created one can be deleted.
+Their notes and category are not locked — `update_transaction` writes those on
+any transaction, split parts included — and labelling and splitting work on any
+transaction too.
 Balances can only be recorded on non-connected accounts, since a connected
 account's balances come from the bank and would be overwritten.
 MARKDOWN)]

--- a/app/Mcp/Tools/Concerns/PresentsTransactions.php
+++ b/app/Mcp/Tools/Concerns/PresentsTransactions.php
@@ -32,6 +32,11 @@ trait PresentsTransactions
             'source' => $transaction->source->value,
             'creditor_name' => $transaction->creditor_name,
             'debtor_name' => $transaction->debtor_name,
+            // Plain text, and editable on any transaction through
+            // update_transaction. Rows the old client-side encryption never
+            // migrated still hold ciphertext here; they are returned as they
+            // are, because only the browser holds the key.
+            'notes' => $transaction->notes,
             // Set when this row is one part of a split. Every part of the same
             // split carries the same value, and merge_transaction_splits takes
             // any one of them.

--- a/app/Mcp/Tools/UpdateTransaction.php
+++ b/app/Mcp/Tools/UpdateTransaction.php
@@ -91,12 +91,7 @@ class UpdateTransaction extends WriteTool
             'debtor_name' => fn () => $this->nullableString($request, 'debtor_name'),
         ]);
 
-        // Writing notes retires whatever legacy client-side ciphertext sat
-        // there: a notes_iv left behind would have the browser try to decrypt
-        // plain text and show the note as broken.
-        if ($request->has('notes')) {
-            $transaction->notes_iv = null;
-        }
+        $this->retireLegacyIvs($request, $transaction);
 
         // A new category is always a manual assignment: reset any AI/rule
         // provenance so the row is not later treated as machine-categorized.
@@ -130,6 +125,22 @@ class UpdateTransaction extends WriteTool
             'transaction' => $this->presentTransaction($transaction->refresh()),
             'balance_updated' => $balanceUpdated,
         ]);
+    }
+
+    /**
+     * Writing one of the legacy encrypted fields in the clear retires its iv:
+     * one left behind would have the browser try to decrypt plain text and
+     * render the field as broken. The web edit dialog clears them for the same
+     * reason, and the client-side encryption they belong to is being migrated
+     * away.
+     */
+    private function retireLegacyIvs(Request $request, Transaction $transaction): void
+    {
+        foreach (['description' => 'description_iv', 'notes' => 'notes_iv'] as $field => $iv) {
+            if ($request->has($field)) {
+                $transaction->{$iv} = null;
+            }
+        }
     }
 
     /**

--- a/app/Mcp/Tools/UpdateTransaction.php
+++ b/app/Mcp/Tools/UpdateTransaction.php
@@ -4,6 +4,7 @@ namespace App\Mcp\Tools;
 
 use App\Enums\CategorySource;
 use App\Enums\TransactionSource;
+use App\Models\Transaction;
 use App\Models\User;
 use App\Services\ManualBalanceAdjuster;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
@@ -12,16 +13,34 @@ use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Attributes\Description;
 
-#[Description('Edit a manually-created transaction; only the fields you pass change. Bank/imported ones keep their core fields locked — use categorize_transaction or label_transaction for those instead.')]
+#[Description('Edit a transaction; only the fields you pass change. Notes and category work on any transaction, bank/imported ones included; the other fields only on manually-created ones.')]
 class UpdateTransaction extends WriteTool
 {
+    /**
+     * The fields that describe the transaction itself. A bank/imported row owns
+     * them through its sync, and a split part takes them from its original, so
+     * they are locked there — while notes and category_id stay editable on any
+     * transaction.
+     *
+     * @var list<string>
+     */
+    private const CORE_FIELDS = [
+        'description',
+        'amount',
+        'transaction_date',
+        'currency_code',
+        'account_id',
+        'creditor_name',
+        'debtor_name',
+    ];
+
     /**
      * @return array<string, mixed>
      */
     public function schema(JsonSchema $schema): array
     {
         return [
-            'transaction_id' => $schema->string()->description('Id of the manually-created transaction to edit.')->required(),
+            'transaction_id' => $schema->string()->description('Id of the transaction to edit.')->required(),
             'description' => $schema->string()->description('New description.'),
             'amount' => $schema->integer()->description('New signed amount, in the minor units of the transaction\'s own currency.'),
             'transaction_date' => $schema->string()->description('New transaction date, YYYY-MM-DD.'),
@@ -30,7 +49,7 @@ class UpdateTransaction extends WriteTool
             'category_id' => $schema->string()->description('New category id, or null to clear the category.'),
             'creditor_name' => $schema->string()->description('New creditor (payee) name.'),
             'debtor_name' => $schema->string()->description('New debtor (payer) name.'),
-            'notes' => $schema->string()->description('New free-text notes.'),
+            'notes' => $schema->string()->description('New free-text notes, or null to clear them. Editable on any transaction, bank/imported ones and split parts included.'),
             'update_balance' => $schema->boolean()->description('When true and the amount/date/account changed, move the account balance snapshots accordingly. Ignored on connected accounts, whose balances come from the bank. Default false.'),
             'space' => $schema->string()->description('Space id. Defaults to the personal space.'),
         ];
@@ -41,12 +60,10 @@ class UpdateTransaction extends WriteTool
         $space = $this->resolveSpace($request, $user);
         $transaction = $this->transactionInSpace($request, $space);
 
-        if ($transaction->source !== TransactionSource::ManuallyCreated) {
-            return Response::error('Only manually-created transactions can be edited. This one came from a bank or import, so its core fields are locked. Use categorize_transaction or label_transaction instead.');
-        }
+        $lockedFieldError = $this->lockedCoreFieldError($request, $transaction);
 
-        if ($transaction->isSplitPart()) {
-            return Response::error('This transaction is one part of a split, so its amount, date and account are locked. Use categorize_transaction or label_transaction instead.');
+        if ($lockedFieldError !== null) {
+            return Response::error($lockedFieldError);
         }
 
         $request->validate([
@@ -73,6 +90,13 @@ class UpdateTransaction extends WriteTool
             'creditor_name' => fn () => $this->nullableString($request, 'creditor_name'),
             'debtor_name' => fn () => $this->nullableString($request, 'debtor_name'),
         ]);
+
+        // Writing notes retires whatever legacy client-side ciphertext sat
+        // there: a notes_iv left behind would have the browser try to decrypt
+        // plain text and show the note as broken.
+        if ($request->has('notes')) {
+            $transaction->notes_iv = null;
+        }
 
         // A new category is always a manual assignment: reset any AI/rule
         // provenance so the row is not later treated as machine-categorized.
@@ -106,5 +130,35 @@ class UpdateTransaction extends WriteTool
             'transaction' => $this->presentTransaction($transaction->refresh()),
             'balance_updated' => $balanceUpdated,
         ]);
+    }
+
+    /**
+     * Why the request cannot go through, or null when it can. Only a request
+     * that actually carries a core field is refused: an edit limited to notes
+     * or the category is allowed on every transaction, which is how an agent
+     * annotates bank/imported rows and split parts.
+     */
+    private function lockedCoreFieldError(Request $request, Transaction $transaction): ?string
+    {
+        $locked = array_values(array_filter(
+            self::CORE_FIELDS,
+            fn (string $field): bool => $request->has($field),
+        ));
+
+        if ($locked === []) {
+            return null;
+        }
+
+        $fields = implode(', ', $locked);
+
+        if ($transaction->source !== TransactionSource::ManuallyCreated) {
+            return "Only manually-created transactions can change {$fields}. This one came from a bank or import, so its core fields are locked; notes and category_id can still be edited here, and label_transaction handles its labels.";
+        }
+
+        if ($transaction->isSplitPart()) {
+            return "This transaction is one part of a split, so it cannot change {$fields} — those come from the original. Notes and category_id can still be edited here, and label_transaction handles its labels.";
+        }
+
+        return null;
     }
 }

--- a/chatgpt-app-submission.json
+++ b/chatgpt-app-submission.json
@@ -4,7 +4,7 @@
   "app_info": {
     "display_name": "Whisper Money",
     "subtitle": "Chat with your own finances",
-    "description": "Whisper Money is a privacy-first personal finance app: your financial data is yours, and it is never shared with third parties. This app connects ChatGPT to your own Whisper Money account so you can analyse your money in plain language instead of clicking through dashboards.\n\nAsk questions like \"how much did I spend on groceries last month\", \"what's my net worth trend this year\", \"which subscriptions are draining me\" or \"break down Q2 by category\" — the app reads your transactions, accounts, categories, labels, budgets, cashflow, net worth and the milestone medals you have earned along the way, and answers with your real numbers. You can also keep your books tidy from the conversation: log manual transactions, recategorize and label existing ones, split a transaction that covered several things into parts with their own categories, record balances for manual accounts, and manage budgets, categories, labels and automation rules — including running an automation rule over the transactions you already have, after previewing what it would match.\n\nYour synced bank data is protected: transactions imported from a bank connection can be categorized and labelled, but never edited or deleted, and balances can only be recorded on manual accounts. You can still add your own manual transactions to a bank-connected account — a sync never removes them. Data is scoped to the account you sign in with, including any shared spaces you belong to. The app reads and writes bookkeeping records only — it can never move money, make payments or reach any account outside Whisper Money.\n\nRequires a Whisper Money account on a paid (Pro) plan. Sign in happens through Whisper Money's own OAuth flow — ChatGPT never sees your password, and access can be revoked at any time from your account settings.",
+    "description": "Whisper Money is a privacy-first personal finance app: your financial data is yours, and it is never shared with third parties. This app connects ChatGPT to your own Whisper Money account so you can analyse your money in plain language instead of clicking through dashboards.\n\nAsk questions like \"how much did I spend on groceries last month\", \"what's my net worth trend this year\", \"which subscriptions are draining me\" or \"break down Q2 by category\" — the app reads your transactions, accounts, categories, labels, budgets, cashflow, net worth and the milestone medals you have earned along the way, and answers with your real numbers. You can also keep your books tidy from the conversation: log manual transactions, recategorize and label existing ones, split a transaction that covered several things into parts with their own categories, record balances for manual accounts, and manage budgets, categories, labels and automation rules — including running an automation rule over the transactions you already have, after previewing what it would match.\n\nYour synced bank data is protected: a transaction imported from a bank connection can be categorized, labelled, split and annotated with notes, but its description, amount, date and account stay locked, it can never be deleted, and balances can only be recorded on manual accounts. You can still add your own manual transactions to a bank-connected account — a sync never removes them. Data is scoped to the account you sign in with, including any shared spaces you belong to. The app reads and writes bookkeeping records only — it can never move money, make payments or reach any account outside Whisper Money.\n\nRequires a Whisper Money account on a paid (Pro) plan. Sign in happens through Whisper Money's own OAuth flow — ChatGPT never sees your password, and access can be revoked at any time from your account settings.",
     "category": "FINANCE"
   },
   "tools": {
@@ -107,9 +107,9 @@
     "update_transaction": {
       "annotations": { "readOnlyHint": false, "openWorldHint": false, "destructiveHint": false },
       "justifications": {
-        "read_only_justification": "Writes: it edits the fields of an existing manual transaction in the user's own account.",
+        "read_only_justification": "Writes: it edits the fields of an existing transaction in the user's own account.",
         "open_world_justification": "Edits a bookkeeping row inside the user's own Whisper Money account, a closed system. No external system is affected.",
-        "destructive_justification": "Reversible: field values can be edited back at any time, and bank-imported transactions are rejected outright so synced data cannot be rewritten."
+        "destructive_justification": "Reversible: field values can be edited back at any time, and a bank-imported transaction only accepts its notes and category, so the data the sync owns cannot be rewritten."
       }
     },
     "delete_transaction": {
@@ -305,10 +305,10 @@
   ],
   "negative_test_cases": [
     {
-      "description": "Bank-connected data is protected. Editing or deleting a transaction imported from a bank connection must be refused by the server, and the model should explain why instead of retrying.",
+      "description": "Bank-connected data is protected. Rewriting the amount, description, date or account of a transaction imported from a bank connection must be refused by the server, and the model should explain why instead of retrying.",
       "user_prompt": "Change the amount of that Amazon charge from my bank account to 10 euros.",
       "tools_triggered": "search_transactions, update_transaction",
-      "expected_output": "The server rejects the write because bank-imported transactions are read-only, and the model explains that only manual transactions can be edited, offering to recategorize or label it instead."
+      "expected_output": "The server rejects the write because the amount of a bank-imported transaction is locked, and the model explains that only manual transactions can have their amount changed, offering to recategorize, label or add a note to it instead."
     },
     {
       "description": "Wide, irreversible deletion must not be executed on a vague instruction. delete_transaction is destructive and single-target, so the model must stop and confirm rather than looping over the user's history.",

--- a/tests/Feature/Mcp/McpToolsTest.php
+++ b/tests/Feature/Mcp/McpToolsTest.php
@@ -54,6 +54,22 @@ it('searches transactions scoped to the user\'s space', function () {
         ->assertSee('Blue Bottle Coffee');
 });
 
+it('returns the notes of a transaction so they can be read back', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->create(['user_id' => $user->id]);
+    Transaction::factory()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'description' => 'Hardware store',
+        'notes' => 'Shelves for the office',
+    ]);
+
+    WhisperMoneyServer::actingAs($user)
+        ->tool(SearchTransactions::class, ['query' => 'Hardware store'])
+        ->assertOk()
+        ->assertSee('Shelves for the office');
+});
+
 it('filters transactions by label id', function () {
     $user = User::factory()->create();
     $account = Account::factory()->create(['user_id' => $user->id]);

--- a/tests/Feature/Mcp/McpWriteToolsTest.php
+++ b/tests/Feature/Mcp/McpWriteToolsTest.php
@@ -211,25 +211,51 @@ it('writes notes on an imported transaction and clears them again', function () 
     expect($transaction->fresh()->notes)->toBeNull();
 });
 
-it('retires the legacy notes iv when it overwrites the notes', function () {
+it('retires the legacy iv of every field it overwrites in the clear', function () {
     $user = User::factory()->create();
     $account = Account::factory()->create(['user_id' => $user->id]);
-    $transaction = Transaction::factory()->imported()->create([
+    $transaction = Transaction::factory()->create([
         'user_id' => $user->id,
         'account_id' => $account->id,
+        'description' => 'B2l0ZXh0cGQ9',
+        'description_iv' => 'MTIzNDU2Nzg5MGFi',
         'notes' => 'k5rXcipherPQ==',
         'notes_iv' => 'YWJjZGVmZ2hpamts',
     ]);
 
     callWriteTool($user, UpdateTransaction::class, [
         'transaction_id' => $transaction->id,
-        'notes' => 'Rewritten in the clear',
+        'description' => 'Rewritten in the clear',
+        'notes' => 'So are the notes',
     ])->assertOk();
 
-    // A stale iv would have the browser decrypt plain text and show the note
-    // as broken, so it has to go along with the ciphertext it described.
-    expect($transaction->fresh()->notes)->toBe('Rewritten in the clear');
-    expect($transaction->fresh()->notes_iv)->toBeNull();
+    // A stale iv would have the browser decrypt plain text and render the
+    // field as broken, so it goes along with the ciphertext it described.
+    $transaction = $transaction->fresh();
+
+    expect($transaction->description)->toBe('Rewritten in the clear');
+    expect($transaction->description_iv)->toBeNull();
+    expect($transaction->notes)->toBe('So are the notes');
+    expect($transaction->notes_iv)->toBeNull();
+});
+
+it('leaves the iv of a field it did not touch alone', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->create(['user_id' => $user->id]);
+    $transaction = Transaction::factory()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'description' => 'B2l0ZXh0cGQ9',
+        'description_iv' => 'MTIzNDU2Nzg5MGFi',
+    ]);
+
+    callWriteTool($user, UpdateTransaction::class, [
+        'transaction_id' => $transaction->id,
+        'notes' => 'Only the notes change',
+    ])->assertOk();
+
+    // The description is still ciphertext, so the browser still needs its iv.
+    expect($transaction->fresh()->description_iv)->toBe('MTIzNDU2Nzg5MGFi');
 });
 
 it('writes notes on one part of a split', function () {

--- a/tests/Feature/Mcp/McpWriteToolsTest.php
+++ b/tests/Feature/Mcp/McpWriteToolsTest.php
@@ -149,18 +149,133 @@ it('moves a transaction onto a connected account, unwinding only the manual side
     expect($connectedAccount->balances()->where('balance_date', '2026-01-15')->value('balance'))->toBe(50_000);
 });
 
-it('refuses to edit an imported transaction', function () {
+it('refuses to edit a core field of an imported transaction, naming the field', function () {
     $user = User::factory()->create();
     $account = Account::factory()->create(['user_id' => $user->id]);
     $transaction = Transaction::factory()->imported()->create([
         'user_id' => $user->id,
         'account_id' => $account->id,
+        'description' => 'Untouched',
     ]);
 
     callWriteTool($user, UpdateTransaction::class, [
         'transaction_id' => $transaction->id,
         'description' => 'Hacked',
-    ])->assertHasErrors(['manually-created']);
+        'amount' => -1,
+    ])->assertHasErrors(['manually-created'])->assertSee('description, amount');
+
+    expect($transaction->fresh()->description)->toBe('Untouched');
+});
+
+it('writes notes on a bank-synced transaction and returns them', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->connected()->create(['user_id' => $user->id]);
+    $transaction = Transaction::factory()->enableBanking()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'notes' => null,
+    ]);
+
+    callWriteTool($user, UpdateTransaction::class, [
+        'transaction_id' => $transaction->id,
+        'notes' => 'Migrated from the old spreadsheet',
+    ])->assertOk()->assertSee('Migrated from the old spreadsheet');
+
+    expect($transaction->fresh()->notes)->toBe('Migrated from the old spreadsheet');
+    // notes_iv belongs to the client-side encryption being migrated away, so a
+    // plain-text note must never claim to be encrypted.
+    expect($transaction->fresh()->notes_iv)->toBeNull();
+});
+
+it('writes notes on an imported transaction and clears them again', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->create(['user_id' => $user->id]);
+    $transaction = Transaction::factory()->imported()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'notes' => null,
+    ]);
+
+    callWriteTool($user, UpdateTransaction::class, [
+        'transaction_id' => $transaction->id,
+        'notes' => 'Reimbursed by work',
+    ])->assertOk();
+
+    expect($transaction->fresh()->notes)->toBe('Reimbursed by work');
+
+    callWriteTool($user, UpdateTransaction::class, [
+        'transaction_id' => $transaction->id,
+        'notes' => null,
+    ])->assertOk();
+
+    expect($transaction->fresh()->notes)->toBeNull();
+});
+
+it('retires the legacy notes iv when it overwrites the notes', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->create(['user_id' => $user->id]);
+    $transaction = Transaction::factory()->imported()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'notes' => 'k5rXcipherPQ==',
+        'notes_iv' => 'YWJjZGVmZ2hpamts',
+    ]);
+
+    callWriteTool($user, UpdateTransaction::class, [
+        'transaction_id' => $transaction->id,
+        'notes' => 'Rewritten in the clear',
+    ])->assertOk();
+
+    // A stale iv would have the browser decrypt plain text and show the note
+    // as broken, so it has to go along with the ciphertext it described.
+    expect($transaction->fresh()->notes)->toBe('Rewritten in the clear');
+    expect($transaction->fresh()->notes_iv)->toBeNull();
+});
+
+it('writes notes on one part of a split', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->create(['user_id' => $user->id]);
+    $original = Transaction::factory()->imported()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'amount' => -5000,
+    ]);
+    $part = Transaction::factory()->imported()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'split_parent_id' => $original->id,
+        'amount' => -3000,
+        'notes' => null,
+    ]);
+
+    callWriteTool($user, UpdateTransaction::class, [
+        'transaction_id' => $part->id,
+        'notes' => 'The camera, not the lens',
+    ])->assertOk()->assertSee('The camera, not the lens');
+
+    expect($part->fresh()->notes)->toBe('The camera, not the lens');
+    expect($part->fresh()->amount)->toBe(-3000);
+});
+
+it('leaves the balance alone when only the notes change', function () {
+    $user = User::factory()->create();
+    $account = Account::factory()->create(['user_id' => $user->id, 'currency_code' => 'EUR']);
+    $account->balances()->create(['balance_date' => '2026-01-15', 'balance' => 9_000]);
+    $transaction = Transaction::factory()->create([
+        'user_id' => $user->id,
+        'account_id' => $account->id,
+        'transaction_date' => '2026-01-15',
+        'amount' => -1_000,
+        'currency_code' => 'EUR',
+    ]);
+
+    callWriteTool($user, UpdateTransaction::class, [
+        'transaction_id' => $transaction->id,
+        'notes' => 'Just an annotation',
+        'update_balance' => true,
+    ])->assertOk()->assertSee('"balance_updated":false');
+
+    expect($account->balances()->where('balance_date', '2026-01-15')->value('balance'))->toBe(9_000);
 });
 
 it('deletes a manual transaction', function () {


### PR DESCRIPTION
Closes the Discord report ["Editar notas con la IA"](https://discord.com/channels/1445741167366111374/1546167704069865552) in `💌-sugerencias`, confirmed by a second user testing with ChatGPT.

## The problem

`update_transaction` rejected the whole call before applying a single field whenever the transaction was not manually created, or was one part of a split:

```php
if ($transaction->source !== TransactionSource::ManuallyCreated) { return Response::error(...); }
if ($transaction->isSplitPart()) { return Response::error(...); }
```

`notes` was already in the tool's schema and validation, so it was collateral damage: a user migrating old notes from a spreadsheet had to open every bank transaction in the web UI by hand.

## The fix

Only the **core fields** a bank sync owns stay locked — `description`, `amount`, `transaction_date`, `currency_code`, `account_id`, `creditor_name`, `debtor_name`. The call is refused only when it actually carries one of them, and the message names which:

> Only manually-created transactions can change `amount, transaction_date`. This one came from a bank or import, so its core fields are locked; notes and category_id can still be edited here, and label_transaction handles its labels.

So `notes` and the already-generic `category_id` now go through on any transaction — bank, imported, or a split part. The **title (`description`) of a bank transaction stays locked**, as agreed. A mixed request (notes + a locked field) is still refused atomically, so nothing is half-written.

`notes` is also added to `PresentsTransactions`, the shared row shape, so the agent can read them back from every transaction tool.

### Second fix, found in review

Writing a plain-text `description` never cleared `description_iv`, so a row the client-side encryption had not migrated yet ended up with plain text next to a stale IV — and the browser would try to decrypt plain text and render the field as broken. The web edit dialog already clears both; `retireLegacyIvs()` now does the same for `description` and `notes` alike. Notes are written as plain text and an IV is never set.

## Docs kept in sync

Per `.ai/rules/mcp.md` these surfaces go red or stale otherwise:

- the tool's `#[Description]` (173 chars, under the 200 cap) and its `notes` / `transaction_id` schema descriptions;
- the `#[Instructions]` block on `WhisperMoneyServer` — both the "Bank/imported transactions" paragraph and the split-parts bullet;
- `chatgpt-app-submission.json` — `update_transaction`'s two justifications, `app_info.description`, and the negative test case that claimed bank rows are "rejected outright".

**No tool is added or removed**, so the counts in `ToolAnnotationsTest`, `LandingToolCountTest` and `welcome.tsx` are untouched.

## Tests

Added to `McpWriteToolsTest` / `McpToolsTest`: notes on a bank-synced row, on an imported row (and cleared again), on a split part; a locked field still refused and the message names it; the IVs retired only for the fields actually written; a notes-only edit leaves the balance alone; and the presenter returning `notes` on the read path.

## QA

Exercised over real HTTP against `/mcp` with a Sanctum read-write token, the way a connector calls it — notes written on an `enablebanking` transaction and on a split part, read back through `search_transactions`, cleared again, locked fields still refused (`amount`, `description`, `amount+transaction_date` on a part), a mixed request confirmed to write nothing, and the legacy-IV row verified in the database. Fixture account deleted afterwards.

`vendor/bin/pint --test`, `bun run format`, `bun run lint`, `bun run dry`, `bun run build` and `php artisan crap --base=origin/main` (no method above complexity 10) all pass.
