### PR TITLE
fix(automation-rules): stop rules overwriting the categories chosen when splitting a transaction

### DIFF
--- a/app/Listeners/ApplyAutomationRules.php
+++ b/app/Listeners/ApplyAutomationRules.php
@@ -2,6 +2,7 @@
 
 namespace App\Listeners;
 
+use App\Enums\CategorySource;
 use App\Events\TransactionCreated;
 use App\Services\AutomationRuleService;
 
@@ -9,8 +10,22 @@ class ApplyAutomationRules
 {
     public function __construct(protected AutomationRuleService $automationRuleService) {}
 
+    /**
+     * Apply the user's rules to a transaction that was just created — unless a
+     * human already categorized it on the way in.
+     *
+     * A brand-new row carrying `manual` was categorized on purpose seconds ago:
+     * the split dialog, a hand-made transaction, the MCP tools. Letting a rule
+     * fire here overwrote that choice (and force-synced the rule's labels onto
+     * it). Re-evaluation is a different path — there the user asked for the
+     * rules to run — and is deliberately left alone.
+     */
     public function handle(TransactionCreated $event): void
     {
+        if ($event->transaction->category_source === CategorySource::Manual) {
+            return;
+        }
+
         $this->automationRuleService->applyRules($event->transaction);
     }
 }

--- a/tests/Feature/AutomationRuleEvaluationTest.php
+++ b/tests/Feature/AutomationRuleEvaluationTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\CategorySource;
 use App\Events\TransactionCreated;
 use App\Events\TransactionUpdated;
 use App\Models\Account;
@@ -450,4 +451,33 @@ test('applies automation rules via listener on TransactionCreated event', functi
     // The TransactionCreated event is dispatched automatically via $dispatchesEvents.
     // The listener should have already run. Verify the result.
     expect($transaction->fresh()->category_id)->toBe($this->category->id);
+});
+
+test('leaves a category the user set at creation time alone', function () {
+    $ruleCategory = Category::factory()->create(['user_id' => $this->user->id]);
+    $ruleLabel = Label::factory()->create(['user_id' => $this->user->id]);
+
+    $rule = AutomationRule::factory()->create([
+        'user_id' => $this->user->id,
+        'priority' => 1,
+        'rules_json' => ['in' => ['grocery', ['var' => 'description']]],
+        'action_category_id' => $ruleCategory->id,
+    ]);
+    $rule->labels()->attach($ruleLabel->id);
+
+    $transaction = Transaction::factory()->enableBanking()->create([
+        'user_id' => $this->user->id,
+        'account_id' => $this->account->id,
+        'description' => 'Grocery Store',
+        'amount' => -5000,
+        'category_id' => $this->category->id,
+        'category_source' => CategorySource::Manual,
+    ]);
+
+    $fresh = $transaction->fresh();
+
+    expect($fresh->category_id)->toBe($this->category->id)
+        ->and($fresh->category_source)->toBe(CategorySource::Manual)
+        ->and($fresh->categorized_by_rule_id)->toBeNull()
+        ->and($fresh->labels)->toBeEmpty();
 });

--- a/tests/Feature/SplitTransactionTest.php
+++ b/tests/Feature/SplitTransactionTest.php
@@ -3,6 +3,7 @@
 use App\Enums\CategorySource;
 use App\Enums\TransactionSource;
 use App\Models\Account;
+use App\Models\AutomationRule;
 use App\Models\Budget;
 use App\Models\BudgetPeriod;
 use App\Models\BudgetTransaction;
@@ -21,13 +22,14 @@ beforeEach(function () {
     $this->category = Category::factory()->create(['user_id' => $this->user->id]);
 });
 
-function splittableTransaction(int $amount = -5340): Transaction
+function splittableTransaction(int $amount = -5340, ?string $description = null): Transaction
 {
     return Transaction::factory()->plaintext()->create([
         'user_id' => test()->user->id,
         'account_id' => test()->account->id,
         'category_id' => null,
         'amount' => $amount,
+        ...($description === null ? [] : ['description' => $description]),
     ]);
 }
 
@@ -57,6 +59,69 @@ it('replaces a transaction with its parts and keeps the original out of sight', 
     // The original is gone from every list and total, but still on the row.
     expect(Transaction::query()->find($original->id))->toBeNull()
         ->and(Transaction::withTrashed()->find($original->id)->trashed())->toBeTrue();
+});
+
+it('keeps the category each part was given, even when an automation rule matches', function () {
+    $ruleCategory = Category::factory()->create(['user_id' => $this->user->id]);
+    $ruleLabel = Label::factory()->create(['user_id' => $this->user->id]);
+    $otherCategory = Category::factory()->create(['user_id' => $this->user->id]);
+
+    $rule = AutomationRule::factory()->create([
+        'user_id' => $this->user->id,
+        'priority' => 1,
+        'rules_json' => ['in' => ['mercadona', ['var' => 'description']]],
+        'action_category_id' => $ruleCategory->id,
+    ]);
+    $rule->labels()->attach($ruleLabel->id);
+
+    $original = splittableTransaction(-5340, 'MERCADONA S.A.');
+
+    $this->actingAs($this->user)->postJson("/transactions/{$original->id}/split", [
+        'splits' => [
+            ['amount' => -3490, 'category_id' => $this->category->id],
+            ['amount' => -1850, 'category_id' => $otherCategory->id],
+        ],
+    ])->assertCreated();
+
+    $parts = Transaction::query()
+        ->where('split_parent_id', $original->id)
+        ->with('labels')
+        ->orderBy('amount')
+        ->get();
+
+    // The rule matches the description, but the user picked these categories a
+    // second ago in the dialog — the rule does not get to overwrite them, nor to
+    // put its own labels on the parts.
+    expect($parts->pluck('category_id')->all())->toBe([$this->category->id, $otherCategory->id])
+        ->and($parts->pluck('category_source')->unique()->all())->toBe([CategorySource::Manual])
+        ->and($parts->pluck('categorized_by_rule_id')->unique()->all())->toBe([null])
+        ->and($parts->pluck('labels')->flatten())->toBeEmpty();
+});
+
+it('still lets an automation rule categorize a part left uncategorized on purpose', function () {
+    $ruleCategory = Category::factory()->create(['user_id' => $this->user->id]);
+
+    AutomationRule::factory()->create([
+        'user_id' => $this->user->id,
+        'priority' => 1,
+        'rules_json' => ['in' => ['mercadona', ['var' => 'description']]],
+        'action_category_id' => $ruleCategory->id,
+    ]);
+
+    $original = splittableTransaction(-5340, 'MERCADONA S.A.');
+
+    $this->actingAs($this->user)->postJson("/transactions/{$original->id}/split", [
+        'splits' => [
+            ['amount' => -3490, 'category_id' => $this->category->id],
+            ['amount' => -1850],
+        ],
+    ])->assertCreated();
+
+    $parts = Transaction::query()->where('split_parent_id', $original->id)->orderBy('amount')->get();
+
+    expect($parts->first()->category_id)->toBe($this->category->id)
+        ->and($parts->last()->category_id)->toBe($ruleCategory->id)
+        ->and($parts->last()->category_source)->toBe(CategorySource::Rule);
 });
 
 it('keeps the dedup fingerprint on the original and off the parts, so a re-sync cannot recreate it', function () {


### PR DESCRIPTION
A user split a transaction in the web modal, giving each part its own category.
The parts came out with a rule's category instead of his. He repaired his rows by
hand, so no data fix is needed — but the bug is still live for everyone else.

## What was happening

`TransactionSplitter::createPart()` does the right thing: each part is created with
the `category_id` the modal sent and `category_source = manual`. The frontend chain
(`split-transaction-dialog.tsx` → `toSplitPayload()` → `transactionSyncService.split()`
→ `TransactionSplitController::store`) is fine too; nothing drops the category.

The overwrite happens straight after, on `$created->save()`:

1. `save()` fires `Transaction`'s `created` event → `App\Events\TransactionCreated`
   (`app/Models/Transaction.php:51`).
2. `App\Listeners\ApplyAutomationRules` runs **synchronously** and calls
   `AutomationRuleService::applyRules()`.
3. `applyActions()` overwrites the category with no guard at all — it sets
   `category_id`, `category_source = rule` and `categorized_by_rule_id` — and
   `syncWithoutDetaching`s the rule's labels onto the part, which can bring back
   labels the user deliberately removed per part.

So any matching rule stomped the category the user picked in the modal, seconds
after the split.

The `only_uncategorized` guard does not cover this. It is a per-application option
(`applyRuleActionsToTransactions()` + `shouldSkipForOnlyUncategorized()`), not a
column on `automation_rules`, and the create-time path never consults it. The
docblock on `applyRuleActionsToTransactions()` already states the intent — "the rule
never silently overwrites a category the user did not ask it to touch" — the
create-time path just didn't honour it.

## Production evidence

User `019f55be-…f5e52847146c` (the reporter), three splits on 2026-09-09. In every
split one part still carries `category_source = 'rule'` with `created_at ==
updated_at` (written at split time, never touched by the user) pointing at category
`d5c992a6-…`; the sibling parts are `manual` with a later `updated_at` — the ones he
re-categorized by hand. One part is `manual` with `created_at == updated_at` because
the rule's category happened to equal the one he chose, so `applyActions()` found
nothing to change.

Blast radius across all of prod:

```sql
select count(*), count(distinct user_id) from transactions
where split_parent_id is not null and category_source = 'rule';
-- 10 rows, 2 users
```

The feature is young (#855), so it stayed small. **No backfill**: the reporter already
fixed his own rows, the agent DB credentials are read-only by design, and 10 rows
across 2 users does not earn a migration.

## The fix

One guard in `App\Listeners\ApplyAutomationRules`: a brand-new transaction that
already carries `category_source = manual` was categorized by a human on purpose, so
rules leave it alone.

That covers every create-time door at once — the split modal, a hand-made
transaction, and the MCP tools all reach `TransactionCreated` the same way.

It is deliberately **not** guarded inside `applyActions()`, because `applyRules()` is
also reached from `ReEvaluateTransactionRulesController::single` and
`ReEvaluateTransactionRulesJob`. There the user explicitly asked for the rules to be
re-run, and that behaviour is unchanged.

Silencing the event in `createPart()` with `saveQuietly()`/`withoutEvents()` was not
an option: three listeners hang off `TransactionCreated`, and `AssignTransactionToBudget`
is what puts each part into its budgets — killing the event would break budgets for
splits. The third, `CategorizeTransactionWithAi`, already skips any row that has a
category.

## Labels

Covered by the same guard, and tested: a part the user gave a category to no longer
gets the rule's labels force-synced onto it either.

For a part left **uncategorized** on purpose, the rule still applies both its category
and its labels. That is existing behaviour and out of scope here — a test now pins it
so the distinction is deliberate rather than accidental.

## Known gap, not fixed here

`TransactionController::store()` never stamps `category_source` at all, even when the
request carries an explicit `category_id` — so a hand-added transaction with a category
still gets `category_source = null` and a rule can still overwrite it. The obvious
one-liner (stamp `Manual` whenever `category_id` is present) would be **wrong**: that
same endpoint is what the CSV importer posts to, and the importer's `category_id` comes
from client-side rule evaluation (`import-transactions-drawer.tsx`), so every imported
row would be mislabelled `manual`. Getting it right means the caller declaring the
provenance, which is a frontend change — out of scope for this PR, which was scoped to
leave `resources/js` untouched. Worth a follow-up.

## Tests

- `tests/Feature/SplitTransactionTest.php` — a rule matches the description, the user
  splits into parts with two different categories, and every part keeps the category
  the caller asked for, with `category_source = manual`, no `categorized_by_rule_id`
  and none of the rule's labels. Plus the counterpart: a part left uncategorized on
  purpose still gets the rule's category.
- `tests/Feature/AutomationRuleEvaluationTest.php` — the manual-creation case, next to
  the existing listener test.

All three fail without the guard (verified by reverting the listener and re-running).
The fixture needs a plaintext description — `applyRules()` returns early when
`description_iv !== null`, so an encrypted one would make the test pass for the wrong
reason.
