### PR TITLE
docs(rules): record why Inertia's HttpNetworkError is not a bug to fix

### DIFF
--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -6,6 +6,7 @@ Before planning or editing, find the row whose globs match the file's path and r
 | --- | --- |
 | app/Console/Commands/AgentDatabaseCommand.php | .ai/rules/agent-db.md |
 | app/Jobs/** | .ai/rules/jobs.md |
+| resources/js/lib/{sentry,failed-navigation-toast,unattended-requests,leave-page}.ts | .ai/rules/lib.md |
 | app/Mcp/** | .ai/rules/mcp.md |
 | app/Services/Demo/**, app/Console/Commands/ResetDemoAccountCommand.php | .ai/rules/seeded-accounts.md |
 | resources/js/pages/transactions/index.tsx, resources/js/components/transactions/transaction-list.tsx, resources/js/components/transactions/transaction-columns.tsx | .ai/rules/transactions-table.md |

--- a/.ai/rules/lib.md
+++ b/.ai/rules/lib.md
@@ -1,0 +1,14 @@
+---
+paths:
+  - 'resources/js/lib/{sentry,failed-navigation-toast,unattended-requests,leave-page}.ts'
+---
+
+# Lib
+
+## HttpNetworkError in Sentry is deliberate residue, not a bug to fix
+`HttpNetworkError: Network error (<url>)` from Inertia's XHR client keeps appearing in Sentry (issue PHP-LARAVEL-5E, and PHP-LARAVEL-5C on /login). Do not "fix" it in code — it is already handled on both sides:
+
+- The user gets a toast: `installFailedNavigationToast()` listens on `router.on('networkError')`, with suppression for page-leave aborts and unattended requests (prefetch/poll), speaking up anyway after 3 lost beats.
+- Sentry drops the noise: `beforeSend` runs `isPageLeaveAbortNoise` and `isUnattendedRequestNoise`.
+
+What still reaches Sentry is the intended signal: an attended request that genuinely failed for a user who stayed put. The filters match Inertia's message tail narrowly on purpose — if the format changes they stop matching and the noise returns, which is the safe direction. The remaining lever is Sentry-side (an ignore rule or a rate threshold), a product call, not a code change. Same class as PHP-LARAVEL-28 (`AxiosError: Network Error`), already ignored in Sentry.


### PR DESCRIPTION
`HttpNetworkError: Network error (<url>)` from Inertia's XHR client keeps
surfacing in Sentry (`PHP-LARAVEL-5E`, currently 19 users / 28 events and
marked `regressed`; `PHP-LARAVEL-5C` is the same thing on `/login`). The
autonomous Sentry triage loop has now dug into it three times and reached the
same conclusion each time, so this records the conclusion.

It is already handled on both sides:

- **The user is told.** `installFailedNavigationToast()` listens on
  `router.on('networkError')`, suppressing page-leave aborts and unattended
  requests, and speaking up anyway after three lost beats.
- **Sentry drops the noise.** `beforeSend` runs `isPageLeaveAbortNoise` and
  `isUnattendedRequestNoise`.

What still arrives is the intended signal — an attended request that genuinely
failed for a user who stayed put. `failed-navigation-toast.ts` names the very
request that started this (`PATCH /settings/accounts/{uuid}`, "a change the
user believed they had made"), so the ground was already covered deliberately.

No code changes. The remaining lever is Sentry-side (an ignore rule or a rate
threshold), which is a product call — the same call already made for
`PHP-LARAVEL-28` (`AxiosError: Network Error`, ignored).