### PR TITLE
feat(achievements): put the visit streak and the categorize prompt in the app chrome

### DIFF
--- a/app/Http/Controllers/AchievementController.php
+++ b/app/Http/Controllers/AchievementController.php
@@ -23,11 +23,11 @@ use Throwable;
  * come.
  *
  * Reached from the account menu rather than the main navigation, and from the
- * streak pill in the header, which puts the two live challenges on every screen
- * and lands here for the rest. The monthly
- * summaries sit beside it in that menu on their own screen: both are records of
- * what already happened, but a report is read once and a medal is collected,
- * and stacking them made one page answer two questions.
+ * streak pill in the header: that one puts the two live challenges on every
+ * screen and lands here for everything else. The monthly summaries sit beside
+ * it in that menu on their own screen: both are records of what already
+ * happened, but a report is read once and a medal is collected, and stacking
+ * them made one page answer two questions.
  */
 class AchievementController extends Controller
 {

--- a/app/Http/Controllers/AchievementController.php
+++ b/app/Http/Controllers/AchievementController.php
@@ -22,8 +22,9 @@ use Throwable;
  * The progress screen: every medal a reader has earned, and every one still to
  * come.
  *
- * Reached from the account menu rather than the main navigation, because it is
- * something to look back at rather than somewhere to work. The monthly
+ * Reached from the account menu rather than the main navigation, and from the
+ * streak pill in the header, which puts the two live challenges on every screen
+ * and lands here for the rest. The monthly
  * summaries sit beside it in that menu on their own screen: both are records of
  * what already happened, but a report is read once and a medal is collected,
  * and stacking them made one page answer two questions.

--- a/app/Http/Controllers/UncategorizedPromptController.php
+++ b/app/Http/Controllers/UncategorizedPromptController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Features\Achievements;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Laravel\Pennant\Feature;
+
+/**
+ * "Not now" on the prompt that asks a reader to categorize the month.
+ *
+ * A snooze rather than a dismissal: the pile does not go away on its own, and a
+ * prompt that can be silenced forever is one nobody ever acts on. Three days is
+ * long enough to stop being nagged and short enough that the month still gets
+ * tidied before it closes.
+ *
+ * Kept on the user rather than in the browser, like the AI consent prompt
+ * beside it, so saying "not now" on the laptop also says it on the phone.
+ */
+class UncategorizedPromptController extends Controller
+{
+    private const SNOOZE_DAYS = 3;
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        abort_unless(Feature::active(Achievements::class), 404);
+
+        $user = $request->user();
+        $user->uncategorized_prompt_snoozed_until = now()->addDays(self::SNOOZE_DAYS);
+        $user->save();
+
+        return response()->json([
+            'snoozed_until' => $user->uncategorized_prompt_snoozed_until->toIso8601String(),
+        ]);
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -11,6 +11,7 @@ use App\Jobs\PurgeResidualEncryptionArtifactsJob;
 use App\Models\BankingConnection;
 use App\Models\User;
 use App\Services\Achievements\Catalog;
+use App\Services\Achievements\Challenges;
 use App\Services\CurrencyOptions;
 use App\Services\Notifications\NotificationFeed;
 use App\Services\Subscriptions\PriceExperiment;
@@ -26,6 +27,7 @@ class HandleInertiaRequests extends Middleware
         private CurrencyOptions $currencyOptions,
         private NotificationFeed $notifications,
         private Catalog $catalog,
+        private Challenges $challenges,
     ) {}
 
     /**
@@ -115,6 +117,7 @@ class HandleInertiaRequests extends Middleware
             'features' => $this->resolveFeatureFlags(),
             'notifications' => fn (): ?array => $this->notificationsFor($user),
             'achievements' => fn (): ?array => $this->achievementsFor($user),
+            'challenges' => fn (): ?array => $this->challengesFor($user),
             ...$this->userCollectionProps($user),
             'hasEncryptedAccounts' => $hasEncryptedAccounts,
             'hasEncryptionSetup' => $user?->encryption_salt !== null,
@@ -151,6 +154,22 @@ class HandleInertiaRequests extends Middleware
             'unlocked' => (int) $user->achievements_count,
             'total' => $this->catalog->all()->count(),
         ];
+    }
+
+    /**
+     * The two medals the chrome puts in front of the reader rather than waiting
+     * to be looked up: the visit streak in the header, and what is left to
+     * categorize this month. Null unless the feature is on for them.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function challengesFor(?User $user): ?array
+    {
+        if ($user === null || ! Feature::for($user)->active(Achievements::class)) {
+            return null;
+        }
+
+        return $this->challenges->for($user);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -37,6 +37,7 @@ use Stripe\Subscription as StripeSubscription;
  * @property ?Carbon $last_active_at
  * @property ?Carbon $transactions_last_visited_at
  * @property ?Carbon $ai_consent_prompt_dismissed_at
+ * @property ?Carbon $uncategorized_prompt_snoozed_until
  * @property int $achievements_count
  * @property int $visit_streak
  * @property int $longest_visit_streak
@@ -107,6 +108,7 @@ class User extends Authenticatable implements HasLocalePreference, MustVerifyEma
             'last_active_at' => 'datetime',
             'transactions_last_visited_at' => 'datetime',
             'ai_consent_prompt_dismissed_at' => 'datetime',
+            'uncategorized_prompt_snoozed_until' => 'datetime',
         ];
     }
 

--- a/app/Services/Achievements/Challenges.php
+++ b/app/Services/Achievements/Challenges.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Services\Achievements;
+
+use App\Models\User;
+
+/**
+ * The two medals the app puts in front of the reader instead of waiting to be
+ * looked up: the visit streak in the header, and the pile of transactions still
+ * without a category.
+ *
+ * This rides along with every screen, so it is deliberately not {@see Progress}:
+ * that one builds all thirteen tracks, the rarity shares and the last monthly
+ * report, which is a page's worth of work to answer two questions. Everything
+ * here is either a column on the reader's own row or one narrow query.
+ *
+ * The prompt is the exception, and it pays for itself: its bar reads the
+ * categorized run, a grouped read over every month the reader has, and it is
+ * only asked for once the prompt is actually due.
+ */
+class Challenges
+{
+    /**
+     * The tracks the header panel draws, in the order it draws them, each with
+     * the column its bar is measured against.
+     *
+     * The longest run rather than the live one, exactly as {@see Standing} does
+     * it and for the same reason: the medal is awarded on the peak, so a bar
+     * reading the live streak would fall back without the medal moving any
+     * further away. The number on the pill is the live one — see the frontend.
+     */
+    private const VISIT_TRACKS = [
+        'visits' => 'longest_visit_streak',
+        'visit_weeks' => 'longest_visit_week_streak',
+    ];
+
+    public function __construct(
+        private Catalog $catalog,
+        private Presenter $presenter,
+        private Standing $standing,
+    ) {}
+
+    /**
+     * @return array{
+     *     visit_streak: int,
+     *     medals: list<array<string, mixed>>,
+     *     uncategorized: array{count: int, medal: array<string, mixed>|null}|null,
+     * }
+     */
+    public function for(User $user): array
+    {
+        $next = $this->catalog->next($user->achievements()->pluck('key')->flip());
+
+        return [
+            'visit_streak' => (int) $user->visit_streak,
+            'medals' => collect(self::VISIT_TRACKS)
+                ->map(fn (string $column, string $track): ?array => $this->medal(
+                    $user,
+                    $next->get($track),
+                    (int) $user->{$column},
+                ))
+                ->filter()
+                ->values()
+                ->all(),
+            'uncategorized' => $this->uncategorized($user, $next->get('categorized')),
+        ];
+    }
+
+    /**
+     * The rung a track is working towards, named and with the figure to reach.
+     * Null on a finished track, which is what a reader past the last rung has:
+     * nothing left to aim at, and a number that keeps going up anyway.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function medal(User $user, ?Definition $definition, ?int $now): ?array
+    {
+        if ($definition === null) {
+            return null;
+        }
+
+        $figure = $this->presenter->milestone($definition, (string) $user->currency_code);
+
+        return [
+            'track' => $definition->track,
+            'rarity' => $definition->rarity->value,
+            'icon' => $definition->icon,
+            'name' => $definition->name,
+            'figure' => $figure,
+            'progress' => $this->presenter->progress($figure, $now),
+        ];
+    }
+
+    /**
+     * What is left to categorize in the month in progress, or null when there
+     * is nothing to ask for.
+     *
+     * The month in progress on purpose: {@see Standing} reads closed months
+     * only, because that is what the nightly sweep awards on, and the whole
+     * point of the prompt is the month nobody has tidied yet.
+     *
+     * Whether the prompt is due is settled here rather than sent as a date for
+     * the frontend to compare against its own clock: one answer, one place, and
+     * the run below is never paid for by a reader who has already said "not now".
+     *
+     * @return array{count: int, medal: array<string, mixed>|null}|null
+     */
+    private function uncategorized(User $user, ?Definition $next): ?array
+    {
+        $snoozedUntil = $user->uncategorized_prompt_snoozed_until;
+
+        if ($snoozedUntil !== null && $snoozedUntil->isFuture()) {
+            return null;
+        }
+
+        $count = $user->transactions()
+            ->whereNull('category_id')
+            ->where('transaction_date', '>=', now()->startOfMonth())
+            ->where('transaction_date', '<', now()->startOfMonth()->addMonth())
+            ->count();
+
+        if ($count === 0) {
+            return null;
+        }
+
+        return [
+            'count' => $count,
+            'medal' => $this->medal($user, $next, $this->standing->categorized($user)),
+        ];
+    }
+}

--- a/app/Services/Achievements/Challenges.php
+++ b/app/Services/Achievements/Challenges.php
@@ -20,20 +20,6 @@ use App\Models\User;
  */
 class Challenges
 {
-    /**
-     * The tracks the header panel draws, in the order it draws them, each with
-     * the column its bar is measured against.
-     *
-     * The longest run rather than the live one, exactly as {@see Standing} does
-     * it and for the same reason: the medal is awarded on the peak, so a bar
-     * reading the live streak would fall back without the medal moving any
-     * further away. The number on the pill is the live one — see the frontend.
-     */
-    private const VISIT_TRACKS = [
-        'visits' => 'longest_visit_streak',
-        'visit_weeks' => 'longest_visit_week_streak',
-    ];
-
     public function __construct(
         private Catalog $catalog,
         private Presenter $presenter,
@@ -53,15 +39,15 @@ class Challenges
 
         return [
             'visit_streak' => (int) $user->visit_streak,
-            'medals' => collect(self::VISIT_TRACKS)
-                ->map(fn (string $column, string $track): ?array => $this->medal(
-                    $user,
-                    $next->get($track),
-                    (int) $user->{$column},
-                ))
-                ->filter()
-                ->values()
-                ->all(),
+            // Both bars read the longest run rather than the live one, exactly
+            // as {@see Standing} does and for the same reason: the medal is
+            // awarded on the peak, so a bar following the live streak would
+            // fall back without the medal moving any further away. Only the
+            // number on the pill is the live run.
+            'medals' => collect([
+                $this->medal($user, $next->get('visits'), (int) $user->longest_visit_streak),
+                $this->medal($user, $next->get('visit_weeks'), (int) $user->longest_visit_week_streak),
+            ])->filter()->values()->all(),
             'uncategorized' => $this->uncategorized($user, $next->get('categorized')),
         ];
     }

--- a/app/Services/Achievements/Presenter.php
+++ b/app/Services/Achievements/Presenter.php
@@ -44,6 +44,33 @@ class Presenter
     }
 
     /**
+     * How far along the reader is towards a medal: where they stand today
+     * against the figure it asks for.
+     *
+     * Null when either half is missing — the first transaction is an event
+     * rather than a count, and the money tracks have no figure a page render
+     * can read — because there is then nothing to draw a bar against.
+     *
+     * @param  array{type: string, value: int|float, currency: ?string}|null  $figure
+     * @return array{now: int, goal: int|float, unlocking: bool}|null
+     */
+    public function progress(?array $figure, ?int $now): ?array
+    {
+        if ($now === null || $figure === null) {
+            return null;
+        }
+
+        return [
+            'now' => $now,
+            'goal' => $figure['value'],
+            // The sweep runs at night, so a reader crossing a threshold today
+            // stands past it with the medal still locked. Say that, rather than
+            // trim the figure back to the goal and call it done.
+            'unlocking' => $now >= $figure['value'],
+        ];
+    }
+
+    /**
      * What the reader actually reached, as it was on the day. Which column the
      * row filled says how to read it.
      *

--- a/app/Services/Achievements/Progress.php
+++ b/app/Services/Achievements/Progress.php
@@ -168,35 +168,9 @@ class Progress
             'figure' => $figure,
             'reached' => $earned === null ? null : $this->presenter->reached($earned),
             'achieved_on' => $earned?->achieved_on->toDateString(),
-            'progress' => $next ? $this->progress($definition, $figure, $standing) : null,
-        ];
-    }
-
-    /**
-     * How far along the reader is towards the next medal, for the tracks whose
-     * figure {@see Standing} can read without building a history.
-     *
-     * @param  array{type: string, value: int|float, currency: ?string}|null  $figure
-     * @param  array<string, int>  $standing
-     * @return array{now: int, goal: int|float, unlocking: bool}|null
-     */
-    private function progress(Definition $definition, ?array $figure, array $standing): ?array
-    {
-        $now = $standing[$definition->track] ?? null;
-
-        // No figure means no number to reach — the first transaction is an
-        // event, not a count — and so nothing to draw a bar against.
-        if ($now === null || $figure === null) {
-            return null;
-        }
-
-        return [
-            'now' => $now,
-            'goal' => $figure['value'],
-            // The sweep runs at night, so a reader crossing a threshold today
-            // stands past it with the medal still locked. Say that, rather than
-            // trim the figure back to the goal and call it done.
-            'unlocking' => $now >= $figure['value'],
+            // Only for the tracks whose figure {@see Standing} can read without
+            // building a history; the rest arrive without a bar.
+            'progress' => $next ? $this->presenter->progress($figure, $standing[$definition->track] ?? null) : null,
         ];
     }
 

--- a/app/Services/Achievements/Standing.php
+++ b/app/Services/Achievements/Standing.php
@@ -48,6 +48,16 @@ class Standing
     }
 
     /**
+     * The categorized run on its own, for the caller that wants that one track
+     * and none of the others: the toast that asks a reader to clear the month
+     * in progress draws the bar of the medal that run feeds.
+     */
+    public function categorized(User $user): int
+    {
+        return $this->categorizedRun($this->closedMonths($user));
+    }
+
+    /**
      * What a reader recorded in each closed month, and how much of it was left
      * without a category, keyed by month.
      *

--- a/database/migrations/2026_09_08_090000_add_uncategorized_prompt_snoozed_until_to_users_table.php
+++ b/database/migrations/2026_09_08_090000_add_uncategorized_prompt_snoozed_until_to_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Until when the "you have transactions with no category" prompt stays quiet.
+ *
+ * Kept on the user rather than in the browser, like every other prompt this app
+ * puts away: somebody who says "not now" on their laptop has said it for their
+ * phone too. Null means it has never been put away, or the snooze has run out.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('uncategorized_prompt_snoozed_until')->nullable()->after('ai_consent_prompt_dismissed_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('uncategorized_prompt_snoozed_until');
+        });
+    }
+};

--- a/lang/es.json
+++ b/lang/es.json
@@ -2938,5 +2938,12 @@
     "See all your medals": "Ver todas tus medallas",
     "{1}1 day|[2,*]:count days": "{1}1 día|[2,*]:count días",
     "{1}1 week|[2,*]:count weeks": "{1}1 semana|[2,*]:count semanas",
-    "+:count to come": "+:count por llegar"
+    "+:count to come": "+:count por llegar",
+    "Current visit streak": "Racha de visitas actual",
+    "The medals below count your best run: :days": "Las medallas de abajo cuentan tu mejor racha: :days",
+    "View all progress": "Ver todo el progreso",
+    "Visit streak: :days": "Racha de visitas: :days",
+    ":count uncategorized transactions": ":count movimientos sin categorizar",
+    "A month with everything categorized is a month you can actually read.": "Un mes con todo categorizado es un mes que puedes leer de verdad.",
+    "Not now": "Ahora no"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2494,5 +2494,12 @@
     "See all your medals": "Voir toutes vos médailles",
     "{1}1 day|[2,*]:count days": "{1}1 jour|[2,*]:count jours",
     "{1}1 week|[2,*]:count weeks": "{1}1 semaine|[2,*]:count semaines",
-    "+:count to come": "+:count à venir"
+    "+:count to come": "+:count à venir",
+    "Current visit streak": "Série de visites en cours",
+    "The medals below count your best run: :days": "Les médailles ci-dessous comptent ta meilleure série : :days",
+    "View all progress": "Voir toute la progression",
+    "Visit streak: :days": "Série de visites : :days",
+    ":count uncategorized transactions": ":count transactions sans catégorie",
+    "A month with everything categorized is a month you can actually read.": "Un mois entièrement catégorisé est un mois vraiment lisible.",
+    "Not now": "Pas maintenant"
 }

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -19,6 +19,7 @@ import { StrictMode, useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { toast, Toaster } from 'sonner';
 import { update as updateTimezone } from './actions/App/Http/Controllers/Settings/TimezoneController';
+import { UncategorizedToast } from './components/achievements/uncategorized-toast';
 import { AppErrorBoundary } from './components/app-error-boundary';
 import { EncryptionKeyProvider } from './contexts/encryption-key-context';
 import { PrivacyModeProvider } from './contexts/privacy-mode-context';
@@ -212,6 +213,7 @@ createInertiaApp({
             (initialPageProps?.expiredBankingConnections as
                 | ExpiredBankingConnectionNotification[]
                 | undefined) ?? [];
+        const initialChallenges = initialPageProps?.challenges ?? null;
 
         const syncUserTimezone = async (pageProps?: Partial<SharedData>) => {
             const user = pageProps?.auth?.user ?? null;
@@ -271,6 +273,9 @@ createInertiaApp({
                                     initialExpiredConnections={
                                         initialExpiredConnections
                                     }
+                                />
+                                <UncategorizedToast
+                                    initialChallenges={initialChallenges}
                                 />
                                 <AppToaster />
                             </SyncProvider>

--- a/resources/js/components/achievements/achievement-cell.tsx
+++ b/resources/js/components/achievements/achievement-cell.tsx
@@ -71,6 +71,16 @@ export function ProgressBar({
 }
 
 /**
+ * How full the bar is. Shared with the streak pill's ring, which fills on the
+ * same rule so the two cannot show different fractions of the same medal.
+ */
+export function progressPercent(progress: AchievementProgress): number {
+    return progress.unlocking
+        ? 100
+        : Math.round((progress.now / progress.goal) * 100);
+}
+
+/**
  * How far along the next medal is, for the tracks that can say.
  *
  * Past the goal with the medal still locked is the everyday case rather than an
@@ -79,14 +89,23 @@ export function ProgressBar({
  * lands instead of showing a count that reads as wrong either way it is
  * written.
  */
-function MedalProgress({ progress }: { progress: AchievementProgress }) {
-    const percent = progress.unlocking
-        ? 100
-        : Math.round((progress.now / progress.goal) * 100);
-
+export function MedalProgress({
+    progress,
+    goalLabel,
+    className,
+}: {
+    progress: AchievementProgress;
+    /**
+     * The goal written with its unit — "2 of 3 months" — for the surfaces that
+     * do not already print the figure above the bar. Defaults to the bare
+     * number, which is what the cell wants.
+     */
+    goalLabel?: string;
+    className?: string;
+}) {
     return (
-        <div className="mt-1.5 flex flex-col gap-[3px]">
-            <ProgressBar percent={percent} />
+        <div className={cn('mt-1.5 flex flex-col gap-[3px]', className)}>
+            <ProgressBar percent={progressPercent(progress)} />
             <span className="text-[11px] leading-[14px] text-muted-foreground tabular-nums">
                 {progress.unlocking
                     ? __('Unlocks tonight')
@@ -94,7 +113,7 @@ function MedalProgress({ progress }: { progress: AchievementProgress }) {
                           // Written like the figure above it rather than as a
                           // bare integer: "4,321 of 10,000", not "4321 of 10000".
                           now: progress.now.toLocaleString(),
-                          goal: progress.goal.toLocaleString(),
+                          goal: goalLabel ?? progress.goal.toLocaleString(),
                       })}
             </span>
         </div>

--- a/resources/js/components/achievements/streak-chip.test.tsx
+++ b/resources/js/components/achievements/streak-chip.test.tsx
@@ -1,0 +1,135 @@
+import { type ChallengeMedal, type Challenges } from '@/types';
+import { render, screen } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { StreakChip } from './streak-chip';
+
+/*
+ * The pill in the header.
+ *
+ * Three states, and none of them may be mistaken for another: a ring filling
+ * towards the next rung, the real medal in the ring's place while the sweep
+ * catches up, and a full ring for a reader with nothing left to reach. A reader
+ * with no live run gets no pill at all — there is nothing to keep.
+ */
+
+const page = vi.hoisted(() => ({
+    props: {} as { challenges: Challenges | null; locale: string },
+}));
+
+vi.mock('@inertiajs/react', () => ({
+    usePage: () => ({ props: page.props }),
+    Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+}));
+
+// jsdom ships no `matchMedia`, which is what the hook reads. The states below
+// are the same on either width; only the pixel sizes differ.
+vi.mock('@/hooks/use-mobile', () => ({ useIsMobile: () => false }));
+
+function medal(overrides: Partial<ChallengeMedal> = {}): ChallengeMedal {
+    return {
+        track: 'visits',
+        rarity: 'uncommon',
+        icon: 'calendar-days',
+        name: 'Visit streak',
+        figure: { type: 'days', value: 30, currency: null },
+        progress: { now: 12, goal: 30, unlocking: false },
+        ...overrides,
+    };
+}
+
+function draw(challenges: Challenges | null) {
+    page.props = { challenges, locale: 'en-US' };
+
+    return render(<StreakChip />);
+}
+
+function chip(challenges: Partial<Challenges> = {}): Challenges {
+    return {
+        visit_streak: 12,
+        medals: [medal()],
+        uncategorized: null,
+        ...challenges,
+    };
+}
+
+/** How much of the ring is struck, as a percentage of the whole circle. */
+function ringFill(container: HTMLElement): number | null {
+    const dash = container
+        .querySelector('circle[stroke-linecap="round"]')
+        ?.getAttribute('stroke-dasharray');
+
+    if (!dash) {
+        return null;
+    }
+
+    const [struck, whole] = dash.split(' ').map(Number);
+
+    return Math.round((struck / whole) * 100);
+}
+
+/** The medallion itself, which the ring is never mistaken for: it is bigger. */
+const medallion = (container: HTMLElement) =>
+    container.querySelector('svg[viewBox="0 0 48 48"]');
+
+describe('StreakChip', () => {
+    it('is not drawn at all with the feature switched off', () => {
+        const { container } = draw(null);
+
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('is not drawn without a live run', () => {
+        // A run of zero is not a streak, and a pill counting zero is an
+        // invitation to ignore it forever.
+        const { container } = draw(chip({ visit_streak: 0 }));
+
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('counts the live run and fills the ring towards the next medal', () => {
+        const { container } = draw(chip());
+
+        expect(screen.getByText('12')).toBeInTheDocument();
+        // Twelve of the thirty days the next medal asks for.
+        expect(ringFill(container)).toBe(40);
+        expect(medallion(container)).toBeNull();
+    });
+
+    it('counts the live run even when the medal is measured on a longer one', () => {
+        const { container } = draw(
+            chip({
+                visit_streak: 5,
+                medals: [medal({ progress: { now: 12, goal: 30, unlocking: false } })],
+            }),
+        );
+
+        // Five days now, twelve at its best: the pill is about what there is to
+        // lose today, and the ring is about how far the medal is.
+        expect(screen.getByText('5')).toBeInTheDocument();
+        expect(ringFill(container)).toBe(40);
+    });
+
+    it('swaps the ring for the real medal once the rung is reached', () => {
+        const { container } = draw(
+            chip({
+                visit_streak: 31,
+                medals: [medal({ progress: { now: 31, goal: 30, unlocking: true } })],
+            }),
+        );
+
+        expect(medallion(container)).not.toBeNull();
+        expect(ringFill(container)).toBeNull();
+        expect(container.querySelector('button')).toHaveClass('bg-muted');
+    });
+
+    it('fills the ring for a reader past the last rung', () => {
+        // A finished track sends no medal: there is no goal left to fall short
+        // of, and the number keeps climbing on its own.
+        const { container } = draw(chip({ visit_streak: 400, medals: [] }));
+
+        expect(screen.getByText('400')).toBeInTheDocument();
+        expect(ringFill(container)).toBe(100);
+        expect(medallion(container)).toBeNull();
+    });
+});

--- a/resources/js/components/achievements/streak-chip.test.tsx
+++ b/resources/js/components/achievements/streak-chip.test.tsx
@@ -100,7 +100,11 @@ describe('StreakChip', () => {
         const { container } = draw(
             chip({
                 visit_streak: 5,
-                medals: [medal({ progress: { now: 12, goal: 30, unlocking: false } })],
+                medals: [
+                    medal({
+                        progress: { now: 12, goal: 30, unlocking: false },
+                    }),
+                ],
             }),
         );
 
@@ -114,7 +118,9 @@ describe('StreakChip', () => {
         const { container } = draw(
             chip({
                 visit_streak: 31,
-                medals: [medal({ progress: { now: 31, goal: 30, unlocking: true } })],
+                medals: [
+                    medal({ progress: { now: 31, goal: 30, unlocking: true } }),
+                ],
             }),
         );
 

--- a/resources/js/components/achievements/streak-chip.tsx
+++ b/resources/js/components/achievements/streak-chip.tsx
@@ -17,7 +17,7 @@ import { Link, usePage } from '@inertiajs/react';
 import { ArrowRightIcon, FlameIcon } from 'lucide-react';
 import { useState } from 'react';
 
-/**
+/*
  * The visit streak, in the header, on every screen.
  *
  * The number is the run as it stands today, not the longest one ever: a streak
@@ -37,6 +37,7 @@ import { useState } from 'react';
  *
  * Not drawn at all without a live run, or with the feature switched off.
  */
+
 const RING_RADIUS = 10;
 const RING_LENGTH = 2 * Math.PI * RING_RADIUS;
 

--- a/resources/js/components/achievements/streak-chip.tsx
+++ b/resources/js/components/achievements/streak-chip.tsx
@@ -1,0 +1,216 @@
+import {
+    MedalProgress,
+    progressPercent,
+} from '@/components/achievements/achievement-cell';
+import {
+    AchievementFigure,
+    daysLabel,
+} from '@/components/achievements/achievement-figure';
+import { Medal } from '@/components/achievements/medal';
+import { AdaptivePopover } from '@/components/ui/adaptive-popover';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { cn } from '@/lib/utils';
+import { index as progressScreen } from '@/routes/achievements';
+import { type ChallengeMedal, type SharedData } from '@/types';
+import { __ } from '@/utils/i18n';
+import { Link, usePage } from '@inertiajs/react';
+import { ArrowRightIcon, FlameIcon } from 'lucide-react';
+import { useState } from 'react';
+
+/**
+ * The visit streak, in the header, on every screen.
+ *
+ * The number is the run as it stands today, not the longest one ever: a streak
+ * with nothing to lose is a trophy, and a trophy is not a reason to come back
+ * tomorrow. The ring around it is a different measurement on purpose — how far
+ * the *medal* is, which the progress screen measures on the longest run so the
+ * two screens cannot disagree. When those two numbers differ the panel says so
+ * rather than leaving the reader to work out which is which.
+ *
+ * Three states, and the pill has to read as itself in all three:
+ *
+ * 1. Mid-run: a ring filling towards the next rung.
+ * 2. Standing on the rung with the medal still locked — the sweep runs at night
+ *    — so the real medal takes the ring's place and the pill fills in.
+ * 3. Past the last rung: nothing left to aim at, so the ring is simply full and
+ *    the number keeps climbing.
+ *
+ * Not drawn at all without a live run, or with the feature switched off.
+ */
+const RING_RADIUS = 10;
+const RING_LENGTH = 2 * Math.PI * RING_RADIUS;
+
+function StreakRing({ percent }: { percent: number }) {
+    return (
+        <span className="relative inline-flex size-[22px] shrink-0 items-center justify-center md:size-6">
+            <svg viewBox="0 0 24 24" className="size-full" aria-hidden>
+                <g transform="rotate(-90 12 12)">
+                    <circle
+                        cx="12"
+                        cy="12"
+                        r={RING_RADIUS}
+                        fill="none"
+                        stroke="var(--border)"
+                        strokeWidth="2.5"
+                    />
+                    <circle
+                        cx="12"
+                        cy="12"
+                        r={RING_RADIUS}
+                        fill="none"
+                        stroke="var(--foreground)"
+                        strokeWidth="2.5"
+                        strokeLinecap="round"
+                        strokeDasharray={`${(percent / 100) * RING_LENGTH} ${RING_LENGTH}`}
+                    />
+                </g>
+            </svg>
+            <FlameIcon className="absolute size-[11px] md:size-3" />
+        </span>
+    );
+}
+
+/**
+ * One track in the panel: the medal turned down inside a dashed slot, the same
+ * treatment the progress screen gives a rung nobody has reached yet.
+ */
+function PanelRow({
+    medal,
+    isMobile,
+}: {
+    medal: ChallengeMedal;
+    isMobile: boolean;
+}) {
+    return (
+        <div className="flex items-center gap-3 py-3">
+            <span
+                className="flex shrink-0 items-center justify-center rounded-[10px] border border-dashed border-ring"
+                style={{
+                    width: isMobile ? 48 : 44,
+                    height: isMobile ? 48 : 44,
+                }}
+            >
+                <Medal
+                    rarity={medal.rarity}
+                    icon={medal.icon}
+                    size={isMobile ? 36 : 32}
+                    className="opacity-50 grayscale-[0.7]"
+                />
+            </span>
+            <div className="flex min-w-0 flex-1 flex-col">
+                <AchievementFigure
+                    figure={medal.figure}
+                    className="text-[13px] leading-4 font-semibold"
+                />
+                <span className="text-xs leading-4 text-muted-foreground">
+                    {medal.name}
+                </span>
+                {medal.progress && (
+                    <MedalProgress progress={medal.progress} className="mt-1" />
+                )}
+            </div>
+        </div>
+    );
+}
+
+export function StreakChip({ className }: { className?: string }) {
+    const { challenges } = usePage<SharedData>().props;
+    const isMobile = useIsMobile();
+    const [open, setOpen] = useState(false);
+
+    if (!challenges || challenges.visit_streak < 1) {
+        return null;
+    }
+
+    const streak = challenges.visit_streak;
+    const visits =
+        challenges.medals.find((medal) => medal.track === 'visits') ?? null;
+    // No next rung left means the track is finished: the ring is full and there
+    // is no goal to fall short of.
+    const percent = visits?.progress ? progressPercent(visits.progress) : 100;
+    const unlocking = visits?.progress?.unlocking ?? false;
+    // What the bars below are measured on. Only worth spelling out when it has
+    // pulled ahead of the live run, which is exactly when the two disagree.
+    const best = visits?.progress?.now ?? null;
+
+    const trigger = (
+        <button
+            type="button"
+            aria-label={__('Visit streak: :days', { days: daysLabel(streak) })}
+            className={cn(
+                // The phone needs 44px of pushable area around a 30px pill, and
+                // padding that big would wreck the pill: `ui/sidebar` solves the
+                // same problem the same way.
+                'relative inline-flex h-[30px] cursor-pointer items-center gap-[7px] rounded-full border pr-[11px] pl-[5px] transition-colors md:h-8',
+                'after:absolute after:-inset-2 md:after:hidden',
+                'hover:border-ring hover:bg-muted',
+                unlocking && 'bg-muted',
+                className,
+            )}
+        >
+            {unlocking && visits ? (
+                <Medal
+                    rarity={visits.rarity}
+                    icon={visits.icon}
+                    size={isMobile ? 22 : 24}
+                />
+            ) : (
+                <StreakRing percent={percent} />
+            )}
+            <span className="text-[13px] leading-none font-semibold tabular-nums">
+                {streak}
+            </span>
+        </button>
+    );
+
+    const panel = (
+        <div className="flex flex-col px-4 py-3.5">
+            <div className="flex flex-col gap-0.5 pb-3">
+                <span className="text-[13px] leading-4 font-semibold">
+                    {daysLabel(streak)}
+                </span>
+                <span className="text-xs leading-4 text-muted-foreground">
+                    {__('Current visit streak')}
+                </span>
+                {best !== null && best > streak && (
+                    <span className="mt-1 text-[11px] leading-[14px] text-pretty text-muted-foreground">
+                        {__('The medals below count your best run: :days', {
+                            days: daysLabel(best),
+                        })}
+                    </span>
+                )}
+            </div>
+
+            {challenges.medals.map((medal) => (
+                <div key={medal.track} className="border-t">
+                    <PanelRow medal={medal} isMobile={isMobile} />
+                </div>
+            ))}
+
+            <Link
+                href={progressScreen()}
+                onClick={() => setOpen(false)}
+                className={cn(
+                    'flex items-center justify-center gap-1 border-t pt-3 text-[13px] font-medium text-muted-foreground transition-colors hover:text-foreground',
+                    isMobile && 'mt-3 h-11 rounded-md border pt-0',
+                )}
+            >
+                {__('View all progress')}
+                <ArrowRightIcon className="size-3.5" />
+            </Link>
+        </div>
+    );
+
+    return (
+        <AdaptivePopover
+            open={open}
+            onOpenChange={setOpen}
+            trigger={trigger}
+            title={__('Visit streak')}
+            className="w-[320px]"
+            openOnHover
+        >
+            {panel}
+        </AdaptivePopover>
+    );
+}

--- a/resources/js/components/achievements/uncategorized-toast.test.tsx
+++ b/resources/js/components/achievements/uncategorized-toast.test.tsx
@@ -1,0 +1,90 @@
+import { type Challenges } from '@/types';
+import { render, screen } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { Toaster } from 'sonner';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/*
+ * The prompt that asks a reader to categorize the month.
+ *
+ * The one thing worth pinning down here is when it is published. Sonner hands a
+ * new toast straight to whoever is subscribed and keeps no backlog, and its
+ * `<Toaster/>` subscribes from an effect — so raising a toast from a sibling
+ * that happens to sit earlier in the shell loses it outright, with the
+ * once-per-session latch already thrown. That is not a hypothetical: it is
+ * exactly how this shipped the first time, and it is invisible without a test,
+ * because nothing throws and nothing logs.
+ *
+ * So the component is mounted here in the order that used to break it — before
+ * the toaster, the way `app.tsx` lays the shell out — and the toast still has to
+ * arrive.
+ */
+
+vi.mock('@inertiajs/react', () => ({
+    router: { on: () => () => {} },
+    Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+}));
+
+vi.mock('axios', () => ({
+    default: { post: vi.fn(() => Promise.resolve({ data: {} })) },
+}));
+
+function challenges(uncategorized: Challenges['uncategorized']): Challenges {
+    return { visit_streak: 3, medals: [], uncategorized };
+}
+
+/**
+ * The shell, in `app.tsx`'s own order: the toast component first, the toaster
+ * after it. Re-imported per test because the once-per-session latch is module
+ * state.
+ */
+async function mountShell(props: Challenges | null) {
+    const { UncategorizedToast } = await import('./uncategorized-toast');
+
+    return render(
+        <>
+            <UncategorizedToast initialChallenges={props} />
+            <Toaster />
+        </>,
+    );
+}
+
+describe('UncategorizedToast', () => {
+    beforeEach(() => {
+        vi.resetModules();
+    });
+
+    it('reaches the toaster even though it is mounted before it', async () => {
+        await mountShell(
+            challenges({
+                count: 4,
+                medal: {
+                    track: 'categorized',
+                    rarity: 'epic',
+                    icon: 'tags',
+                    name: 'Fully categorized',
+                    figure: { type: 'months', value: 24, currency: null },
+                    progress: { now: 12, goal: 24, unlocking: false },
+                },
+            }),
+        );
+
+        expect(
+            await screen.findByText('4 uncategorized transactions'),
+        ).toBeInTheDocument();
+        // The bar reads the medal the work feeds, written with its unit so the
+        // number is not a bare "12 of 24" floating over a pile of transactions.
+        expect(await screen.findByText('12 of 24 months')).toBeInTheDocument();
+        expect(screen.getByText('Categorize')).toBeInTheDocument();
+        expect(screen.getByText('Not now')).toBeInTheDocument();
+    });
+
+    it('says nothing when there is nothing to categorize', async () => {
+        await mountShell(challenges(null));
+
+        // Give the publish the same tick it would have had.
+        await Promise.resolve();
+
+        expect(screen.queryByText('Categorize')).toBeNull();
+    });
+});

--- a/resources/js/components/achievements/uncategorized-toast.tsx
+++ b/resources/js/components/achievements/uncategorized-toast.tsx
@@ -6,6 +6,7 @@ import { type Challenges, type SharedData } from '@/types';
 import { __ } from '@/utils/i18n';
 import { Link, router } from '@inertiajs/react';
 import axios from 'axios';
+import { endOfMonth, format, startOfMonth } from 'date-fns';
 import { TagsIcon } from 'lucide-react';
 import { useEffect } from 'react';
 import { toast } from 'sonner';
@@ -25,10 +26,23 @@ const TOAST_ID = 'uncategorized-transactions';
 
 let shown = false;
 
-/** Straight to the pile it is asking about, filtered to exactly that. */
-const categorizeHref = transactionsIndex({
-    query: { category_ids: 'uncategorized' },
-}).url;
+/**
+ * Straight to the pile it is asking about, and to nothing else: the count is
+ * the month in progress, so the list has to be the month in progress too. An
+ * unbounded "uncategorized" filter would open on a longer list than the number
+ * the reader just clicked.
+ */
+function categorizeHref(): string {
+    const today = new Date();
+
+    return transactionsIndex({
+        query: {
+            category_ids: 'uncategorized',
+            date_from: format(startOfMonth(today), 'yyyy-MM-dd'),
+            date_to: format(endOfMonth(today), 'yyyy-MM-dd'),
+        },
+    }).url;
+}
 
 function UncategorizedToastBody({
     prompt,
@@ -65,7 +79,7 @@ function UncategorizedToastBody({
 
                 <div className="mt-2 flex items-center gap-2">
                     <Link
-                        href={categorizeHref}
+                        href={categorizeHref()}
                         onClick={() => toast.dismiss(TOAST_ID)}
                         className="inline-flex h-[26px] items-center rounded-md bg-primary px-2.5 text-xs font-medium text-primary-foreground transition-opacity hover:opacity-90"
                     >

--- a/resources/js/components/achievements/uncategorized-toast.tsx
+++ b/resources/js/components/achievements/uncategorized-toast.tsx
@@ -113,11 +113,21 @@ function show(challenges: Challenges | null | undefined): void {
 
     const prompt = challenges.uncategorized;
 
-    toast.custom(() => <UncategorizedToastBody prompt={prompt} />, {
-        id: TOAST_ID,
-        duration: Infinity,
-        dismissible: false,
-    });
+    // Published a tick late, on purpose. Sonner hands a new toast straight to
+    // whoever is subscribed and keeps no backlog, and `<Toaster/>` subscribes
+    // from an effect of its own — so a toast raised while the shell is still
+    // mounting is broadcast to nobody and lost, silently and for good, because
+    // the latch above has already been thrown. Sibling effects flush in the
+    // order the components appear, which would make this work or not depending
+    // on where in `app.tsx` this one sits; a microtask runs after the whole
+    // flush instead, so the position stops mattering.
+    queueMicrotask(() =>
+        toast.custom(() => <UncategorizedToastBody prompt={prompt} />, {
+            id: TOAST_ID,
+            duration: Infinity,
+            dismissible: false,
+        }),
+    );
 }
 
 /**

--- a/resources/js/components/achievements/uncategorized-toast.tsx
+++ b/resources/js/components/achievements/uncategorized-toast.tsx
@@ -1,0 +1,131 @@
+import { MedalProgress } from '@/components/achievements/achievement-cell';
+import { monthsLabel } from '@/components/achievements/achievement-figure';
+import { snooze } from '@/routes/achievements/uncategorized';
+import { index as transactionsIndex } from '@/routes/transactions';
+import { type Challenges, type SharedData } from '@/types';
+import { __ } from '@/utils/i18n';
+import { Link, router } from '@inertiajs/react';
+import axios from 'axios';
+import { TagsIcon } from 'lucide-react';
+import { useEffect } from 'react';
+import { toast } from 'sonner';
+
+/**
+ * "You have transactions with no category" — the one nudge that asks for work
+ * rather than announcing something.
+ *
+ * Persistent on purpose: no timer, no close button, no swipe. It goes away by
+ * being acted on or by being put away for three days, and putting it away is
+ * recorded on the user so the phone honours what was said on the laptop.
+ *
+ * One per session. It is fired from the shell rather than from a page, so
+ * without the guard every navigation would stack another copy of the same ask.
+ */
+const TOAST_ID = 'uncategorized-transactions';
+
+let shown = false;
+
+/** Straight to the pile it is asking about, filtered to exactly that. */
+const categorizeHref = transactionsIndex({
+    query: { category_ids: 'uncategorized' },
+}).url;
+
+function UncategorizedToastBody({
+    prompt,
+}: {
+    prompt: NonNullable<Challenges['uncategorized']>;
+}) {
+    const progress = prompt.medal?.progress ?? null;
+
+    return (
+        <div className="flex w-full gap-3 rounded-lg border bg-popover p-3.5 text-popover-foreground shadow-lg">
+            <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted">
+                <TagsIcon className="size-[17px]" />
+            </span>
+
+            <div className="flex min-w-0 flex-1 flex-col gap-1">
+                <span className="text-[13px] leading-4 font-medium">
+                    {__(':count uncategorized transactions', {
+                        count: prompt.count,
+                    })}
+                </span>
+                <span className="text-[13px] leading-[17px] text-pretty text-muted-foreground">
+                    {__(
+                        'A month with everything categorized is a month you can actually read.',
+                    )}
+                </span>
+
+                {progress && (
+                    <MedalProgress
+                        progress={progress}
+                        goalLabel={monthsLabel(progress.goal)}
+                        className="mt-0.5"
+                    />
+                )}
+
+                <div className="mt-2 flex items-center gap-2">
+                    <Link
+                        href={categorizeHref}
+                        onClick={() => toast.dismiss(TOAST_ID)}
+                        className="inline-flex h-[26px] items-center rounded-md bg-primary px-2.5 text-xs font-medium text-primary-foreground transition-opacity hover:opacity-90"
+                    >
+                        {__('Categorize')}
+                    </Link>
+                    <button
+                        type="button"
+                        onClick={() => {
+                            toast.dismiss(TOAST_ID);
+                            // Nothing to do with the answer, and nothing to
+                            // show if it never lands: the toast is already gone
+                            // and the next page load asks again.
+                            void axios.post(snooze.url()).catch(() => {});
+                        }}
+                        className="inline-flex h-[26px] cursor-pointer items-center rounded-md px-2 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+                    >
+                        {__('Not now')}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function show(challenges: Challenges | null | undefined): void {
+    if (shown || !challenges?.uncategorized) {
+        return;
+    }
+
+    shown = true;
+
+    const prompt = challenges.uncategorized;
+
+    toast.custom(() => <UncategorizedToastBody prompt={prompt} />, {
+        id: TOAST_ID,
+        duration: Infinity,
+        dismissible: false,
+    });
+}
+
+/**
+ * Mounted once in the shell, beside the toaster. Fires on the first page that
+ * carries the prompt — the props are lazy, so the very first render of a hard
+ * reload already has them — and re-checks on navigation for the reader whose
+ * first screen had nothing to categorize.
+ */
+export function UncategorizedToast({
+    initialChallenges,
+}: {
+    initialChallenges: Challenges | null;
+}) {
+    useEffect(() => {
+        show(initialChallenges);
+
+        return router.on('navigate', (event) => {
+            const pageProps = event.detail.page.props as unknown as SharedData;
+
+            show(pageProps.challenges);
+        });
+    }, [initialChallenges]);
+
+    return null;
+}

--- a/resources/js/components/app-sidebar-header.tsx
+++ b/resources/js/components/app-sidebar-header.tsx
@@ -1,3 +1,4 @@
+import { StreakChip } from '@/components/achievements/streak-chip';
 import { Breadcrumbs } from '@/components/breadcrumbs';
 import { EncryptionKeyButton } from '@/components/encryption-key-button';
 import { NotificationBell } from '@/components/notifications/notification-bell';
@@ -45,6 +46,7 @@ export function AppSidebarHeader({
                     <Breadcrumbs breadcrumbs={breadcrumbs} />
                 </div>
                 <div className="flex items-center gap-2">
+                    <StreakChip />
                     <ImportTransactionsButton />
                     {showEncryptionButton && (
                         <>

--- a/resources/js/components/notifications/notification-bell.tsx
+++ b/resources/js/components/notifications/notification-bell.tsx
@@ -1,26 +1,18 @@
 import { index } from '@/actions/App/Http/Controllers/NotificationController';
 import { NotificationList } from '@/components/notifications/notification-list';
 import { useMarkAllRead } from '@/components/notifications/use-mark-all-read';
+import {
+    AdaptivePopover,
+    type PopoverAlign,
+    type PopoverSide,
+} from '@/components/ui/adaptive-popover';
 import { Button } from '@/components/ui/button';
-import {
-    Drawer,
-    DrawerContent,
-    DrawerHeader,
-    DrawerTitle,
-    DrawerTrigger,
-} from '@/components/ui/drawer';
-import {
-    Popover,
-    PopoverContent,
-    PopoverTrigger,
-} from '@/components/ui/popover';
-import { useIsMobile } from '@/hooks/use-mobile';
 import { cn } from '@/lib/utils';
 import { type NotificationItem, type SharedData } from '@/types';
 import { __ } from '@/utils/i18n';
 import { Link, usePage } from '@inertiajs/react';
 import { BellIcon, CheckCheckIcon } from 'lucide-react';
-import { type ComponentProps, useState } from 'react';
+import { useState } from 'react';
 
 /**
  * The bell next to the account: a badge with the unread count and a panel with
@@ -41,11 +33,10 @@ export function NotificationBell({
     align = 'end',
 }: {
     className?: string;
-    side?: ComponentProps<typeof PopoverContent>['side'];
-    align?: ComponentProps<typeof PopoverContent>['align'];
+    side?: PopoverSide;
+    align?: PopoverAlign;
 }) {
     const { notifications } = usePage<SharedData>().props;
-    const isMobile = useIsMobile();
     const [open, setOpen] = useState(false);
     const { items, unread, markAllRead } = useMarkAllRead(
         notifications?.recent ?? NO_ROWS,
@@ -117,30 +108,16 @@ export function NotificationBell({
         </>
     );
 
-    if (isMobile) {
-        return (
-            <Drawer open={open} onOpenChange={setOpen}>
-                <DrawerTrigger asChild>{trigger}</DrawerTrigger>
-                <DrawerContent>
-                    <DrawerHeader className="sr-only">
-                        <DrawerTitle>{__('Notifications')}</DrawerTitle>
-                    </DrawerHeader>
-                    <div className="overflow-y-auto pb-3">{panel}</div>
-                </DrawerContent>
-            </Drawer>
-        );
-    }
-
     return (
-        <Popover open={open} onOpenChange={setOpen}>
-            <PopoverTrigger asChild>{trigger}</PopoverTrigger>
-            <PopoverContent
-                side={side}
-                align={align}
-                className="w-[360px] overflow-hidden p-0"
-            >
-                {panel}
-            </PopoverContent>
-        </Popover>
+        <AdaptivePopover
+            open={open}
+            onOpenChange={setOpen}
+            trigger={trigger}
+            title={__('Notifications')}
+            side={side}
+            align={align}
+        >
+            {panel}
+        </AdaptivePopover>
     );
 }

--- a/resources/js/components/ui/adaptive-popover.tsx
+++ b/resources/js/components/ui/adaptive-popover.tsx
@@ -18,6 +18,20 @@ export type PopoverSide = ComponentProps<typeof PopoverContent>['side'];
 export type PopoverAlign = ComponentProps<typeof PopoverContent>['align'];
 
 /**
+ * Above the toaster, which sonner pins at 999999999.
+ *
+ * A panel is opened on purpose and closes on its own; a toast is ambient, and
+ * the categorize prompt in particular never leaves until it is answered. Left at
+ * the `z-50` these primitives ship with, that prompt paints straight over the
+ * streak panel and the bell — the reader opens a panel and reads a toast.
+ *
+ * On the phone this also puts the drawer over the toast rather than under it,
+ * which is the whole point: the drawer owns the bottom of the screen, and that
+ * is exactly where the toast sits.
+ */
+const ABOVE_TOASTS = 'z-[1000000000]';
+
+/**
  * A panel hung off a button in the chrome: a popover on desktop, a bottom
  * drawer on the phone, where a popover would fight the thumb.
  *
@@ -58,7 +72,7 @@ export function AdaptivePopover({
         return (
             <Drawer open={open} onOpenChange={onOpenChange}>
                 <DrawerTrigger asChild>{trigger}</DrawerTrigger>
-                <DrawerContent>
+                <DrawerContent className={ABOVE_TOASTS}>
                     <DrawerHeader className="sr-only">
                         <DrawerTitle>{title}</DrawerTitle>
                     </DrawerHeader>
@@ -76,7 +90,11 @@ export function AdaptivePopover({
             <PopoverContent
                 side={side}
                 align={align}
-                className={cn('w-[360px] overflow-hidden p-0', className)}
+                className={cn(
+                    'w-[360px] overflow-hidden p-0',
+                    ABOVE_TOASTS,
+                    className,
+                )}
                 // Hovering is not asking to be moved: pulling focus into the
                 // panel the moment the pointer grazes the trigger steals the
                 // keyboard from whatever the reader was doing.

--- a/resources/js/components/ui/adaptive-popover.tsx
+++ b/resources/js/components/ui/adaptive-popover.tsx
@@ -1,0 +1,117 @@
+import {
+    Drawer,
+    DrawerContent,
+    DrawerHeader,
+    DrawerTitle,
+    DrawerTrigger,
+} from '@/components/ui/drawer';
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from '@/components/ui/popover';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { cn } from '@/lib/utils';
+import { type ComponentProps, type ReactNode, useEffect, useRef } from 'react';
+
+export type PopoverSide = ComponentProps<typeof PopoverContent>['side'];
+export type PopoverAlign = ComponentProps<typeof PopoverContent>['align'];
+
+/**
+ * A panel hung off a button in the chrome: a popover on desktop, a bottom
+ * drawer on the phone, where a popover would fight the thumb.
+ *
+ * The bell and the streak pill both do exactly this, so the switch lives here
+ * rather than twice — one place to fix when the phone breakpoint moves, and one
+ * clone fewer for the duplication check to fail the build over.
+ */
+export function AdaptivePopover({
+    open,
+    onOpenChange,
+    trigger,
+    title,
+    children,
+    side = 'bottom',
+    align = 'end',
+    className,
+    openOnHover = false,
+}: {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    trigger: ReactNode;
+    /** Read out to a screen reader as the drawer's name. */
+    title: string;
+    children: ReactNode;
+    side?: PopoverSide;
+    align?: PopoverAlign;
+    className?: string;
+    /**
+     * Open the popover on hover as well as on click. Desktop only: there is no
+     * hover on a phone, and the drawer stays a deliberate tap either way.
+     */
+    openOnHover?: boolean;
+}) {
+    const isMobile = useIsMobile();
+    const hover = useHoverToOpen(openOnHover && !isMobile, onOpenChange);
+
+    if (isMobile) {
+        return (
+            <Drawer open={open} onOpenChange={onOpenChange}>
+                <DrawerTrigger asChild>{trigger}</DrawerTrigger>
+                <DrawerContent>
+                    <DrawerHeader className="sr-only">
+                        <DrawerTitle>{title}</DrawerTitle>
+                    </DrawerHeader>
+                    <div className="overflow-y-auto pb-3">{children}</div>
+                </DrawerContent>
+            </Drawer>
+        );
+    }
+
+    return (
+        <Popover open={open} onOpenChange={onOpenChange}>
+            <PopoverTrigger asChild {...hover}>
+                {trigger}
+            </PopoverTrigger>
+            <PopoverContent
+                side={side}
+                align={align}
+                className={cn('w-[360px] overflow-hidden p-0', className)}
+                // Hovering is not asking to be moved: pulling focus into the
+                // panel the moment the pointer grazes the trigger steals the
+                // keyboard from whatever the reader was doing.
+                onOpenAutoFocus={
+                    openOnHover ? (event) => event.preventDefault() : undefined
+                }
+                {...hover}
+            >
+                {children}
+            </PopoverContent>
+        </Popover>
+    );
+}
+
+/**
+ * Open on pointer enter, close on pointer leave — with a beat before closing,
+ * so the pointer can cross the gap between the trigger and the panel without
+ * the panel disappearing out from under it.
+ */
+function useHoverToOpen(enabled: boolean, onOpenChange: (open: boolean) => void) {
+    const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+    useEffect(() => () => clearTimeout(timer.current), []);
+
+    if (!enabled) {
+        return {};
+    }
+
+    return {
+        onMouseEnter: () => {
+            clearTimeout(timer.current);
+            onOpenChange(true);
+        },
+        onMouseLeave: () => {
+            timer.current = setTimeout(() => onOpenChange(false), 120);
+        },
+    };
+}

--- a/resources/js/components/user-menu-content.tsx
+++ b/resources/js/components/user-menu-content.tsx
@@ -65,8 +65,11 @@ export function UserMenuContent({
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
             {/* What already happened: the medals, and the months we closed.
-                Not in the main navigation — this is something to look back at,
-                not somewhere to work. */}
+                Still out of the main navigation, but no longer only somewhere
+                to look back at: the streak pill in the header now hangs the two
+                live challenges off this same screen, and its footer lands here.
+                This entry is the full record; the pill is the bit worth chasing
+                today. */}
             <DropdownMenuGroup>
                 {achievements && (
                     <DropdownMenuItem asChild>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -117,6 +117,39 @@ export interface AchievementMedal {
     progress: AchievementProgress | null;
 }
 
+/**
+ * The next rung of one track, as the header panel and the categorize prompt
+ * draw it: enough to put a medal, a name and a bar on the screen, and nothing
+ * the progress screen needs on top of that.
+ */
+export interface ChallengeMedal {
+    track: string;
+    rarity: AchievementRarity;
+    icon: string;
+    name: string;
+    figure: AchievementFigureValue | null;
+    progress: AchievementProgress | null;
+}
+
+/**
+ * The two medals the chrome puts in front of the reader on every screen.
+ *
+ * `visit_streak` is the run as it stands today — what the pill counts, because
+ * a number with nothing to lose is not a streak. The bars under the medals are
+ * measured on the longest run instead, the way the progress screen measures
+ * them, so the two screens cannot disagree.
+ */
+export interface Challenges {
+    visit_streak: number;
+    /** `visits` then `visit_weeks`. A finished track is absent. */
+    medals: ChallengeMedal[];
+    /** Null when there is nothing to categorize, or the prompt is snoozed. */
+    uncategorized: {
+        count: number;
+        medal: ChallengeMedal | null;
+    } | null;
+}
+
 export interface AchievementTrack {
     key: string;
     label: string;
@@ -182,6 +215,8 @@ export interface SharedData {
     notifications: NotificationsBell | null;
     /** Null unless the achievements feature is on for this reader. */
     achievements: AchievementsProgress | null;
+    /** Null unless the achievements feature is on for this reader. */
+    challenges: Challenges | null;
     expiredBankingConnections: ExpiredBankingConnectionNotification[];
     hasEncryptedAccounts: boolean;
     hasEncryptedTransactions: boolean;

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,6 +41,7 @@ use App\Http\Controllers\SitemapController;
 use App\Http\Controllers\SubscriptionController;
 use App\Http\Controllers\TransactionController;
 use App\Http\Controllers\TransactionSplitController;
+use App\Http\Controllers\UncategorizedPromptController;
 use App\Models\Bank;
 use App\Support\Marketing\ComparisonPages;
 use App\Support\Marketing\IntegrationsPage;
@@ -193,6 +194,12 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('progress/medal/{medal}/{format}/{theme}', [AchievementController::class, 'card'])
             ->where('medal', '[a-z_]+\.[0-9]+')
             ->name('achievements.card');
+
+        // "Not now" on the categorize prompt. Beside the progress screen and
+        // outside the paywall for the same reason the bell is: the prompt is
+        // drawn wherever the app shell is, so silencing it has to be too.
+        Route::post('progress/uncategorized/snooze', UncategorizedPromptController::class)
+            ->name('achievements.uncategorized.snooze');
 
         Route::get('notifications', [NotificationController::class, 'index'])->name('notifications.list');
         Route::post('notifications/read-all', [NotificationController::class, 'readAll'])->name('notifications.read-all');

--- a/tests/Feature/Achievements/AchievementChallengesTest.php
+++ b/tests/Feature/Achievements/AchievementChallengesTest.php
@@ -1,0 +1,236 @@
+<?php
+
+use App\Enums\CategoryType;
+use App\Models\Account;
+use App\Models\Achievement;
+use App\Models\Category;
+use App\Models\Transaction;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Inertia\Testing\AssertableInertia;
+
+/*
+ * The two challenges the chrome carries on every screen: the visit streak in
+ * the header, and what is left to categorize this month.
+ *
+ * Both ride along with every render, so the shape matters as much as the
+ * numbers: the pill counts the run as it stands today, the bar under the medal
+ * is measured on the longest run the way the progress screen measures it, and a
+ * reader past the last rung gets no medal to aim at rather than a bar stuck at
+ * full.
+ */
+
+beforeEach(function (): void {
+    Cache::flush();
+    // Protected on the TestCase, so it has to be switched off from here rather
+    // than from the helper below.
+    $this->withoutVite();
+    config()->set('achievements.enabled', true);
+    // Same reason as the progress screen's own suite: left on, Inertia posts
+    // every page to its SSR gateway and the stray-request guard fails the test
+    // for something that has nothing to do with the props.
+    config()->set('inertia.ssr.enabled', false);
+});
+
+/**
+ * A reader whose visit run is exactly what the test says it is. `last_active_at`
+ * is set to now so `TrackLastActiveAt` leaves the run alone: a null column reads
+ * as a first visit ever and resets it to one.
+ */
+function challenged(array $attributes = []): User
+{
+    return User::factory()->onboarded()->create([
+        'currency_code' => 'EUR',
+        'locale' => 'en',
+        'last_active_at' => now(),
+        'visit_streak' => 1,
+        'longest_visit_streak' => 1,
+        'visit_week_streak' => 1,
+        'longest_visit_week_streak' => 1,
+        ...$attributes,
+    ]);
+}
+
+/**
+ * The shared challenges prop, as the reader's next page render sends it.
+ *
+ * @return array<string, mixed>|null
+ */
+function challengesFor(User $user): ?array
+{
+    $props = [];
+
+    test()->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertOk()
+        ->assertInertia(function (AssertableInertia $page) use (&$props): void {
+            $props = $page->toArray()['props'];
+        });
+
+    return $props['challenges'] ?? null;
+}
+
+function earn(User $user, string ...$keys): void
+{
+    foreach ($keys as $key) {
+        Achievement::factory()->key($key)->create([
+            'user_id' => $user->id,
+            'space_id' => $user->activeSpace()->id,
+        ]);
+    }
+}
+
+/**
+ * Transactions in one month, categorized or not. Dated four days in, because
+ * subtracting whole months from a 31st slides into the wrong one.
+ */
+function recordFor(User $user, int $count, int $monthsAgo, bool $categorized = false): void
+{
+    $space = $user->activeSpace();
+
+    $account = $user->accounts()->first() ?? Account::factory()->create([
+        'user_id' => $user->id,
+        'space_id' => $space->id,
+        'currency_code' => 'EUR',
+    ]);
+
+    Transaction::factory()->count($count)->create([
+        'user_id' => $user->id,
+        'space_id' => $space->id,
+        'account_id' => $account->id,
+        'category_id' => $categorized ? Category::query()->firstOrCreate(
+            ['user_id' => $user->id, 'name' => 'Groceries'],
+            ['space_id' => $space->id, 'type' => CategoryType::Expense],
+        )->id : null,
+        'transaction_date' => now()->startOfMonth()->subMonths($monthsAgo)->addDays(4),
+        'currency_code' => 'EUR',
+    ]);
+}
+
+it('sends nothing at all with the feature switched off', function (): void {
+    config()->set('achievements.enabled', false);
+
+    expect(challengesFor(challenged()))->toBeNull();
+});
+
+it('counts the run as it stands today, and measures the medal on the longest one', function (): void {
+    // Twelve days once, five days now: the pill has to say five — there is
+    // nothing to lose about a run that already broke — while the bar keeps
+    // reading the peak, exactly as the progress screen does.
+    $user = challenged(['visit_streak' => 5, 'longest_visit_streak' => 12]);
+    earn($user, 'visits.1', 'visits.2');
+
+    $challenges = challengesFor($user);
+
+    expect($challenges['visit_streak'])->toBe(5);
+
+    $visits = collect($challenges['medals'])->firstWhere('track', 'visits');
+
+    expect($visits['name'])->toBe('Visit streak')
+        ->and($visits['icon'])->toBe('calendar-days')
+        ->and($visits['rarity'])->toBe('uncommon')
+        ->and($visits['figure'])->toBe(['type' => 'days', 'value' => 30, 'currency' => null])
+        ->and($visits['progress'])->toBe(['now' => 12, 'goal' => 30, 'unlocking' => false]);
+});
+
+it('sends both visit tracks, in the order the panel draws them', function (): void {
+    $tracks = collect(challengesFor(challenged())['medals'])->pluck('track');
+
+    expect($tracks->all())->toBe(['visits', 'visit_weeks']);
+});
+
+it('draws a run of zero without pretending it is one', function (): void {
+    // A reader who has never been counted: the payload says zero and the pill
+    // is not drawn at all.
+    $user = challenged(['visit_streak' => 0, 'longest_visit_streak' => 0, 'last_active_at' => now()]);
+
+    expect(challengesFor($user)['visit_streak'])->toBe(0);
+});
+
+it('says a medal is unlocking once the reader stands on its rung', function (): void {
+    // Past day 7 with `visits.1` in hand, so the next rung is `visits.2` and the
+    // reader is already through it — the sweep that awards it runs at night.
+    $user = challenged(['visit_streak' => 9, 'longest_visit_streak' => 9]);
+    earn($user, 'visits.1');
+
+    $visits = collect(challengesFor($user)['medals'])->firstWhere('track', 'visits');
+
+    expect($visits['progress'])->toBe(['now' => 9, 'goal' => 7, 'unlocking' => true]);
+});
+
+it('leaves a finished track without a medal to aim at', function (): void {
+    $user = challenged(['visit_streak' => 400, 'longest_visit_streak' => 400]);
+    earn($user, 'visits.1', 'visits.2', 'visits.3', 'visits.4', 'visits.5');
+
+    $challenges = challengesFor($user);
+
+    // The number keeps climbing with nothing left to reach: the pill fills its
+    // ring rather than showing a goal that no longer exists.
+    expect($challenges['visit_streak'])->toBe(400)
+        ->and(collect($challenges['medals'])->firstWhere('track', 'visits'))->toBeNull()
+        ->and(collect($challenges['medals'])->firstWhere('track', 'visit_weeks'))->not->toBeNull();
+});
+
+it('counts only what the month in progress left without a category', function (): void {
+    $user = challenged();
+
+    recordFor($user, 3, monthsAgo: 0);
+    recordFor($user, 2, monthsAgo: 0, categorized: true);
+    // Last month is somebody else's problem — the prompt is about the month
+    // nobody has tidied yet.
+    recordFor($user, 4, monthsAgo: 1);
+
+    expect(challengesFor($user)['uncategorized']['count'])->toBe(3);
+});
+
+it('never counts another reader\'s pile', function (): void {
+    $user = challenged();
+    $stranger = challenged();
+
+    recordFor($stranger, 5, monthsAgo: 0);
+
+    expect(challengesFor($user)['uncategorized'])->toBeNull();
+});
+
+it('carries the categorized medal so the prompt can show what the work is worth', function (): void {
+    $user = challenged();
+
+    recordFor($user, 1, monthsAgo: 0);
+    recordFor($user, 2, monthsAgo: 1, categorized: true);
+
+    $medal = challengesFor($user)['uncategorized']['medal'];
+
+    expect($medal['track'])->toBe('categorized')
+        ->and($medal['figure'])->toBe(['type' => 'months', 'value' => 1, 'currency' => null])
+        ->and($medal['progress'])->toBe(['now' => 1, 'goal' => 1, 'unlocking' => true]);
+});
+
+it('stops asking for three days once the reader says not now', function (): void {
+    $user = challenged();
+    recordFor($user, 2, monthsAgo: 0);
+
+    expect(challengesFor($user)['uncategorized']['count'])->toBe(2);
+
+    $this->actingAs($user)
+        ->post(route('achievements.uncategorized.snooze'))
+        ->assertOk();
+
+    expect($user->fresh()->uncategorized_prompt_snoozed_until->toDateString())
+        ->toBe(now()->addDays(3)->toDateString())
+        ->and(challengesFor($user)['uncategorized'])->toBeNull();
+});
+
+it('asks again once the snooze has run out', function (): void {
+    $user = challenged(['uncategorized_prompt_snoozed_until' => now()->subMinute()]);
+    recordFor($user, 2, monthsAgo: 0);
+
+    expect(challengesFor($user)['uncategorized']['count'])->toBe(2);
+});
+
+it('refuses to snooze a prompt that is switched off', function (): void {
+    config()->set('achievements.enabled', false);
+
+    $this->actingAs(challenged())
+        ->post(route('achievements.uncategorized.snooze'))
+        ->assertNotFound();
+});


### PR DESCRIPTION
The medals were buried in the account menu, so nobody saw them. Two of them now
travel with the app shell, behind the `Achievements` Pennant flag: the visit
streak, and the pile of transactions still without a category.

## What ships

**A · The streak pill**, in the header on desktop and on the phone, just left of
"Import transactions". A flame inside a progress ring plus a number, in three
states:

1. Mid-run — the ring fills towards the next visit medal.
2. Standing on the rung with the medal not yet awarded (the sweep runs at night)
   — the real `<Medal>` takes the ring's place and the pill fills in.
3. Past the last rung — the ring is simply full, the number keeps climbing, and
   there is no goal left to fall short of.

It is not drawn at all without a live run, or with the feature off. Hovering it
on desktop (tapping on the phone) opens a panel with the two visit tracks, each
as a dimmed medal in a dashed slot with its figure and bar, and a footer that
lands on the progress screen.

**B · A persistent categorize prompt**, fired once per session when the month in
progress has transactions with no category and the prompt is not snoozed. No
timer, no close button, no swipe: it leaves by being acted on ("Categorize",
straight to that month's filtered list) or by being put away ("Not now", three
days, recorded on the user so the phone honours what was said on the laptop).

## Backend

A new `challenges` shared prop, built by `App\Services\Achievements\Challenges`.
Deliberately not `Progress`: that one builds all thirteen tracks, the rarity
shares and the last monthly report, which is a page's worth of work for two
questions. Everything here is a column on the reader's own row or one narrow
query, and it returns `null` end to end with the feature off.

Two things were extracted rather than copied:

- `Progress::progress()` moved to `Presenter::progress()`. The progress screen
  and the new payload now share it, so the "unlocking" rule and the bar fraction
  cannot drift between the two surfaces.
- `AdaptivePopover` was lifted out of `notification-bell.tsx` — popover on
  desktop, drawer on the phone — and the bell was rewired onto it. Copying that
  shape would have left a clone big enough to fail `bun run dry`, which is a
  required check.

## Decisions worth arguing about

- **The pill counts the live run; the bars count the longest one.** A streak with
  nothing to lose is a trophy, not a reason to come back tomorrow — but the medal
  is awarded on the peak, and the progress screen already measures it that way,
  so a bar following the live run would fall back without the medal moving. When
  the two numbers differ the panel says which is which, which is why it carries a
  short header the design did not have.
- **The server settles whether the prompt is due**, rather than shipping
  `uncategorized_prompt_snoozed_until` for the client to compare against its own
  clock. One answer in one place — and the categorized run below it, which is a
  grouped read over every month the reader has, is then never paid for by
  somebody who already said "not now".
- **The toast's bar reads the `categorized` track**, which the brief's payload
  list did not mention but the design asks for. It is only computed when the
  prompt is actually due, for the reason above.
- **"Categorize" carries the current month's dates** as well as
  `category_ids=uncategorized`. Both are existing filters — no new one was built
  — but the count is scoped to the month in progress, so the list has to be too:
  otherwise the toast announces four and opens on forty.
- **`user-menu-content.tsx` said Progress was "something to look back at, not
  somewhere to work".** This change contradicts that on purpose, so the comment
  was rewritten rather than left lying, along with the same claim in
  `AchievementController`'s docblock.

## Two bugs QA caught, both fixed here

- **The toast never appeared.** Sonner hands a new toast straight to whoever is
  subscribed and keeps no backlog, and its `<Toaster/>` subscribes from an effect
  of its own — so a toast raised from a sibling that flushes earlier is broadcast
  to nobody and lost, with the once-per-session latch already thrown. Nothing
  throws and nothing logs. It is now published from a microtask, after the whole
  effect flush, so it no longer depends on where in the shell it is mounted; the
  regression test mounts it in the order that broke it and fails without the fix.
- **The prompt painted over the panels.** Sonner pins its toaster at
  `z-index: 999999999` while Radix Popover and vaul Drawer both ship at `z-50`,
  so a persistent toast covered anything the reader opened — the bell included.
  Both surfaces of `AdaptivePopover` now outrank it.

## Cost

With the feature on, a render adds a pluck of the reader's earned medal keys and
one `COUNT` over the month in progress. The grouped closed-month read only runs
when the prompt is actually due. Nothing is added for a reader with the feature
off, or for a guest.

## Tests

- `AchievementChallengesTest` — the payload with the feature on and off, a run of
  zero, the live-vs-longest split, `unlocking`, a finished track, the count
  scoped to the month and to the reader, the snooze setting +3 days and silencing
  the prompt, the snooze expiring, and a 404 on the endpoint with the feature off.
- `streak-chip.test.tsx` — the three states and that nothing is drawn without a
  run.
- `uncategorized-toast.test.tsx` — the ordering regression described above.

Browser QA covered all of it against the running app on desktop and at 390×844,
including both fixes above.

## Note for whoever picks this up next

`ExpiredConnectionsToast` sits in the same position in `app.tsx` as this toast
did and publishes the same way, so on a hard reload it is very likely lost for
the same reason. Left alone here — it is not this change's to fix, and it wants
its own testing.

## Demo

https://github.com/user-attachments/assets/a7f31fe7-c37b-4ed6-ae26-4d846b991f01


