### PR TITLE
fix(tests): pin the seed accounts so the type-filtered sole() cannot collide

### DIFF
--- a/tests/Feature/Mcp/McpWriteToolsTest.php
+++ b/tests/Feature/Mcp/McpWriteToolsTest.php
@@ -1222,7 +1222,7 @@ it('creates a loan with its details and backfills the balance history', function
     Queue::fake();
 
     $user = User::factory()->create();
-    Account::factory()->create(['user_id' => $user->id]);
+    Account::factory()->create(['user_id' => $user->id, 'type' => 'checking']);
 
     callWriteTool($user, CreateAccount::class, [
         'name' => 'Mortgage',
@@ -1252,7 +1252,7 @@ it('creates a property with its details and backfills the value history', functi
     Queue::fake();
 
     $user = User::factory()->create();
-    Account::factory()->create(['user_id' => $user->id]);
+    Account::factory()->create(['user_id' => $user->id, 'type' => 'checking']);
 
     callWriteTool($user, CreateAccount::class, [
         'name' => 'The flat',


### PR DESCRIPTION
## What

Two MCP account tests were flaky and reddened CI on `main` ([run 34345023098](https://github.com/whisper-money/whisper-money/actions/runs/34345023098/job/102444472654)):

```
FAILED  Tests\Feature\Mcp\McpWriteToolsTest  MultipleRecordsFoundException: 2 records were found.
  tests/Feature/Mcp/McpWriteToolsTest.php:1238
  tests/Feature/Mcp/McpWriteToolsTest.php:1269
```

## Why it failed

Both tests seeded a throwaway account without pinning its type, so `AccountFactory` took its
`fake()->randomElement(AccountType::cases())` default — one of eight types, picked at random.
Each test then fetched the account the `CreateAccount` tool had just created with a type-filtered
`sole()`:

| Test | Seed | Assertion filter | Collides when faker rolls |
| --- | --- | --- | --- |
| `creates a loan with its details and backfills the balance history` | untyped | `where('type', 'loan')->sole()` | `loan` |
| `creates a property with its details and backfills the value history` | untyped | `where('type', 'real_estate')->sole()` | `real_estate` |

Whenever the roll landed on the very type the assertion filtered on, `sole()` saw two rows instead of
one and threw `MultipleRecordsFoundException` — **one run in eight for each test**. Nothing to do with
the change that happened to be on the tip of `main`; the flake came in with #958.

## The fix

Pin both seeds to `checking`, which neither assertion filters on:

```php
Account::factory()->create(['user_id' => $user->id, 'type' => 'checking']);
```

This keeps the seed's real purpose intact. `CreateAccount` writes `user.currency_code` from the
user's *first* account (`AccountUserCurrencyService::syncFromFirstAccount()` fires only when
`accounts()->count() === 1`), so these two tests seed a prior account precisely so the tool-created
one is not the first and that side effect stays out of the picture. Both gates the seed passes
through are count/existence-based and never look at the type, so `checking` satisfies them exactly as
well as any random type did. It also matches the convention the neighbouring tests already follow —
they pin `'type' => 'loan'` / `'type' => 'real_estate'` on their seeds.

`AccountFactory`'s random default is deliberately left alone: making it deterministic would fix the
whole class of bug but touches every test in the suite that uses the factory, which is too big a
blast radius for a red-CI fix. Tracked separately as a follow-up.

No new test — the fix *is* determinism in existing tests, and asserting on a pinned factory attribute
would be noise.

## Verification

- Forced the collision (seed pinned to `loan` / `real_estate` instead) and reproduced the exact CI
  error on both tests — `2 records were found.` — confirming the mechanism rather than assuming it.
- With the fix, ran the two tests **20 times in a row: 20/20 green**. Faker is unseeded in this suite,
  so repeated runs really do exercise different rolls. Before the fix ~23% of runs would have gone red.
- Full suite: `./vendor/bin/pest --exclude-testsuite=Browser` → 3245 tests, 3244 passed, 1 skipped,
  1 incomplete, exit 0.
- `vendor/bin/pint --dirty` → passed.