### PR TITLE
feat(achievements): give the visit streak a warm skin and a life of its own

### DIFF
--- a/app/Http/Middleware/TrackLastActiveAt.php
+++ b/app/Http/Middleware/TrackLastActiveAt.php
@@ -2,11 +2,15 @@
 
 namespace App\Http\Middleware;
 
+use App\Features\Achievements;
 use App\Models\User;
+use App\Services\Achievements\Awarder;
 use Carbon\CarbonInterface;
 use Closure;
 use Illuminate\Http\Request;
+use Laravel\Pennant\Feature;
 use Symfony\Component\HttpFoundation\Response;
+use Throwable;
 
 class TrackLastActiveAt
 {
@@ -15,41 +19,95 @@ class TrackLastActiveAt
      */
     private const THROTTLE_SECONDS = 300;
 
+    public function __construct(private Awarder $awarder) {}
+
     /**
      * Handle an incoming request.
+     *
+     * Before the response, not after it. The shared Inertia props are closures
+     * the renderer calls further down the stack, so a run carried forward here
+     * is the run the page is drawn with — the reader sees the day they are on,
+     * and the medal it just earned, on the request that earned it rather than
+     * on the next one.
      *
      * @param  Closure(Request): (Response)  $next
      */
     public function handle(Request $request, Closure $next): Response
     {
-        $response = $next($request);
-
         $user = $request->user();
 
         if ($user instanceof User) {
-            $lastActiveAt = $user->last_active_at;
-
-            // A new day is always written, however recent the last write: the
-            // day is what a visit streak counts, and someone who comes back a
-            // minute after midnight has started a new one.
-            if ($lastActiveAt === null
-                || ! $this->sameSpan($user, $lastActiveAt, now(), 'day')
-                || $lastActiveAt->lte(now()->subSeconds(self::THROTTLE_SECONDS))) {
-                $this->carryStreak($user, $lastActiveAt, 'day', 'visit_streak', 'longest_visit_streak');
-                $this->carryStreak($user, $lastActiveAt, 'week', 'visit_week_streak', 'longest_visit_week_streak');
-                $user->last_active_at = now();
-                $user->saveQuietly();
-            }
+            $this->track($user);
         }
 
-        return $response;
+        return $next($request);
+    }
+
+    private function track(User $user): void
+    {
+        $lastActiveAt = $user->last_active_at;
+
+        // A new day is always written, however recent the last write: the day
+        // is what a visit streak counts, and someone who comes back a minute
+        // after midnight has started a new one.
+        if ($lastActiveAt !== null
+            && $this->sameSpan($user, $lastActiveAt, now(), 'day')
+            && $lastActiveAt->gt(now()->subSeconds(self::THROTTLE_SECONDS))) {
+            return;
+        }
+
+        $before = $this->runs($user);
+
+        $this->carryStreak($user, $lastActiveAt, 'day', 'visit_streak', 'longest_visit_streak');
+        $this->carryStreak($user, $lastActiveAt, 'week', 'visit_week_streak', 'longest_visit_week_streak');
+        $user->last_active_at = now();
+        $user->saveQuietly();
+
+        if ($this->runs($user) !== $before) {
+            $this->award($user);
+        }
+    }
+
+    /**
+     * Both runs as they stand, which is the whole of what a visit medal is
+     * judged on: unchanged means there is nothing new to award.
+     *
+     * @return array{int, int}
+     */
+    private function runs(User $user): array
+    {
+        return [(int) $user->longest_visit_streak, (int) $user->longest_visit_week_streak];
+    }
+
+    /**
+     * The medal a run just reached, settled now instead of overnight.
+     *
+     * Cheap enough to sit on a request — one read of the reader's own medal
+     * keys against a catalog held in memory, and at most one insert — and only
+     * reached on the first request of a new day, which is the only time a run
+     * moves. A reader still onboarding is left to the sweep, the way every
+     * other medal is.
+     */
+    private function award(User $user): void
+    {
+        if ($user->onboarded_at === null || ! Feature::for($user)->active(Achievements::class)) {
+            return;
+        }
+
+        try {
+            $this->awarder->awardVisitRuns($user);
+        } catch (Throwable $exception) {
+            // Never at the cost of the page the reader actually asked for: the
+            // sweep will find the same medal tonight.
+            report($exception);
+        }
     }
 
     /**
      * Carries one run forward: one more when the span before this one counted,
      * one when the run is broken or has never started. The longest is kept
-     * alongside it, because the nightly sweep is what turns a run into a medal
-     * and a peak between two sweeps still happened.
+     * alongside it, because that is what a medal is judged on: a run that
+     * peaked and broke before anyone looked still happened.
      */
     private function carryStreak(User $user, ?CarbonInterface $lastActiveAt, string $unit, string $current, string $longest): void
     {

--- a/app/Services/Achievements/Awarder.php
+++ b/app/Services/Achievements/Awarder.php
@@ -17,6 +17,10 @@ use Illuminate\Support\Collection;
  * are recorded silently and one welcome row says how many. Every sweep after
  * that is about something that just happened, so each medal gets its own row in
  * the bell and the day's batch gets one email between them.
+ *
+ * {@see awardVisitRuns()} is the one thing that does not wait for the sweep,
+ * and it announces itself through the same two methods so a medal reads the
+ * same whether the night found it or the visit did.
  */
 class Awarder
 {
@@ -28,12 +32,12 @@ class Awarder
     public function sweep(User $user, bool $notify = true): Collection
     {
         $backfill = ! $user->achievements()->exists();
-        $recorded = $this->record($user);
+        $recorded = $this->record($user, $this->evaluator->for($user));
 
         // Rewritten on every pass, not only when something was awarded: the
         // account menu reads this instead of counting on every page render, and
         // a row deleted by hand should not leave the badge wrong forever.
-        $user->forceFill(['achievements_count' => $user->achievements()->count()])->saveQuietly();
+        $this->tally($user);
 
         if ($recorded->isEmpty() || ! $notify) {
             return $recorded;
@@ -45,6 +49,51 @@ class Awarder
             return $recorded;
         }
 
+        return $this->announce($user, $recorded);
+    }
+
+    /**
+     * The visit medals a run has just earned, recorded on the request that
+     * moved it rather than on the sweep that night.
+     *
+     * A run is the one thing the app knows the whole truth about the instant it
+     * changes — two columns, no history to read — so making the reader wait
+     * until the small hours to be told they kept a week going was a delay with
+     * nothing behind it. Everything else still waits for the sweep, which is
+     * where a closed month or a balance at a month end can actually be judged.
+     *
+     * Skipped for a reader with no medals at all, which is a reader the sweep
+     * has never been through: their first pass reads a whole life and says so
+     * with a single welcome row, and taking that first medal here would turn it
+     * into a pile of individual ones instead.
+     *
+     * @return Collection<int, Achievement> the medals recorded by this visit
+     */
+    public function awardVisitRuns(User $user): Collection
+    {
+        if (! $user->achievements()->exists()) {
+            return collect();
+        }
+
+        $recorded = $this->record($user, $this->evaluator->visitRuns($user));
+
+        if ($recorded->isEmpty()) {
+            return $recorded;
+        }
+
+        $this->tally($user);
+
+        return $this->announce($user, $recorded);
+    }
+
+    /**
+     * One row in the bell per medal, and one email for the batch.
+     *
+     * @param  Collection<int, Achievement>  $recorded
+     * @return Collection<int, Achievement>
+     */
+    private function announce(User $user, Collection $recorded): Collection
+    {
         $recorded->each(fn (Achievement $achievement) => $user->notify(new AchievementUnlocked($achievement)));
 
         if ($user->wantsAchievementsEmail()) {
@@ -54,13 +103,19 @@ class Awarder
         return $recorded;
     }
 
+    private function tally(User $user): void
+    {
+        $user->forceFill(['achievements_count' => $user->achievements()->count()])->saveQuietly();
+    }
+
     /**
+     * @param  array<string, Unlock>  $found
      * @return Collection<int, Achievement>
      */
-    private function record(User $user): Collection
+    private function record(User $user, array $found): Collection
     {
         $known = $user->achievements()->pluck('key')->all();
-        $found = array_diff_key($this->evaluator->for($user), array_flip($known));
+        $found = array_diff_key($found, array_flip($known));
 
         if ($found === []) {
             return collect();

--- a/app/Services/Achievements/Catalog.php
+++ b/app/Services/Achievements/Catalog.php
@@ -19,6 +19,15 @@ use Illuminate\Support\Collection;
 class Catalog
 {
     /**
+     * The tracks a visit run feeds, which are the only ones awarded off a
+     * column rather than off a history — and so the only ones that can be
+     * settled the moment the run reaches the rung.
+     *
+     * @var list<string>
+     */
+    public const VISIT_TRACKS = ['visits', 'visit_weeks'];
+
+    /**
      * @return Collection<string, Definition> keyed by medal key
      */
     public function all(): Collection

--- a/app/Services/Achievements/Challenges.php
+++ b/app/Services/Achievements/Challenges.php
@@ -3,6 +3,7 @@
 namespace App\Services\Achievements;
 
 use App\Models\User;
+use Illuminate\Support\Collection;
 
 /**
  * The two medals the app puts in front of the reader instead of waiting to be
@@ -30,12 +31,16 @@ class Challenges
      * @return array{
      *     visit_streak: int,
      *     medals: list<array<string, mixed>>,
+     *     unlocked: array<string, mixed>|null,
      *     uncategorized: array{count: int, medal: array<string, mixed>|null}|null,
      * }
      */
     public function for(User $user): array
     {
-        $next = $this->catalog->next($user->achievements()->pluck('key')->flip());
+        // Oldest first, which is the one read that answers both questions
+        // below: what is next to fall, and which visit medal landed last.
+        $earned = $user->achievements()->orderBy('created_at')->orderBy('id')->pluck('key');
+        $next = $this->catalog->next($earned->flip());
 
         return [
             'visit_streak' => (int) $user->visit_streak,
@@ -48,8 +53,35 @@ class Challenges
                 $this->medal($user, $next->get('visits'), (int) $user->longest_visit_streak),
                 $this->medal($user, $next->get('visit_weeks'), (int) $user->longest_visit_week_streak),
             ])->filter()->values()->all(),
+            // No progress bar on this one: it is on the shelf, and the reader
+            // is being told so rather than shown how far off it is.
+            'unlocked' => $this->medal($user, $this->lastVisitMedal($earned), null),
             'uncategorized' => $this->uncategorized($user, $next->get('categorized')),
         ];
+    }
+
+    /**
+     * The visit medal that landed most recently, or null for a reader with
+     * none yet.
+     *
+     * In the order the rows were written rather than the order the catalog
+     * lists them: `visits` is written above `visit_weeks`, so a reader who
+     * takes a third day after their first full week would otherwise be told
+     * about the week all over again.
+     *
+     * @param  Collection<int, string>  $earned  medal keys, oldest first
+     */
+    private function lastVisitMedal(Collection $earned): ?Definition
+    {
+        $definitions = $this->catalog->all();
+
+        $key = $earned->last(fn (string $key): bool => in_array(
+            $definitions->get($key)?->track,
+            Catalog::VISIT_TRACKS,
+            true,
+        ));
+
+        return $key === null ? null : $definitions->get($key);
     }
 
     /**
@@ -68,6 +100,7 @@ class Challenges
         $figure = $this->presenter->milestone($definition, (string) $user->currency_code);
 
         return [
+            'key' => $definition->key,
             'track' => $definition->track,
             'rarity' => $definition->rarity->value,
             'icon' => $definition->icon,

--- a/app/Services/Achievements/Evaluator.php
+++ b/app/Services/Achievements/Evaluator.php
@@ -31,7 +31,7 @@ class Evaluator
     public function for(User $user): array
     {
         $history = $this->builder->for($user);
-        $visits = $this->visits($user);
+        $visits = $this->visitRuns($user);
 
         // Visits are the one thing that does not need a history: somebody who
         // has recorded nothing yet is still showing up, and that is the streak
@@ -308,9 +308,13 @@ class Evaluator
      * Days, and weeks, in a row opening the app, read off the runs the
      * middleware keeps.
      *
+     * Public because these are the one family the nightly sweep is not needed
+     * for: they read two columns rather than a history, so {@see Awarder} can
+     * settle them on the request that moves the run.
+     *
      * @return array<string, Unlock>
      */
-    private function visits(User $user): array
+    public function visitRuns(User $user): array
     {
         $on = $user->last_active_at?->toDateString();
 

--- a/app/Services/Achievements/Presenter.php
+++ b/app/Services/Achievements/Presenter.php
@@ -65,7 +65,10 @@ class Presenter
             'goal' => $figure['value'],
             // The sweep runs at night, so a reader crossing a threshold today
             // stands past it with the medal still locked. Say that, rather than
-            // trim the figure back to the goal and call it done.
+            // trim the figure back to the goal and call it done. Visit medals
+            // are the exception: {@see Awarder::awardVisitRuns()} settles those
+            // on the request that earns them, so they are past this almost as
+            // soon as they reach it.
             'unlocking' => $now >= $figure['value'],
         ];
     }

--- a/lang/es.json
+++ b/lang/es.json
@@ -2860,7 +2860,7 @@
     "Every milestone your money has crossed, dated when it actually happened, and the months we have closed.": "Cada hito que ha cruzado tu dinero, con la fecha en que ocurrió de verdad, y los meses que hemos cerrado.",
     "Latest": "Lo último",
     "Nothing unlocked yet.": "Aún no has desbloqueado nada.",
-    "Nothing unlocked yet. Achievements are checked once a day: the first ones land as soon as you record a transaction or connect a bank, and anything you crossed before today unlocks with its real date.": "Aún no has desbloqueado nada. Los logros se revisan una vez al día: los primeros llegan en cuanto registres un movimiento o conectes un banco, y todo lo que ya cruzaste antes de hoy se desbloquea con su fecha real.",
+    "Nothing unlocked yet. Visit streaks unlock the moment you earn them; the rest are checked once a day, and anything you crossed before today unlocks with its real date.": "Aún no has desbloqueado nada. Las rachas de visitas se desbloquean en el momento en que las consigues; el resto se revisa una vez al día, y todo lo que ya cruzaste antes de hoy se desbloquea con su fecha real.",
     "Nothing yet": "Nada todavía",
     "One email a day when you unlock something, however many you unlock. They always show up in the app either way.": "Un correo al día cuando desbloqueas algo, por muchos que desbloquees. En la app aparecen igualmente.",
     "Rare": "Raro",
@@ -2945,5 +2945,7 @@
     "Visit streak: :days": "Racha de visitas: :days",
     ":count uncategorized transactions": ":count movimientos sin categorizar",
     "A month with everything categorized is a month you can actually read.": "Un mes con todo categorizado es un mes que puedes leer de verdad.",
-    "Not now": "Ahora no"
+    "Not now": "Ahora no",
+    "Medal unlocked": "Medalla desbloqueada",
+    "See it": "Verla"
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -116,6 +116,15 @@
     --medal-gold: oklch(0.52 0.12 72);
     --medal-obsidian: oklch(0.45 0.075 74);
 
+    /* The visit streak pill in the header, struck in the same chroma family as
+       the copper/gold medals so the chrome reads as one set of colours. */
+    --streak-fill: oklch(0.968 0.028 72);
+    --streak-border: oklch(0.885 0.075 70);
+    --streak-track: oklch(0.93 0.035 74);
+    --streak-from: oklch(0.72 0.16 52);
+    --streak-to: oklch(0.63 0.19 34);
+    --streak-ink: oklch(0.46 0.12 40);
+
     --radius: 0.625rem;
     --sidebar: oklch(0.985 0 0);
     --sidebar-foreground: oklch(0.145 0 0);
@@ -151,6 +160,12 @@
     --medal-steel: oklch(0.8 0.012 252);
     --medal-gold: oklch(0.84 0.13 90);
     --medal-obsidian: oklch(0.84 0.13 90);
+    --streak-fill: oklch(0.3 0.055 55);
+    --streak-border: oklch(0.44 0.09 55);
+    --streak-track: oklch(0.36 0.055 58);
+    --streak-from: oklch(0.8 0.15 66);
+    --streak-to: oklch(0.72 0.18 44);
+    --streak-ink: oklch(0.9 0.1 78);
     --chart-1: var(--color-zinc-200);
     --chart-2: var(--color-zinc-300);
     --chart-3: var(--color-zinc-400);
@@ -388,6 +403,142 @@
 
     .unlock-icon-pulse {
         animation: icon-pulse 2s ease-in-out infinite;
+    }
+
+    /*
+     * The visit streak pill.
+     *
+     * Two registers. The flame flickers and the halo breathes for as long as
+     * the pill is on screen, which is what makes a run look alive rather than
+     * counted. On top of that the `-flare` / `-burst` / `streak-pop` variants
+     * play once, the morning the run went up; they restate the resting
+     * animation after their own delay so the flame settles back into its
+     * flicker instead of freezing.
+     *
+     * Everything here is switched off wholesale for a reader who asked for
+     * less motion — see the media query at the end of the block. A pill that
+     * moves forever in the app chrome is exactly what that setting is for.
+     */
+    @keyframes streak-flicker {
+        0%,
+        100% {
+            transform: scale(1) rotate(0deg);
+            opacity: 0.92;
+        }
+        42% {
+            transform: scale(1.16) rotate(-4deg);
+            opacity: 1;
+        }
+        68% {
+            transform: scale(1.04) rotate(3deg);
+            opacity: 0.96;
+        }
+    }
+
+    @keyframes streak-glow {
+        0%,
+        100% {
+            opacity: 0.28;
+            transform: scale(0.86);
+        }
+        50% {
+            opacity: 0.7;
+            transform: scale(1.18);
+        }
+    }
+
+    /* The ring drawing itself up to its percentage. `--streak-dash` is the
+       struck length the component already computes for `stroke-dasharray`. */
+    @keyframes streak-draw {
+        from {
+            stroke-dashoffset: var(--streak-dash);
+        }
+        to {
+            stroke-dashoffset: 0;
+        }
+    }
+
+    @keyframes streak-flare {
+        0% {
+            transform: scale(1) rotate(0deg);
+        }
+        35% {
+            transform: scale(1.75) rotate(-8deg);
+            opacity: 1;
+        }
+        100% {
+            transform: scale(1) rotate(0deg);
+        }
+    }
+
+    @keyframes streak-burst {
+        0% {
+            opacity: 0.35;
+            transform: scale(0.8);
+        }
+        40% {
+            opacity: 0.95;
+            transform: scale(2.1);
+        }
+        100% {
+            opacity: 0.28;
+            transform: scale(0.86);
+        }
+    }
+
+    /* The new number arriving from below, the way a counter rolls over. */
+    @keyframes streak-pop {
+        0% {
+            transform: translateY(60%) scale(0.7);
+            opacity: 0;
+        }
+        55% {
+            transform: translateY(0) scale(1.4);
+            opacity: 1;
+        }
+        100% {
+            transform: none;
+        }
+    }
+
+    .streak-flame {
+        transform-origin: center;
+        animation: streak-flicker 1.9s ease-in-out infinite;
+    }
+
+    .streak-halo {
+        animation: streak-glow 2.6s ease-in-out infinite;
+    }
+
+    .streak-ring {
+        animation: streak-draw 0.9s cubic-bezier(0.22, 0.9, 0.3, 1);
+    }
+
+    /* The celebration variants replace the resting class rather than stacking
+       on it — two animations driving one transform fight — and hand the
+       element back to its resting loop once they are done. */
+    .streak-flame-flare {
+        animation:
+            streak-flare 0.9s cubic-bezier(0.22, 0.9, 0.3, 1),
+            streak-flicker 1.9s ease-in-out 0.9s infinite;
+    }
+
+    .streak-halo-burst {
+        animation:
+            streak-burst 0.9s cubic-bezier(0.22, 0.9, 0.3, 1),
+            streak-glow 2.6s ease-in-out 0.9s infinite;
+    }
+
+    .streak-count-pop {
+        display: inline-block;
+        animation: streak-pop 0.7s cubic-bezier(0.22, 0.9, 0.3, 1);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .streak-chip,
+        .streak-chip * {
+            animation: none !important;
+        }
     }
 }
 

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -540,6 +540,90 @@
             animation: none !important;
         }
     }
+
+    /*
+     * A medal being struck, for the toast that announces one.
+     *
+     * Visit medals land on the request that earns them rather than overnight,
+     * so there is a moment to mark: the medal turns into place, a sweep of
+     * light crosses it and the warmth behind it flares out once. It plays a
+     * single time and the toast is gone ten seconds later.
+     */
+    @keyframes medal-strike {
+        0% {
+            transform: perspective(400px) rotateY(-180deg) scale(0.4);
+            opacity: 0;
+        }
+        45% {
+            transform: perspective(400px) rotateY(0deg) scale(1.25);
+            opacity: 1;
+        }
+        70% {
+            transform: perspective(400px) rotateY(0deg) scale(0.94);
+        }
+        100% {
+            transform: none;
+        }
+    }
+
+    @keyframes medal-shine {
+        0%,
+        14% {
+            opacity: 0;
+            transform: translateX(-150%) skewX(-18deg);
+        }
+        45% {
+            opacity: 1;
+        }
+        78%,
+        100% {
+            opacity: 0;
+            transform: translateX(150%) skewX(-18deg);
+        }
+    }
+
+    @keyframes medal-burst {
+        0% {
+            opacity: 0;
+            transform: scale(0.4);
+        }
+        35% {
+            opacity: 0.8;
+            transform: scale(1.55);
+        }
+        100% {
+            opacity: 0;
+            transform: scale(2.2);
+        }
+    }
+
+    .medal-strike {
+        animation: medal-strike 0.85s cubic-bezier(0.22, 0.9, 0.3, 1) both;
+    }
+
+    .medal-shine {
+        animation: medal-shine 1.4s ease-in-out 0.25s both;
+    }
+
+    .medal-burst {
+        animation: medal-burst 1.1s ease-out both;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        /* The medal still arrives, it just stops performing: `both` would
+           otherwise leave the burst frozen on its last frame, invisible, and
+           the medal frozen on its first, turned edge-on and gone. */
+        .medal-strike,
+        .medal-shine,
+        .medal-burst {
+            animation: none !important;
+        }
+
+        .medal-shine,
+        .medal-burst {
+            display: none;
+        }
+    }
 }
 
 /*

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -19,6 +19,7 @@ import { StrictMode, useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { toast, Toaster } from 'sonner';
 import { update as updateTimezone } from './actions/App/Http/Controllers/Settings/TimezoneController';
+import { MedalUnlockedToast } from './components/achievements/medal-unlocked-toast';
 import { UncategorizedToast } from './components/achievements/uncategorized-toast';
 import { AppErrorBoundary } from './components/app-error-boundary';
 import { EncryptionKeyProvider } from './contexts/encryption-key-context';
@@ -276,6 +277,10 @@ createInertiaApp({
                                 />
                                 <UncategorizedToast
                                     initialChallenges={initialChallenges}
+                                />
+                                <MedalUnlockedToast
+                                    initialChallenges={initialChallenges}
+                                    userId={initialUser?.id}
                                 />
                                 <AppToaster />
                             </SyncProvider>

--- a/resources/js/components/achievements/medal-unlocked-toast.test.tsx
+++ b/resources/js/components/achievements/medal-unlocked-toast.test.tsx
@@ -1,0 +1,135 @@
+import { type ChallengeMedal, type Challenges } from '@/types';
+import { render, screen, waitFor } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { Toaster } from 'sonner';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/*
+ * "You just earned a medal".
+ *
+ * Visit medals land on the request that earns them, so the prop carrying the
+ * last one is always set for a reader who holds any. What decides whether it is
+ * news is this device's memory of the last one announced: a medal nobody has
+ * been told about is a moment, the same medal on the next page is not, and a
+ * device that has never been told anything has no moment to replay.
+ */
+
+const USER_ID = 'a1b2c3d4';
+const MEDAL_SEEN_KEY = 'medal-seen';
+
+vi.mock('@inertiajs/react', () => ({
+    router: { on: () => () => {} },
+    Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+}));
+
+function medal(overrides: Partial<ChallengeMedal> = {}): ChallengeMedal {
+    return {
+        key: 'visits.3',
+        track: 'visits',
+        rarity: 'uncommon',
+        icon: 'calendar-days',
+        name: 'Visit streak',
+        figure: { type: 'days', value: 30, currency: null },
+        progress: null,
+        ...overrides,
+    };
+}
+
+function challenges(unlocked: ChallengeMedal | null): Challenges {
+    return {
+        visit_streak: 30,
+        medals: [],
+        unlocked,
+        uncategorized: null,
+    };
+}
+
+/**
+ * The shell, in `app.tsx`'s own order: the toast component first, the toaster
+ * after it. Re-imported per test because the once-per-session latch is module
+ * state, exactly as the categorize prompt's suite does it.
+ */
+async function mountShell(
+    props: Challenges | null,
+    userId: string | undefined = USER_ID,
+) {
+    const { MedalUnlockedToast } = await import('./medal-unlocked-toast');
+
+    return render(
+        <>
+            <MedalUnlockedToast initialChallenges={props} userId={userId} />
+            <Toaster />
+        </>,
+    );
+}
+
+const announced = () => screen.queryByText('Medal unlocked');
+
+describe('MedalUnlockedToast', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        localStorage.clear();
+    });
+
+    it('says nothing on a device that has never been told anything', async () => {
+        // The shelf may be years old. Greeting a new phone with a medal from
+        // March would be a lie, so the first visit only takes note.
+        await mountShell(challenges(medal()));
+
+        await waitFor(() =>
+            expect(localStorage.getItem(MEDAL_SEEN_KEY)).toBe(
+                `${USER_ID}:visits.3`,
+            ),
+        );
+        expect(announced()).toBeNull();
+    });
+
+    it('announces a medal this device has not seen before', async () => {
+        localStorage.setItem(MEDAL_SEEN_KEY, `${USER_ID}:visits.2`);
+
+        await mountShell(challenges(medal()));
+
+        expect(await screen.findByText('Medal unlocked')).toBeInTheDocument();
+        expect(screen.getByText('Visit streak')).toBeInTheDocument();
+        expect(localStorage.getItem(MEDAL_SEEN_KEY)).toBe(
+            `${USER_ID}:visits.3`,
+        );
+    });
+
+    it('says nothing about the same medal twice', async () => {
+        // Which is what every page after the one that earned it is.
+        localStorage.setItem(MEDAL_SEEN_KEY, `${USER_ID}:visits.3`);
+
+        await mountShell(challenges(medal()));
+
+        await waitFor(() => expect(announced()).toBeNull());
+    });
+
+    it('ignores the medal another account left behind', async () => {
+        // One browser, two logins. The other reader's shelf says nothing about
+        // this one's, and replaying it would be somebody else's moment.
+        localStorage.setItem(MEDAL_SEEN_KEY, 'someone-else:visits.1');
+
+        await mountShell(challenges(medal()));
+
+        await waitFor(() =>
+            expect(localStorage.getItem(MEDAL_SEEN_KEY)).toBe(
+                `${USER_ID}:visits.3`,
+            ),
+        );
+        expect(announced()).toBeNull();
+    });
+
+    it('says nothing for a reader holding no medals at all', async () => {
+        await mountShell(challenges(null));
+
+        await waitFor(() => expect(announced()).toBeNull());
+        expect(localStorage.getItem(MEDAL_SEEN_KEY)).toBeNull();
+    });
+
+    it('says nothing with the feature switched off', async () => {
+        await mountShell(null);
+
+        await waitFor(() => expect(announced()).toBeNull());
+    });
+});

--- a/resources/js/components/achievements/medal-unlocked-toast.tsx
+++ b/resources/js/components/achievements/medal-unlocked-toast.tsx
@@ -1,0 +1,141 @@
+import { AchievementFigure } from '@/components/achievements/achievement-figure';
+import { Medal } from '@/components/achievements/medal';
+import { useChallengesToast } from '@/components/achievements/use-challenges-toast';
+import { readOwnedValue, writeOwnedValue } from '@/lib/safe-storage';
+import { index as progressScreen } from '@/routes/achievements';
+import { type ChallengeMedal, type Challenges } from '@/types';
+import { __ } from '@/utils/i18n';
+import { Link } from '@inertiajs/react';
+import { ArrowRightIcon } from 'lucide-react';
+import { useCallback } from 'react';
+import { toast } from 'sonner';
+
+/*
+ * "You just earned a medal" — the one toast that announces rather than asks.
+ *
+ * Visit medals are settled the moment the run reaches the rung, on the request
+ * that moves it, so by the time a screen renders the medal is already on the
+ * shelf. Something has to say so out loud: a row quietly appearing in the bell
+ * is a record, not a moment, and the run is the one thing in the app the reader
+ * earned by simply turning up.
+ *
+ * Ten seconds and dismissible, unlike the categorize prompt next door: that one
+ * asks for work and waits to be acted on, this one is over once it has been
+ * read.
+ */
+const TOAST_ID = 'medal-unlocked';
+
+/**
+ * The last medal announced on this device, keyed by reader.
+ *
+ * Same bargain the streak pill makes, and for the same reason: the server knows
+ * the medal was awarded but not whether this reader has been told, and a column
+ * to carry "have you seen it" would be a migration and a write on the request
+ * path for something purely cosmetic. Nothing stored yet means nothing is
+ * announced — a shelf full of old medals is not news, and greeting a new device
+ * with a medal from March would be a lie.
+ */
+const MEDAL_SEEN_KEY = 'medal-seen';
+
+let shown = false;
+
+function MedalUnlockedToastBody({ medal }: { medal: ChallengeMedal }) {
+    return (
+        <div className="flex w-full items-center gap-3 rounded-lg border bg-popover p-3.5 text-popover-foreground shadow-lg">
+            <span className="relative flex size-12 shrink-0 items-center justify-center">
+                <span
+                    aria-hidden
+                    className="medal-burst absolute inset-0 rounded-full bg-[radial-gradient(circle,var(--streak-to)_0%,transparent_70%)]"
+                />
+                {/* The sweep of light rides on its own clipped layer: the medal
+                    itself is an SVG of gradients and must not be masked. */}
+                <span className="medal-strike relative flex size-12 items-center justify-center overflow-hidden rounded-full">
+                    <Medal rarity={medal.rarity} icon={medal.icon} size={44} />
+                    <span
+                        aria-hidden
+                        className="medal-shine absolute -inset-x-2 inset-y-0 bg-linear-to-r from-transparent via-white/70 to-transparent"
+                    />
+                </span>
+            </span>
+
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                <span className="text-[13px] leading-4 font-semibold">
+                    {__('Medal unlocked')}
+                </span>
+                <span className="text-xs leading-4 text-muted-foreground">
+                    {medal.name}
+                </span>
+                {medal.figure && (
+                    <AchievementFigure
+                        figure={medal.figure}
+                        className="text-[13px] leading-4 font-semibold text-[var(--streak-ink)]"
+                    />
+                )}
+            </div>
+
+            <Link
+                href={progressScreen()}
+                onClick={() => toast.dismiss(TOAST_ID)}
+                className="flex shrink-0 items-center gap-1 self-center rounded-md px-2 py-1 text-[13px] font-medium text-muted-foreground transition-colors hover:text-foreground"
+            >
+                {__('See it')}
+                <ArrowRightIcon className="size-3.5" />
+            </Link>
+        </div>
+    );
+}
+
+/** Whether this medal is news to this reader, recording it either way. */
+function isNews(medal: ChallengeMedal, userId: string): boolean {
+    const seen = readOwnedValue(MEDAL_SEEN_KEY, userId);
+
+    writeOwnedValue(MEDAL_SEEN_KEY, userId, medal.key);
+
+    return seen !== null && seen !== medal.key;
+}
+
+function show(challenges: Challenges | null, userId: string | undefined): void {
+    const medal = challenges?.unlocked ?? null;
+
+    if (shown || medal === null || userId === undefined) {
+        return;
+    }
+
+    shown = true;
+
+    if (!isNews(medal, userId)) {
+        return;
+    }
+
+    // A tick late, for the same reason the categorize prompt is: sonner keeps
+    // no backlog, and `<Toaster/>` subscribes from an effect of its own, so a
+    // toast raised while the shell is still mounting is broadcast to nobody.
+    queueMicrotask(() =>
+        toast.custom(() => <MedalUnlockedToastBody medal={medal} />, {
+            id: TOAST_ID,
+            duration: 10000,
+        }),
+    );
+}
+
+/**
+ * Mounted once in the shell, beside the toaster and the categorize prompt.
+ */
+export function MedalUnlockedToast({
+    initialChallenges,
+    userId,
+}: {
+    initialChallenges: Challenges | null;
+    userId: string | undefined;
+}) {
+    // Stable, or the hook would drop and re-take its navigation subscription
+    // on every render of the shell.
+    const fire = useCallback(
+        (challenges: Challenges | null) => show(challenges, userId),
+        [userId],
+    );
+
+    useChallengesToast(initialChallenges, fire);
+
+    return null;
+}

--- a/resources/js/components/achievements/streak-chip.test.tsx
+++ b/resources/js/components/achievements/streak-chip.test.tsx
@@ -39,6 +39,7 @@ vi.mock('@/hooks/use-mobile', () => ({ useIsMobile: () => false }));
 
 function medal(overrides: Partial<ChallengeMedal> = {}): ChallengeMedal {
     return {
+        key: 'visits.3',
         track: 'visits',
         rarity: 'uncommon',
         icon: 'calendar-days',
@@ -63,6 +64,7 @@ function chip(challenges: Partial<Challenges> = {}): Challenges {
     return {
         visit_streak: 12,
         medals: [medal()],
+        unlocked: null,
         uncategorized: null,
         ...challenges,
     };

--- a/resources/js/components/achievements/streak-chip.test.tsx
+++ b/resources/js/components/achievements/streak-chip.test.tsx
@@ -1,7 +1,7 @@
 import { type ChallengeMedal, type Challenges } from '@/types';
 import { render, screen } from '@testing-library/react';
-import { type ReactNode } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { StrictMode, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { StreakChip } from './streak-chip';
 
 /*
@@ -11,10 +11,21 @@ import { StreakChip } from './streak-chip';
  * towards the next rung, the real medal in the ring's place while the sweep
  * catches up, and a full ring for a reader with nothing left to reach. A reader
  * with no live run gets no pill at all — there is nothing to keep.
+ *
+ * The fourth thing under test is the celebration: the pill flares only when the
+ * run has grown past the last number this device saw for *this* user, and never
+ * on a device that has never seen one.
  */
 
+const USER_ID = 'a1b2c3d4';
+const STREAK_SEEN_KEY = 'streak-seen';
+
 const page = vi.hoisted(() => ({
-    props: {} as { challenges: Challenges | null; locale: string },
+    props: {} as {
+        auth: { user: { id: string } };
+        challenges: Challenges | null;
+        locale: string;
+    },
 }));
 
 vi.mock('@inertiajs/react', () => ({
@@ -39,7 +50,11 @@ function medal(overrides: Partial<ChallengeMedal> = {}): ChallengeMedal {
 }
 
 function draw(challenges: Challenges | null) {
-    page.props = { challenges, locale: 'en-US' };
+    page.props = {
+        auth: { user: { id: USER_ID } },
+        challenges,
+        locale: 'en-US',
+    };
 
     return render(<StreakChip />);
 }
@@ -71,6 +86,14 @@ function ringFill(container: HTMLElement): number | null {
 /** The medallion itself, which the ring is never mistaken for: it is bigger. */
 const medallion = (container: HTMLElement) =>
     container.querySelector('svg[viewBox="0 0 48 48"]');
+
+/** Whether the one-off "+1" flare is on, rather than the resting flicker. */
+const celebrating = (container: HTMLElement) =>
+    container.querySelector('.streak-flame-flare') !== null;
+
+beforeEach(() => {
+    localStorage.clear();
+});
 
 describe('StreakChip', () => {
     it('is not drawn at all with the feature switched off', () => {
@@ -126,7 +149,11 @@ describe('StreakChip', () => {
 
         expect(medallion(container)).not.toBeNull();
         expect(ringFill(container)).toBeNull();
-        expect(container.querySelector('button')).toHaveClass('bg-muted');
+        // The warm skin is the pill's own and does not change with the state:
+        // it is the medal, not a fill, that marks this one out.
+        expect(container.querySelector('button')).toHaveClass(
+            'bg-[var(--streak-fill)]',
+        );
     });
 
     it('fills the ring for a reader past the last rung', () => {
@@ -137,5 +164,112 @@ describe('StreakChip', () => {
         expect(screen.getByText('400')).toBeInTheDocument();
         expect(ringFill(container)).toBe(100);
         expect(medallion(container)).toBeNull();
+    });
+
+    it('plays the entrance once per page load, not on every visit', async () => {
+        // No screen keeps the header across an Inertia visit, so the pill
+        // remounts on every click. A plain mount animation would replay the
+        // entrance each time; a fresh module is a fresh page load.
+        vi.resetModules();
+        const { StreakChip: Fresh } = await import('./streak-chip');
+
+        page.props = {
+            auth: { user: { id: USER_ID } },
+            challenges: chip(),
+            locale: 'en-US',
+        };
+
+        const first = render(<Fresh />);
+
+        expect(first.container.querySelector('button')).toHaveClass(
+            'animate-in',
+        );
+        expect(first.container.querySelector('.streak-ring')).not.toBeNull();
+
+        first.unmount();
+
+        const second = render(<Fresh />);
+
+        expect(second.container.querySelector('button')).not.toHaveClass(
+            'animate-in',
+        );
+        expect(second.container.querySelector('.streak-ring')).toBeNull();
+    });
+
+    it('does not celebrate on a device that has never seen this run', () => {
+        // Nothing stored: the reader may have been on this run for weeks, and
+        // cheering it now would be a lie.
+        const { container } = draw(chip());
+
+        expect(celebrating(container)).toBe(false);
+        expect(localStorage.getItem(STREAK_SEEN_KEY)).toBe(`${USER_ID}:12`);
+    });
+
+    it('celebrates once when the run has grown since the last visit', () => {
+        localStorage.setItem(STREAK_SEEN_KEY, `${USER_ID}:11`);
+
+        const { container } = draw(chip());
+
+        expect(celebrating(container)).toBe(true);
+        expect(localStorage.getItem(STREAK_SEEN_KEY)).toBe(`${USER_ID}:12`);
+    });
+
+    it('survives an effect that runs twice for the same number', () => {
+        // StrictMode replays effects in development, and the effect reads the
+        // very value it then overwrites: a second pass must not talk itself out
+        // of the celebration the first one earned.
+        localStorage.setItem(STREAK_SEEN_KEY, `${USER_ID}:11`);
+        page.props = {
+            auth: { user: { id: USER_ID } },
+            challenges: chip(),
+            locale: 'en-US',
+        };
+
+        const { container } = render(
+            <StrictMode>
+                <StreakChip />
+            </StrictMode>,
+        );
+
+        expect(celebrating(container)).toBe(true);
+    });
+
+    it('does not celebrate the same number twice', () => {
+        // Which is what every navigation after the first one of the day is.
+        localStorage.setItem(STREAK_SEEN_KEY, `${USER_ID}:12`);
+
+        const { container } = draw(chip());
+
+        expect(celebrating(container)).toBe(false);
+    });
+
+    it('does not celebrate another account\u2019s number', () => {
+        // One browser, two logins: the number left behind by the other account
+        // says nothing about this one.
+        localStorage.setItem(STREAK_SEEN_KEY, 'someone-else:3');
+
+        const { container } = draw(chip());
+
+        expect(celebrating(container)).toBe(false);
+        expect(localStorage.getItem(STREAK_SEEN_KEY)).toBe(`${USER_ID}:12`);
+    });
+
+    it('celebrates a run restarted after a break', () => {
+        // The break stored a zero, so day one of the next run is a rise.
+        localStorage.setItem(STREAK_SEEN_KEY, `${USER_ID}:0`);
+
+        const { container } = draw(chip({ visit_streak: 1 }));
+
+        expect(celebrating(container)).toBe(true);
+    });
+
+    it('records the broken run so the next day reads as a rise', () => {
+        localStorage.setItem(STREAK_SEEN_KEY, `${USER_ID}:12`);
+
+        // No pill is drawn for a dead run, but the number is still the last one
+        // the reader saw: leaving 12 behind would swallow the whole next run.
+        draw(chip({ visit_streak: 0 }));
+
+        expect(localStorage.getItem(STREAK_SEEN_KEY)).toBe(`${USER_ID}:0`);
     });
 });

--- a/resources/js/components/achievements/streak-chip.tsx
+++ b/resources/js/components/achievements/streak-chip.tsx
@@ -9,13 +9,14 @@ import {
 import { Medal } from '@/components/achievements/medal';
 import { AdaptivePopover } from '@/components/ui/adaptive-popover';
 import { useIsMobile } from '@/hooks/use-mobile';
+import { readStoredValue, writeStoredValue } from '@/lib/safe-storage';
 import { cn } from '@/lib/utils';
 import { index as progressScreen } from '@/routes/achievements';
 import { type ChallengeMedal, type SharedData } from '@/types';
 import { __ } from '@/utils/i18n';
 import { Link, usePage } from '@inertiajs/react';
 import { ArrowRightIcon, FlameIcon } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useId, useRef, useState, type CSSProperties } from 'react';
 
 /*
  * The visit streak, in the header, on every screen.
@@ -36,39 +37,161 @@ import { useState } from 'react';
  *    the number keeps climbing.
  *
  * Not drawn at all without a live run, or with the feature switched off.
+ *
+ * The skin is warm — fill, border, ring and number all come from the
+ * `--streak-*` tokens — and the flame is alive: it flickers over a halo that
+ * breathes, and both stop dead for a reader who asked for less motion. The
+ * medal in state 2 keeps its own metal; only the pill around it is tinted.
  */
 
 const RING_RADIUS = 10;
 const RING_LENGTH = 2 * Math.PI * RING_RADIUS;
 
-function StreakRing({ percent }: { percent: number }) {
+function StreakRing({
+    percent,
+    celebrating,
+    entering,
+}: {
+    percent: number;
+    celebrating: boolean;
+    entering: boolean;
+}) {
+    // Same treatment `medal.tsx` gives its own gradients: a hand-written id
+    // would be shared by every ring on the page.
+    const gradient = useId();
+    const struck = (percent / 100) * RING_LENGTH;
+
     return (
         <span className="relative inline-flex size-[22px] shrink-0 items-center justify-center md:size-6">
+            <span
+                aria-hidden
+                className={cn(
+                    'absolute -inset-0.5 rounded-full bg-[radial-gradient(circle,var(--streak-to)_0%,transparent_68%)] opacity-40',
+                    celebrating ? 'streak-halo-burst' : 'streak-halo',
+                )}
+            />
             <svg viewBox="0 0 24 24" className="size-full" aria-hidden>
+                <defs>
+                    <linearGradient id={gradient} x1="0" y1="0" x2="1" y2="1">
+                        {/* `style`, not the `stop-color` attribute: Safari
+                            does not substitute `var()` inside an SVG
+                            presentation attribute and the ring comes out
+                            black. */}
+                        <stop
+                            offset="0"
+                            style={{ stopColor: 'var(--streak-from)' }}
+                        />
+                        <stop
+                            offset="1"
+                            style={{ stopColor: 'var(--streak-to)' }}
+                        />
+                    </linearGradient>
+                </defs>
                 <g transform="rotate(-90 12 12)">
                     <circle
                         cx="12"
                         cy="12"
                         r={RING_RADIUS}
                         fill="none"
-                        stroke="var(--border)"
+                        stroke="var(--streak-track)"
                         strokeWidth="2.5"
                     />
                     <circle
+                        className={cn(entering && 'streak-ring')}
+                        // The arc draws itself in from nothing: the keyframes
+                        // walk `stroke-dashoffset` down from the struck length
+                        // to zero, which leaves the dash array itself alone.
+                        style={{ '--streak-dash': struck } as CSSProperties}
                         cx="12"
                         cy="12"
                         r={RING_RADIUS}
                         fill="none"
-                        stroke="var(--foreground)"
+                        stroke={`url(#${gradient})`}
                         strokeWidth="2.5"
                         strokeLinecap="round"
-                        strokeDasharray={`${(percent / 100) * RING_LENGTH} ${RING_LENGTH}`}
+                        strokeDasharray={`${struck} ${RING_LENGTH}`}
                     />
                 </g>
             </svg>
-            <FlameIcon className="absolute size-[11px] md:size-3" />
+            <FlameIcon
+                className={cn(
+                    'absolute size-[11px] fill-current stroke-none text-[var(--streak-to)] md:size-3',
+                    celebrating ? 'streak-flame-flare' : 'streak-flame',
+                )}
+            />
         </span>
     );
+}
+
+/*
+ * Whether the run has grown since this reader last looked.
+ *
+ * Nothing on the server says "the streak advanced": `TrackLastActiveAt` carries
+ * the run forward silently and the shared props only ever state today's number.
+ * So the last number the reader saw is remembered here, on the device, keyed by
+ * user the way the onboarding resume point is — one browser is shared by more
+ * than one account often enough to matter.
+ *
+ * Per device on purpose: opening the app on the phone after the laptop replays
+ * the moment. That is the right side to err on for something that only ever
+ * adds a flourish, and it buys a celebration that survives a hard refresh
+ * without a column on the users table to carry it.
+ *
+ * No number stored at all — the first visit on this device — means no
+ * celebration. Cheering a run the reader has been on for weeks would be a lie.
+ */
+const STREAK_SEEN_KEY = 'streak-seen';
+
+/*
+ * Whether this is the first time the pill has been drawn since the page loaded.
+ *
+ * "On mount" is not the same thing here: no screen keeps the header across an
+ * Inertia visit, so the whole chrome remounts on every click and a plain mount
+ * animation would replay the entrance every time the reader opens a screen.
+ * Module scope is exactly the lifetime wanted instead — it outlives a
+ * client-side visit and dies with the page — so the entrance lands once per
+ * full load, which is what the design asks for.
+ */
+let entered = false;
+
+function useEntrance(): boolean {
+    const [entering] = useState(() => !entered);
+
+    useEffect(() => {
+        entered = true;
+    }, []);
+
+    return entering;
+}
+
+function useStreakRaised(userId: string, streak: number | null): boolean {
+    const [raised, setRaised] = useState(false);
+    // The effect reads what it is about to overwrite, so running it twice for
+    // the same number answers "no rise" the second time and swallows the
+    // celebration. StrictMode does exactly that in development, and an Inertia
+    // navigation that remounts the header would do it in production. Recording
+    // the number already handled makes the second pass a no-op while still
+    // letting a genuinely new number through.
+    const recorded = useRef<number | null>(null);
+
+    useEffect(() => {
+        if (streak === null || recorded.current === streak) {
+            return;
+        }
+
+        recorded.current = streak;
+
+        const [owner, seen] = (readStoredValue(STREAK_SEEN_KEY) ?? '').split(
+            ':',
+        );
+
+        // `Number(undefined)` is NaN and every comparison against it is false,
+        // which is exactly the "nothing stored yet" answer we want.
+        setRaised(owner === userId && streak > Number(seen));
+        writeStoredValue(STREAK_SEEN_KEY, `${userId}:${streak}`);
+    }, [userId, streak]);
+
+    return raised;
 }
 
 /**
@@ -115,9 +238,16 @@ function PanelRow({
 }
 
 export function StreakChip({ className }: { className?: string }) {
-    const { challenges } = usePage<SharedData>().props;
+    const { auth, challenges } = usePage<SharedData>().props;
     const isMobile = useIsMobile();
     const [open, setOpen] = useState(false);
+    // Above the early return, so the number the reader is looking at is
+    // recorded even on the renders that draw no pill at all.
+    const celebrating = useStreakRaised(
+        auth.user.id,
+        challenges ? challenges.visit_streak : null,
+    );
+    const entering = useEntrance();
 
     if (!challenges || challenges.visit_streak < 1) {
         return null;
@@ -142,10 +272,12 @@ export function StreakChip({ className }: { className?: string }) {
                 // The phone needs 44px of pushable area around a 30px pill, and
                 // padding that big would wreck the pill: `ui/sidebar` solves the
                 // same problem the same way.
-                'relative inline-flex h-[30px] cursor-pointer items-center gap-[7px] rounded-full border pr-[11px] pl-[5px] transition-colors md:h-8',
+                // `streak-chip` is what the reduced-motion rule in app.css
+                // hangs off: it silences every animation inside the pill.
+                'streak-chip relative inline-flex h-[30px] cursor-pointer items-center gap-[7px] rounded-full border border-[var(--streak-border)] bg-[var(--streak-fill)] pr-[11px] pl-[5px] transition-colors md:h-8',
                 'after:absolute after:-inset-2 md:after:hidden',
-                'hover:border-ring hover:bg-muted',
-                unlocking && 'bg-muted',
+                'hover:border-[var(--streak-to)]',
+                entering && 'animate-in duration-500 fade-in-0 zoom-in-95',
                 className,
             )}
         >
@@ -156,9 +288,18 @@ export function StreakChip({ className }: { className?: string }) {
                     size={isMobile ? 22 : 24}
                 />
             ) : (
-                <StreakRing percent={percent} />
+                <StreakRing
+                    percent={percent}
+                    celebrating={celebrating}
+                    entering={entering}
+                />
             )}
-            <span className="text-[13px] leading-none font-semibold tabular-nums">
+            <span
+                className={cn(
+                    'text-[13px] leading-none font-semibold text-[var(--streak-ink)] tabular-nums',
+                    celebrating && 'streak-count-pop',
+                )}
+            >
                 {streak}
             </span>
         </button>

--- a/resources/js/components/achievements/streak-chip.tsx
+++ b/resources/js/components/achievements/streak-chip.tsx
@@ -9,7 +9,7 @@ import {
 import { Medal } from '@/components/achievements/medal';
 import { AdaptivePopover } from '@/components/ui/adaptive-popover';
 import { useIsMobile } from '@/hooks/use-mobile';
-import { readStoredValue, writeStoredValue } from '@/lib/safe-storage';
+import { readOwnedValue, writeOwnedValue } from '@/lib/safe-storage';
 import { cn } from '@/lib/utils';
 import { index as progressScreen } from '@/routes/achievements';
 import { type ChallengeMedal, type SharedData } from '@/types';
@@ -31,8 +31,10 @@ import { useEffect, useId, useRef, useState, type CSSProperties } from 'react';
  * Three states, and the pill has to read as itself in all three:
  *
  * 1. Mid-run: a ring filling towards the next rung.
- * 2. Standing on the rung with the medal still locked — the sweep runs at night
- *    — so the real medal takes the ring's place and the pill fills in.
+ * 2. Standing on the rung with the medal still locked, so the real medal takes
+ *    the ring's place. Rare now that a visit medal is awarded on the request
+ *    that earns it: what is left is the reader the sweep has never been
+ *    through, whose first pass is the one that reads a whole life.
  * 3. Past the last rung: nothing left to aim at, so the ring is simply full and
  *    the number keeps climbing.
  *
@@ -129,8 +131,8 @@ function StreakRing({
  * Nothing on the server says "the streak advanced": `TrackLastActiveAt` carries
  * the run forward silently and the shared props only ever state today's number.
  * So the last number the reader saw is remembered here, on the device, keyed by
- * user the way the onboarding resume point is — one browser is shared by more
- * than one account often enough to matter.
+ * user — see `readOwnedValue`, which is why another account's number reads as
+ * nothing rather than as a rise.
  *
  * Per device on purpose: opening the app on the phone after the laptop replays
  * the moment. That is the right side to err on for something that only ever
@@ -181,14 +183,10 @@ function useStreakRaised(userId: string, streak: number | null): boolean {
 
         recorded.current = streak;
 
-        const [owner, seen] = (readStoredValue(STREAK_SEEN_KEY) ?? '').split(
-            ':',
-        );
+        const seen = readOwnedValue(STREAK_SEEN_KEY, userId);
 
-        // `Number(undefined)` is NaN and every comparison against it is false,
-        // which is exactly the "nothing stored yet" answer we want.
-        setRaised(owner === userId && streak > Number(seen));
-        writeStoredValue(STREAK_SEEN_KEY, `${userId}:${streak}`);
+        setRaised(seen !== null && streak > Number(seen));
+        writeOwnedValue(STREAK_SEEN_KEY, userId, String(streak));
     }, [userId, streak]);
 
     return raised;

--- a/resources/js/components/achievements/uncategorized-toast.test.tsx
+++ b/resources/js/components/achievements/uncategorized-toast.test.tsx
@@ -30,7 +30,7 @@ vi.mock('axios', () => ({
 }));
 
 function challenges(uncategorized: Challenges['uncategorized']): Challenges {
-    return { visit_streak: 3, medals: [], uncategorized };
+    return { visit_streak: 3, medals: [], unlocked: null, uncategorized };
 }
 
 /**
@@ -59,6 +59,7 @@ describe('UncategorizedToast', () => {
             challenges({
                 count: 4,
                 medal: {
+                    key: 'categorized.4',
                     track: 'categorized',
                     rarity: 'epic',
                     icon: 'tags',

--- a/resources/js/components/achievements/uncategorized-toast.tsx
+++ b/resources/js/components/achievements/uncategorized-toast.tsx
@@ -1,14 +1,14 @@
 import { MedalProgress } from '@/components/achievements/achievement-cell';
 import { monthsLabel } from '@/components/achievements/achievement-figure';
+import { useChallengesToast } from '@/components/achievements/use-challenges-toast';
 import { snooze } from '@/routes/achievements/uncategorized';
 import { index as transactionsIndex } from '@/routes/transactions';
-import { type Challenges, type SharedData } from '@/types';
+import { type Challenges } from '@/types';
 import { __ } from '@/utils/i18n';
-import { Link, router } from '@inertiajs/react';
+import { Link } from '@inertiajs/react';
 import axios from 'axios';
 import { endOfMonth, format, startOfMonth } from 'date-fns';
 import { TagsIcon } from 'lucide-react';
-import { useEffect } from 'react';
 import { toast } from 'sonner';
 
 /**
@@ -141,15 +141,7 @@ export function UncategorizedToast({
 }: {
     initialChallenges: Challenges | null;
 }) {
-    useEffect(() => {
-        show(initialChallenges);
-
-        return router.on('navigate', (event) => {
-            const pageProps = event.detail.page.props as unknown as SharedData;
-
-            show(pageProps.challenges);
-        });
-    }, [initialChallenges]);
+    useChallengesToast(initialChallenges, show);
 
     return null;
 }

--- a/resources/js/components/achievements/use-challenges-toast.ts
+++ b/resources/js/components/achievements/use-challenges-toast.ts
@@ -1,0 +1,27 @@
+import { type Challenges, type SharedData } from '@/types';
+import { router } from '@inertiajs/react';
+import { useEffect } from 'react';
+
+/**
+ * Fires a challenges toast from the shell: once on the first page, and again on
+ * every visit for the reader whose first screen had nothing to say.
+ *
+ * The shell is where these belong rather than a page — every screen carries the
+ * props — but the shell is also mounted once and never again, so the navigation
+ * subscription is the whole of the second half. `show` is expected to hold its
+ * own latch; this only decides when to ask.
+ */
+export function useChallengesToast(
+    initialChallenges: Challenges | null,
+    show: (challenges: Challenges | null) => void,
+): void {
+    useEffect(() => {
+        show(initialChallenges);
+
+        return router.on('navigate', (event) => {
+            const pageProps = event.detail.page.props as unknown as SharedData;
+
+            show(pageProps.challenges);
+        });
+    }, [initialChallenges, show]);
+}

--- a/resources/js/lib/safe-storage.test.ts
+++ b/resources/js/lib/safe-storage.test.ts
@@ -1,7 +1,12 @@
 import { initializeTheme } from '@/hooks/use-appearance';
 import { initializeChartColorScheme } from '@/hooks/use-chart-color-scheme';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { readStoredValue, writeStoredValue } from './safe-storage';
+import {
+    readOwnedValue,
+    readStoredValue,
+    writeOwnedValue,
+    writeStoredValue,
+} from './safe-storage';
 
 const realStorage = Object.getOwnPropertyDescriptor(
     window,
@@ -104,5 +109,32 @@ describe('boot initializers', () => {
         initializeTheme();
 
         expect(document.documentElement.classList.contains('dark')).toBe(true);
+    });
+});
+
+describe('per-user values', () => {
+    it('reads back what the same user wrote', () => {
+        writeOwnedValue('medal-seen', 'user-1', 'visits.3');
+
+        expect(readOwnedValue('medal-seen', 'user-1')).toBe('visits.3');
+    });
+
+    it('reads nothing for a different user on the same browser', () => {
+        // A household laptop, or a demo account opened beside a real one:
+        // replaying somebody else's moment is worse than replaying none.
+        writeOwnedValue('medal-seen', 'user-1', 'visits.3');
+
+        expect(readOwnedValue('medal-seen', 'user-2')).toBeNull();
+    });
+
+    it('reads nothing when nothing was ever written', () => {
+        expect(readOwnedValue('medal-seen', 'user-1')).toBeNull();
+    });
+
+    it('keeps a value that contains the separator whole', () => {
+        // Only the first separator divides owner from value.
+        writeOwnedValue('note', 'user-1', 'a:b:c');
+
+        expect(readOwnedValue('note', 'user-1')).toBe('a:b:c');
     });
 });

--- a/resources/js/lib/safe-storage.ts
+++ b/resources/js/lib/safe-storage.ts
@@ -54,3 +54,37 @@ export function removeStoredValue(key: string): void {
         // Same as above: nothing was persisted, so nothing needs clearing.
     }
 }
+
+/*
+ * A value remembered for one user in a store that belongs to the browser.
+ *
+ * One browser is shared by more than one account often enough to matter — a
+ * household laptop, a demo account opened next to a real one — and a "what did
+ * you last see" note read by the wrong reader is worse than no note at all: it
+ * either replays somebody else's moment or swallows your own. The owner is
+ * written next to the value and checked on the way out, so the wrong reader
+ * simply reads nothing.
+ */
+const OWNER_SEPARATOR = ':';
+
+export function readOwnedValue(key: string, userId: string): string | null {
+    const stored = readStoredValue(key);
+
+    if (stored === null) {
+        return null;
+    }
+
+    const separator = stored.indexOf(OWNER_SEPARATOR);
+
+    return separator !== -1 && stored.slice(0, separator) === userId
+        ? stored.slice(separator + 1)
+        : null;
+}
+
+export function writeOwnedValue(
+    key: string,
+    userId: string,
+    value: string,
+): void {
+    writeStoredValue(key, `${userId}${OWNER_SEPARATOR}${value}`);
+}

--- a/resources/js/pages/achievements/index.tsx
+++ b/resources/js/pages/achievements/index.tsx
@@ -301,7 +301,7 @@ export default function AchievementsIndex({ overview, tracks }: Props) {
                     {overview.unlocked === 0 && (
                         <p className="mx-auto max-w-160 rounded-lg border border-dashed px-8 py-7 text-center text-sm text-pretty text-muted-foreground">
                             {__(
-                                'Nothing unlocked yet. Achievements are checked once a day: the first ones land as soon as you record a transaction or connect a bank, and anything you crossed before today unlocks with its real date.',
+                                'Nothing unlocked yet. Visit streaks unlock the moment you earn them; the rest are checked once a day, and anything you crossed before today unlocks with its real date.',
                             )}
                         </p>
                     )}

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -95,7 +95,11 @@ export type AchievementState = 'earned' | 'next' | 'locked';
 export interface AchievementProgress {
     now: number;
     goal: number;
-    /** Already past the goal, waiting on the nightly sweep. */
+    /**
+     * Already past the goal with the medal not recorded yet. Visit medals are
+     * settled on the request that earns them, so this is the nightly sweep's
+     * tracks — and, for visits, only a reader it has never run for.
+     */
     unlocking: boolean;
 }
 
@@ -123,6 +127,8 @@ export interface AchievementMedal {
  * the progress screen needs on top of that.
  */
 export interface ChallengeMedal {
+    /** The catalog key, e.g. `visits.3`. Stable across renames and rethresholds. */
+    key: string;
     track: string;
     rarity: AchievementRarity;
     icon: string;
@@ -143,6 +149,12 @@ export interface Challenges {
     visit_streak: number;
     /** `visits` then `visit_weeks`. A finished track is absent. */
     medals: ChallengeMedal[];
+    /**
+     * The visit medal that landed most recently, with no progress bar: it is on
+     * the shelf. Null for a reader holding none. Visit medals are awarded on the
+     * request that earns them, so this is how the shell knows to say so.
+     */
+    unlocked: ChallengeMedal | null;
     /** Null when there is nothing to categorize, or the prompt is snoozed. */
     uncategorized: {
         count: number;

--- a/tests/Feature/Achievements/AchievementScreenTest.php
+++ b/tests/Feature/Achievements/AchievementScreenTest.php
@@ -313,19 +313,31 @@ it('measures a visit streak by the longest run, which is what the medal is award
     expect($medal['progress'])->toBe(['now' => 2, 'goal' => 3, 'unlocking' => false]);
 });
 
-it('says a medal unlocks tonight once the reader is already past it', function (): void {
+it('says a medal unlocks tonight for a reader the sweep has never been through', function (): void {
     $user = readerWithMedals(0);
     $user->forceFill(['longest_visit_streak' => 35])->saveQuietly();
 
-    collect(['visits.1', 'visits.2'])->each(fn (string $key) => Achievement::factory()->key($key)->create([
-        'user_id' => $user->id,
-        'space_id' => $user->activeSpace()->id,
-    ]));
+    // No medals at all is a reader the sweep has never run for, and its first
+    // pass is the one that reads a whole life and announces itself once. The
+    // visit award stays out of its way, so the rung is still standing here
+    // waiting for tonight — which is what every other track looks like.
+    $medal = medalsIn(progressProps($user))->firstWhere('key', 'visits.1');
 
-    // Thirty days crossed today, with the sweep that awards it still hours off.
-    $medal = medalsIn(progressProps($user))->firstWhere('key', 'visits.3');
+    expect($medal['progress'])->toBe(['now' => 35, 'goal' => 3, 'unlocking' => true]);
+});
 
-    expect($medal['progress'])->toBe(['now' => 35, 'goal' => 30, 'unlocking' => true]);
+it('hands a run its medals on the request that earns them, not on the sweep', function (): void {
+    $user = readerWithMedals(1);
+    $user->forceFill(['longest_visit_streak' => 35])->saveQuietly();
+
+    // Thirty days crossed: every visit rung up to it is on the shelf by the
+    // time the screen renders, and the hundred-day one is what is left to
+    // chase. Nothing here waited for the small hours.
+    $next = medalsIn(progressProps($user))->firstWhere('key', 'visits.4');
+
+    expect($user->achievements()->pluck('key')->all())
+        ->toContain('visits.1', 'visits.2', 'visits.3');
+    expect($next['progress'])->toBe(['now' => 35, 'goal' => 100, 'unlocking' => false]);
 });
 
 it('counts the transactions a reader recorded in closed months', function (): void {

--- a/tests/Feature/TrackLastActiveAtTest.php
+++ b/tests/Feature/TrackLastActiveAtTest.php
@@ -1,6 +1,9 @@
 <?php
 
+use App\Models\Achievement;
 use App\Models\User;
+use App\Notifications\AchievementUnlocked;
+use Illuminate\Support\Facades\Notification;
 
 beforeEach(function (): void {
     // These assertions are about what the middleware wrote, never about the
@@ -150,4 +153,104 @@ test('another day of the same week leaves the weekly streak where it is', functi
 
     expect($user->fresh()->visit_week_streak)->toBe(5)
         ->and($user->fresh()->visit_streak)->toBe(1);
+});
+
+/*
+ * The medal a run reaches is settled here, on the request that moves the run,
+ * rather than by the nightly sweep. Everything else still waits for the sweep:
+ * a closed month cannot be judged mid-month.
+ */
+
+/**
+ * A reader the sweep has already been through, which is what the visit award
+ * asks for: their first pass is the one that reads a whole life and announces
+ * itself with a single welcome row.
+ */
+function sweptReader(array $attributes = []): User
+{
+    config()->set('achievements.enabled', true);
+
+    $user = User::factory()->onboarded()->create($attributes);
+
+    Achievement::factory()->key('transactions.1')->create([
+        'user_id' => $user->id,
+        'space_id' => $user->activeSpace()->id,
+    ]);
+
+    return $user;
+}
+
+test('a run reaching a rung is awarded on the request that reaches it', function () {
+    Notification::fake();
+
+    // Two days behind, so today's visit is the third in a row.
+    $user = sweptReader([
+        'last_active_at' => now()->subDay(),
+        'visit_streak' => 2,
+        'longest_visit_streak' => 2,
+    ]);
+
+    $this->actingAs($user)->get(route('dashboard'))->assertOk();
+
+    expect($user->achievements()->pluck('key')->all())->toContain('visits.1');
+    Notification::assertSentTo($user, AchievementUnlocked::class);
+});
+
+test('the medal is on the shelf before the page that earned it is drawn', function () {
+    // The whole point of doing this before the response rather than after it:
+    // the props the header is drawn with are the ones that carry the medal.
+    $user = sweptReader([
+        'last_active_at' => now()->subDay(),
+        'visit_streak' => 2,
+        'longest_visit_streak' => 2,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('challenges.visit_streak', 3)
+            ->where('challenges.unlocked.key', 'visits.1'));
+});
+
+test('a reader the sweep has never been through is left to it', function () {
+    Notification::fake();
+    config()->set('achievements.enabled', true);
+
+    // No medals at all: the first sweep reads their whole life and says so in
+    // one row, and taking the first medal here would turn that into a pile.
+    $user = User::factory()->onboarded()->create([
+        'last_active_at' => now()->subDay(),
+        'visit_streak' => 2,
+        'longest_visit_streak' => 2,
+    ]);
+
+    $this->actingAs($user)->get(route('dashboard'))->assertOk();
+
+    expect($user->achievements()->count())->toBe(0);
+    Notification::assertNothingSent();
+});
+
+test('a run that has not moved is not awarded again', function () {
+    Notification::fake();
+
+    // Already past the three-day rung and already holding it: a second visit
+    // the same day, in a week already counted, has nothing new to say.
+    $user = sweptReader([
+        'last_active_at' => now()->subHour(),
+        'visit_streak' => 9,
+        'longest_visit_streak' => 9,
+        'visit_week_streak' => 3,
+        'longest_visit_week_streak' => 3,
+    ]);
+
+    Achievement::factory()->key('visits.1')->create([
+        'user_id' => $user->id,
+        'space_id' => $user->activeSpace()->id,
+    ]);
+
+    $this->actingAs($user)->get(route('dashboard'))->assertOk();
+
+    expect($user->achievements()->where('key', 'visits.1')->count())->toBe(1);
+    Notification::assertNothingSent();
 });


### PR DESCRIPTION
The pill counting the visit run was grey chrome: a neutral border, a
foreground-coloured ring and an outlined flame, indistinguishable from the icons
either side of it. A run worth keeping should look like one.

This is Option A of the design canvas, **"Llama viva"**. The pill keeps its exact
geometry and anatomy — same `h-[30px]` / `md:h-8`, same 22px/24px ring, same
ring + flame + number — and takes a warm skin instead.

## What changed

**Colour.** Six new `--streak-*` tokens in `:root` and `.dark` carry the fill,
the border, the ring track, the two ends of the ring gradient and the number's
ink. They are struck in the same chroma family as the `--medal-*` tokens right
above them, so the chrome reads as one set of colours rather than a new accent.
Dark mode goes through the tokens; there are no raw colours behind `dark:`.

**Motion.** The flame is filled rather than outlined and flickers continuously
over a soft radial halo that breathes. Two moments sit on top of that resting
state:

- *On page load*, the ring draws itself up to its percentage and the pill fades
  and scales in. Deliberately quiet — it fires on every full load.
- *The morning the run goes up*, a distinctly bigger one-off: the flame flares,
  the halo bursts and the number rolls in from below. Each element then hands
  itself back to its resting loop rather than freezing.

**`prefers-reduced-motion: reduce` silences all of it** through a single rule
hung off the pill's own class (`.streak-chip, .streak-chip *`). That is
non-negotiable for an element that otherwise moves forever in the app chrome:
with the setting on, the ring renders fully drawn, the flame sits still and the
halo holds its resting opacity.

The `unlocking` state is untouched beyond the pill around it. The medal is metal
and must not be tinted, so it keeps its own gradients; only the skin behind it is
warm. The old `bg-muted` that used to mark that state is gone — it is the medal,
not a fill, that tells the state apart — and the test asserting it was updated.

## How "+1" is detected, and why it lives in local storage

Nothing on the server says *"the streak advanced"*. `TrackLastActiveAt` carries
the run forward silently and `HandleInertiaRequests::challengesFor()` only ever
shares today's number, so there is no flag to read and no obvious place to put
one: a "celebrated_at" column would be a migration, a write on the request path
and a second source of truth for something purely cosmetic.

Instead the last number the reader saw is remembered on the device, under a
single `streak-seen` key holding `<user id>:<streak>` — the same shape
`use-onboarding-state` uses for its resume point, because one browser is shared
by more than one account often enough to matter. It goes through the existing
`safe-storage` wrapper, which swallows the `SecurityError` private mode throws on
the very first access.

On mount: stored number lower than today's → play the celebration, then record
the new one. Nothing stored at all (first visit on this device) → record it and
say nothing, because cheering a run the reader has been on for weeks would be a
lie. A broken run records its zero, so day one of the next run reads as a rise.

This is per-device on purpose: opening the app on the phone after the laptop
replays the moment. That is the right side to err on for something that only ever
adds a flourish, and it buys a celebration that survives a hard refresh with no
backend involved at all.

## Two things worth a reviewer's eye

**The entrance is once per page load, not once per mount.** No screen keeps the
header across an Inertia visit — every page inlines its own layout — so the pill
remounts on every click and a plain mount animation replayed the entrance every
time a reader opened a screen. A module-scoped flag is exactly the lifetime
wanted: it outlives a client-side visit and dies with the page. Verified in the
browser: the entrance plays on load and on reload, and not on a client-side
visit.

**The effect that decides "+1" reads the value it then overwrites**, so running
it twice for the same number answers "no rise" the second time and swallows the
celebration. StrictMode does exactly that in development. A ref recording the
number already handled makes the second pass a no-op while still letting a
genuinely new number through; there is a test that fails without it.

## Tests

`streak-chip.test.tsx` goes from 6 to 14 cases. The three existing states are
unchanged; the new ones cover the celebration (never on a fresh device, once on a
rise, not twice for the same number, never on another account's number, and after
a break) and the once-per-load entrance. Both guards above were checked by
reverting them and watching the matching test go red.

## QA

Checked in Chrome against the dev server on all four combinations — mobile 390px
and desktop 1440px, light and dark — plus the `unlocking` state in both themes
and `prefers-reduced-motion: reduce`. Geometry measured back at 30px pill / 22px
ring on the phone and 32px / 24px on desktop.

One detail found there: the ring's gradient stops set `stop-color` through
`style`, not the SVG presentation attribute, because Safari does not substitute
`var()` inside a presentation attribute and the ring would come out black.

---

# Second change: visit medals unlock the moment they are earned

A visit run is the one thing the app knows the whole truth about the instant it
changes — two columns, no history to read — and it was still waiting for the
nightly sweep. A reader who kept a week going was told at three in the morning,
on a screen they were not looking at.

## Awarded on the request that earns it

`TrackLastActiveAt` now settles those medals itself, and does its work **before**
the response rather than after it. The shared Inertia props are closures the
renderer calls further down the stack, so the run carried forward is the run the
page is drawn with: the reader sees the day they are on, and the medal it just
earned, on the request that earned it rather than on the next one.

The award is cheap enough to sit on a request — one read of the reader's own
medal keys against a catalog held in memory, and at most one insert — and is only
reached on the first request of a new day, which is the only time a run moves. It
runs behind the same feature flag and onboarding guard every other medal does,
and a throw is reported and swallowed: the sweep will find the same medal
tonight, and a medal is never worth a 500 on the page the reader asked for.

`Awarder::awardVisitRuns()` announces itself through the same two private methods
the sweep uses, so a medal reads the same in the bell and in the daily email
whether the night found it or the visit did. **Everything else still waits for the
sweep**, which is where a closed month or a balance at a month end can actually be
judged.

One deliberate exception: a reader holding no medals at all is left alone. That is
a reader the sweep has never run for, and its first pass reads a whole life and
announces itself with a single welcome row — taking the first medal here would
turn that into a pile of individual ones.

## Saying it out loud

A row quietly appearing in the bell is a record, not a moment. A toast announces
the medal with it being struck: it turns into place, a sweep of light crosses it,
and the warmth behind it flares out once. Ten seconds and dismissible, unlike the
categorize prompt next door — that one asks for work and waits to be acted on,
this one is over once it has been read. It is fired from the shell beside that
prompt, and the two now share the "on mount and on every visit" hook rather than
each keeping a copy of it.

`prefers-reduced-motion: reduce` switches all three animations off; the medal
still arrives, it just stops performing.

## How "news" is decided, and why it is local again

The server knows the medal was awarded but not whether *this* reader has been
told. A column to carry "have you seen it" would be a migration and a write on the
request path for something purely cosmetic, so the last medal announced is
remembered per user on the device — the same bargain the streak's "+1" makes.
`challenges.unlocked` carries the visit medal that landed most recently, by row
order rather than by where the rung sits in the catalog: `visits` is written above
`visit_weeks`, so a reader who takes a third day after their first full week would
otherwise be told about the week all over again.

Nothing stored yet means nothing is announced. Greeting a new device with a medal
from March would be a lie.

The per-user storage shape both features need is now one pair of helpers in
`safe-storage` (`readOwnedValue` / `writeOwnedValue`) instead of two hand-rolled
copies — this is the extraction the first review asked for, now that there are
enough callers to justify it. `use-onboarding-state` still has its own copy and
was left alone as unrelated.

## Two things that fall out of it

- **The pill's `unlocking` state is now rare rather than normal for visits.** The
  medal lands with the run, so "standing on the rung waiting for tonight" is left
  to the reader the sweep has never been through. The comments and the type doc
  saying otherwise were corrected rather than left to rot, and the screen's test
  for that state was rewritten to describe the case that still reaches it, with a
  new test asserting the medal now arrives on the same request.
- **The progress screen no longer claims everything is checked once a day**,
  because visit streaks no longer are.

## Tests

`TrackLastActiveAtTest` gains four: the medal is awarded on the request that
reaches the rung, it is on the shelf before the page that earned it is drawn (the
whole point of moving the middleware ahead of the response), a reader the sweep
has never been through is left to it, and a run that has not moved is not awarded
again — no repeat insert, no repeat notification. `medal-unlocked-toast.test.tsx`
adds six covering when the toast is and is not news, including another account's
medal on the same browser. `safe-storage.test.ts` covers the new helpers.

Full suites: **3222/3223 pest** (one pre-existing skip, zero failures) and **765
vitest**, plus `pint`, `lint`, `format`, `dry` and `crap` clean.

## QA

Recorded end to end against the dev server on a demo account primed one day short
of the three-day rung: the visit crosses it, the medal is awarded on that request,
the pill reads 3, and the toast announces it. Checked on desktop 1440px in light
and mobile 390px in dark, and the toast clears the mobile tab bar (bottom 734 vs
tab bar top 752).

https://github.com/user-attachments/assets/41530101-32c3-4c8d-9fb8-61b8974b65f4


https://github.com/user-attachments/assets/4d487b82-2748-4bbb-a9a0-0b757ffdf341


https://github.com/user-attachments/assets/c0227f27-d614-4f3a-8588-f4afe8f23596


