### PR TITLE
fix(accounts): let the bank own the shape of a connected account

### DIFF
--- a/app/Http/Controllers/Settings/AccountController.php
+++ b/app/Http/Controllers/Settings/AccountController.php
@@ -331,10 +331,17 @@ class AccountController extends Controller
 
     /**
      * Hard delete the specified account and cascade delete all transactions.
+     *
+     * A connected account has to be archived first: archiving detaches it from
+     * the bank and revokes the connection when it was the last account on it,
+     * which deleting does not do. Both menus hide the option, so this only
+     * catches a stale page or a hand-made request.
      */
     public function destroy(Account $account): RedirectResponse
     {
         $this->authorize('delete', $account);
+
+        abort_if($account->isConnected(), 403, __('Archive this account first: it is still connected to your bank.'));
 
         $account->transactions()->delete();
         $account->delete();

--- a/app/Http/Requests/Settings/UpdateAccountRequest.php
+++ b/app/Http/Requests/Settings/UpdateAccountRequest.php
@@ -34,7 +34,7 @@ class UpdateAccountRequest extends FormRequest
 
         $rules = [
             'name' => ['required', 'string'],
-            'bank_id' => ['nullable', 'exists:banks,id'],
+            'bank_id' => $this->bankIdRules(),
             'currency_code' => [
                 'required',
                 'string',
@@ -63,6 +63,17 @@ class UpdateAccountRequest extends FormRequest
     }
 
     /**
+     * The account being updated, when the bank is the one that owns its shape.
+     * Null for a manual account, which the user owns end to end.
+     */
+    private function connectedAccount(): ?Account
+    {
+        $account = $this->route('account');
+
+        return $account instanceof Account && $account->isConnected() ? $account : null;
+    }
+
+    /**
      * The bank owns the currency of a connected account: everything already
      * synced is in it, so only the code it already has is accepted. A manual
      * account can move to any supported currency.
@@ -71,12 +82,26 @@ class UpdateAccountRequest extends FormRequest
      */
     private function allowedCurrencyCodes(): array
     {
-        $account = $this->route('account');
+        $account = $this->connectedAccount();
 
-        if ($account instanceof Account && $account->isConnected()) {
-            return [$account->currency_code];
-        }
+        return $account
+            ? [$account->currency_code]
+            : app(CurrencyOptions::class)->accountCodes();
+    }
 
-        return app(CurrencyOptions::class)->accountCodes();
+    /**
+     * A connected account inherits its bank from the connection, so it can
+     * neither be pointed at another one nor be cleared. Every path that
+     * connects an account gives it a bank, so requiring one is safe here.
+     *
+     * @return array<mixed>
+     */
+    private function bankIdRules(): array
+    {
+        $account = $this->connectedAccount();
+
+        return $account
+            ? ['required', Rule::in([$account->bank_id])]
+            : ['nullable', 'exists:banks,id'];
     }
 }

--- a/app/Http/Requests/Settings/UpdateAccountRequest.php
+++ b/app/Http/Requests/Settings/UpdateAccountRequest.php
@@ -5,6 +5,7 @@ namespace App\Http\Requests\Settings;
 use App\Enums\AccountType;
 use App\Http\Requests\Concerns\ValidatesAccountDetailRules;
 use App\Http\Requests\Concerns\ValidatesUserOwnedResources;
+use App\Models\Account;
 use App\Services\CurrencyOptions;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
@@ -30,7 +31,6 @@ class UpdateAccountRequest extends FormRequest
     public function rules(): array
     {
         $isRealEstate = $this->input('type') === AccountType::RealEstate->value;
-        $currencyOptions = app(CurrencyOptions::class);
 
         $rules = [
             'name' => ['required', 'string'],
@@ -38,7 +38,7 @@ class UpdateAccountRequest extends FormRequest
             'currency_code' => [
                 'required',
                 'string',
-                Rule::in($currencyOptions->accountCodes()),
+                Rule::in($this->allowedCurrencyCodes()),
             ],
             'type' => [
                 'required',
@@ -60,5 +60,23 @@ class UpdateAccountRequest extends FormRequest
         }
 
         return $rules;
+    }
+
+    /**
+     * The bank owns the currency of a connected account: everything already
+     * synced is in it, so only the code it already has is accepted. A manual
+     * account can move to any supported currency.
+     *
+     * @return list<string>
+     */
+    private function allowedCurrencyCodes(): array
+    {
+        $account = $this->route('account');
+
+        if ($account instanceof Account && $account->isConnected()) {
+            return [$account->currency_code];
+        }
+
+        return app(CurrencyOptions::class)->accountCodes();
     }
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -2947,5 +2947,7 @@
     "A month with everything categorized is a month you can actually read.": "Un mes con todo categorizado es un mes que puedes leer de verdad.",
     "Not now": "Ahora no",
     "Medal unlocked": "Medalla desbloqueada",
-    "See it": "Verla"
+    "See it": "Verla",
+    "Your bank sets the currency of a connected account.": "El banco fija la moneda de una cuenta conectada.",
+    "Archive this account first: it is still connected to your bank.": "Archiva primero esta cuenta: sigue conectada a tu banco."
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -2948,6 +2948,7 @@
     "Not now": "Ahora no",
     "Medal unlocked": "Medalla desbloqueada",
     "See it": "Verla",
+    "A connected account keeps the bank of its connection.": "Una cuenta conectada mantiene el banco de su conexión.",
     "Your bank sets the currency of a connected account.": "El banco fija la moneda de una cuenta conectada.",
     "Archive this account first: it is still connected to your bank.": "Archiva primero esta cuenta: sigue conectada a tu banco."
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2501,5 +2501,7 @@
     "Visit streak: :days": "Série de visites : :days",
     ":count uncategorized transactions": ":count transactions sans catégorie",
     "A month with everything categorized is a month you can actually read.": "Un mois entièrement catégorisé est un mois vraiment lisible.",
-    "Not now": "Pas maintenant"
+    "Not now": "Pas maintenant",
+    "Your bank sets the currency of a connected account.": "Votre banque définit la devise d’un compte connecté.",
+    "Archive this account first: it is still connected to your bank.": "Archivez d’abord ce compte : il est encore connecté à votre banque."
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2502,6 +2502,7 @@
     ":count uncategorized transactions": ":count transactions sans catégorie",
     "A month with everything categorized is a month you can actually read.": "Un mois entièrement catégorisé est un mois vraiment lisible.",
     "Not now": "Pas maintenant",
+    "A connected account keeps the bank of its connection.": "Un compte connecté conserve la banque de sa connexion.",
     "Your bank sets the currency of a connected account.": "Votre banque définit la devise d’un compte connecté.",
     "Archive this account first: it is still connected to your bank.": "Archivez d’abord ce compte : il est encore connecté à votre banque."
 }

--- a/resources/js/components/accounts/account-form.test.tsx
+++ b/resources/js/components/accounts/account-form.test.tsx
@@ -18,8 +18,8 @@ vi.mock('@inertiajs/react', () => ({
 }));
 
 vi.mock('./bank-combobox', () => ({
-    BankCombobox: ({ clearable }: { clearable?: boolean }) => (
-        <div data-testid="bank-combobox" data-clearable={String(clearable)} />
+    BankCombobox: ({ disabled }: { disabled?: boolean }) => (
+        <div data-testid="bank-combobox" data-disabled={String(disabled)} />
     ),
 }));
 
@@ -52,9 +52,14 @@ describe('AccountForm', () => {
             ),
         ).toBeInTheDocument();
         expect(screen.getByTestId('bank-combobox')).toHaveAttribute(
-            'data-clearable',
-            'false',
+            'data-disabled',
+            'true',
         );
+        expect(
+            screen.getByText(
+                'A connected account keeps the bank of its connection.',
+            ),
+        ).toBeInTheDocument();
     });
 
     it('leaves the currency and the bank open on a manual account', () => {
@@ -64,8 +69,13 @@ describe('AccountForm', () => {
 
         expect(currencySelect(container)).toBeEnabled();
         expect(screen.getByTestId('bank-combobox')).toHaveAttribute(
-            'data-clearable',
-            'true',
+            'data-disabled',
+            'false',
         );
+        expect(
+            screen.getByText(
+                'Leave empty for cash or any account without a bank.',
+            ),
+        ).toBeInTheDocument();
     });
 });

--- a/resources/js/components/accounts/account-form.test.tsx
+++ b/resources/js/components/accounts/account-form.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { AccountForm } from './account-form';
+
+vi.mock('@inertiajs/react', () => ({
+    usePage: () => ({
+        props: {
+            currencies: {
+                accounts: [
+                    { code: 'EUR', name: 'Euro' },
+                    { code: 'USD', name: 'US Dollar' },
+                ],
+                profile: [{ code: 'EUR', name: 'Euro' }],
+            },
+        },
+    }),
+}));
+
+vi.mock('./bank-combobox', () => ({
+    BankCombobox: ({ clearable }: { clearable?: boolean }) => (
+        <div data-testid="bank-combobox" data-clearable={String(clearable)} />
+    ),
+}));
+
+const initialValues = {
+    displayName: 'Checking',
+    bank: null,
+    type: 'checking' as const,
+    currencyCode: 'EUR',
+};
+
+// Radix renders the trigger's selected value into a portal, so it has no
+// accessible name in jsdom; the field's form name is what identifies it.
+const currencySelect = (container: HTMLElement) =>
+    container.querySelector('[name="currency_code"]');
+
+describe('AccountForm', () => {
+    it('locks the currency and the bank of a connected account', () => {
+        const { container } = render(
+            <AccountForm
+                initialValues={initialValues}
+                isConnected
+                onChange={() => {}}
+            />,
+        );
+
+        expect(currencySelect(container)).toBeDisabled();
+        expect(
+            screen.getByText(
+                'Your bank sets the currency of a connected account.',
+            ),
+        ).toBeInTheDocument();
+        expect(screen.getByTestId('bank-combobox')).toHaveAttribute(
+            'data-clearable',
+            'false',
+        );
+    });
+
+    it('leaves the currency and the bank open on a manual account', () => {
+        const { container } = render(
+            <AccountForm initialValues={initialValues} onChange={() => {}} />,
+        );
+
+        expect(currencySelect(container)).toBeEnabled();
+        expect(screen.getByTestId('bank-combobox')).toHaveAttribute(
+            'data-clearable',
+            'true',
+        );
+    });
+});

--- a/resources/js/components/accounts/account-form.tsx
+++ b/resources/js/components/accounts/account-form.tsx
@@ -335,7 +335,9 @@ export function AccountForm({
 
             {!isRealEstate && (
                 <div className="space-y-2">
-                    <Label htmlFor="bank_id">{__('Bank (optional)')}</Label>
+                    <Label htmlFor="bank_id">
+                        {isConnected ? __('Bank') : __('Bank (optional)')}
+                    </Label>
                     <div className="mt-1">
                         {isCreatingCustomBank ? (
                             <CustomBankForm
@@ -359,16 +361,20 @@ export function AccountForm({
                                         initialValues?.bank ?? undefined
                                     }
                                     onCreateCustomBank={handleCreateCustomBank}
-                                    clearable={!isConnected}
+                                    disabled={isConnected}
                                 />
                             </>
                         )}
                     </div>
                     {!isCreatingCustomBank && (
                         <p className="pl-1 text-xs text-muted-foreground">
-                            {__(
-                                'Leave empty for cash or any account without a bank.',
-                            )}
+                            {isConnected
+                                ? __(
+                                      'A connected account keeps the bank of its connection.',
+                                  )
+                                : __(
+                                      'Leave empty for cash or any account without a bank.',
+                                  )}
                         </p>
                     )}
                 </div>

--- a/resources/js/components/accounts/account-form.tsx
+++ b/resources/js/components/accounts/account-form.tsx
@@ -85,7 +85,7 @@ interface AccountFormProps {
     hiddenAccountTypes?: AccountType[];
     availableLoanAccounts?: Account[];
     usePrimaryCurrenciesOnly?: boolean;
-    bankClearable?: boolean;
+    isConnected?: boolean;
     onChange: (data: AccountFormData) => void;
     errors?: Record<string, string>;
 }
@@ -122,7 +122,7 @@ export function AccountForm({
     hiddenAccountTypes = [],
     availableLoanAccounts = [],
     usePrimaryCurrenciesOnly = false,
-    bankClearable = true,
+    isConnected = false,
     onChange,
     errors = {},
 }: AccountFormProps) {
@@ -359,7 +359,7 @@ export function AccountForm({
                                         initialValues?.bank ?? undefined
                                     }
                                     onCreateCustomBank={handleCreateCustomBank}
-                                    clearable={bankClearable}
+                                    clearable={!isConnected}
                                 />
                             </>
                         )}
@@ -380,6 +380,7 @@ export function AccountForm({
                     <Select
                         name="currency_code"
                         value={selectedCurrency ?? undefined}
+                        disabled={isConnected}
                         onValueChange={(value) =>
                             setSelectedCurrency(value as CurrencyCode)
                         }
@@ -400,6 +401,13 @@ export function AccountForm({
                         </SelectContent>
                     </Select>
                 </div>
+                {isConnected && (
+                    <p className="pl-1 text-xs text-muted-foreground">
+                        {__(
+                            'Your bank sets the currency of a connected account.',
+                        )}
+                    </p>
+                )}
             </div>
 
             {showBalanceField && selectedCurrency && !initialValues && (

--- a/resources/js/components/accounts/bank-combobox.tsx
+++ b/resources/js/components/accounts/bank-combobox.tsx
@@ -26,7 +26,7 @@ interface BankComboboxProps {
     onValueChange: (value: string | null) => void;
     defaultBank?: Bank;
     onCreateCustomBank?: (searchQuery: string) => void;
-    clearable?: boolean;
+    disabled?: boolean;
 }
 
 const bankCache = new Map<string, Bank[]>();
@@ -36,7 +36,7 @@ export function BankCombobox({
     onValueChange,
     defaultBank,
     onCreateCustomBank,
-    clearable = true,
+    disabled = false,
 }: BankComboboxProps) {
     const [open, setOpen] = useState(false);
     const [searchQuery, setSearchQuery] = useState('');
@@ -114,6 +114,7 @@ export function BankCombobox({
                     variant="outline"
                     role="combobox"
                     aria-expanded={open}
+                    disabled={disabled}
                     className="w-full justify-between"
                     data-testid="bank-select"
                 >
@@ -152,7 +153,7 @@ export function BankCombobox({
                                   ? __('Type at least 3 characters to search')
                                   : __('No bank found.')}
                         </CommandEmpty>
-                        {clearable && selectedBank && (
+                        {selectedBank && (
                             <>
                                 <CommandGroup>
                                     <CommandItem

--- a/resources/js/components/accounts/edit-account-dialog.tsx
+++ b/resources/js/components/accounts/edit-account-dialog.tsx
@@ -343,7 +343,7 @@ export function EditAccountDialog({
                         <>
                             <AccountForm
                                 initialValues={initialValues}
-                                bankClearable={!account.banking_connection_id}
+                                isConnected={!!account.banking_connection_id}
                                 onChange={handleFormChange}
                                 errors={errors}
                             />

--- a/resources/js/pages/settings/accounts.test.tsx
+++ b/resources/js/pages/settings/accounts.test.tsx
@@ -1,0 +1,97 @@
+import type { Account } from '@/types/account';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import AccountsPage from './accounts';
+
+vi.mock('@inertiajs/react', () => ({
+    Head: () => null,
+    router: { patch: vi.fn(), reload: vi.fn() },
+}));
+
+vi.mock('@/actions/App/Http/Controllers/AccountController', () => ({
+    updateArchived: { url: (id: string) => `/accounts/${id}/archived` },
+}));
+
+vi.mock('@/actions/App/Http/Controllers/Settings/AccountController', () => ({
+    index: { url: () => '/settings/accounts' },
+}));
+
+vi.mock('@/layouts/app-layout', () => ({
+    default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/layouts/settings/layout', () => ({
+    default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/accounts/create-account-dialog', () => ({
+    CreateAccountDialog: () => null,
+}));
+
+vi.mock('@/components/accounts/edit-account-dialog', () => ({
+    EditAccountDialog: () => null,
+}));
+
+vi.mock('@/components/accounts/delete-account-dialog', () => ({
+    DeleteAccountDialog: () => null,
+}));
+
+vi.mock('@/components/accounts/archive-account-dialog', () => ({
+    ArchiveAccountDialog: () => null,
+}));
+
+function makeAccount(overrides: Partial<Account>): Account {
+    return {
+        id: 'account-1',
+        name: 'Checking',
+        name_iv: null,
+        encrypted: false,
+        bank: null,
+        type: 'checking',
+        currency_code: 'EUR',
+        banking_connection_id: null,
+        external_account_id: null,
+        linked_at: null,
+        ...overrides,
+    };
+}
+
+function openRowMenu() {
+    fireEvent.pointerDown(screen.getByLabelText('Open menu'), {
+        button: 0,
+        ctrlKey: false,
+    });
+
+    return screen.findByRole('menu');
+}
+
+describe('Accounts settings page', () => {
+    it('offers deleting a manual account', async () => {
+        render(<AccountsPage accounts={[makeAccount({})]} />);
+
+        const menu = await openRowMenu();
+
+        expect(
+            within(menu).getByRole('menuitem', { name: 'Delete' }),
+        ).toBeInTheDocument();
+    });
+
+    it('archives instead of deleting a connected account', async () => {
+        render(
+            <AccountsPage
+                accounts={[makeAccount({ banking_connection_id: 'conn-1' })]}
+            />,
+        );
+
+        const menu = await openRowMenu();
+
+        expect(
+            within(menu).queryByRole('menuitem', { name: 'Delete' }),
+        ).toBeNull();
+        expect(
+            within(menu).getByRole('menuitem', { name: 'Archive' }),
+        ).toBeInTheDocument();
+    });
+});

--- a/resources/js/pages/settings/accounts.tsx
+++ b/resources/js/pages/settings/accounts.tsx
@@ -53,6 +53,11 @@ import { type Account, formatAccountType } from '@/types/account';
  * This settings list is the one place an archived account stays visible, so it
  * can be brought back. Restoring needs no warning; archiving explains itself in
  * ArchiveAccountDialog first.
+ *
+ * Deleting is offered on manual accounts only, matching the account page: a
+ * connected one has to be archived first, which is what detaches it from the
+ * bank and revokes the connection. Archiving clears the connection, so an
+ * archived account can then be deleted from here.
  */
 function unarchive(account: Account) {
     router.patch(
@@ -100,12 +105,14 @@ function AccountActions({
                             {__('Archive')}
                         </DropdownMenuItem>
                     )}
-                    <DropdownMenuItem
-                        onClick={() => setDeleteOpen(true)}
-                        className="text-red-600"
-                    >
-                        {__('Delete')}
-                    </DropdownMenuItem>
+                    {!account.banking_connection_id && (
+                        <DropdownMenuItem
+                            onClick={() => setDeleteOpen(true)}
+                            className="text-red-600"
+                        >
+                            {__('Delete')}
+                        </DropdownMenuItem>
+                    )}
                 </DropdownMenuContent>
             </DropdownMenu>
 
@@ -182,12 +189,14 @@ function AccountRow({
                             {__('Archive')}
                         </ContextMenuItem>
                     )}
-                    <ContextMenuItem
-                        onClick={() => setDeleteOpen(true)}
-                        className="text-red-600"
-                    >
-                        {__('Delete')}
-                    </ContextMenuItem>
+                    {!account.banking_connection_id && (
+                        <ContextMenuItem
+                            onClick={() => setDeleteOpen(true)}
+                            className="text-red-600"
+                        >
+                            {__('Delete')}
+                        </ContextMenuItem>
+                    )}
                 </ContextMenuContent>
             </ContextMenu>
 

--- a/tests/Feature/Settings/AccountTest.php
+++ b/tests/Feature/Settings/AccountTest.php
@@ -395,6 +395,70 @@ it('deletes all transactions when deleting account', function () {
     expect(Transaction::find($transaction2->id))->toBeNull();
 });
 
+it('keeps the currency of a connected account', function () {
+    actingAs($this->user);
+
+    $account = Account::factory()->connected()->create([
+        'user_id' => $this->user->id,
+        'bank_id' => $this->bank->id,
+        'currency_code' => 'EUR',
+        'type' => AccountType::Checking,
+    ]);
+
+    $response = $this->patch(route('accounts.update', $account), [
+        'name' => 'Renamed',
+        'bank_id' => $this->bank->id,
+        'currency_code' => 'USD',
+        'type' => AccountType::Checking->value,
+    ]);
+
+    $response->assertSessionHasErrors(['currency_code']);
+    assertDatabaseHas('accounts', [
+        'id' => $account->id,
+        'currency_code' => 'EUR',
+    ]);
+});
+
+it('still updates a connected account when the currency is left alone', function () {
+    actingAs($this->user);
+
+    $account = Account::factory()->connected()->create([
+        'user_id' => $this->user->id,
+        'bank_id' => $this->bank->id,
+        'currency_code' => 'EUR',
+        'type' => AccountType::Checking,
+    ]);
+
+    $response = $this->patch(route('accounts.update', $account), [
+        'name' => 'Renamed',
+        'bank_id' => $this->bank->id,
+        'currency_code' => 'EUR',
+        'type' => AccountType::Checking->value,
+    ]);
+
+    $response->assertRedirect(route('accounts.index'));
+    assertDatabaseHas('accounts', [
+        'id' => $account->id,
+        'name' => 'Renamed',
+    ]);
+});
+
+// Archiving is what detaches an account from the bank (see AccountControllerTest),
+// and an archived account is no longer connected, so it can then be deleted.
+it('prevents deleting a connected account', function () {
+    actingAs($this->user);
+
+    $account = Account::factory()->connected()->create([
+        'user_id' => $this->user->id,
+        'bank_id' => $this->bank->id,
+    ]);
+
+    $response = $this->delete(route('accounts.destroy', $account));
+
+    $response->assertForbidden();
+    assertDatabaseHas('accounts', ['id' => $account->id, 'deleted_at' => null]);
+});
+
 it('prevents deleting another users account', function () {
     $otherUser = User::factory()->create();
     $account = Account::factory()->create([

--- a/tests/Feature/Settings/AccountTest.php
+++ b/tests/Feature/Settings/AccountTest.php
@@ -419,6 +419,55 @@ it('keeps the currency of a connected account', function () {
     ]);
 });
 
+it('keeps the bank of a connected account', function () {
+    actingAs($this->user);
+
+    $account = Account::factory()->connected()->create([
+        'user_id' => $this->user->id,
+        'bank_id' => $this->bank->id,
+        'currency_code' => 'EUR',
+        'type' => AccountType::Checking,
+    ]);
+    $otherBank = Bank::factory()->create();
+
+    $response = $this->patch(route('accounts.update', $account), [
+        'name' => 'Renamed',
+        'bank_id' => $otherBank->id,
+        'currency_code' => 'EUR',
+        'type' => AccountType::Checking->value,
+    ]);
+
+    $response->assertSessionHasErrors(['bank_id']);
+    assertDatabaseHas('accounts', [
+        'id' => $account->id,
+        'bank_id' => $this->bank->id,
+    ]);
+});
+
+it('refuses to clear the bank of a connected account', function () {
+    actingAs($this->user);
+
+    $account = Account::factory()->connected()->create([
+        'user_id' => $this->user->id,
+        'bank_id' => $this->bank->id,
+        'currency_code' => 'EUR',
+        'type' => AccountType::Checking,
+    ]);
+
+    $response = $this->patch(route('accounts.update', $account), [
+        'name' => 'Renamed',
+        'bank_id' => null,
+        'currency_code' => 'EUR',
+        'type' => AccountType::Checking->value,
+    ]);
+
+    $response->assertSessionHasErrors(['bank_id']);
+    assertDatabaseHas('accounts', [
+        'id' => $account->id,
+        'bank_id' => $this->bank->id,
+    ]);
+});
+
 it('still updates a connected account when the currency is left alone', function () {
     actingAs($this->user);
 


### PR DESCRIPTION
Three inconsistencies around connected (open banking) accounts: things the app let the reader change that the bank connection actually owns, or offered on one screen and not the other.

## Deleting

Deleting a connected account was offered in the settings list while the account page had already hidden it. Deleting is the one path that leaves the bank behind, so the settings list is the screen that was wrong: **archiving is the path to deleting a connected account**. Archiving detaches the account from its connection and revokes the session when it was the last account on it, and it nulls `banking_connection_id` — so once archived, the account can be deleted from the same list.

- Both menus in `settings/accounts` (the row dropdown and the context menu) hide **Delete** on a connected account, matching the account page.
- `AccountController@destroy` refuses one outright, for a stale page or a hand-made request.

## Currency

The bank sets the currency of a connected account and everything already synced is in it, so it is not ours to edit.

- `UpdateAccountRequest` accepts only the code the account already has; a manual account still moves to any supported currency.
- The form renders the field disabled with the reason under it.

## Bank

The bank comes from the connection. It was already stopped from being cleared, but it could still be pointed at a different bank.

- `UpdateAccountRequest` accepts only the bank the account already has, which rules out clearing it too. Requiring one is safe: every path that connects an account gives it a bank.
- The combobox is disabled rather than merely non-clearable, which retires the `clearable` prop — the "No bank" entry lives inside the popover, so a field that cannot be opened cannot be cleared either, and the prop had no other caller.
- The label drops its "(optional)" and the line under it stops telling the reader to leave empty a field they cannot empty.

The form's `bankClearable` prop became `isConnected`: one fact about the account now drives the locked currency, the locked bank and the copy that explains both.

## Tests

- `tests/Feature/Settings/AccountTest.php` — the currency and the bank are both rejected on a connected account (changed or cleared), an unrelated edit still goes through when they are left alone, and deleting is forbidden.
- `resources/js/components/accounts/account-form.test.tsx` — disabled currency and bank plus both explanations when connected, everything open with the manual copy otherwise.
- `resources/js/pages/settings/accounts.test.tsx` — no Delete item on a connected account, Delete present on a manual one.

Detaching on archive is already covered by `AccountControllerTest`.

## Demo

<!-- PLACEHOLDER: drag the QA video here -->

https://github.com/user-attachments/assets/4c9d6a03-dc22-420f-8be1-ac364a4f5847



QA'd in the browser on both account kinds. Connected: bank and currency disabled with their reasons, label without "(optional)", no Delete in either menu, and a name-only edit still saving (303) — which proves the locked fields keep submitting their existing values. Manual: bank combobox opening with its "No bank" entry, currency listing every option, and Delete still reaching its confirmation dialog.