### PR TITLE
fix(achievements): bound the sweep to the history it can value and to one reader's memory

### DIFF
--- a/app/Console/Commands/SweepAchievementsCommand.php
+++ b/app/Console/Commands/SweepAchievementsCommand.php
@@ -28,11 +28,6 @@ class SweepAchievementsCommand extends Command
 
     protected $description = 'Record the achievements every user has earned';
 
-    public function __construct(private Awarder $awarder)
-    {
-        parent::__construct();
-    }
-
     public function handle(): int
     {
         $swept = 0;
@@ -50,10 +45,23 @@ class SweepAchievementsCommand extends Command
         return self::SUCCESS;
     }
 
+    /**
+     * One reader, with an {@see Awarder} of their own.
+     *
+     * Resolved here rather than held for the run because of what hangs off it:
+     * the rate service behind the calculators memoizes every month-end rate it
+     * reads, and one kept for the whole command grows by a reader's worth of
+     * rate maps on every pass until the process runs out of memory. A reader's
+     * history is freed with the graph that read it, so the peak is one member
+     * rather than all of them, and the cost is a dozen constructor calls
+     * against the hundreds of queries a history already takes.
+     */
     private function sweep(User $user): int
     {
         try {
-            return $this->awarder->sweep($user, notify: ! $this->option('quiet-notifications'))->count();
+            return $this->laravel->make(Awarder::class)
+                ->sweep($user, notify: ! $this->option('quiet-notifications'))
+                ->count();
         } catch (Throwable $exception) {
             report($exception);
             $this->warn("Skipped {$user->email}: {$exception->getMessage()}");

--- a/app/Services/Achievements/HistoryBuilder.php
+++ b/app/Services/Achievements/HistoryBuilder.php
@@ -12,6 +12,7 @@ use App\Services\ExchangeRateService;
 use App\Services\NetWorthCalculator;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection as BaseCollection;
 use RuntimeException;
 
 /**
@@ -23,6 +24,10 @@ use RuntimeException;
  * hundred rows and one balance walk per user, on a nightly job — if it ever
  * stops being cheap, the fix is to skip users with no new transactions since
  * their last sweep, not to shorten the window.
+ *
+ * The whole past as far back as it can be valued, that is: a reader holding a
+ * foreign currency is read from {@see firstConvertibleMonth()} on, because a
+ * month whose money no rate can convert is a month with no figures in it.
  */
 class HistoryBuilder
 {
@@ -36,14 +41,14 @@ class HistoryBuilder
     public function for(User $user): History
     {
         $currency = $this->ladders->currencyFor($user->currency_code);
-        $first = $this->firstMonth($user);
+        $accounts = Account::query()->where('user_id', $user->id)->get();
+        $first = $this->firstConvertibleMonth($user, $accounts, $currency);
         $last = now()->subMonth()->startOfMonth();
 
         if ($first === null || $first->gt($last)) {
             return new History($currency);
         }
 
-        $accounts = Account::query()->where('user_id', $user->id)->get();
         $lookup = BalanceLookup::forAccounts($accounts->pluck('id'), $first, $last->copy()->endOfMonth());
         $months = $this->cashflow->forMonths($user->id, $currency, $first, $last->copy()->endOfMonth());
         $counts = $this->transactionCounts($user, $first, $last);
@@ -64,6 +69,50 @@ class HistoryBuilder
     }
 
     /**
+     * The first month of a history whose money can be valued.
+     *
+     * Their first transaction, unless they hold a currency other than the one
+     * they are measured in and that transaction predates
+     * `achievements.rates_from`. The rate provider has nothing before that
+     * month and never will, so no sweep can ever put a figure on an earlier
+     * one: demanding a rate for it only skips the reader again every night,
+     * for a gap that will not close. Their medals start where their money can
+     * first be read instead, which costs them the milestones of a statement
+     * imported from further back than any rate exists for.
+     *
+     * @param  Collection<int, Account>  $accounts
+     */
+    private function firstConvertibleMonth(User $user, Collection $accounts, string $currency): ?Carbon
+    {
+        $first = $this->firstMonth($user);
+
+        if ($first === null || $this->foreignCurrencies($accounts, $currency)->isEmpty()) {
+            return $first;
+        }
+
+        $floor = Carbon::createFromFormat('Y-m-d', config('achievements.rates_from').'-01')->startOfMonth();
+
+        return $first->lt($floor) ? $floor : $first;
+    }
+
+    /**
+     * The currencies the reader keeps money in other than the one their medals
+     * are measured in, lowercased the way a rate map keys them.
+     *
+     * @param  Collection<int, Account>  $accounts
+     * @return BaseCollection<int, string>
+     */
+    private function foreignCurrencies(Collection $accounts, string $currency): BaseCollection
+    {
+        return $accounts
+            ->pluck('currency_code')
+            ->map(fn (string $code): string => strtolower($code))
+            ->unique()
+            ->reject(fn (string $code): bool => $code === strtolower($currency))
+            ->values();
+    }
+
+    /**
      * Refuse to read a history whose money cannot all be converted.
      *
      * An account in another currency is worth what the rate on the day says,
@@ -74,19 +123,16 @@ class HistoryBuilder
      * wrong month, or awarded on a figure nobody ever had, permanently.
      *
      * Better to record nothing today: the sweep runs again tomorrow, and the
-     * command reports the reader it skipped.
+     * command reports the reader it skipped. That is a bet on tomorrow, so it
+     * is only made for months a rate can actually arrive for —
+     * {@see firstConvertibleMonth()} has already dropped the ones it cannot.
      *
      * @param  Collection<int, Account>  $accounts
      * @param  list<string>  $months
      */
     private function ensureRates(Collection $accounts, string $currency, array $months): void
     {
-        $foreign = $accounts
-            ->pluck('currency_code')
-            ->map(fn (string $code): string => strtolower($code))
-            ->unique()
-            ->reject(fn (string $code): bool => $code === strtolower($currency))
-            ->values();
+        $foreign = $this->foreignCurrencies($accounts, $currency);
 
         if ($foreign->isEmpty()) {
             return;

--- a/app/Services/Achievements/HistoryBuilder.php
+++ b/app/Services/Achievements/HistoryBuilder.php
@@ -101,7 +101,7 @@ class HistoryBuilder
      * are measured in, lowercased the way a rate map keys them.
      *
      * @param  Collection<int, Account>  $accounts
-     * @return BaseCollection<int, string>
+     * @return BaseCollection<int, lowercase-string>
      */
     private function foreignCurrencies(Collection $accounts, string $currency): BaseCollection
     {

--- a/app/Services/Achievements/HistoryBuilder.php
+++ b/app/Services/Achievements/HistoryBuilder.php
@@ -90,7 +90,8 @@ class HistoryBuilder
             return $first;
         }
 
-        $floor = Carbon::createFromFormat('Y-m-d', config('achievements.rates_from').'-01')->startOfMonth();
+        $from = (string) config('achievements.rates_from');
+        $floor = Carbon::createFromFormat('Y-m-d', $from.'-01')->startOfMonth();
 
         return $first->lt($floor) ? $floor : $first;
     }

--- a/config/achievements.php
+++ b/config/achievements.php
@@ -18,6 +18,23 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Where convertible history starts
+    |--------------------------------------------------------------------------
+    |
+    | The rate provider holds nothing before this month and never will, so
+    | money kept in another currency cannot be valued any earlier than it. A
+    | reader holding a foreign currency is read from this month on rather than
+    | from their first transaction: a medal is dated to the month it happened,
+    | and a month whose money nobody can convert is a month nobody can date.
+    | Readers whose money is all in one currency need no rate and keep their
+    | whole past. YYYY-MM.
+    |
+    */
+
+    'rates_from' => env('ACHIEVEMENTS_RATES_FROM', '2024-03'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Rarity
     |--------------------------------------------------------------------------
     |

--- a/tests/Feature/Achievements/AchievementSweepTest.php
+++ b/tests/Feature/Achievements/AchievementSweepTest.php
@@ -6,11 +6,14 @@ use App\Jobs\Drip\SendAchievementsEmailJob;
 use App\Models\Account;
 use App\Models\AccountBalance;
 use App\Models\Category;
+use App\Models\ExchangeRate;
 use App\Models\Transaction;
 use App\Models\User;
 use App\Notifications\AchievementsWelcome;
 use App\Notifications\AchievementUnlocked;
 use App\Services\Achievements\Awarder;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Queue;
@@ -67,6 +70,40 @@ function recordMonth(User $user, string $month, int $income, int $saved): void
         'transaction_date' => $date,
         'amount' => -$saved,
         'currency_code' => 'EUR',
+    ]);
+}
+
+/**
+ * The rate provider as it really answers: a rate map from
+ * `achievements.rates_from` on, and a 404 for every date before it, which is
+ * what a month end in 2001 gets asked for and always will.
+ */
+function fakeCoveredCurrencyApi(): void
+{
+    $from = (string) config('achievements.rates_from');
+
+    Http::fake(function (Request $request) use ($from) {
+        if (! preg_match('#(\d{4}-\d{2})-\d{2}/(?:v1/)?currencies/([a-z0-9]+)\.min\.json#i', $request->url(), $matches)) {
+            return null;
+        }
+
+        if ($matches[1] < $from) {
+            return Http::response([], 404);
+        }
+
+        return Http::response([strtolower($matches[2]) => ['btc' => 0.00001, 'eur' => 1.0, 'usd' => 1.1]]);
+    });
+}
+
+/**
+ * A reader holding a currency other than the one their medals are measured in.
+ */
+function withForeignAccount(User $user): void
+{
+    Account::factory()->create([
+        'user_id' => $user->id,
+        'space_id' => $user->activeSpace()->id,
+        'currency_code' => 'BTC',
     ]);
 }
 
@@ -246,4 +283,73 @@ it('records a year of growth off a near-zero start instead of failing the whole 
     app(Awarder::class)->sweep($user);
 
     expect($user->achievements()->where('key', 'momentum.2')->first()?->percent)->toBe(999999.99);
+});
+
+it('reads a foreign-currency reader from the first month a rate can exist', function (): void {
+    fakeCoveredCurrencyApi();
+
+    $user = reader();
+
+    // A statement imported from further back than any rate provider goes, and
+    // a month from the covered period.
+    recordMonth($user, '2001-01', 300000, 150000);
+    recordMonth($user, now()->subMonths(3)->format('Y-m'), 300000, 150000);
+
+    withForeignAccount($user);
+
+    $this->artisan('achievements:sweep', ['--user' => $user->email])
+        ->doesntExpectOutputToContain('Skipped')
+        ->assertSuccessful();
+
+    // The medals their convertible history earns, rather than nothing at all
+    // every night forever because January 2001 has no rate and never will.
+    // Their 2001 months are the price: no rate can date a medal to them.
+    expect($user->achievements()->where('key', 'monthly_saving.2')->exists())->toBeTrue()
+        ->and($user->achievements()->where('key', 'transactions.1')->firstOrFail()->achieved_on->format('Y-m'))
+        ->toBe(now()->subMonths(3)->format('Y-m'));
+});
+
+it('reads the rates afresh for every reader instead of hoarding them for the run', function (): void {
+    $month = now()->subMonths(3)->format('Y-m');
+    $first = reader();
+    $second = reader();
+
+    foreach ([$first, $second] as $user) {
+        recordMonth($user, $month, 300000, 150000);
+        withForeignAccount($user);
+    }
+
+    // Every month end the sweep needs, already in the database, so a rate
+    // lookup is a query and never a request: counting the queries counts the
+    // lookups.
+    foreach (range(1, 3) as $monthsBack) {
+        ExchangeRate::factory()->create([
+            'base_currency' => 'eur',
+            'date' => now()->subMonths($monthsBack)->endOfMonth()->toDateString(),
+            'rates' => ['btc' => 0.00001, 'eur' => 1.0, 'usd' => 1.1],
+        ]);
+    }
+
+    $lookups = function (array $options): int {
+        $count = 0;
+
+        DB::listen(function ($query) use (&$count): void {
+            if (str_starts_with(strtolower($query->sql), 'select') && str_contains($query->sql, 'exchange_rates')) {
+                $count++;
+            }
+        });
+
+        $this->artisan('achievements:sweep', [...$options, '--quiet-notifications' => true])->assertSuccessful();
+
+        return $count;
+    };
+
+    $one = $lookups(['--user' => $first->email]);
+    $both = $lookups([]);
+
+    // Two readers cost two readers' worth of lookups: neither inherits the
+    // rates the one before it cached, which is what keeps a run over the whole
+    // member list inside the memory of one history.
+    expect($one)->toBeGreaterThan(0)
+        ->and($both)->toBe($one * 2);
 });


### PR DESCRIPTION
Fixes PHP-LARAVEL-5Z
Fixes PHP-LARAVEL-61

The first production `achievements:sweep` after cf7e252a took the Pennant gate
off met the real member base and threw twice in the same run. Both failures are
the same shape — a reader with a very long transaction history — and neither is
reachable from the seeded accounts the job had been running against until then.

## PHP-LARAVEL-5Z — a permanent gap treated as a transient one

`HistoryBuilder::for()` read every reader from their earliest
`transactions.transaction_date` with nothing bounding how far back that is, and
`ensureRates()` refuses to build a history when any month end lacks a rate for a
foreign-currency account. That refusal is right and stays: a medal is written
once and never revoked, so a rate that failed to arrive would date a milestone to
the wrong month, or award one on a figure nobody ever had, permanently. Better to
record nothing today and let tomorrow's sweep try again.

Only there is no tomorrow for January 2001. The rate provider holds nothing
before **2024-03-04** — verified by probing it, both the jsdelivr CDN and the
pages.dev mirror 404 for every earlier date — so five readers were skipped with a
fresh Sentry error every night, and would have been forever.

The window now starts at `achievements.rates_from` (default `2024-03`,
env-overridable) whenever the reader keeps money in a currency other than the one
their medals are measured in. `ensureRates()` is untouched for the months inside
that window, where a missing rate really is one that failed to arrive today, so
the invariant and the retry it protects both survive.

The default was checked against every base the sweep can ask for, not just one:
all seven ladder currencies and the USD fallback return a full map (~700
currencies, `btc`/`gbp`/`eur`/`usd` among them) from 2024-03-04 on, so no reader
is left in a gap between the floor and their own currency's coverage. 2024-03-31
is the first usable month end — February's 2024-02-29 is a 404 and the provider's
seven-day walk-back only goes backwards, so it never reaches March.

### The trade-off, and why this one

A floored reader's medals only reach back to the covered period: their "first
transaction" is dated to their first covered month, and the running counts
(`transactions.N`, `yearly_saving.N`) start from the floor rather than from their
true first transaction. Those figures are real and honestly computed, just
partial. Nothing is fabricated — `BalanceLookup` carries the opening balance
forward from before the range, so `net_worth.N` and the emergency-fund medals are
still dated against the balance the reader actually had.

The two alternatives were weighed and dropped:

- **Skip the uncovered months instead of trimming the window.** This is what the
  `ensureRates()` docblock forbids. A hole in the series joins two runs into one
  (`categorized` counts across the whole history), and a crossing that happened
  inside the hole gets dated to the next visible month — the same misdating,
  plus a run nobody kept.
- **Tell "the provider has no data" apart from "the lookup failed today" at the
  service.** That is the honest discriminator, but `CurrencyConversionService`
  answers a 404 and a connection failure with the same empty array, so it means
  threading a new signal up through a service ten other callers share. A date
  before the provider's coverage *is* that discriminator, and it is a date
  comparison.

Only readers holding a foreign currency are affected; a reader whose money is all
in one currency needs no rate and keeps their whole past, unchanged.

## PHP-LARAVEL-61 — the sweep's rate cache outlived the reader

`ExchangeRateService` memoizes the full rate payload per base+date for the life of
the instance, and `SweepAchievementsCommand` took `Awarder` in its **constructor**
— so the container built `Awarder → Evaluator → HistoryBuilder →
ExchangeRateService` once and every reader in the run poured their month ends into
it. Nothing evicted anything between readers, so memory grew monotonically across
the whole run until the 128 MB limit went. The `Illuminate\Http\Client\Response`
culprit frame is just where the final allocation happened to land.

The command resolves an `Awarder` per reader instead, so a reader's history is
freed with the graph that read it and the peak is one member rather than all of
them. That is the whole fix: the lifetime was the bug, and the constructor was the
lifetime. It also avoids putting a cache-eviction method on a service that
`NetWorthCalculator`, `CashflowSummaryService`, `SummaryBuilder`,
`ManualBalanceAdjuster` and five API controllers share — none of whose
`getRates()`/`convert()` behaviour changes here.

Worth naming: month-end rates are no longer shared between readers in one run, so
each foreign-currency reader now issues its own `exchange_rates` preload. That is
one batched query per reader, bounded by the window the floor gives it, in
exchange for a run that fits in memory.

## Known limitations, deliberately left

- **`safety.1` (loan paid off) can be missed by a floored reader.** It is an event
  detector: it needs to see the loan owing money and then reaching zero *inside*
  the visible months. A foreign-currency reader whose loan was cleared before the
  floor never shows as having owed anything, so the medal is not written. Dating
  it would mean either a wrong month or a second, unbounded balance walk for one
  row on a nightly job — and an unearned medal omitted is a smaller wrong than a
  medal dated to a month it did not happen in. Today those readers get no medals
  at all, so this is still strictly better for them.
- **The floor keys off any account in another currency, not off money that needs
  converting.** A stray zero-balance foreign account keeps a reader floored even
  though no rate is needed for a balance of zero. Narrowing it means modelling
  both per-month balances and per-month transaction currencies, and getting that
  subtly wrong writes a permanent row — the coarse check only ever truncates,
  never fabricates, so it stays coarse.

## Tests

`tests/Feature/Achievements/AchievementSweepTest.php`, both failing without the
fix (verified by reverting the two app files and re-running):

- `reads a foreign-currency reader from the first month a rate can exist` — a
  reader with a 2001 statement and a BTC account against a provider fake that
  answers the way the real one does. Fails with `Output "Skipped" was printed`,
  which is exactly PHP-LARAVEL-5Z.
- `reads the rates afresh for every reader instead of hoarding them for the run` —
  two readers sharing the same month ends, with the rates pre-seeded so a lookup
  is a query. Two readers must cost two readers' worth of lookups; before the fix
  the second inherits the first's cache and costs none.

The existing `records nothing when a foreign balance cannot be converted` still
passes: its months are all inside the covered window, so a provider outage still
skips the reader and retries tomorrow.

## Not in this PR

PHP-LARAVEL-60 (the `percent` column overflow) comes from the same run and is
being fixed separately. `Unlock.php` and `Evaluator::firstYearOfGrowth()` are
untouched here.

## QA

Run against an ephemeral MySQL, driving the command the way cron does.

**A reader shaped like PHP-LARAVEL-5Z** — a BTC account and monthly transactions
from 2001-01 to 2026-08 (~308 months), against a provider fake that answers the
way the real one does:

```
Swept 1 user(s), awarded 17 achievement(s).
```

No `Skipped`, 17 rows written, none dated before the floor: `transactions.1`,
`hygiene.1`, `categorized.1`, `monthly_saving.1/2`, `yearly_saving.1/2/3` and
`savings_rate.1-4` at `2024-03`, then `categorized.2-5` and `transactions.2`
progressing through 2024-05 → 2026-03 as the history accumulates. Previously: no
rows at all, and a Sentry event.

**A run over many readers, shaped like PHP-LARAVEL-61.** Readers holding money in
a currency that has to be converted, on many distinct days — because the rate
cache is keyed by base **and date**, so one full rate map is read and kept per
date, and transaction-date granularity is where a run grows rather than month
ends. Rates seeded into `exchange_rates`, and payloads sized the way the provider
really sends them (~200 currencies), so what is measured is the sweep's own
retention and not a test double's.

| 8 readers x distinct dates each | retained after the run | peak |
| --- | --- | --- |
| 100 (1,033 rate maps) - before | 16.0 MB | 173 MB |
| 100 (1,033 rate maps) - after | **4.0 MB** | 159 MB |
| 300 (2,289 rate maps) - before | 40.0 MB | 197 MB |
| 300 (2,289 rate maps) - after | **6.0 MB** | 163 MB |

That is the shape the fix is meant to change. Before, retention tracks every
reader in the run summed together (16 -> 40 MB as the run grows); after, it
tracks only the largest single reader (4 -> 6 MB), because each reader's graph is
freed with the reader. At roughly 5 MB per reader of this shape the old command
reaches 128 MB somewhere around two dozen of them, which is what the member base
handed it the first night it ran ungated.

## Checks

- `vendor/bin/pint --test` clean
- `vendor/bin/phpstan analyse` clean
- `php artisan test --exclude-testsuite=Browser --filter=Achievement` green
- `php artisan crap --base=origin/main --no-coverage` — 5 methods analysed, none
  above complexity 10
- `bun run dry` green
