### PR TITLE
fix(interactive-brokers): treat a Flex transport timeout as transient, not as an unexpected error

### DIFF
--- a/app/Services/Banking/InteractiveBrokersClient.php
+++ b/app/Services/Banking/InteractiveBrokersClient.php
@@ -4,6 +4,7 @@ namespace App\Services\Banking;
 
 use App\Exceptions\Banking\TransientBankingProviderException;
 use GuzzleHttp\Psr7\Response as PsrResponse;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
@@ -56,15 +57,7 @@ class InteractiveBrokersClient
 
     private function sendRequest(): string
     {
-        $response = $this->http()->get(self::BASE_URL.'/SendRequest', [
-            't' => $this->token,
-            'q' => $this->queryId,
-            'v' => self::VERSION,
-        ]);
-
-        $response->throw();
-
-        $xml = $this->loadXml($response->body());
+        $xml = $this->fetchXml('SendRequest', $this->queryId);
 
         if ((string) $xml->Status !== 'Success') {
             $this->throwForError((string) $xml->ErrorCode, (string) $xml->ErrorMessage);
@@ -85,15 +78,7 @@ class InteractiveBrokersClient
     private function getStatement(string $referenceCode): SimpleXMLElement
     {
         for ($attempt = 1; $attempt <= self::MAX_STATEMENT_ATTEMPTS; $attempt++) {
-            $response = $this->http()->get(self::BASE_URL.'/GetStatement', [
-                't' => $this->token,
-                'q' => $referenceCode,
-                'v' => self::VERSION,
-            ]);
-
-            $response->throw();
-
-            $xml = $this->loadXml($response->body());
+            $xml = $this->fetchXml('GetStatement', $referenceCode);
 
             if ($xml->getName() === 'FlexQueryResponse') {
                 return $xml;
@@ -184,6 +169,45 @@ class InteractiveBrokersClient
         }
 
         return $accounts;
+    }
+
+    /**
+     * Both Flex calls take the same shape, so they share the transport
+     * classification: an unattended sync can do nothing about IB being down or
+     * slow, so a timeout or a 5xx becomes transient — logged as a warning, kept
+     * out of Sentry and, crucially, not charged to the connection's retry
+     * budget. Failures IB reports inside the XML stay with throwForError().
+     */
+    private function fetchXml(string $endpoint, string $query): SimpleXMLElement
+    {
+        try {
+            $response = $this->http()->get(self::BASE_URL.'/'.$endpoint, [
+                't' => $this->token,
+                'q' => $query,
+                'v' => self::VERSION,
+            ]);
+
+            $response->throw();
+        } catch (ConnectionException $e) {
+            throw new TransientBankingProviderException(
+                'Interactive Brokers did not respond in time.',
+                provider: 'interactivebrokers',
+                previous: $e,
+            );
+        } catch (RequestException $e) {
+            if (! $e->response->serverError()) {
+                throw $e;
+            }
+
+            throw new TransientBankingProviderException(
+                'Interactive Brokers could not serve the request right now.',
+                provider: 'interactivebrokers',
+                statusCode: $e->response->status(),
+                previous: $e,
+            );
+        }
+
+        return $this->loadXml($response->body());
     }
 
     private function http(): PendingRequest

--- a/tests/Feature/OpenBanking/InteractiveBrokersTransientErrorTest.php
+++ b/tests/Feature/OpenBanking/InteractiveBrokersTransientErrorTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use App\Exceptions\Banking\TransientBankingProviderException;
+use App\Models\Account;
+use App\Models\BankingConnection;
+use App\Models\User;
+use App\Services\Banking\InteractiveBrokersClient;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+
+/** The helpers in InteractiveBrokersBalanceSyncTest are not loaded when this file runs alone. */
+function ibReferenceCodeXml(): string
+{
+    return '<FlexStatementResponse><Status>Success</Status><ReferenceCode>1234567890</ReferenceCode></FlexStatementResponse>';
+}
+
+test('a timeout on SendRequest is reclassified as transient', function () {
+    Http::fake(fn () => throw new ConnectionException('cURL error 28: Operation timed out'));
+
+    try {
+        (new InteractiveBrokersClient('token', '123456'))->fetchStatement();
+        $this->fail('Expected a TransientBankingProviderException');
+    } catch (TransientBankingProviderException $e) {
+        expect($e->provider)->toBe('interactivebrokers')
+            ->and($e->getPrevious())->toBeInstanceOf(ConnectionException::class);
+    }
+});
+
+test('a timeout on GetStatement is reclassified as transient', function () {
+    Http::fake([
+        '*SendRequest*' => Http::response(ibReferenceCodeXml()),
+        '*GetStatement*' => fn () => throw new ConnectionException('cURL error 28: Operation timed out'),
+    ]);
+
+    try {
+        (new InteractiveBrokersClient('token', '123456'))->fetchStatement();
+        $this->fail('Expected a TransientBankingProviderException');
+    } catch (TransientBankingProviderException $e) {
+        expect($e->provider)->toBe('interactivebrokers')
+            ->and($e->getPrevious())->toBeInstanceOf(ConnectionException::class);
+    }
+});
+
+test('a flex 5xx is reclassified as transient', function () {
+    Http::fake(['*SendRequest*' => Http::response('Service Unavailable', 503)]);
+
+    try {
+        (new InteractiveBrokersClient('token', '123456'))->fetchStatement();
+        $this->fail('Expected a TransientBankingProviderException');
+    } catch (TransientBankingProviderException $e) {
+        expect($e->provider)->toBe('interactivebrokers')
+            ->and($e->statusCode)->toBe(503);
+    }
+});
+
+test('a flex 4xx stays raw so the sync job can act on it', function () {
+    Http::fake(['*SendRequest*' => Http::response('Forbidden', 403)]);
+
+    expect(fn () => (new InteractiveBrokersClient('token', '123456'))->fetchStatement())
+        ->toThrow(RequestException::class);
+});
+
+/**
+ * The point of the reclassification: consecutive_sync_failures is the budget of
+ * scheduled retries, and running it out drops the connection out of every future
+ * scheduled sync. An IB timeout must not spend it.
+ */
+test('an IB timeout does not spend the connection scheduled-retry budget', function () {
+    $user = User::factory()->onboarded()->create();
+    $connection = BankingConnection::factory()->interactiveBrokers()->create([
+        'user_id' => $user->id,
+        'consecutive_sync_failures' => 1,
+    ]);
+    Account::factory()->connected()->create([
+        'user_id' => $user->id,
+        'banking_connection_id' => $connection->id,
+        'external_account_id' => 'U1234567',
+    ]);
+
+    Http::fake(fn () => throw new ConnectionException('cURL error 28: Operation timed out after 15002 milliseconds'));
+
+    expect(fn () => runSync(finalAttemptJobFor($connection)))
+        ->toThrow(TransientBankingProviderException::class);
+
+    $connection->refresh();
+
+    expect($connection->consecutive_sync_failures)->toBe(1)
+        ->and($connection->error_message)->toBe('The bank provider is temporarily unavailable. We will try syncing again later.');
+});


### PR DESCRIPTION
Fixes PHP-LARAVEL-5Y

## The problem

A read timeout against IB's Flex Web Service (`cURL error 28: Operation timed out after 15002 milliseconds`) escaped `InteractiveBrokersClient` as a raw `ConnectionException`.

The client's job is to translate IB failures into the taxonomy `SyncBankingConnectionJob` understands — its own docblock says so — but it only ever translated the failures IB *reports in its XML*. A **transport** failure was not translated at all: `sendRequest()` and `getStatement()` called `$this->http()->get(...)` with no try/catch, and the 5-attempt loop in `getStatement()` only retries IB's "still generating" replies, so a timeout escaped before `$response->throw()` was even reached.

Downstream, `handleTemporaryError()` only spares the retry budget for a `TransientBankingProviderException`:

```php
'consecutive_sync_failures' => $isTransient
    ? $connection->consecutive_sync_failures
    : $connection->consecutive_sync_failures + 1,
```

So each IB timeout charged the connection's budget of scheduled retries. That budget is not cosmetic: exhausting it drops the connection out of every future scheduled sync, silently, with no way back other than reconnecting. Two further consequences of the same misclassification: the user saw *"An unexpected error occurred during sync"* instead of *"The bank provider is temporarily unavailable"*, and the failure logged at `error` level, which is why it reached Sentry.

## The fix

Both Flex calls now go through one private `fetchXml()` helper that reclassifies a timeout or a 5xx as `TransientBankingProviderException` (`provider: 'interactivebrokers'`, original exception kept as `previous`). This mirrors `WiseClient::get()` — and `EnableBankingProvider` — so it is a plain omission being closed against an established house pattern, not a new design.

`throwForError()` is untouched: IB answers its own failures with HTTP 200 + XML, so a bad token or a throttle never enters the new catch blocks and still surfaces as `RequestException` 401/429 for the job to act on. A genuinely broken connection is not masked.

Routing both call sites through one helper (rather than copying the try/catch) also keeps the required duplication check green.

**User-facing consequence:** a transient IB timeout no longer spends the connection's scheduled-retry budget, so a slow afternoon at Interactive Brokers can no longer silently disable a user's automatic bank sync. It now surfaces as a temporary provider outage and retries later.

## Out of scope

- `BinanceClient`, `CoinbaseClient`, `BitpandaClient` and `IndexaCapitalClient` share the same latent gap, but none has fired in Sentry and each needs its own message and tests — a separate change.
- Classifying `ConnectionException` centrally in `SyncBankingConnectionJob` would cover every provider at once, but the house pattern puts the translation in the client, and that job also owns the backoff and the retry budget.
- Whether 15 s is the right timeout for Flex is a separate question.

## Tests

`tests/Feature/OpenBanking/InteractiveBrokersTransientErrorTest.php`, all of which fail without the fix except the deliberate regression guard:

- a timeout on `SendRequest` → transient, with the `ConnectionException` as `previous`
- a timeout on `GetStatement` → same
- a Flex 5xx → transient, `statusCode` preserved
- a Flex 4xx → stays a raw `RequestException` so the job can act on it (guard, green either way)
- end-to-end through the real `SyncBankingConnectionJob`: an IB timeout on the final attempt leaves `consecutive_sync_failures` unchanged and sets the "temporarily unavailable" copy

## QA

Driven through the real job with a faked cURL 28. Observed: `consecutive_sync_failures` held at 1, `error_message` = *"The bank provider is temporarily unavailable. We will try syncing again later."*, and exactly one log call, at `warning`. Guard rail re-checked in the same run: an XML `1015 Invalid token` still burns the connection to `MAX_SCHEDULED_RETRIES + 1` and logs at `error`.

`tests/Feature/OpenBanking` 480 passed · `pint --test` clean · `bun run dry` clean · `crap` no method above complexity 10.