### PR TITLE
fix(savings-goals): reject a mistyped year in the goal target date

### DIFF
--- a/app/Http/Requests/StoreSavingsGoalRequest.php
+++ b/app/Http/Requests/StoreSavingsGoalRequest.php
@@ -29,7 +29,13 @@ class StoreSavingsGoalRequest extends FormRequest
             ],
             'target_amount' => ['required', 'integer', 'min:1'],
             'initial_amount' => ['nullable', 'integer', 'min:0'],
-            'target_date' => ['nullable', 'date', 'after:today'],
+            // Pin the format and cap the year: 'date' alone silently mangles a
+            // five-digit year typo like 20026-11-10 into 2006-11-10, so every
+            // range rule sees a plausible date while the raw string is what
+            // reaches MySQL and blows up as an out-of-range date (PHP-LARAVEL-5X).
+            // The date picker always sends Y-m-d, and 2100 rejects typos rather
+            // than real target dates.
+            'target_date' => ['nullable', 'date_format:Y-m-d', 'after:today', 'before_or_equal:2100-01-01'],
         ];
     }
 

--- a/app/Http/Requests/StoreSavingsGoalRequest.php
+++ b/app/Http/Requests/StoreSavingsGoalRequest.php
@@ -46,6 +46,7 @@ class StoreSavingsGoalRequest extends FormRequest
     {
         return [
             'name.unique' => __('You already have a label or goal with this name.'),
+            'target_date.date_format' => __('Please enter a valid target date.'),
         ];
     }
 }

--- a/app/Http/Requests/UpdateSavingsGoalRequest.php
+++ b/app/Http/Requests/UpdateSavingsGoalRequest.php
@@ -31,7 +31,10 @@ class UpdateSavingsGoalRequest extends FormRequest
             ],
             'target_amount' => ['sometimes', 'required', 'integer', 'min:1'],
             'initial_amount' => ['sometimes', 'required', 'integer', 'min:0'],
-            'target_date' => ['nullable', 'date'],
+            // Pin the format and cap the year for the same reason as in
+            // StoreSavingsGoalRequest: a five-digit year typo passes 'date' and
+            // then blows up as an out-of-range MySQL date (PHP-LARAVEL-5X).
+            'target_date' => ['nullable', 'date_format:Y-m-d', 'before_or_equal:2100-01-01'],
         ];
     }
 

--- a/app/Http/Requests/UpdateSavingsGoalRequest.php
+++ b/app/Http/Requests/UpdateSavingsGoalRequest.php
@@ -31,10 +31,13 @@ class UpdateSavingsGoalRequest extends FormRequest
             ],
             'target_amount' => ['sometimes', 'required', 'integer', 'min:1'],
             'initial_amount' => ['sometimes', 'required', 'integer', 'min:0'],
-            // Pin the format and cap the year for the same reason as in
+            // Pin the format and bound the year for the same reason as in
             // StoreSavingsGoalRequest: a five-digit year typo passes 'date' and
-            // then blows up as an out-of-range MySQL date (PHP-LARAVEL-5X).
-            'target_date' => ['nullable', 'date_format:Y-m-d', 'before_or_equal:2100-01-01'],
+            // then blows up as an out-of-range MySQL date (PHP-LARAVEL-5X). There
+            // is no `after:today` here on purpose — a goal whose target date has
+            // already passed still has to be editable — so 1900 is the floor that
+            // keeps a dropped-digit typo like 0026-11-10 out.
+            'target_date' => ['nullable', 'date_format:Y-m-d', 'after_or_equal:1900-01-01', 'before_or_equal:2100-01-01'],
         ];
     }
 
@@ -45,6 +48,7 @@ class UpdateSavingsGoalRequest extends FormRequest
     {
         return [
             'name.unique' => __('You already have a label or goal with this name.'),
+            'target_date.date_format' => __('Please enter a valid target date.'),
         ];
     }
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -1377,6 +1377,7 @@
     "Please describe the problem and what you were doing when it happened. Keep the details below — they help us debug.": "Describe el problema y qué estabas haciendo cuando ocurrió. Conserva los detalles de abajo: nos ayudan a depurar.",
     "Please enter a bank name.": "Por favor, ingresa un nombre de banco.",
     "Please enter an account name.": "Por favor, ingresa un nombre de cuenta.",
+    "Please enter a valid target date.": "Por favor, ingresa una fecha objetivo válida.",
     "Please enter your new password below": "Por favor ingresa tu nueva contraseña a continuación",
     "Please fill in all required fields.": "Por favor, completa todos los campos obligatorios.",
     "Please cancel your subscription before deleting your account.": "Por favor cancela tu suscripción antes de eliminar tu cuenta.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1273,6 +1273,7 @@
     "Please describe the problem and what you were doing when it happened. Keep the details below — they help us debug.": "Décrivez le problème et ce que vous faisiez lorsqu'il s'est produit. Conservez les détails ci-dessous : ils nous aident à déboguer.",
     "Please enter a bank name.": "Veuillez saisir un nom de banque.",
     "Please enter an account name.": "Veuillez saisir un nom de compte.",
+    "Please enter a valid target date.": "Veuillez saisir une date cible valide.",
     "Please enter your new password below": "Veuillez entrer votre nouveau mot de passe ci-dessous",
     "Please fill in all required fields.": "Veuillez remplir tous les champs obligatoires.",
     "Please proceed with caution, this cannot be undone.": "Veuillez procéder avec prudence, cela ne peut pas être annulé.",

--- a/resources/js/components/savings-goals/create-savings-goal-dialog.tsx
+++ b/resources/js/components/savings-goals/create-savings-goal-dialog.tsx
@@ -172,6 +172,7 @@ export function CreateSavingsGoalDialog({
                                 id="goal-target-date"
                                 type="date"
                                 min={today}
+                                max="2100-01-01"
                                 value={targetDate}
                                 onChange={(e) => setTargetDate(e.target.value)}
                             />

--- a/resources/js/components/savings-goals/edit-savings-goal-dialog.tsx
+++ b/resources/js/components/savings-goals/edit-savings-goal-dialog.tsx
@@ -157,6 +157,7 @@ export function EditSavingsGoalDialog({
                             <Input
                                 id="edit-goal-target-date"
                                 type="date"
+                                min="1900-01-01"
                                 max="2100-01-01"
                                 value={targetDate}
                                 onChange={(e) => setTargetDate(e.target.value)}

--- a/resources/js/components/savings-goals/edit-savings-goal-dialog.tsx
+++ b/resources/js/components/savings-goals/edit-savings-goal-dialog.tsx
@@ -157,6 +157,7 @@ export function EditSavingsGoalDialog({
                             <Input
                                 id="edit-goal-target-date"
                                 type="date"
+                                max="2100-01-01"
                                 value={targetDate}
                                 onChange={(e) => setTargetDate(e.target.value)}
                             />

--- a/tests/Feature/SavingsGoalTest.php
+++ b/tests/Feature/SavingsGoalTest.php
@@ -299,6 +299,46 @@ test('the starting amount cannot be negative', function () {
     expect(SavingsGoal::where('user_id', $user->id)->count())->toBe(0);
 });
 
+test('a target date with an out-of-range year is rejected when creating', function () {
+    $user = onboardedSavingsUser();
+
+    $this->actingAs($user)->post('/savings-goals', [
+        'name' => 'Typo',
+        'target_amount' => 500000,
+        'target_date' => '20026-11-10',
+    ])->assertSessionHasErrors('target_date');
+
+    expect(SavingsGoal::where('user_id', $user->id)->count())->toBe(0);
+});
+
+test('a target date with an out-of-range year is rejected when editing', function (string $targetDate) {
+    $user = onboardedSavingsUser();
+
+    $goal = SavingsGoal::factory()->create([
+        'user_id' => $user->id,
+        'target_date' => '2026-11-10',
+    ]);
+
+    $this->actingAs($user)->patch("/savings-goals/{$goal->id}", [
+        'target_date' => $targetDate,
+    ])->assertSessionHasErrors('target_date');
+
+    expect($goal->fresh()->target_date->toDateString())->toBe('2026-11-10');
+})->with(['20026-11-10', '9999-12-31']);
+
+test('editing a goal accepts a normal future target date', function () {
+    $user = onboardedSavingsUser();
+
+    $goal = SavingsGoal::factory()->create(['user_id' => $user->id]);
+    $targetDate = now()->addYear()->toDateString();
+
+    $this->actingAs($user)->patch("/savings-goals/{$goal->id}", [
+        'target_date' => $targetDate,
+    ])->assertRedirect();
+
+    expect($goal->fresh()->target_date->toDateString())->toBe($targetDate);
+});
+
 test('the starting amount does not inflate the projected pace', function () {
     $start = Carbon::parse('2026-07-20');
     $today = Carbon::parse('2026-07-30');

--- a/tests/Feature/SavingsGoalTest.php
+++ b/tests/Feature/SavingsGoalTest.php
@@ -324,7 +324,7 @@ test('a target date with an out-of-range year is rejected when editing', functio
     ])->assertSessionHasErrors('target_date');
 
     expect($goal->fresh()->target_date->toDateString())->toBe('2026-11-10');
-})->with(['20026-11-10', '9999-12-31']);
+})->with(['20026-11-10', '9999-12-31', '0026-11-10']);
 
 test('editing a goal accepts a normal future target date', function () {
     $user = onboardedSavingsUser();


### PR DESCRIPTION
Editing a savings goal with a mistyped year in `target_date` returned a 500 and
silently lost the user's edit.

Fixes PHP-LARAVEL-5X

## The bug

`PATCH /savings-goals/{id}` with `target_date=20026-11-10` — a plausible typo for
`2026-11-10` — crashed with:

```
SQLSTATE[22007]: Invalid datetime format: 1292 Incorrect date value: '20026-11-10'
for column 'target_date' at row 1
```

## Root cause

Not simply "`date` accepts a five-digit year". PHP's date parser **mangles** it:

```
strtotime('20026-11-10')  =>  2006-11-10 20:02:00
```

So the `date` rule sees a perfectly plausible date in 2006, and so does every
range rule you stack on top of it — `before_or_equal:2100-01-01` passes happily.
Meanwhile Eloquent writes the **raw request string** to the column, not the
parsed date, and MySQL rejects `'20026-11-10'` as out of range.

That is why bounding the range alone does not fix this: the bound compares a
value that never reaches the database. The format has to be pinned.

Incidentally this is also why `POST /savings-goals` did *not* crash — its
pre-existing `after:today` rule rejects `20026-11-10` by accident, because the
mangled value lands in the past. A five-digit year that happened to mangle into
a future date would have crashed there too.

## The fix

`target_date` in both Form Requests now pins the format the date picker actually
sends and bounds the year:

```php
// Store
['nullable', 'date_format:Y-m-d', 'after:today', 'before_or_equal:2100-01-01']

// Update
['nullable', 'date_format:Y-m-d', 'after_or_equal:1900-01-01', 'before_or_equal:2100-01-01']
```

`date_format:Y-m-d` is what closes the crash; the range bounds are what give a
readable message for a real out-of-range date like `9999-12-31`. This mirrors how
account detail dates are already bounded on both ends in
`ValidatesAccountDetailRules`, and `date_format:Y-m-d` is already the house
pattern for date inputs (`IndexTransactionRequest`,
`BulkUpdateTransactionsRequest`, `StoreSavedFilterRequest`).

`after:today` is deliberately **not** added to the update request — a goal whose
target date has already passed has to stay editable. `after_or_equal:1900-01-01`
is the floor that keeps a dropped-digit typo like `0026-11-10` out without
breaking that. To be clear about what that rule does and does not do: MySQL
accepts `0026-11-10` without complaining, so the floor is data sanity, not a
second 500.

The stock `date_format` message leaked an internal token to the user ("must match
the format Y-m-d"), so both requests override it with "Please enter a valid target
date." (translated to es/fr).

The two dialogs get `max="2100-01-01"` (and `min="1900-01-01"` on the edit one,
which had no `min`), matching the `min={today}` the create dialog already had.
The server-side rule is what actually protects the write; this is just the native
constraint next to it.

## Scope

No controller changes, no shared concern extracted for two call sites, no data
migration, and no behaviour change for any valid input.

## Tests

Three new tests in `tests/Feature/SavingsGoalTest.php`: store rejects the
mistyped year, update rejects it (dataset over `20026-11-10`, `9999-12-31` and
`0026-11-10`, covering the format pin and both bounds), and a normal future date
still saves on update. `php artisan test --filter=SavingsGoal` → 40 passed.

## QA

Browser-QA'd against the running app: create and edit with a valid future date
both persist, editing to a **past** date still saves (the deliberate asymmetry),
and the forced invalid year now returns 303 with errors in-browser / 422 JSON
directly, rendering "Please enter a valid target date." under the field with the
dialog left open. No new exception in `laravel.log`.

Worth noting: Chrome's native date input already refuses a five-digit year via
`checkValidity()`, so the invalid value had to be forced past `noValidate` to
reach the server at all.

## Demo

https://github.com/user-attachments/assets/98aae783-2a1d-4245-90f1-0a1001b80056


