### PR TITLE
feat(locale): write amounts in the reader's region, not their language

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -5,6 +5,7 @@ namespace App\Actions\Fortify;
 use App\Enums\Locale;
 use App\Enums\SignupPlan;
 use App\Models\User;
+use App\Services\FormatLocaleOptions;
 use App\Services\Subscriptions\PriceExperiment;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
@@ -13,6 +14,8 @@ use Laravel\Fortify\Contracts\CreatesNewUsers;
 class CreateNewUser implements CreatesNewUsers
 {
     use PasswordValidationRules;
+
+    public function __construct(private FormatLocaleOptions $formatLocales) {}
 
     /**
      * Validate and create a newly registered user.
@@ -38,12 +41,18 @@ class CreateNewUser implements CreatesNewUsers
         ])->validate();
 
         $signupPlan = SignupPlan::fromRequest($input['signup_plan'] ?? null);
+        $acceptLanguage = request()->header('Accept-Language');
+        $locale = Locale::detectFromHeader($acceptLanguage)->value;
 
         $user = User::create([
             'name' => $input['name'],
             'email' => $input['email'],
             'password' => $input['password'],
-            'locale' => Locale::detectFromHeader(request()->header('Accept-Language'))->value,
+            'locale' => $locale,
+            // The same header read a second time, for the region rather than
+            // the language: which of the two "es" they are decides where their
+            // decimal separator goes.
+            'format_locale' => $this->formatLocales->detectFromHeader($acceptLanguage, $locale),
             'timezone' => $this->normalizeTimezone($input['timezone'] ?? null),
             // Freeze the arm this visitor was quoted as an anonymous browser, so
             // the price on the landing is the price at checkout. Null when they

--- a/app/Http/Controllers/AchievementController.php
+++ b/app/Http/Controllers/AchievementController.php
@@ -78,6 +78,7 @@ class AchievementController extends Controller
                 $achievement,
                 $definition,
                 $this->ladders->currencyFor($request->user()->currency_code),
+                $request->user()->formatLocale(),
                 $format,
                 $theme,
                 $amount,

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -11,6 +11,7 @@ use App\Models\User;
 use App\Services\Achievements\Catalog;
 use App\Services\Achievements\Challenges;
 use App\Services\CurrencyOptions;
+use App\Services\FormatLocaleOptions;
 use App\Services\Notifications\NotificationFeed;
 use App\Services\Subscriptions\PriceExperiment;
 use Closure;
@@ -23,6 +24,7 @@ class HandleInertiaRequests extends Middleware
 {
     public function __construct(
         private CurrencyOptions $currencyOptions,
+        private FormatLocaleOptions $formatLocales,
         private NotificationFeed $notifications,
         private Catalog $catalog,
         private Challenges $challenges,
@@ -120,7 +122,7 @@ class HandleInertiaRequests extends Middleware
             'hasEncryptedAccounts' => $hasEncryptedAccounts,
             'hasEncryptionSetup' => $user?->encryption_salt !== null,
             'hasEncryptedTransactions' => $hasEncryptedTransactions,
-            'locale' => app()->getLocale(),
+            'locale' => $this->formatLocaleFor($request, $user),
             'translations' => $this->getTranslations(),
             'currencies' => [
                 'profile' => $this->currencyOptions->primaryOptions(),
@@ -308,6 +310,29 @@ class HandleInertiaRequests extends Middleware
             'cashflow' => true,
             'calculateBalancesOnImport' => Feature::for($user)->active(CalculateBalancesOnImport::class),
         ];
+    }
+
+    /**
+     * The locale the client writes amounts and dates in — a full region like
+     * `es-MX`, and deliberately NOT `app()->getLocale()`, which this prop used
+     * to carry.
+     *
+     * The two diverge on purpose and both are right. `app()->getLocale()` names
+     * the language `lang/` is translated into and has to stay two letters, or
+     * `App::setLocale('es-MX')` sends the translator after a directory that does
+     * not exist. This prop names the region, which is what decides where the
+     * decimal separator goes and how a date is ordered — and a reader is allowed
+     * to want the app in English with Mexican numbers.
+     *
+     * Nothing is lost by the swap: `i18n.ts` translates off the `translations`
+     * prop and never reads this one. See `use-locale.ts`.
+     */
+    private function formatLocaleFor(Request $request, ?User $user): string
+    {
+        // A signed-out visitor has no row to have detected anything onto, so
+        // the header is read for them on every request instead.
+        return $user?->formatLocale()
+            ?? $this->formatLocales->detectFromHeader($request->header('Accept-Language'), app()->getLocale());
     }
 
     /**

--- a/app/Http/Middleware/SetLocale.php
+++ b/app/Http/Middleware/SetLocale.php
@@ -3,6 +3,8 @@
 namespace App\Http\Middleware;
 
 use App\Enums\Locale;
+use App\Http\Controllers\Settings\TimezoneController;
+use App\Services\FormatLocaleOptions;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
@@ -10,6 +12,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class SetLocale
 {
+    public function __construct(private FormatLocaleOptions $formatLocales) {}
+
     /**
      * Handle an incoming request.
      *
@@ -19,9 +23,46 @@ class SetLocale
     {
         $locale = $this->determineLocale($request);
 
+        // Two letters, always: `App::setLocale('es-MX')` would send the
+        // translator looking for a `lang/es-MX/` that does not exist. The
+        // region lives on the user instead, and reaches the client through
+        // the `locale` prop {@see HandleInertiaRequests::share()} shares.
         App::setLocale($locale);
 
+        $this->rememberFormatLocale($request, $locale);
+
         return $next($request);
+    }
+
+    /**
+     * Pin the region the browser asks for onto the user, once.
+     *
+     * Written only when the column is still empty, the same way
+     * {@see TimezoneController} settles a timezone: the header is a guess, and
+     * a reader who has since picked a region in their settings must not have it
+     * overwritten by whichever browser they happen to be signed in on today.
+     *
+     * Existing accounts are filled in the same way on their next request, which
+     * is what carries the fix to them without a data migration.
+     */
+    protected function rememberFormatLocale(Request $request, string $locale): void
+    {
+        $user = $request->user();
+
+        if ($user === null || $user->format_locale !== null) {
+            return;
+        }
+
+        // The reader's own language decides the fallback, not the one this
+        // request resolved to: a `?lang=` on the link they arrived through is a
+        // display override, and it has no business deciding where their decimal
+        // separator lands for good.
+        $user->update([
+            'format_locale' => $this->formatLocales->detectFromHeader(
+                $request->header('Accept-Language'),
+                $user->locale ?? $locale,
+            ),
+        ]);
     }
 
     /**

--- a/app/Mail/Drip/AchievementsEmail.php
+++ b/app/Mail/Drip/AchievementsEmail.php
@@ -120,10 +120,11 @@ class AchievementsEmail extends DripMail
         $renderer = app(CardRenderer::class);
         $catalog = app(Catalog::class);
         $currency = app(Ladders::class)->currencyFor($this->user->currency_code);
+        $formatLocale = $this->user->formatLocale();
 
         return $this->cards = $this->achievements
             ->take(self::MAX_CARDS)
-            ->mapWithKeys(function (Achievement $achievement) use ($renderer, $catalog, $currency): array {
+            ->mapWithKeys(function (Achievement $achievement) use ($renderer, $catalog, $currency, $formatLocale): array {
                 $definition = $catalog->find($achievement->key);
 
                 if ($definition === null) {
@@ -135,6 +136,7 @@ class AchievementsEmail extends DripMail
                         $achievement,
                         $definition,
                         $currency,
+                        $formatLocale,
                         CardFormat::default(),
                         CardTheme::default(),
                         amount: true,
@@ -173,11 +175,13 @@ class AchievementsEmail extends DripMail
     {
         $catalog = app(Catalog::class);
         $presenter = app(Presenter::class);
-        $locale = app()->getLocale();
+        // A milestone is a figure, so it is written in the reader's region
+        // rather than in the language the line around it is written in.
+        $formatLocale = $this->user->formatLocale();
         $cards = $this->cards();
 
         return $this->achievements
-            ->map(function (Achievement $achievement) use ($catalog, $presenter, $locale, $cards): ?array {
+            ->map(function (Achievement $achievement) use ($catalog, $presenter, $formatLocale, $cards): ?array {
                 $definition = $catalog->find($achievement->key);
 
                 if ($definition === null) {
@@ -186,7 +190,7 @@ class AchievementsEmail extends DripMail
 
                 return [
                     'name' => $definition->name,
-                    'milestone' => $presenter->write($presenter->milestone($definition, $this->user->currency_code), $locale),
+                    'milestone' => $presenter->write($presenter->milestone($definition, $this->user->currency_code), $formatLocale),
                     'rarity' => $definition->rarity->label(),
                     'card' => isset($cards[$achievement->key]) ? $this->cid($achievement->key) : null,
                 ];

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Enums\DripEmailType;
 use App\Enums\PlanFeature;
 use App\Notifications\VerifyEmailNotification;
+use App\Services\FormatLocaleOptions;
 use Carbon\Carbon;
 use Database\Factories\UserFactory;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
@@ -66,6 +67,7 @@ class User extends Authenticatable implements HasLocalePreference, MustVerifyEma
         'paywall_seen_at',
         'currency_code',
         'locale',
+        'format_locale',
         'timezone',
         'current_space_id',
         'price_arm',
@@ -622,6 +624,18 @@ class User extends Authenticatable implements HasLocalePreference, MustVerifyEma
     public function preferredLocale(): string
     {
         return $this->locale ?? 'en';
+    }
+
+    /**
+     * The locale this reader's amounts and dates are written in — a full region
+     * like `es-MX`, not the two letters {@see preferredLocale()} returns.
+     *
+     * Null until a request detects it from the browser, so until then it reads
+     * as whatever the language formatted like before the column existed.
+     */
+    public function formatLocale(): string
+    {
+        return $this->format_locale ?? app(FormatLocaleOptions::class)->fallbackFor($this->locale);
     }
 
     public function isDeleted(): bool

--- a/app/Services/Achievements/CardPresenter.php
+++ b/app/Services/Achievements/CardPresenter.php
@@ -33,6 +33,11 @@ class CardPresenter
      *                        Medals whose figure is a rate, a run of months or
      *                        a count ignore this: those are safe to post, and
      *                        the summary cards have shown them from the start.
+     * @param  string  $formatLocale  The reader's region, which writes the
+     *                                figure. Separate from the app locale above
+     *                                it, which writes the month and the copy: a
+     *                                medal can read in English and count in
+     *                                Mexican.
      * @param  bool  $pro  Whether the footer carries the Pro member badge.
      * @return array<string, mixed>
      */
@@ -40,6 +45,7 @@ class CardPresenter
         Definition $definition,
         Carbon $achievedOn,
         string $currency,
+        string $formatLocale,
         CardFormat $format,
         CardTheme $theme,
         bool $amount,
@@ -57,7 +63,7 @@ class CardPresenter
             'glyph' => $this->pictograms->path($definition->icon),
             'track' => $this->catalog->tracks()[$definition->track] ?? $definition->track,
             'name' => $definition->name,
-            'figure' => $this->figure($definition, $currency, $locale, $amount),
+            'figure' => $this->figure($definition, $currency, $formatLocale, $amount),
             'tier' => $definition->rarity->label(),
             // Derived from the medal's own metal rather than from a second table
             // of label colours: on paper the struck edge reads, on a dark card
@@ -72,7 +78,7 @@ class CardPresenter
      * to write — an event medal has no number, and a money medal whose reader
      * asked to keep the amount out has none either.
      */
-    private function figure(Definition $definition, string $currency, string $locale, bool $amount): ?string
+    private function figure(Definition $definition, string $currency, string $formatLocale, bool $amount): ?string
     {
         $milestone = $this->presenter->milestone($definition, $currency);
 
@@ -84,15 +90,15 @@ class CardPresenter
 
         return match ($milestone['type']) {
             Figure::Money->value => $amount && $milestone['currency'] !== null
-                ? Money::formatIn((int) $value, $milestone['currency'], $locale, decimals: 0)
+                ? Money::formatIn((int) $value, $milestone['currency'], $formatLocale, decimals: 0)
                 : null,
             // A milestone is a round rung — 20, 30, 50, 75 — so it is written
             // without decimals, the same as the screen writes it.
-            Figure::Percent->value => Figures::percent((float) $value, $locale, decimals: 0),
-            Figure::Months->value => trans_choice(':count month|:count months', (int) $value, ['count' => Figures::count((int) $value, $locale)]),
-            Figure::Weeks->value => trans_choice(':count week|:count weeks', (int) $value, ['count' => Figures::count((int) $value, $locale)]),
-            Figure::Days->value => trans_choice(':count day|:count days', (int) $value, ['count' => Figures::count((int) $value, $locale)]),
-            default => Figures::count((int) $value, $locale),
+            Figure::Percent->value => Figures::percent((float) $value, $formatLocale, decimals: 0),
+            Figure::Months->value => trans_choice(':count month|:count months', (int) $value, ['count' => Figures::count((int) $value, $formatLocale)]),
+            Figure::Weeks->value => trans_choice(':count week|:count weeks', (int) $value, ['count' => Figures::count((int) $value, $formatLocale)]),
+            Figure::Days->value => trans_choice(':count day|:count days', (int) $value, ['count' => Figures::count((int) $value, $formatLocale)]),
+            default => Figures::count((int) $value, $formatLocale),
         };
     }
 

--- a/app/Services/Achievements/CardRenderer.php
+++ b/app/Services/Achievements/CardRenderer.php
@@ -57,12 +57,13 @@ class CardRenderer
         Achievement $achievement,
         Definition $definition,
         string $currency,
+        string $formatLocale,
         CardFormat $format,
         CardTheme $theme,
         bool $amount,
         bool $pro,
     ): string {
-        $path = $this->pathFor($achievement, $format, $theme, $amount, $pro);
+        $path = $this->pathFor($achievement, $formatLocale, $format, $theme, $amount, $pro);
 
         if (! Storage::disk(self::DISK)->exists($path)) {
             [$width, $height] = $format->dimensions();
@@ -75,6 +76,7 @@ class CardRenderer
                         $definition,
                         $achievement->achieved_on,
                         $currency,
+                        $formatLocale,
                         $format,
                         $theme,
                         $amount,
@@ -107,12 +109,12 @@ class CardRenderer
      * byte-identical to before. Bumping would have redrawn every medal for
      * everybody for nothing.
      */
-    private function pathFor(Achievement $achievement, CardFormat $format, CardTheme $theme, bool $amount, bool $pro): string
+    private function pathFor(Achievement $achievement, string $formatLocale, CardFormat $format, CardTheme $theme, bool $amount, bool $pro): string
     {
         $locale = app()->getLocale();
         $suffix = ($amount ? '' : '-plain').($pro ? '-pro' : '');
 
-        return $this->directoryFor($achievement->user_id)."/{$achievement->key}-{$format->value}-{$theme->value}-{$locale}{$suffix}.png";
+        return $this->directoryFor($achievement->user_id)."/{$achievement->key}-{$format->value}-{$theme->value}-{$locale}-{$formatLocale}{$suffix}.png";
     }
 
     private function directoryFor(string $userId): string

--- a/app/Services/FormatLocaleOptions.php
+++ b/app/Services/FormatLocaleOptions.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Services;
+
+use Symfony\Component\HttpFoundation\AcceptHeader;
+
+/**
+ * The locale a reader's amounts and dates are written in.
+ *
+ * Sibling of {@see CurrencyOptions}: one closed list in `config/format_locales.php`,
+ * read here and nowhere else. It is deliberately not the app locale — that one
+ * names the language `lang/` is translated into and stays two letters, while
+ * this one carries the region that decides where the decimal separator goes.
+ */
+class FormatLocaleOptions
+{
+    /**
+     * @return list<string>
+     */
+    public function codes(): array
+    {
+        /** @var list<string> $codes */
+        $codes = config('format_locales.options', []);
+
+        return $codes;
+    }
+
+    /**
+     * The region a browser is asking for, or the language's own default when it
+     * names none the app knows.
+     *
+     * The header is read in the browser's own order of preference — Symfony's
+     * parser sorts on `q` — and the first tag on the list wins. A tag we do not
+     * offer is skipped rather than widened to its language: "de-DE" has no
+     * German list to fall back to, and guessing a region from a language is how
+     * a Mexican ended up reading Spain's separators in the first place.
+     */
+    public function detectFromHeader(?string $acceptLanguage, ?string $language): string
+    {
+        $supported = $this->byLowercaseCode();
+
+        foreach (array_keys(AcceptHeader::fromString($acceptLanguage ?? '')->all()) as $tag) {
+            $code = $supported[strtolower(str_replace('_', '-', $tag))] ?? null;
+
+            if ($code !== null) {
+                return $code;
+            }
+        }
+
+        return $this->fallbackFor($language);
+    }
+
+    /**
+     * What this language formatted like before the region existed, so a reader
+     * the header says nothing useful about is left exactly where they were.
+     */
+    public function fallbackFor(?string $language): string
+    {
+        /** @var array<string, string> $fallbacks */
+        $fallbacks = config('format_locales.fallbacks', []);
+
+        return $fallbacks[substr((string) $language, 0, 2)] ?? (string) config('format_locales.default', 'en-US');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function byLowercaseCode(): array
+    {
+        $codes = $this->codes();
+
+        return array_combine(array_map(strtolower(...), $codes), $codes);
+    }
+}

--- a/app/Services/MonthlySummary/AchievementsSection.php
+++ b/app/Services/MonthlySummary/AchievementsSection.php
@@ -48,10 +48,13 @@ class AchievementsSection
     {
         $earned = $user->achievements()->orderBy('key')->get()->keyBy('key');
         $currency = $this->ladders->currencyFor($user->currency_code);
+        // Milestones are figures, so they follow the reader's region rather
+        // than the language the sentences around them are written in.
+        $formatLocale = $user->formatLocale();
 
         $groups = array_values(array_filter([
-            $this->unlocked($earned, $summary, $currency, $locale),
-            $this->next($user, $earned, $summary, $currency, $locale),
+            $this->unlocked($earned, $summary, $currency, $locale, $formatLocale),
+            $this->next($user, $earned, $summary, $currency, $formatLocale),
         ]));
 
         return $groups === [] ? null : $groups;
@@ -68,7 +71,7 @@ class AchievementsSection
      * @param  Collection<string, Achievement>  $earned
      * @return array{title: string, lines: list<string>}|null
      */
-    private function unlocked(Collection $earned, MonthlySummary $summary, string $currency, string $locale): ?array
+    private function unlocked(Collection $earned, MonthlySummary $summary, string $currency, string $locale, string $formatLocale): ?array
     {
         $month = $summary->periodStart();
 
@@ -76,7 +79,7 @@ class AchievementsSection
             ->filter(fn (Achievement $achievement): bool => $achievement->achieved_on->toDateString() === $month->toDateString())
             ->map(fn (Achievement $achievement): ?Definition => $this->catalog->find($achievement->key))
             ->filter()
-            ->map(fn (Definition $definition): string => $this->earnedLine($definition, $currency, $locale))
+            ->map(fn (Definition $definition): string => $this->earnedLine($definition, $currency, $formatLocale))
             ->values()
             ->all();
 
@@ -96,7 +99,7 @@ class AchievementsSection
      * @param  Collection<string, Achievement>  $earned
      * @return array{title: string, lines: list<string>}|null
      */
-    private function next(User $user, Collection $earned, MonthlySummary $summary, string $currency, string $locale): ?array
+    private function next(User $user, Collection $earned, MonthlySummary $summary, string $currency, string $formatLocale): ?array
     {
         $figures = $this->figures($user, $summary);
         $candidates = [];
@@ -117,7 +120,7 @@ class AchievementsSection
 
             $candidates[] = [
                 'share' => $now / $goal['value'],
-                'line' => $this->nextLine($definition, $goal, $now, $locale),
+                'line' => $this->nextLine($definition, $goal, $now, $formatLocale),
             ];
         }
 
@@ -163,9 +166,9 @@ class AchievementsSection
         return $figures;
     }
 
-    private function earnedLine(Definition $definition, string $currency, string $locale): string
+    private function earnedLine(Definition $definition, string $currency, string $formatLocale): string
     {
-        $milestone = $this->presenter->write($this->presenter->milestone($definition, $currency), $locale);
+        $milestone = $this->presenter->write($this->presenter->milestone($definition, $currency), $formatLocale);
         $name = $this->strong($definition->name);
 
         return $milestone === null
@@ -176,12 +179,12 @@ class AchievementsSection
     /**
      * @param  array{type: string, value: int|float, currency: ?string}  $goal
      */
-    private function nextLine(Definition $definition, array $goal, int|float $now, string $locale): string
+    private function nextLine(Definition $definition, array $goal, int|float $now, string $formatLocale): string
     {
         return __(':name, :milestone. :remaining to go.', [
             'name' => $this->strong($definition->name),
-            'milestone' => e((string) $this->presenter->write($goal, $locale)),
-            'remaining' => $this->strong((string) $this->presenter->write([...$goal, 'value' => $goal['value'] - $now], $locale)),
+            'milestone' => e((string) $this->presenter->write($goal, $formatLocale)),
+            'remaining' => $this->strong((string) $this->presenter->write([...$goal, 'value' => $goal['value'] - $now], $formatLocale)),
         ]);
     }
 

--- a/app/Services/MonthlySummary/AnalysisWriter.php
+++ b/app/Services/MonthlySummary/AnalysisWriter.php
@@ -130,7 +130,7 @@ class AnalysisWriter
             self::LANGUAGES[$locale] ?? self::LANGUAGES['en'],
             $summary->periodStart()->locale($locale)->isoFormat('MMMM YYYY'),
         ))->prompt(
-            $this->payloadFor($summary, $locale),
+            $this->payloadFor($summary, $user->formatLocale()),
             provider: Lab::from((string) config('ai_monthly_summary.provider')),
             model: (string) config('ai_monthly_summary.model'),
             timeout: (int) config('ai_monthly_summary.timeout'),
@@ -180,20 +180,21 @@ class AnalysisWriter
     /**
      * The month's frozen figures plus the previous months already inside them,
      * with every amount and percentage rendered the way the reader will see them
-     * elsewhere in the email. Nothing is added that is not already in the
+     * elsewhere in the email — their region's way, which is not their language's:
+     * the model is told to write in Spanish and handed Mexican numbers. Nothing is added that is not already in the
      * payload, which is what keeps the promise printed under the block true.
      */
-    private function payloadFor(MonthlySummary $summary, string $locale): string
+    private function payloadFor(MonthlySummary $summary, string $formatLocale): string
     {
         $payload = $summary->payload;
         $currency = (string) ($payload['currency'] ?? 'EUR');
 
         foreach (self::MONEY_PATHS as $path) {
-            $payload = $this->rewrite($payload, $path, fn (int|float $value): string => Money::formatIn((int) $value, $currency, $locale));
+            $payload = $this->rewrite($payload, $path, fn (int|float $value): string => Money::formatIn((int) $value, $currency, $formatLocale));
         }
 
         foreach (self::PERCENT_PATHS as $path) {
-            $payload = $this->rewrite($payload, $path, fn (int|float $value): string => Figures::percent((float) $value, $locale));
+            $payload = $this->rewrite($payload, $path, fn (int|float $value): string => Figures::percent((float) $value, $formatLocale));
         }
 
         return (string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);

--- a/app/Services/MonthlySummary/EmailPresenter.php
+++ b/app/Services/MonthlySummary/EmailPresenter.php
@@ -443,9 +443,17 @@ class EmailPresenter
         return max(0, min(100, (int) round($percent)));
     }
 
+    /**
+     * Read off the summary's own reader rather than taken as an argument: the
+     * region belongs to the user, and threading it down through every row and
+     * sentence below would touch a dozen signatures to say one thing. The app
+     * locale is only a last resort — it names a language, not a region.
+     */
     private function money(MonthlySummary $summary, int $amount): string
     {
-        return Money::formatIn($amount, (string) $summary->figure('currency', 'EUR'), app()->getLocale());
+        $locale = $summary->user?->formatLocale() ?? app()->getLocale();
+
+        return Money::formatIn($amount, (string) $summary->figure('currency', 'EUR'), $locale);
     }
 
     /**

--- a/config/format_locales.php
+++ b/config/format_locales.php
@@ -1,0 +1,84 @@
+<?php
+
+return [
+    /*
+     * The locale a reader's amounts and dates are written in — a full region
+     * like `es-MX`, and a different thing from `locale`, which only picks the
+     * language the app is translated into. A Mexican reading Spanish still
+     * wants "1,234.56", not Spain's "1.234,56".
+     *
+     * One entry per country whose currency `config/currencies.php` offers, so
+     * anybody the app can hold money for can be written to properly. The euro
+     * is the one currency with several homes; BTC has none. Plus `es-419`,
+     * which is not a country at all — see below.
+     *
+     * These are CLDR's rules for the country as they come, which for three of
+     * them means more than a separator moving: `th-TH` writes the Buddhist era
+     * (2569 for 2026), and `ar-SA`/`ar-KW` write Arabic-Indic digits
+     * (٩ for 9). That is what a phone sold in Bangkok or Riyadh shows, and only
+     * a reader whose own browser asks for one of these is ever given it.
+     */
+    'options' => [
+        'ar-KW', // KWD
+        'ar-SA', // SAR
+        'cs-CZ', // CZK
+        'da-DK', // DKK
+        'de-CH', // CHF
+        'de-DE', // EUR
+        'en-AU', // AUD
+        'en-CA', // CAD
+        'en-GB', // GBP
+        'en-GH', // GHS
+        'en-IE', // EUR
+        'en-IN', // INR
+        'en-NG', // NGN
+        'en-NZ', // NZD
+        'en-PK', // PKR
+        'en-SG', // SGD
+        'en-US', // USD
+        // Not a country: the tag Chrome and Android send for "Spanish (Latin
+        // America)", which is what a great many of the readers this change is
+        // for actually have set. Without it they fall through to Spain's
+        // separators — the exact bug being fixed. CLDR writes it the Mexican
+        // way, which is what their own device shows them.
+        'es-419',
+        'es-AR', // ARS
+        'es-BO', // BOB
+        'es-CL', // CLP
+        'es-CO', // COP
+        'es-DO', // DOP
+        'es-ES', // EUR
+        'es-GT', // GTQ
+        'es-HN', // HNL
+        'es-MX', // MXN
+        'es-PE', // PEN
+        'es-PY', // PYG
+        'es-UY', // UYU
+        'es-VE', // VES
+        'fr-CA', // CAD
+        'fr-FR', // EUR
+        'it-IT', // EUR
+        'ja-JP', // JPY
+        'nl-NL', // EUR
+        'pt-BR', // BRL
+        'pt-PT', // EUR
+        'sr-RS', // RSD
+        'sv-SE', // SEK
+        'th-TH', // THB
+        'zh-CN', // CNY
+        'zh-HK', // HKD
+    ],
+
+    /*
+     * What each language formatted like before it had a region of its own, so
+     * a reader whose browser names no region we know is left exactly where
+     * they were rather than moved somewhere new.
+     */
+    'fallbacks' => [
+        'en' => 'en-US',
+        'es' => 'es-ES',
+        'fr' => 'fr-FR',
+    ],
+
+    'default' => 'en-US',
+];

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -66,6 +66,11 @@ class UserFactory extends Factory
         return $this->state(fn (array $attributes) => [
             'onboarded_at' => now(),
             'locale' => 'en',
+            // Settled alongside the language: a user who has been through
+            // onboarding has made requests, and `SetLocale` pins the region on
+            // the first one. Leaving it null makes every test request pay for
+            // that one-time write, which the query-count ceilings then count.
+            'format_locale' => 'en-US',
         ]);
     }
 

--- a/database/migrations/2026_09_10_090000_add_format_locale_to_users_table.php
+++ b/database/migrations/2026_09_10_090000_add_format_locale_to_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Left null for everybody, existing accounts included: the middleware fills
+     * it in from the browser's own header on the next request, which is what
+     * gets the fix to a user who never opens their settings. Backfilling it
+     * here could only guess from `locale`, which is the guess the column exists
+     * to replace.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('format_locale', 12)->nullable()->after('locale');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('format_locale');
+        });
+    }
+};

--- a/resources/js/hooks/use-locale.test.ts
+++ b/resources/js/hooks/use-locale.test.ts
@@ -1,0 +1,38 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useLocale } from './use-locale';
+
+const props = { locale: 'en-US' };
+
+vi.mock('@inertiajs/react', () => ({
+    usePage: () => ({ props }),
+}));
+
+describe('useLocale', () => {
+    beforeEach(() => {
+        props.locale = 'en-US';
+    });
+
+    it('hands back the region the server shared', () => {
+        props.locale = 'es-MX';
+
+        expect(renderHook(() => useLocale()).result.current).toBe('es-MX');
+    });
+
+    it('falls back rather than letting a malformed tag blank the screen', () => {
+        // Every Intl constructor throws RangeError on these, and the throw
+        // costs the whole page instead of one badly written number.
+        for (const malformed of ['es_MX', '', 'not a locale']) {
+            props.locale = malformed;
+
+            expect(renderHook(() => useLocale()).result.current).toBe('en-US');
+        }
+    });
+
+    it('leaves a well-formed tag it does not know alone', () => {
+        // Intl falls back on its own for these, so there is nothing to catch.
+        props.locale = 'xx-YY';
+
+        expect(renderHook(() => useLocale()).result.current).toBe('xx-YY');
+    });
+});

--- a/resources/js/hooks/use-locale.ts
+++ b/resources/js/hooks/use-locale.ts
@@ -1,9 +1,34 @@
 import { type SharedData } from '@/types';
 import { usePage } from '@inertiajs/react';
 
+/** What `en` formatted like before regions existed, and the only safe last resort. */
+const FALLBACK_LOCALE = 'en-US';
+
 /**
- * Hook to get the current locale from Inertia shared props
+ * The locale this reader's amounts and dates are written in — a full region
+ * like `es-MX`, not the two-letter language the app is translated into.
+ *
+ * The prop carries the region while the server's own `app()->getLocale()` stays
+ * two letters, and that divergence is deliberate: see
+ * `HandleInertiaRequests::formatLocaleFor()`. Translations are unaffected either
+ * way, because `i18n.ts` reads the `translations` prop and never this one.
+ *
+ * The value comes off the user's row, so it is never module state: two SSR
+ * renders sharing one process must not be able to read each other's region. See
+ * the warning on `setCurrencyDecimals()` in `utils/currency.ts`.
  */
 export function useLocale(): string {
-    return usePage<SharedData>().props.locale;
+    const locale = usePage<SharedData>().props.locale;
+
+    try {
+        // Every Intl constructor throws RangeError on a malformed tag, which
+        // costs the whole screen rather than one mis-written number. The server
+        // only ever sends a value off a closed list, so this catches a prop
+        // that has gone stale or been tampered with, nothing else.
+        Intl.getCanonicalLocales(locale);
+    } catch {
+        return FALLBACK_LOCALE;
+    }
+
+    return locale;
 }

--- a/resources/js/utils/currency.test.ts
+++ b/resources/js/utils/currency.test.ts
@@ -153,3 +153,25 @@ describe('per-currency scale', () => {
         expect(formatCurrency(164545, 'EUR', 'en-US', 0, 0)).toBe('€1,645');
     });
 });
+
+describe('formatCurrency across regions', () => {
+    // The locale is a full region, not a language: the same Spanish reader
+    // writes "1.234,56" in Madrid and "1,234.56" in Mexico City, and getting
+    // that from the language alone is what this column exists to stop.
+    it('separates a Mexican amount the Mexican way', () => {
+        expect(formatCurrency(123456, 'MXN', 'es-MX')).toBe('$1,234.56');
+        expect(formatCurrency(123456, 'EUR', 'es-ES')).toBe('1.234,56\u202F€');
+    });
+
+    it('keeps a British reader off American separators', () => {
+        expect(formatCurrency(123456, 'USD', 'en-GB')).toBe('US$1,234.56');
+        expect(formatCurrency(123456, 'USD', 'en-US')).toBe('$1,234.56');
+    });
+
+    it('groups thousands below ten thousand, which Spanish CLDR does not', () => {
+        // Without `useGrouping: 'always'` this is "1234,56 €": es-ES only starts
+        // grouping at 10,000. Dropping the option is the regression to watch.
+        expect(formatCurrency(123456, 'EUR', 'es-ES')).toContain('1.234');
+        expect(formatCurrency(123456, 'EUR', 'fr-FR')).toContain('1\u202F234');
+    });
+});

--- a/tests/Feature/SetLocaleTest.php
+++ b/tests/Feature/SetLocaleTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Http\Middleware\SetLocale;
+use App\Models\User;
+use App\Services\FormatLocaleOptions;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\App;
@@ -13,7 +15,7 @@ function resolveLocaleFor(Request $request): string
 {
     $request->setLaravelSession(app('session.store'));
 
-    (new SetLocale)->handle($request, fn () => new Response);
+    app(SetLocale::class)->handle($request, fn () => new Response);
 
     return App::getLocale();
 }
@@ -46,4 +48,114 @@ it('falls back to English for an unrecognized Accept-Language header', function 
     $request = Request::create('/', 'GET', server: ['HTTP_ACCEPT_LANGUAGE' => 'de-DE,de;q=0.9']);
 
     expect(resolveLocaleFor($request))->toBe('en');
+});
+
+/**
+ * Runs a request through the middleware as `$user` and hands back their row,
+ * refreshed: the middleware writes to it, and the caller wants to see what.
+ */
+function formatLocaleAfter(User $user, ?string $acceptLanguage): ?string
+{
+    // Explicitly emptied rather than left out: `Request::create()` supplies an
+    // `en-us` header of its own when none is given, which is not what "no
+    // header" means here.
+    $request = Request::create('/', 'GET', server: ['HTTP_ACCEPT_LANGUAGE' => (string) $acceptLanguage]);
+    $request->setLaravelSession(app('session.store'));
+    $request->setUserResolver(fn (): User => $user);
+
+    app(SetLocale::class)->handle($request, fn () => new Response);
+
+    return $user->refresh()->format_locale;
+}
+
+it('pins the region the browser asks for onto a user who has none', function () {
+    $user = User::factory()->create(['locale' => 'es', 'format_locale' => null]);
+
+    expect(formatLocaleAfter($user, 'es-MX,es;q=0.9,en;q=0.8'))->toBe('es-MX');
+});
+
+it('reads the region rather than the language, even when the two disagree', function () {
+    // A reader who set the app to English on a British browser gets British
+    // amounts, not American ones: language and region are separate choices.
+    $user = User::factory()->create(['locale' => 'en', 'format_locale' => null]);
+
+    expect(formatLocaleAfter($user, 'en-GB,en;q=0.9'))->toBe('en-GB');
+});
+
+it('honours the quality the browser puts on each language', function () {
+    $user = User::factory()->create(['locale' => 'es', 'format_locale' => null]);
+
+    expect(formatLocaleAfter($user, 'en;q=0.5,es-AR;q=0.9'))->toBe('es-AR');
+});
+
+it('leaves a header with no region where the reader already was', function (string $locale, string $expected) {
+    $user = User::factory()->create(['locale' => $locale, 'format_locale' => null]);
+
+    expect(formatLocaleAfter($user, $locale))->toBe($expected);
+})->with([['es', 'es-ES'], ['en', 'en-US'], ['fr', 'fr-FR']]);
+
+it('takes the Latin American tag a browser sends instead of a country', function () {
+    // Chrome and Android send this for "Spanish (Latin America)", and reading
+    // it as plain Spanish is what put Spain's separators on Mexican screens.
+    $user = User::factory()->create(['locale' => 'es', 'format_locale' => null]);
+
+    expect(formatLocaleAfter($user, 'es-419,es;q=0.9'))->toBe('es-419');
+});
+
+it('does not let a ?lang= override decide the region fallback', function () {
+    // The query parameter switches the language of the page being looked at;
+    // the region is settled once and for good, so it follows the reader's own.
+    $user = User::factory()->create(['locale' => 'es', 'format_locale' => null]);
+
+    $request = Request::create('/', 'GET', ['lang' => 'en'], server: ['HTTP_ACCEPT_LANGUAGE' => 'nb-NO']);
+    $request->setLaravelSession(app('session.store'));
+    $request->setUserResolver(fn (): User => $user);
+
+    app(SetLocale::class)->handle($request, fn () => new Response);
+
+    expect($user->refresh()->format_locale)->toBe('es-ES');
+});
+
+it('falls back to the language when the header names a region the app does not offer', function () {
+    $user = User::factory()->create(['locale' => 'fr', 'format_locale' => null]);
+
+    expect(formatLocaleAfter($user, 'nb-NO,nb;q=0.9'))->toBe('fr-FR');
+});
+
+it('falls back to the language when there is no header at all', function () {
+    $user = User::factory()->create(['locale' => 'es', 'format_locale' => null]);
+
+    expect(formatLocaleAfter($user, null))->toBe('es-ES');
+});
+
+it('never overwrites a region the reader already has', function () {
+    // The header is a guess and the stored value may be a deliberate choice, so
+    // signing in from a borrowed laptop must not rewrite it.
+    $user = User::factory()->create(['locale' => 'es', 'format_locale' => 'es-MX']);
+
+    expect(formatLocaleAfter($user, 'en-US,en;q=0.9'))->toBe('es-MX');
+});
+
+it('reads a region for a signed-out visitor without storing anything', function () {
+    $request = Request::create('/', 'GET', server: ['HTTP_ACCEPT_LANGUAGE' => 'es-CO,es;q=0.9']);
+    $request->setLaravelSession(app('session.store'));
+
+    app(SetLocale::class)->handle($request, fn () => new Response);
+
+    expect(app(FormatLocaleOptions::class)->detectFromHeader('es-CO,es;q=0.9', 'es'))->toBe('es-CO');
+});
+
+it('can write an amount in every region it offers', function () {
+    // A tag ICU does not know leaves its failure on the formatter rather than in
+    // the return value, and a duplicate would quietly double a row in the picker.
+    $codes = app(FormatLocaleOptions::class)->codes();
+
+    expect($codes)->not->toBeEmpty()->and(array_unique($codes))->toBe($codes);
+
+    foreach ($codes as $code) {
+        $formatter = new NumberFormatter($code, NumberFormatter::CURRENCY);
+        $formatter->formatCurrency(1234.56, 'EUR');
+
+        expect(intl_is_failure($formatter->getErrorCode()))->toBeFalse("ICU does not know {$code}");
+    }
 });


### PR DESCRIPTION
## The problem

The decimal separator and the thousands grouping of every amount in the app came from `users.locale` — the **language** the interface is translated into, two letters. So the region never got a say:

| Reader | Saw | Should see |
| --- | --- | --- |
| Mexican, app in Spanish | `1.234,56` (Spain) | `1,234.56` |
| British, app in English | `$1,234.56` (US) | `US$1,234.56` |
| Colombian, app in Spanish | `1.234,56` ✓ | `1.234,56` |

Twelve of the thirty-six currencies the app can hold money in are Latin American, so this is not a corner.

## What this does

Adds `users.format_locale` — the **region**, a full tag like `es-MX` — detected from the browser's own `Accept-Language` header and written **once**, only while the column is still null, the way `TimezoneController` settles a timezone. A reader who later picks a region (PR 2) keeps it whatever laptop they sign in on.

**No backfill.** The column stays null and is filled on the reader's next request. That is what carries the fix to existing accounts without a data migration — and it is why there is nothing to migrate.

### The list

`config/format_locales.php` is the closed list, read through `FormatLocaleOptions`, a sibling of `CurrencyOptions`. One region per country whose currency `config/currencies.php` offers — 42 of them; the euro is the one currency with several homes, BTC has none — plus `es-419`.

`es-419` is not a country: it is what Chrome and Android send for "Spanish (Latin America)", and without it those readers fell straight through to Spain's separators, which is the bug being fixed. It came out of review.

A header naming no region the app knows leaves the reader exactly where they were: `es` still means `es-ES`, `en` still `en-US`, `fr` still `fr-FR` — today's behaviour, unchanged.

### The one-line swap that does the work

The Inertia `locale` prop now carries the region instead of `app()->getLocale()`. That is the whole client-side change: the 25 `formatCurrency` calls, the 33 `AmountDisplay`s and `Intl.DisplayNames` in the bank-connect flow all became regional without a new hook or a touched call site.

`app()->getLocale()` stays two letters on the server, and the divergence is deliberate — `App::setLocale('es-MX')` would send the translator after a `lang/es-MX/` that does not exist. Nothing is lost: `i18n.ts` translates off the `translations` prop and has never read this one. Both sides carry a docblock saying so, because the next person through would otherwise "fix" it.

`useLocale()` also guards the tag with `Intl.getCanonicalLocales`: every `Intl` constructor throws `RangeError` on a malformed one, and that costs the whole screen rather than one badly written number.

### Server side

The four callers of `Money::formatIn()` read the region off the model rather than the request — they are queue jobs, where there is no request to read. Achievement card PNGs fold it into their cache key, since "2.000 €" and "2,000 €" are different pictures; existing cards are redrawn once on first use.

## Deliberately untouched

- **Amount entry.** `normalizeAmountText` already accepts both separators.
- **`Money::format()`.** Stays locale-blind; its docblock argues why.
- **Dates.** PR 2.
- **Per-currency decimal scale.** That is storage, not display.
- **Percentages on the monthly-summary card** still follow the language rather than the region. Out of scope here — worth a follow-up.

## Known trade-offs

- `th-TH` writes the Buddhist era (2569 for 2026) and `ar-SA`/`ar-KW` write Arabic-Indic digits. That is what a phone sold in Bangkok or Riyadh shows, and only a reader whose own browser asks for one is ever given it. Documented in the config.
- `es-US` is **not** on the list: it would put a second "United States" row in PR 2's picker for a tag browsers almost always pair with `es-419` anyway. Those readers keep today's behaviour, so nothing regresses.
- The demo account's region gets pinned by whoever signs in first — exactly as its **language** already is (`demoDataset()` leaves `locale` null on purpose and the reset does not clear it). No new behaviour, so `app/Services/Demo/**` is untouched.

## Also in here

`UserFactory::onboarded()` now settles `format_locale` alongside `locale`. Without it the one-time write happened on *every* test request and pushed 16 query-count ceilings over the line in the `performance-tests` suite — a user who has been through onboarding has made requests, so the factory should say so.

## Testing

- `SetLocaleTest` covers detection with a region, the `es-419` tag, `q`-value ordering, a header with no region, a header naming a region we do not offer, no header at all, never overwriting an existing value, a signed-out visitor, `?lang=` not deciding the fallback, and that ICU can write an amount in all 43 regions with no duplicates in the list.
- `currency.test.ts` covers Mexican vs Spanish separators, British vs American, and that `useGrouping: 'always'` still groups below 10,000 — es-ES CLDR does not, so dropping it would silently give `1234,56`.
- New `use-locale.test.ts` covers the malformed-tag fallback.
- Green: `pest` (3233), `--testsuite=Performance`, `--testsuite=Browser`, `phpstan`, `pint --test`, `bun run build`, `lint`, `format`, `dry`, `crap`.

## Demo

Browser QA on the seeded press account (Spanish UI, EUR, 1248 transactions), verified live: detection writes `es-MX` from the header and amounts turn Mexican while the interface stays Spanish; flipping the stored value to `es-ES` turns them back; a second request with a different header does not overwrite; a deliberately malformed `es_MX` falls back to en-US formatting instead of blanking the page; no console errors across dashboard, transactions, accounts, budgets and settings.

<!-- DEMO VIDEO: drag whisper-money-format-locale-qa.mp4 here -->

https://github.com/user-attachments/assets/181f6419-7cbf-4f5c-aecf-1db46241354a


