### PR TITLE
fix(achievements): bound a growth rate to what the percent column holds

### DIFF
--- a/app/Services/Achievements/Unlock.php
+++ b/app/Services/Achievements/Unlock.php
@@ -11,6 +11,11 @@ namespace App\Services\Achievements;
  */
 final readonly class Unlock
 {
+    /**
+     * The largest rate the `percent` column holds, as `decimal(8, 2)`.
+     */
+    private const float MAX_PERCENT = 999999.99;
+
     private function __construct(
         public string $month,
         private ?int $value = null,
@@ -44,9 +49,14 @@ final readonly class Unlock
         return new self(substr($date, 0, 7), value: $length, on: $date);
     }
 
+    /**
+     * A rate is bounded by what the `percent` column can hold: a net worth that
+     * grew out of nothing gives a figure with no ceiling, and a medal that was
+     * really earned should be recorded rather than rejected by the column.
+     */
     public static function rate(string $month, float $percent): self
     {
-        return new self($month, percent: $percent);
+        return new self($month, percent: max(-self::MAX_PERCENT, min(self::MAX_PERCENT, $percent)));
     }
 
     /**

--- a/tests/Feature/Achievements/AchievementSweepTest.php
+++ b/tests/Feature/Achievements/AchievementSweepTest.php
@@ -1,8 +1,10 @@
 <?php
 
+use App\Enums\AccountType;
 use App\Enums\CategoryType;
 use App\Jobs\Drip\SendAchievementsEmailJob;
 use App\Models\Account;
+use App\Models\AccountBalance;
 use App\Models\Category;
 use App\Models\Transaction;
 use App\Models\User;
@@ -212,4 +214,36 @@ it('keeps the account menu count in step, even on a sweep that awards nothing', 
     app(Awarder::class)->sweep($user);
 
     expect($user->fresh()->achievements_count)->toBe($user->achievements()->count());
+});
+
+it('records a year of growth off a near-zero start instead of failing the whole sweep', function (): void {
+    $user = reader();
+
+    // Pinned rather than left to the factory's random type: a loan subtracts
+    // from net worth and a credit card is left out of it altogether, and either
+    // one would leave nothing for a growth rate to be read against.
+    $account = Account::factory()->create([
+        'user_id' => $user->id,
+        'space_id' => $user->activeSpace()->id,
+        'currency_code' => 'EUR',
+        'type' => AccountType::Checking,
+    ]);
+
+    recordMonth($user, now()->subMonths(13)->format('Y-m'), 300000, 150000);
+    recordMonth($user, now()->subMonth()->format('Y-m'), 300000, 150000);
+
+    // A few cents a year ago against an ordinary balance today. The rate that
+    // comes out of that is seven figures, well past what the `percent` column
+    // holds, and the insert used to take every other medal down with it.
+    foreach ([13 => 100, 1 => 1092000] as $monthsAgo => $balance) {
+        AccountBalance::factory()->create([
+            'account_id' => $account->id,
+            'balance_date' => now()->subMonths($monthsAgo)->endOfMonth()->toDateString(),
+            'balance' => $balance,
+        ]);
+    }
+
+    app(Awarder::class)->sweep($user);
+
+    expect($user->achievements()->where('key', 'momentum.2')->first()?->percent)->toBe(999999.99);
 });


### PR DESCRIPTION
The nightly `achievements:sweep` has been failing for a user since the Pennant gate
came off in #961 and the sweep started reading real long-history data:

```
SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'percent' at row 1
insert into `achievements` (..., `key`, ..., `percent`, ...)
values (..., momentum.2, ..., 1092000, ...)
```

## What happens

`Evaluator::firstYearOfGrowth()` reads net worth growth over a year as a percentage:

```php
$growth = round((($now - $yearAgo) / $yearAgo) * 100, 2);
```

`$yearAgo` only has to be greater than zero, so a net worth of a few minor units a
year ago against an ordinary balance today gives a percentage with no ceiling — here
1,092,000%. `achievements.percent` is `decimal(8, 2)`, which stops at 999999.99, and
nothing between the division and the insert bounded the value.

`Awarder::record()` writes a user's medals in one pass and the sweep catches per user, so
the whole run survives — but that user's pass stops at the rejected insert. Every medal
sorted at or after `momentum.2`'s month goes unwritten, `tally()` never runs so
`achievements_count` keeps a stale number, and the command reports the user as skipped.
The next night starts over and hits the same row again, so the medal is never earned.

Running the command against a reproduction of the reported history confirms it: with the
fix the user gets 12 medals, without it 11 land and `momentum.2` is the one lost, every
night. Nothing needs backfilling beyond the medals that were never written.

## The fix

`Unlock::rate()` clamps the figure to what the column holds. `Unlock`'s named constructors
are already documented as "the only way to build one, so the figure and the column it lands
in can never disagree", so the bound belongs there rather than at one caller: it also covers
`savings_rate.*`, the other `Unlock::rate()` caller, which can blow up the same way when
income is near zero.

The award condition is deliberately left alone. Whether growth measured against a near-zero
base *should* earn `momentum.2` is a product question, not a crash fix — and `momentum.2` is
a medal this user genuinely earned, so it keeps being awarded.

## Trade-off

A user whose net worth grew out of roughly nothing now reads 999,999.99% instead of
1,092,000%. That is cosmetic, on a figure nobody can interpret either way, and it only
affects a history that started at near zero. The alternative — a migration widening the
column — buys more digits of a meaningless number and costs a schema change, so it did not
seem worth it.

## Testing

New test in `tests/Feature/Achievements/AchievementSweepTest.php` drives a real history
(balances of €1.00 thirteen months back and €10,920 in the last closed month) through
`Awarder::sweep()`. Without the clamp it fails with the exact production error; with it the
`momentum.2` row lands at 999999.99.

Fixes PHP-LARAVEL-60
