### PR TITLE
fix(banking): time out and reclassify transport failures in four API-key clients

### DIFF
--- a/app/Enums/BankingProvider.php
+++ b/app/Enums/BankingProvider.php
@@ -15,6 +15,21 @@ enum BankingProvider: string
     case EnableBanking = 'enablebanking';
 
     /**
+     * The provider's name as a person reads it, for log lines and error
+     * messages. The case name would do for most of them but not all:
+     * `IndexaCapital` is one word, the company is two.
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::IndexaCapital => 'Indexa Capital',
+            self::InteractiveBrokers => 'Interactive Brokers',
+            self::EnableBanking => 'Enable Banking',
+            default => $this->name,
+        };
+    }
+
+    /**
      * Whether the provider authenticates with user-supplied API keys
      * rather than EnableBanking's hosted OAuth flow.
      */

--- a/app/Services/Banking/BinanceClient.php
+++ b/app/Services/Banking/BinanceClient.php
@@ -2,14 +2,17 @@
 
 namespace App\Services\Banking;
 
+use App\Enums\BankingProvider;
+use App\Services\Banking\Concerns\TranslatesTransportFailures;
 use Exception;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\RequestException;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
 class BinanceClient
 {
+    use TranslatesTransportFailures;
+
     private const BASE_URL = 'https://api.binance.com';
 
     /** @var array<int, int> Retry backoff: 10s, 30s, 60s */
@@ -37,11 +40,13 @@ class BinanceClient
      */
     public function getTickerPrices(): array
     {
-        $response = $this->publicClient()->get('/api/v3/ticker/price');
+        return $this->translateTransportFailures(function () {
+            $response = $this->publicClient()->get('/api/v3/ticker/price');
 
-        $response->throw();
+            $response->throw();
 
-        return $response->json();
+            return $response->json();
+        });
     }
 
     /**
@@ -101,12 +106,17 @@ class BinanceClient
         return $this->signedRequest('/sapi/v1/capital/withdraw/history', $params);
     }
 
+    protected function provider(): BankingProvider
+    {
+        return BankingProvider::Binance;
+    }
+
     /**
      * Execute a signed request with fresh timestamp on each retry attempt.
      */
     private function signedRequest(string $path, array $params = []): array
     {
-        return retry(
+        return $this->translateTransportFailures(fn () => retry(
             self::RETRY_BACKOFF_MS,
             function () use ($path, $params) {
                 $params['timestamp'] = (int) (microtime(true) * 1000);
@@ -121,12 +131,12 @@ class BinanceClient
                 return $response->json();
             },
             when: fn (Exception $e) => $e instanceof RequestException && $e->response->status() === 429,
-        );
+        ));
     }
 
     private function authenticatedClient(): PendingRequest
     {
-        return Http::baseUrl(self::BASE_URL)
+        return $this->transportClient(self::BASE_URL)
             ->withHeaders(['X-MBX-APIKEY' => $this->apiKey])
             ->acceptJson()
             ->throw(function ($response, $exception) {
@@ -139,7 +149,7 @@ class BinanceClient
 
     private function publicClient(): PendingRequest
     {
-        return Http::baseUrl(self::BASE_URL)
+        return $this->transportClient(self::BASE_URL)
             ->acceptJson()
             ->retry(
                 self::RETRY_BACKOFF_MS,

--- a/app/Services/Banking/BinanceClient.php
+++ b/app/Services/Banking/BinanceClient.php
@@ -140,7 +140,7 @@ class BinanceClient
             ->withHeaders(['X-MBX-APIKEY' => $this->apiKey])
             ->acceptJson()
             ->throw(function ($response, $exception) {
-                Log::error('Binance API error', [
+                Log::log($response->serverError() ? 'warning' : 'error', 'Binance API error', [
                     'status' => $response->status(),
                     'body' => $response->json(),
                 ]);

--- a/app/Services/Banking/BitpandaClient.php
+++ b/app/Services/Banking/BitpandaClient.php
@@ -2,14 +2,17 @@
 
 namespace App\Services\Banking;
 
+use App\Enums\BankingProvider;
+use App\Services\Banking\Concerns\TranslatesTransportFailures;
 use Exception;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\RequestException;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
 class BitpandaClient
 {
+    use TranslatesTransportFailures;
+
     private const BASE_URL = 'https://api.bitpanda.com/v1';
 
     /** @var array<int, int> Retry backoff: 10s, 30s, 60s */
@@ -169,12 +172,17 @@ class BitpandaClient
         return array_reverse($allTrades);
     }
 
+    protected function provider(): BankingProvider
+    {
+        return BankingProvider::Bitpanda;
+    }
+
     /**
      * Execute an authenticated GET request with retry on rate limiting.
      */
     private function get(string $path, array $params = []): array
     {
-        return retry(
+        return $this->translateTransportFailures(fn () => retry(
             self::RETRY_BACKOFF_MS,
             function () use ($path, $params) {
                 $response = $this->client()->get($path, $params);
@@ -184,12 +192,12 @@ class BitpandaClient
                 return $response->json();
             },
             when: fn (Exception $e) => $e instanceof RequestException && $e->response->status() === 429,
-        );
+        ));
     }
 
     private function client(): PendingRequest
     {
-        return Http::baseUrl(self::BASE_URL)
+        return $this->transportClient(self::BASE_URL)
             ->withHeaders(['X-Api-Key' => $this->apiKey])
             ->acceptJson()
             ->throw(function ($response, $exception) {

--- a/app/Services/Banking/BitpandaClient.php
+++ b/app/Services/Banking/BitpandaClient.php
@@ -201,7 +201,7 @@ class BitpandaClient
             ->withHeaders(['X-Api-Key' => $this->apiKey])
             ->acceptJson()
             ->throw(function ($response, $exception) {
-                Log::error('Bitpanda API error', [
+                Log::log($response->serverError() ? 'warning' : 'error', 'Bitpanda API error', [
                     'status' => $response->status(),
                     'body' => $response->json(),
                 ]);

--- a/app/Services/Banking/CoinbaseClient.php
+++ b/app/Services/Banking/CoinbaseClient.php
@@ -194,7 +194,7 @@ class CoinbaseClient
             ->withToken($jwt)
             ->acceptJson()
             ->throw(function ($response) {
-                Log::error('Coinbase API error', [
+                Log::log($response->serverError() ? 'warning' : 'error', 'Coinbase API error', [
                     'status' => $response->status(),
                     'body' => $response->json(),
                 ]);

--- a/app/Services/Banking/CoinbaseClient.php
+++ b/app/Services/Banking/CoinbaseClient.php
@@ -2,15 +2,18 @@
 
 namespace App\Services\Banking;
 
+use App\Enums\BankingProvider;
+use App\Services\Banking\Concerns\TranslatesTransportFailures;
 use Exception;
 use Firebase\JWT\JWT;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\RequestException;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
 class CoinbaseClient
 {
+    use TranslatesTransportFailures;
+
     private const BASE_URL = 'https://api.coinbase.com';
 
     private const HOST = 'api.coinbase.com';
@@ -120,6 +123,11 @@ class CoinbaseClient
         ]);
     }
 
+    protected function provider(): BankingProvider
+    {
+        return BankingProvider::Coinbase;
+    }
+
     /**
      * Execute a signed JWT request with retry on rate limiting.
      *
@@ -128,7 +136,7 @@ class CoinbaseClient
      */
     private function signedRequest(string $method, string $path, array $params = []): array
     {
-        return retry(
+        return $this->translateTransportFailures(fn () => retry(
             self::RETRY_BACKOFF_MS,
             function () use ($method, $path, $params) {
                 $jwt = $this->buildJwt($method, $path);
@@ -154,7 +162,7 @@ class CoinbaseClient
                 return $response->json();
             },
             when: fn (Exception $e) => $e instanceof RequestException && $e->response->status() === 429,
-        );
+        ));
     }
 
     /**
@@ -182,7 +190,7 @@ class CoinbaseClient
 
     private function client(string $jwt): PendingRequest
     {
-        return Http::baseUrl(self::BASE_URL)
+        return $this->transportClient(self::BASE_URL)
             ->withToken($jwt)
             ->acceptJson()
             ->throw(function ($response) {

--- a/app/Services/Banking/Concerns/TranslatesTransportFailures.php
+++ b/app/Services/Banking/Concerns/TranslatesTransportFailures.php
@@ -61,7 +61,7 @@ trait TranslatesTransportFailures
             return $request();
         } catch (ConnectionException $e) {
             throw new TransientBankingProviderException(
-                "{$this->provider()->name} did not respond in time.",
+                "{$this->provider()->label()} did not respond in time.",
                 provider: $this->provider()->value,
                 previous: $e,
             );
@@ -71,7 +71,7 @@ trait TranslatesTransportFailures
             }
 
             throw new TransientBankingProviderException(
-                "{$this->provider()->name} could not serve the request right now.",
+                "{$this->provider()->label()} could not serve the request right now.",
                 provider: $this->provider()->value,
                 statusCode: $e->response->status(),
                 previous: $e,

--- a/app/Services/Banking/Concerns/TranslatesTransportFailures.php
+++ b/app/Services/Banking/Concerns/TranslatesTransportFailures.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Services\Banking\Concerns;
+
+use App\Enums\BankingProvider;
+use App\Exceptions\Banking\TransientBankingProviderException;
+use App\Services\Banking\WiseClient;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Shared transport handling for the API-key banking clients, mirroring the one
+ * {@see WiseClient} already carries.
+ *
+ * An unattended sync can do nothing about a provider being down or slow, so a
+ * timeout or a 5xx is reclassified as transient: the job logs it as a warning,
+ * keeps it out of Sentry, and leaves the connection's budget of scheduled
+ * retries alone rather than spending it on an outage. Statuses the caller acts
+ * on - 401/403 auth failures, 429 rate limits - stay as they are.
+ *
+ * Consumers name themselves through {@see provider()}.
+ */
+trait TranslatesTransportFailures
+{
+    /**
+     * Explicit rather than the framework's 30s default: with no timeout at all a
+     * hung provider holds a queue worker for as long as it likes.
+     */
+    private const int HTTP_TIMEOUT_SECONDS = 15;
+
+    private const int HTTP_CONNECT_TIMEOUT_SECONDS = 5;
+
+    abstract protected function provider(): BankingProvider;
+
+    /**
+     * A request builder that cannot outlive the timeouts above.
+     */
+    protected function transportClient(string $baseUrl): PendingRequest
+    {
+        return Http::baseUrl($baseUrl)
+            ->timeout(self::HTTP_TIMEOUT_SECONDS)
+            ->connectTimeout(self::HTTP_CONNECT_TIMEOUT_SECONDS);
+    }
+
+    /**
+     * Run a request, reclassifying its transport failures as transient.
+     *
+     * Wrap the whole `retry()` call, never the callback inside it: a translated
+     * exception no longer matches the `when:` closure that retries a 429.
+     *
+     * @template TResult
+     *
+     * @param  callable(): TResult  $request
+     * @return TResult
+     */
+    protected function translateTransportFailures(callable $request): mixed
+    {
+        try {
+            return $request();
+        } catch (ConnectionException $e) {
+            throw new TransientBankingProviderException(
+                "{$this->provider()->name} did not respond in time.",
+                provider: $this->provider()->value,
+                previous: $e,
+            );
+        } catch (RequestException $e) {
+            if (! $e->response->serverError()) {
+                throw $e;
+            }
+
+            throw new TransientBankingProviderException(
+                "{$this->provider()->name} could not serve the request right now.",
+                provider: $this->provider()->value,
+                statusCode: $e->response->status(),
+                previous: $e,
+            );
+        }
+    }
+}

--- a/app/Services/Banking/IndexaCapitalClient.php
+++ b/app/Services/Banking/IndexaCapitalClient.php
@@ -2,12 +2,15 @@
 
 namespace App\Services\Banking;
 
+use App\Enums\BankingProvider;
+use App\Services\Banking\Concerns\TranslatesTransportFailures;
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
 class IndexaCapitalClient
 {
+    use TranslatesTransportFailures;
+
     private const BASE_URL = 'https://api.indexacapital.com';
 
     public function __construct(
@@ -21,11 +24,7 @@ class IndexaCapitalClient
      */
     public function getUser(): array
     {
-        $response = $this->client()->get('/users/me');
-
-        $response->throw();
-
-        return $response->json();
+        return $this->get('/users/me');
     }
 
     /**
@@ -54,11 +53,7 @@ class IndexaCapitalClient
      */
     public function getAccount(string $accountNumber): array
     {
-        $response = $this->client()->get("/accounts/{$accountNumber}");
-
-        $response->throw();
-
-        return $response->json();
+        return $this->get("/accounts/{$accountNumber}");
     }
 
     /**
@@ -67,31 +62,54 @@ class IndexaCapitalClient
      * Returns an empty array when Indexa Capital responds with 404 (no
      * performance data available yet for the account, e.g. brand-new or
      * inactive accounts) instead of throwing, so the sync can no-op cleanly.
+     * That is why this endpoint builds its own request rather than going
+     * through {@see get()}: it needs the response back before it throws.
      *
      * @return array{total_amount?: float, return?: float, return_percentage?: float, portfolios?: array<int, array{date?: string, total_amount?: float, return?: float}>, net_amounts?: array<string, float>}
      */
     public function getPerformance(string $accountNumber): array
     {
-        $response = $this->client(throwOnError: false)->get("/accounts/{$accountNumber}/performance");
+        return $this->translateTransportFailures(function () use ($accountNumber) {
+            $response = $this->client(throwOnError: false)->get("/accounts/{$accountNumber}/performance");
 
-        if ($response->status() === 404) {
-            Log::info('No Indexa Capital performance data available', [
-                'account_number' => $accountNumber,
-            ]);
+            if ($response->status() === 404) {
+                Log::info('No Indexa Capital performance data available', [
+                    'account_number' => $accountNumber,
+                ]);
 
-            return [];
-        }
+                return [];
+            }
 
-        $response->throw();
+            $response->throw();
 
-        $json = $response->json();
+            $json = $response->json();
 
-        return is_array($json) ? $json : [];
+            return is_array($json) ? $json : [];
+        });
+    }
+
+    protected function provider(): BankingProvider
+    {
+        return BankingProvider::IndexaCapital;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private function get(string $path): array
+    {
+        return $this->translateTransportFailures(function () use ($path) {
+            $response = $this->client()->get($path);
+
+            $response->throw();
+
+            return $response->json() ?? [];
+        });
     }
 
     private function client(bool $throwOnError = true): PendingRequest
     {
-        $client = Http::baseUrl(self::BASE_URL)
+        $client = $this->transportClient(self::BASE_URL)
             ->withHeaders(['X-AUTH-TOKEN' => $this->apiToken])
             ->acceptJson();
 

--- a/app/Services/Banking/IndexaCapitalClient.php
+++ b/app/Services/Banking/IndexaCapitalClient.php
@@ -118,7 +118,7 @@ class IndexaCapitalClient
         }
 
         return $client->throw(function ($response, $exception) {
-            Log::error('Indexa Capital API error', [
+            Log::log($response->serverError() ? 'warning' : 'error', 'Indexa Capital API error', [
                 'status' => $response->status(),
                 'body' => $response->json(),
             ]);

--- a/tests/Feature/OpenBanking/BankingClientTransientErrorTest.php
+++ b/tests/Feature/OpenBanking/BankingClientTransientErrorTest.php
@@ -8,6 +8,7 @@ use App\Services\Banking\IndexaCapitalClient;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Sleep;
 
 beforeEach(function () {
@@ -33,35 +34,49 @@ function transientErrorEcPrivateKey(): string
 
 /**
  * The API-key clients that share TranslatesTransportFailures, each paired with
- * the provider slug the translated exception must carry. Wise and Interactive
- * Brokers translate the same way but keep their own copy for now.
+ * the provider slug the translated exception must carry and the name a person
+ * reads in its message. Wise and Interactive Brokers translate the same way but
+ * keep their own copy for now.
  */
 dataset('api key banking clients', [
-    'binance' => ['binance', fn () => (new BinanceClient('api-key', 'api-secret'))->getAccount()],
-    'coinbase' => ['coinbase', fn () => (new CoinbaseClient('organizations/org/apiKeys/key', transientErrorEcPrivateKey()))->getAccounts()],
-    'bitpanda' => ['bitpanda', fn () => (new BitpandaClient('api-key'))->getCryptoWallets()],
-    'indexacapital' => ['indexacapital', fn () => (new IndexaCapitalClient('api-token'))->getUser()],
+    'binance' => ['binance', 'Binance', fn () => (new BinanceClient('api-key', 'api-secret'))->getAccount()],
+    'coinbase' => ['coinbase', 'Coinbase', fn () => (new CoinbaseClient('organizations/org/apiKeys/key', transientErrorEcPrivateKey()))->getAccounts()],
+    'bitpanda' => ['bitpanda', 'Bitpanda', fn () => (new BitpandaClient('api-key'))->getCryptoWallets()],
+    'indexacapital' => ['indexacapital', 'Indexa Capital', fn () => (new IndexaCapitalClient('api-token'))->getUser()],
 ]);
 
-test('a provider timeout is reclassified as transient', function (string $provider, Closure $call) {
+test('a provider timeout is reclassified as transient', function (string $provider, string $label, Closure $call) {
     Http::fake(fn () => throw new ConnectionException('cURL error 28: Operation timed out'));
 
-    expect($call)
-        ->toThrow(TransientBankingProviderException::class)
-        ->and(transientErrorFrom($call)->provider)->toBe($provider);
+    $exception = transientErrorFrom($call);
+
+    expect($exception->provider)->toBe($provider)
+        ->and($exception->getMessage())->toStartWith($label)
+        ->and($exception->getPrevious())->toBeInstanceOf(ConnectionException::class);
 })->with('api key banking clients');
 
-test('a provider 500 is reclassified as transient', function (string $provider, Closure $call) {
+test('a provider 500 is reclassified as transient', function (string $provider, string $label, Closure $call) {
     Http::fake(Http::response(['error' => 'oops'], 500));
 
     $exception = transientErrorFrom($call);
 
     expect($exception->provider)->toBe($provider)
         ->and($exception->statusCode)->toBe(500)
+        ->and($exception->getMessage())->toStartWith($label)
         ->and($exception->getPrevious())->toBeInstanceOf(RequestException::class);
 })->with('api key banking clients');
 
-test('auth and rate-limit responses stay raw so the sync job can act on them', function (string $provider, Closure $call, int $status) {
+test('a provider 500 is logged as a warning, so an outage is not an error', function (string $provider, string $label, Closure $call) {
+    Http::fake(Http::response(['error' => 'oops'], 500));
+    Log::spy();
+
+    transientErrorFrom($call);
+
+    Log::shouldNotHaveReceived('error');
+    Log::shouldHaveReceived('log')->with('warning', "{$label} API error", Mockery::any());
+})->with('api key banking clients');
+
+test('auth and rate-limit responses stay raw so the sync job can act on them', function (string $provider, string $label, Closure $call, int $status) {
     Http::fake(Http::response(['error' => 'nope'], $status));
 
     expect($call)->toThrow(RequestException::class);

--- a/tests/Feature/OpenBanking/BankingClientTransientErrorTest.php
+++ b/tests/Feature/OpenBanking/BankingClientTransientErrorTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use App\Exceptions\Banking\TransientBankingProviderException;
+use App\Services\Banking\BinanceClient;
+use App\Services\Banking\BitpandaClient;
+use App\Services\Banking\CoinbaseClient;
+use App\Services\Banking\IndexaCapitalClient;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Sleep;
+
+beforeEach(function () {
+    // The 429 cases below run through each client's rate-limit backoff.
+    Sleep::fake();
+});
+
+afterEach(function () {
+    Sleep::fake(false);
+});
+
+function transientErrorEcPrivateKey(): string
+{
+    $key = openssl_pkey_new([
+        'private_key_type' => OPENSSL_KEYTYPE_EC,
+        'curve_name' => 'prime256v1',
+    ]);
+
+    openssl_pkey_export($key, $pem);
+
+    return $pem;
+}
+
+/**
+ * The API-key clients that share TranslatesTransportFailures, each paired with
+ * the provider slug the translated exception must carry. Wise and Interactive
+ * Brokers translate the same way but keep their own copy for now.
+ */
+dataset('api key banking clients', [
+    'binance' => ['binance', fn () => (new BinanceClient('api-key', 'api-secret'))->getAccount()],
+    'coinbase' => ['coinbase', fn () => (new CoinbaseClient('organizations/org/apiKeys/key', transientErrorEcPrivateKey()))->getAccounts()],
+    'bitpanda' => ['bitpanda', fn () => (new BitpandaClient('api-key'))->getCryptoWallets()],
+    'indexacapital' => ['indexacapital', fn () => (new IndexaCapitalClient('api-token'))->getUser()],
+]);
+
+test('a provider timeout is reclassified as transient', function (string $provider, Closure $call) {
+    Http::fake(fn () => throw new ConnectionException('cURL error 28: Operation timed out'));
+
+    expect($call)
+        ->toThrow(TransientBankingProviderException::class)
+        ->and(transientErrorFrom($call)->provider)->toBe($provider);
+})->with('api key banking clients');
+
+test('a provider 500 is reclassified as transient', function (string $provider, Closure $call) {
+    Http::fake(Http::response(['error' => 'oops'], 500));
+
+    $exception = transientErrorFrom($call);
+
+    expect($exception->provider)->toBe($provider)
+        ->and($exception->statusCode)->toBe(500)
+        ->and($exception->getPrevious())->toBeInstanceOf(RequestException::class);
+})->with('api key banking clients');
+
+test('auth and rate-limit responses stay raw so the sync job can act on them', function (string $provider, Closure $call, int $status) {
+    Http::fake(Http::response(['error' => 'nope'], $status));
+
+    expect($call)->toThrow(RequestException::class);
+})->with('api key banking clients')->with([401, 403, 429]);
+
+test('an indexa capital 404 on performance still degrades to an empty result', function () {
+    Http::fake([
+        'api.indexacapital.com/accounts/*/performance' => Http::response(['error' => 'not found'], 404),
+    ]);
+
+    expect((new IndexaCapitalClient('api-token'))->getPerformance('IC-001'))->toBe([]);
+});
+
+/**
+ * Run a client call that is expected to fail and hand back the transient
+ * exception, so its provider and status can be asserted.
+ */
+function transientErrorFrom(Closure $call): TransientBankingProviderException
+{
+    try {
+        $call();
+    } catch (TransientBankingProviderException $e) {
+        return $e;
+    }
+
+    throw new RuntimeException('Expected a TransientBankingProviderException.');
+}


### PR DESCRIPTION
`BinanceClient`, `CoinbaseClient`, `BitpandaClient` and `IndexaCapitalClient` set no
HTTP timeout and handled no transport failure. Two consequences, one of them
user-visible.

With no timeout, a hung provider holds a queue worker for as long as it likes — the
framework default of 30s never applied because these clients never opted into it.

And a `ConnectionException` or a 5xx reached `SyncBankingConnectionJob` unclassified.
`handleTemporaryError()` only spares the connection's `consecutive_sync_failures`
counter for a `TransientBankingProviderException`; everything else takes the `+ 1`
branch. Its own docblock says what running that budget out costs:

> MAX_SCHEDULED_RETRIES failures drop it out of every future scheduled sync, silently
> and with no way back other than reconnecting. Reaching that state because the bank
> was down for three cycles is the wrong trade.

So a provider being down for a few cycles could quietly disable a user's automatic
sync. It also put the wrong message on the connection — a timeout fell all the way
through to "An unexpected error occurred during sync", a 5xx landed on "The provider is
experiencing issues" — where "The bank provider is temporarily unavailable. We will try
syncing again later." is the honest one. And it logged at `error` where an outage
deserves a `warning`.

## What changed

All four clients now use `TranslatesTransportFailures`, a concern carrying the
handling `WiseClient` already had:

- Wise's 15s read / 5s connect timeouts on every request.
- A timeout or a 5xx reclassified as `TransientBankingProviderException`, with the
  provider slug, the status code and the original exception as `previous`.
- 401/403 auth failures and 429 rate limits still surface as raw `RequestException`s,
  because the job acts on them — it marks the connection permanently failed on an auth
  error and applies a rate-limit backoff on a 429.

The concern exists rather than four copies of the same try/catch because four
near-identical blocks would trip `bun run dry`, a required check.

The translation sits **outside** each client's `retry()` call, never inside its
`when:` closure — translating inside would hand that closure a
`TransientBankingProviderException` and kill the 429 retry that works today.

`IndexaCapitalClient` had no request choke point at all, so `getUser()` and
`getAccount()` now go through a private `get()`. `getPerformance()` keeps building its
own request because it needs the response back before it throws, to return `[]` on a
404 — there is a test pinning that.

Two follow-ups from review are in the second commit: the transient message was built
from the enum case name, so Indexa Capital introduced itself as "IndexaCapital" in a
message the job logs and stores on the connection (`BankingProvider::label()` fixes
that); and the four clients still called `Log::error()` for the very 5xx this change
reclassifies as transient, so they now pick the level off the status the way
`WiseClient` and `EnableBankingProvider` already do.

## Why there is no `Fixes` line

There is no Sentry issue behind this. It is a latent gap found while fixing the same
bug in `InteractiveBrokersClient` for PHP-LARAVEL-5Y.

`WiseClient` and `InteractiveBrokersClient` are deliberately untouched: Wise works, and
IB is being changed right now in a parallel PR. Folding both into
`TranslatesTransportFailures` is the obvious follow-up once IB lands — it would delete
Wise's private timeout constants and its copy of the try/catch.

## Tests

`tests/Feature/OpenBanking/BankingClientTransientErrorTest.php`, modelled on
`WiseTransientErrorTest.php` but driven by a dataset over the four clients, since they
now share one implementation: a faked `ConnectionException` and a faked 500 each become
transient (asserting provider, status code, `previous` and the message), a 500 is
logged as a warning rather than an error, 401/403/429 stay `RequestException`, and
`getPerformance()` still returns `[]` on a 404.

## QA

Driven through the real path — `SyncBankingConnectionJob::handle()` → the real syncer →
the real client, with `Http::fake()` only at the transport layer and the job mocked onto
its final attempt — for Binance and Indexa Capital, seeding `consecutive_sync_failures`
at 1:

| Scenario | `consecutive_sync_failures` | Status | `error_message` |
| --- | --- | --- | --- |
| 5xx | 1 (unchanged) | `Error` | "The bank provider is temporarily unavailable…" |
| Timeout | 1 (unchanged) | `Error` | "The bank provider is temporarily unavailable…" |
| 401 | forced to `MAX_SCHEDULED_RETRIES + 1` | `Error` | "Authentication failed…" |
| 429 | 1 (unchanged) | `Active` | — (`rate_limited_until` set) |

The last two are the sanity check that this branch leaves the auth and rate-limit paths
exactly as they were. `tests/Feature/OpenBanking/` is green at 500 tests.
