### PR TITLE
feat(locale): let the reader pick their region, and write dates in it

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -132,6 +132,11 @@ class HandleInertiaRequests extends Middleware
                 // still has to render at the right scale.
                 'decimals' => $this->currencyOptions->decimalsMap(),
             ],
+            // Codes only: the picker writes each one's country name and its
+            // live example with `Intl`, the way `useConnectCountries()` already
+            // does, so 43 country names never need a translation entry — and
+            // the list never exists twice, once in PHP and once in TypeScript.
+            'formatLocales' => $this->formatLocales->codes(),
         ];
     }
 

--- a/app/Http/Requests/Settings/ProfileUpdateRequest.php
+++ b/app/Http/Requests/Settings/ProfileUpdateRequest.php
@@ -5,6 +5,7 @@ namespace App\Http\Requests\Settings;
 use App\Enums\Locale;
 use App\Models\User;
 use App\Services\CurrencyOptions;
+use App\Services\FormatLocaleOptions;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -33,6 +34,10 @@ class ProfileUpdateRequest extends FormRequest
             ],
             'currency_code' => ['required', 'string', 'max:3', Rule::in($currencyOptions->primaryCodes())],
             'locale' => ['nullable', 'string', Rule::enum(Locale::class)],
+            // A closed list, because an unknown tag is not a cosmetic problem:
+            // every `Intl` constructor throws `RangeError` on a malformed one
+            // and takes the whole screen with it.
+            'format_locale' => ['nullable', 'string', Rule::in(app(FormatLocaleOptions::class)->codes())],
         ];
     }
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -2951,5 +2951,7 @@
     "See it": "Verla",
     "A connected account keeps the bank of its connection.": "Una cuenta conectada mantiene el banco de su conexión.",
     "Your bank sets the currency of a connected account.": "El banco fija la moneda de una cuenta conectada.",
-    "Archive this account first: it is still connected to your bank.": "Archiva primero esta cuenta: sigue conectada a tu banco."
+    "Archive this account first: it is still connected to your bank.": "Archiva primero esta cuenta: sigue conectada a tu banco.",
+    "Number and date format": "Formato de números y fechas",
+    "Select a region": "Seleccionar región"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2505,5 +2505,7 @@
     "Not now": "Pas maintenant",
     "A connected account keeps the bank of its connection.": "Un compte connecté conserve la banque de sa connexion.",
     "Your bank sets the currency of a connected account.": "Votre banque définit la devise d’un compte connecté.",
-    "Archive this account first: it is still connected to your bank.": "Archivez d’abord ce compte : il est encore connecté à votre banque."
+    "Archive this account first: it is still connected to your bank.": "Archivez d’abord ce compte : il est encore connecté à votre banque.",
+    "Number and date format": "Format des nombres et des dates",
+    "Select a region": "Sélectionner une région"
 }

--- a/resources/js/components/dashboard/net-worth-chart.tsx
+++ b/resources/js/components/dashboard/net-worth-chart.tsx
@@ -36,7 +36,7 @@ import {
 } from '@/lib/chart-calculations';
 import { fetchJson } from '@/lib/fetch-json';
 import { SharedData } from '@/types';
-import { formatDayFromDate } from '@/utils/date';
+import { formatDayFromDate, formatMonthFromYearMonth } from '@/utils/date';
 import { __ } from '@/utils/i18n';
 import { router, usePage } from '@inertiajs/react';
 import { format, subDays } from 'date-fns';
@@ -64,25 +64,19 @@ interface TrendData {
     currentAmount: number;
 }
 
+/**
+ * The monthly branch used to be a hand-rolled copy of
+ * {@see formatMonthFromYearMonth}, which is how this chart alone kept printing
+ * "oct 25" for a prior year after every other one started writing it out.
+ */
 function formatXAxisLabel(
     value: string,
-    locale: string = 'en',
+    locale: string = 'en-US',
     granularity: ChartGranularity = 'monthly',
 ): string {
-    if (granularity === 'daily') {
-        return formatDayFromDate(value, locale);
-    }
-
-    const [year, month] = value.split('-');
-    const date = new Date(parseInt(year), parseInt(month) - 1);
-    const monthName = date.toLocaleString(locale, { month: 'short' });
-    const currentYear = new Date().getFullYear();
-
-    if (parseInt(year) === currentYear) {
-        return monthName;
-    }
-
-    return `${monthName} ${year.slice(-2)}`;
+    return granularity === 'daily'
+        ? formatDayFromDate(value, locale)
+        : formatMonthFromYearMonth(value, locale);
 }
 
 function calculateTrend(

--- a/resources/js/components/user-menu-content.test.tsx
+++ b/resources/js/components/user-menu-content.test.tsx
@@ -85,6 +85,7 @@ const user: User = {
     email: 'test@example.com',
     currency_code: 'USD',
     locale: 'en',
+    format_locale: 'en-US',
     timezone: 'UTC',
     email_verified_at: null,
     created_at: '2026-01-01T00:00:00.000000Z',

--- a/resources/js/lib/file-parser.test.ts
+++ b/resources/js/lib/file-parser.test.ts
@@ -62,6 +62,20 @@ describe('getLocaleDateFormat', () => {
     it('handles underscored locales like en_US', () => {
         expect(getLocaleDateFormat('en_US')).toBe(DateFormat.MonthDayYear);
     });
+
+    // The whole reason this used to be dead code: the app's `locale` prop was
+    // two letters, so a US reader arrived here as 'en' and got the rest of the
+    // world's order suggested for their own bank export. It carries the region
+    // now, so the comparison against 'en-US' finally has something to match.
+    it('suggests the American order to an American, which a bare language never did', () => {
+        expect(getLocaleDateFormat('en')).toBe(DateFormat.DayMonthYear);
+        expect(getLocaleDateFormat('en-US')).toBe(DateFormat.MonthDayYear);
+    });
+
+    it('keeps a Latin American reader on day-first', () => {
+        expect(getLocaleDateFormat('es-MX')).toBe(DateFormat.DayMonthYear);
+        expect(getLocaleDateFormat('es-419')).toBe(DateFormat.DayMonthYear);
+    });
 });
 
 describe('convertRowsToTransactions', () => {

--- a/resources/js/pages/settings/account.tsx
+++ b/resources/js/pages/settings/account.tsx
@@ -17,6 +17,7 @@ import {
     SelectValue,
 } from '@/components/ui/select';
 import { Separator } from '@/components/ui/separator';
+import { useLocale } from '@/hooks/use-locale';
 import { useTwoFactorAuth } from '@/hooks/use-two-factor-auth';
 import AppLayout from '@/layouts/app-layout';
 import SettingsLayout from '@/layouts/settings/layout';
@@ -25,11 +26,56 @@ import { disable, enable } from '@/routes/two-factor';
 import { send } from '@/routes/verification';
 import { type BreadcrumbItem, type SharedData } from '@/types';
 import { LANGUAGE_OPTIONS } from '@/types/language';
+import { formatLocaleOptions } from '@/utils/format-locale';
 import { __ } from '@/utils/i18n';
 import { Transition } from '@headlessui/react';
 import { Form, Head, Link, usePage } from '@inertiajs/react';
 import { ShieldBan, ShieldCheck } from 'lucide-react';
-import { useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
+
+/**
+ * One labelled dropdown in the profile form. Three of these sit in a row —
+ * currency, language, region — and they were the same twenty-five lines three
+ * times over until they were not.
+ */
+function PreferenceSelect({
+    name,
+    label,
+    placeholder,
+    defaultValue,
+    options,
+    error,
+    required = false,
+}: {
+    name: string;
+    label: string;
+    placeholder: string;
+    defaultValue?: string;
+    options: readonly { code: string; label: string }[];
+    error?: string;
+    required?: boolean;
+}) {
+    return (
+        <div className="grid gap-2">
+            <Label htmlFor={name}>{label}</Label>
+
+            <Select name={name} defaultValue={defaultValue} required={required}>
+                <SelectTrigger className="mt-1 w-full">
+                    <SelectValue placeholder={placeholder} />
+                </SelectTrigger>
+                <SelectContent>
+                    {options.map((option) => (
+                        <SelectItem key={option.code} value={option.code}>
+                            {option.label}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+
+            <InputError className="mt-2" message={error} />
+        </div>
+    );
+}
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
@@ -49,7 +95,23 @@ export default function Account({
     requiresConfirmation?: boolean;
     twoFactorEnabled?: boolean;
 }) {
-    const { auth, currencies } = usePage<SharedData>().props;
+    const { auth, currencies, formatLocales } = usePage<SharedData>().props;
+    const locale = useLocale();
+    // Each row carries a live example, so a reader picks by what it does to
+    // their money rather than by guessing what a tag means.
+    const formatOptions = useMemo(
+        () =>
+            formatLocaleOptions(formatLocales, auth.user.currency_code, locale),
+        [formatLocales, auth.user.currency_code, locale],
+    );
+    const currencyOptions = useMemo(
+        () =>
+            currencies.profile.map((currency) => ({
+                code: currency.code,
+                label: `${currency.code} - ${currency.name}`,
+            })),
+        [currencies.profile],
+    );
     const passwordInput = useRef<HTMLInputElement>(null);
     const currentPasswordInput = useRef<HTMLInputElement>(null);
 
@@ -126,81 +188,35 @@ export default function Account({
                                     />
                                 </div>
 
-                                <div className="grid gap-2">
-                                    <Label htmlFor="currency_code">
-                                        {__('Currency')}
-                                    </Label>
+                                <PreferenceSelect
+                                    name="currency_code"
+                                    label={__('Currency')}
+                                    placeholder={__('Select currency')}
+                                    defaultValue={auth.user.currency_code}
+                                    options={currencyOptions}
+                                    error={errors.currency_code}
+                                    required
+                                />
 
-                                    <Select
-                                        name="currency_code"
-                                        defaultValue={auth.user.currency_code}
-                                        required
-                                    >
-                                        <SelectTrigger className="mt-1 w-full">
-                                            <SelectValue
-                                                placeholder={__(
-                                                    'Select currency',
-                                                )}
-                                            />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            {currencies.profile.map(
-                                                (currency) => (
-                                                    <SelectItem
-                                                        key={currency.code}
-                                                        value={currency.code}
-                                                    >
-                                                        {currency.code} -{' '}
-                                                        {currency.name}
-                                                    </SelectItem>
-                                                ),
-                                            )}
-                                        </SelectContent>
-                                    </Select>
+                                <PreferenceSelect
+                                    name="locale"
+                                    label={__('Language')}
+                                    placeholder={__('Select language')}
+                                    defaultValue={auth.user.locale ?? undefined}
+                                    options={LANGUAGE_OPTIONS}
+                                    error={errors.locale}
+                                />
 
-                                    <InputError
-                                        className="mt-2"
-                                        message={errors.currency_code}
-                                    />
-                                </div>
-
-                                <div className="grid gap-2">
-                                    <Label htmlFor="locale">
-                                        {__('Language')}
-                                    </Label>
-
-                                    <Select
-                                        name="locale"
-                                        defaultValue={
-                                            auth.user.locale ?? undefined
-                                        }
-                                    >
-                                        <SelectTrigger className="mt-1 w-full">
-                                            <SelectValue
-                                                placeholder={__(
-                                                    'Select language',
-                                                )}
-                                            />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            {LANGUAGE_OPTIONS.map(
-                                                (language) => (
-                                                    <SelectItem
-                                                        key={language.code}
-                                                        value={language.code}
-                                                    >
-                                                        {language.label}
-                                                    </SelectItem>
-                                                ),
-                                            )}
-                                        </SelectContent>
-                                    </Select>
-
-                                    <InputError
-                                        className="mt-2"
-                                        message={errors.locale}
-                                    />
-                                </div>
+                                <PreferenceSelect
+                                    name="format_locale"
+                                    label={__('Number and date format')}
+                                    placeholder={__('Select a region')}
+                                    defaultValue={
+                                        auth.user.format_locale ?? undefined
+                                    }
+                                    options={formatOptions}
+                                    error={errors.format_locale}
+                                />
 
                                 {mustVerifyEmail &&
                                     auth.user.email_verified_at === null && (

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -239,6 +239,11 @@ export interface SharedData {
         /** Minor-unit decimals per currency code, e.g. EUR 2, COP 0, BTC 8. */
         decimals: Record<string, number>;
     };
+    /**
+     * The regions offered in settings, as bare tags: the picker writes each
+     * one's country name and live example with `Intl`.
+     */
+    formatLocales: string[];
     [key: string]: unknown;
 }
 
@@ -248,6 +253,8 @@ export interface User {
     email: string;
     currency_code: CurrencyCode;
     locale: string | null;
+    /** The region amounts and dates are written in, e.g. `es-MX`. */
+    format_locale: string | null;
     timezone: string | null;
     avatar?: string;
     email_verified_at: string | null;

--- a/resources/js/utils/date.test.ts
+++ b/resources/js/utils/date.test.ts
@@ -1,5 +1,9 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { formatDate } from './date';
+import {
+    formatDate,
+    formatDayFromDate,
+    formatMonthFromYearMonth,
+} from './date';
 
 describe('formatDate', () => {
     // Reported from America/Buenos_Aires: budget periods rendered a day early
@@ -14,14 +18,71 @@ describe('formatDate', () => {
         process.env.TZ = originalTimeZone;
     });
 
+    // Asserted in Swedish, the one region on the list that writes a date in ISO
+    // order: the pattern names the fields now, and the region decides where
+    // they go, so a bare "yyyy-MM-dd" in en-US comes back as "08/01/2026".
     it('keeps the calendar day of a bare date key at a negative UTC offset', () => {
-        expect(formatDate('2026-08-01', 'yyyy-MM-dd')).toBe('2026-08-01');
-        expect(formatDate('2026-08-31', 'yyyy-MM-dd')).toBe('2026-08-31');
+        expect(formatDate('2026-08-01', 'yyyy-MM-dd', 'sv-SE')).toBe(
+            '2026-08-01',
+        );
+        expect(formatDate('2026-08-31', 'yyyy-MM-dd', 'sv-SE')).toBe(
+            '2026-08-31',
+        );
     });
 
     it('still formats a full instant in the local time zone', () => {
-        expect(formatDate('2026-08-01T12:00:00.000000Z', 'yyyy-MM-dd')).toBe(
-            '2026-08-01',
+        expect(
+            formatDate('2026-08-01T12:00:00.000000Z', 'yyyy-MM-dd', 'sv-SE'),
+        ).toBe('2026-08-01');
+    });
+});
+
+describe('chart axis labels outside the current year', () => {
+    // date-fns wrote these as "Sep '25", and the apostrophe was what said the
+    // number was a year. `Intl` cannot be asked for one, so the year is written
+    // out instead: "Sep 10 25" is three numbers in a row on a chart axis.
+    it('writes the year out rather than leaving a bare two digits', () => {
+        expect(formatMonthFromYearMonth('2025-09', 'en-US')).toBe('Sep 2025');
+        expect(formatDayFromDate('2025-09-10', 'en-US')).toBe('Sep 10, 2025');
+    });
+
+    it('still drops the year inside the current one', () => {
+        const thisYear = new Date().getFullYear();
+
+        expect(formatMonthFromYearMonth(`${thisYear}-09`, 'en-US')).toBe('Sep');
+        expect(formatDayFromDate(`${thisYear}-09-10`, 'en-US')).toBe('Sep 10');
+    });
+});
+
+describe('formatDate across regions', () => {
+    // The one reason this moved off date-fns: the pattern used to fix the order
+    // as well as the fields, so every reader got the American one.
+    it('orders the fields the way the region does, not the way the pattern does', () => {
+        expect(formatDate('2026-09-10', 'MMM d, yyyy', 'en-US')).toBe(
+            'Sep 10, 2026',
+        );
+        expect(formatDate('2026-09-10', 'MMM d, yyyy', 'es-ES')).toBe(
+            '10 sept 2026',
+        );
+        expect(formatDate('2026-09-10', 'MMM d, yyyy', 'es-MX')).toBe(
+            '10 sep 2026',
+        );
+    });
+
+    it('splits the two regions that share a language', () => {
+        // en-US is the only one of the forty-three that writes month first.
+        expect(formatDate('2026-09-10', 'd/M/yyyy', 'en-US')).toBe('9/10/2026');
+        expect(formatDate('2026-09-10', 'd/M/yyyy', 'en-GB')).toBe(
+            '10/09/2026',
+        );
+    });
+
+    it('reads a pattern for its fields and nothing else', () => {
+        expect(formatDate('2026-09-10', 'yyyy', 'en-US')).toBe('2026');
+        expect(formatDate('2026-09-10', 'EEEE', 'en-US')).toBe('Thursday');
+        // The escaped quote in date-fns' "''yy" is not a field.
+        expect(formatDate('2026-09-10', "MMM d, ''yy", 'en-US')).toBe(
+            'Sep 10, 26',
         );
     });
 });

--- a/resources/js/utils/date.ts
+++ b/resources/js/utils/date.ts
@@ -1,21 +1,38 @@
 import { __ } from '@/utils/i18n';
 import {
-    format as dateFnsFormat,
     isToday as dateFnsIsToday,
     isYesterday as dateFnsIsYesterday,
 } from 'date-fns';
-import { es } from 'date-fns/locale';
 
 /**
- * Get the date-fns locale object based on locale code
+ * The date-fns tokens this app uses, as the `Intl` option each one asks for.
+ *
+ * Only the fields are carried over, never the order: `Intl` puts them where the
+ * reader's region puts them, which is the whole point. So "MMM d, yyyy" prints
+ * "Sep 10, 2026" in Boston and "10 sept 2026" in Madrid off the same call — and
+ * a Mexican no longer reads a British date because they read Spanish.
  */
-function getDateFnsLocale(locale: string) {
-    switch (locale) {
-        case 'es':
-            return es;
-        default:
-            return undefined; // Uses English by default
-    }
+const TOKEN_OPTIONS: Record<string, Intl.DateTimeFormatOptions> = {
+    yyyy: { year: 'numeric' },
+    yy: { year: '2-digit' },
+    MMMM: { month: 'long' },
+    MMM: { month: 'short' },
+    MM: { month: '2-digit' },
+    M: { month: 'numeric' },
+    dd: { day: '2-digit' },
+    d: { day: 'numeric' },
+    EEEE: { weekday: 'long' },
+    EEE: { weekday: 'short' },
+};
+
+/** Quoted literals in a pattern — date-fns' "''yy" — carry no field of their own. */
+const TOKENS = /y{2,4}|M{1,4}|d{1,2}|E{3,4}/g;
+
+function toIntlOptions(pattern: string): Intl.DateTimeFormatOptions {
+    return (pattern.match(TOKENS) ?? []).reduce<Intl.DateTimeFormatOptions>(
+        (options, token) => ({ ...options, ...TOKEN_OPTIONS[token] }),
+        {},
+    );
 }
 
 /**
@@ -33,25 +50,28 @@ function toLocalDate(date: Date | string | number): Date {
 }
 
 /**
- * Format a date using the user's locale
+ * A date written the way the reader's region writes it.
+ *
+ * `formatStr` still names the fields in date-fns' spelling, because that is what
+ * every call site already passes; what it no longer decides is their order.
  */
 export function formatDate(
     date: Date | string | number,
     formatStr: string,
     locale: string = 'en-US',
 ): string {
-    const dateObj = toLocalDate(date);
-
-    const dateFnsLocale = getDateFnsLocale(locale);
-
-    return dateFnsFormat(dateObj, formatStr, {
-        locale: dateFnsLocale,
-    });
+    return new Intl.DateTimeFormat(locale, toIntlOptions(formatStr)).format(
+        toLocalDate(date),
+    );
 }
 
 /**
- * Format a month from YYYY-MM string
- * Shows abbreviated month for current year, or "MMM 'YY" for other years
+ * A month from a YYYY-MM key, for chart axes: the month alone inside the
+ * current year, the month and the full year outside it.
+ *
+ * The year is written out rather than abbreviated. date-fns wrote "Sep '25" and
+ * the apostrophe was doing the work of saying "this is a year"; `Intl` has no
+ * way to ask for one, and "Sep 25" beside "Sep 10" reads as a day.
  */
 export function formatMonthFromYearMonth(
     yearMonth: string,
@@ -61,7 +81,7 @@ export function formatMonthFromYearMonth(
     const date = new Date(parseInt(year), parseInt(month) - 1);
     const isCurrentYear = date.getFullYear() === new Date().getFullYear();
 
-    const formatStr = isCurrentYear ? 'MMM' : "MMM ''yy";
+    const formatStr = isCurrentYear ? 'MMM' : 'MMM yyyy';
 
     return formatDate(date, formatStr, locale);
 }
@@ -145,8 +165,8 @@ export function formatRelativeDate(
 }
 
 /**
- * Format a date from YYYY-MM-DD string for daily chart X-axis labels
- * Shows "MMM d" (e.g., "Feb 14") for current year, or "MMM d 'YY" for other years
+ * A day for a daily chart's X axis: "Feb 14" inside the current year, and the
+ * full year alongside it outside — "Feb 14 25" would be three numbers in a row.
  */
 export function formatDayFromDate(
     dateStr: string,
@@ -155,7 +175,7 @@ export function formatDayFromDate(
     const date = new Date(dateStr + 'T00:00:00');
     const isCurrentYear = date.getFullYear() === new Date().getFullYear();
 
-    const formatStr = isCurrentYear ? 'MMM d' : "MMM d ''yy";
+    const formatStr = isCurrentYear ? 'MMM d' : 'MMM d yyyy';
 
     return formatDate(date, formatStr, locale);
 }

--- a/resources/js/utils/format-locale.test.ts
+++ b/resources/js/utils/format-locale.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { formatLocaleOptions } from './format-locale';
+
+describe('formatLocaleOptions', () => {
+    it('names the country and shows what it does to an amount and a date', () => {
+        const [mexico] = formatLocaleOptions(['es-MX'], 'MXN', 'en-US');
+
+        expect(mexico.code).toBe('es-MX');
+        expect(mexico.label).toBe('Mexico — $1,234.56 · 25/12/2026');
+    });
+
+    it('tells apart two regions that share a language', () => {
+        const [spain] = formatLocaleOptions(['es-ES'], 'EUR', 'en-US');
+        const [mexico] = formatLocaleOptions(['es-MX'], 'EUR', 'en-US');
+
+        expect(spain.label).toContain('1.234,56');
+        expect(mexico.label).toContain('1,234.56');
+    });
+
+    it('names the Latin American tag, which has no country of its own', () => {
+        const [latam] = formatLocaleOptions(['es-419'], 'USD', 'en-US');
+
+        expect(latam.label).toContain('Latin America');
+    });
+
+    it('writes the country names in the reader’s own language', () => {
+        const [spain] = formatLocaleOptions(['es-ES'], 'EUR', 'es-ES');
+
+        expect(spain.label).toContain('España');
+    });
+
+    it('sorts by label so a long list can be read down', () => {
+        const labels = formatLocaleOptions(
+            ['es-MX', 'de-DE', 'en-AU'],
+            'EUR',
+            'en-US',
+        ).map((option) => option.code);
+
+        expect(labels).toEqual(['en-AU', 'de-DE', 'es-MX']);
+    });
+});

--- a/resources/js/utils/format-locale.ts
+++ b/resources/js/utils/format-locale.ts
@@ -1,0 +1,51 @@
+import { formatCurrency } from '@/utils/currency';
+import { formatDate } from '@/utils/date';
+
+/**
+ * A fixed sample rather than today's date. The point of the example is the
+ * order of the fields, and on the 5th of May every region on the list prints
+ * the same thing; a day past the 12th can never be read as a month.
+ */
+const SAMPLE_DATE = '2026-12-25';
+
+/** 1234.56 in minor units — enough digits to show the grouping separator too. */
+const SAMPLE_AMOUNT = 123456;
+
+export interface FormatLocaleOption {
+    code: string;
+    label: string;
+}
+
+/**
+ * The picker's rows: the country, then the same amount and date written the way
+ * that region writes them, in the reader's own currency.
+ *
+ * The example is the whole reason this reads as a choice rather than a list of
+ * codes — nobody knows what `es-419` does to a number, everybody can read
+ * "1,234.56". Two countries printing the same example is the honest answer, not
+ * a reason to hide one of them.
+ *
+ * `Intl` owns the country names, the way `useConnectCountries()` already has
+ * them, so 43 of them never need a translation entry.
+ */
+export function formatLocaleOptions(
+    locales: string[],
+    currencyCode: string,
+    displayIn: string,
+): FormatLocaleOption[] {
+    const countries = new Intl.DisplayNames([displayIn], { type: 'region' });
+    const collator = new Intl.Collator(displayIn);
+
+    return locales
+        .map((code) => {
+            const region = code.split('-')[1] ?? code;
+            const amount = formatCurrency(SAMPLE_AMOUNT, currencyCode, code);
+            const date = formatDate(SAMPLE_DATE, 'd/M/yyyy', code);
+
+            return {
+                code,
+                label: `${countries.of(region) ?? code} — ${amount} · ${date}`,
+            };
+        })
+        .sort((a, b) => collator.compare(a.label, b.label));
+}

--- a/tests/Feature/Settings/ProfileUpdateTest.php
+++ b/tests/Feature/Settings/ProfileUpdateTest.php
@@ -293,3 +293,52 @@ test('user with a subscription Stripe cannot collect on can delete their account
     'canceled with no end date' => ['canceled', false],
     'paused, so nothing to collect' => ['paused', false],
 ]);
+
+test('the reader can pick the region their amounts are written in', function () {
+    $user = User::factory()->create(['format_locale' => 'es-ES']);
+
+    $response = $this
+        ->actingAs($user)
+        ->patch(route('profile.update'), [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'currency_code' => 'EUR',
+            'format_locale' => 'es-MX',
+        ]);
+
+    $response->assertSessionHasNoErrors();
+
+    expect($user->refresh()->format_locale)->toBe('es-MX');
+});
+
+test('a region the app does not offer is rejected rather than stored', function (string $region) {
+    // An unknown tag is not cosmetic: a malformed one makes every `Intl`
+    // constructor throw and takes the whole screen with it, so the list is
+    // closed on the way in.
+    $user = User::factory()->create(['format_locale' => 'es-ES']);
+
+    $response = $this
+        ->actingAs($user)
+        ->patch(route('profile.update'), [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'currency_code' => 'EUR',
+            'format_locale' => $region,
+        ]);
+
+    $response->assertSessionHasErrors('format_locale');
+
+    expect($user->refresh()->format_locale)->toBe('es-ES');
+})->with(['es_MX', 'nb-NO', 'not a locale', 'es']);
+
+test('the settings page is handed every region it has to draw', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('account.edit'))
+        ->assertInertia(fn ($page) => $page
+            ->where('formatLocales', fn ($locales): bool => collect($locales)
+                ->intersect(['es-MX', 'es-419', 'en-US'])
+                ->count() === 3)
+        );
+});


### PR DESCRIPTION
> Stacked on #969. Review that one first — this branch contains its commit.

PR 1 detected a region from the browser and put amounts in it. This gives the reader the choice, and does the same for dates.

## The picker

Sits under **Language** in account settings, because they are two different questions: which language do you read, and where do you write numbers like. A reader can want the app in English and Mexican amounts, and now they can have it.

Each of the 43 rows carries a live example in the reader's own currency:

```
Latin America — 1.234,56 € · 25/12/2026
Mexico        — 1.234,56 € · 25/12/2026
Spain         — 1.234,56 € · 25/12/2026
United States — 1.234,56 € · 25/12/2026
```

…each written by that region, so the differences are the point. Nobody knows what `es-419` does to a number; everybody can read the example. Two regions printing the same one is the honest answer, not a reason to hide either.

The sample date is fixed at the 25th rather than today's: the example exists to show the *order* of the fields, and on the 5th of May every region on the list prints the same thing.

`Intl` writes the country names, the way `useConnectCountries()` already does, so 43 of them never need a translation entry — and the list crosses to the client as bare tags, so it exists once, in `config/format_locales.php`.

`Rule::in` closes the list on the way in too. An unknown tag is not cosmetic: every `Intl` constructor throws `RangeError` on a malformed one and takes the whole screen with it.

## Dates

`resources/js/utils/date.ts` moves off date-fns' fixed patterns onto `Intl.DateTimeFormat`. `formatDate()` keeps its signature and all ~30 call sites: the pattern still names *which* fields to show, it just no longer decides their **order** — the region does. `date-fns` stays for `isToday`/`isYesterday`; `getDateFnsLocale` is gone.

**This changes what today's Spanish and French readers see**, deliberately: `sept 10, 2026` becomes `10 sept 2026`. That is the order their own phones have always used.

Chart labels for points outside the current year now write the year out — `Sep 2025`, not the old `Sep '25`. date-fns' apostrophe was what said "this is a year" and `Intl` has no way to ask for one; `Sep 10 25` on an axis is three numbers in a row. Caught in review.

The net-worth chart kept printing `oct 25` anyway: it had its own hand-rolled copy of `formatMonthFromYearMonth` that no one had noticed. It now calls the shared one, which deletes the copy. Caught in QA.

## The importer needed nothing

`getLocaleDateFormat()` has always compared against `en-US` and never once matched, because it was handed `en`. With a region it finally does, so an American gets month-first suggested for their own bank export instead of the rest of the world's order. Covered by a test rather than a change.

Two regions the existing table still gets wrong — `zh-HK` (suggested month-first; Hong Kong is day-first) and `en-CA` (day-first; Canada is year-first) — are newly reachable now that the prop carries a region. Both only affect a *suggestion* the import UI already flags as ambiguous and lets the user override, so they are left for a follow-up rather than folded in here.

## Also in here

The three settings dropdowns — currency, language, region — were the same 25 lines three times over. `jscpd` flagged the new pair; they now share one small `PreferenceSelect`, which is a net deletion. Came out of review.

## Testing

- `format-locale.test.ts`: the label names the country and shows what the region does to an amount and a date; two regions sharing a language come out different; `es-419` gets named; country names follow the reader's language; the list sorts.
- `date.test.ts`: the region orders the fields, not the pattern; `en-US` is the only one of the 43 that writes month first; a pattern is read for its fields and nothing else; chart labels outside the current year write the year out and still drop it inside.
- `file-parser.test.ts`: `en` gave day-first and `en-US` gives month-first — the gap this closes — and Latin American readers stay on day-first.
- `ProfileUpdateTest`: a region can be picked and is stored; `es_MX`, `nb-NO`, `not a locale` and a bare `es` are all rejected and leave the stored value alone; the settings page is handed every region it has to draw.
- Green: `pest`, `phpstan`, `pint --test`, `bun run build`, `lint`, `format:check`, `dry`, `crap`, `vitest` (787). `bun run types` adds no error over `main` (477 both).

## Demo

Browser QA on the seeded press account (Spanish UI, EUR, 1248 transactions), verified live: the picker lists 43 regions with a euro example each (`Mexico — EUR 1,234.56 · 25/12/2026`, `Spain — 1.234,56 € · 25/12/2026`, `Latin America — EUR 1,234.56 · 25/12/2026`); picking Mexico stores `es-MX` and turns the dashboard Mexican while the interface stays Spanish; transaction dates go `10 sep` under `es-MX` and `Sep 10` under `en-US`; prior-year chart labels read `oct 2025`; a `PATCH` with `es_MX` comes back 422 and leaves the stored value alone; no console errors across dashboard, cashflow, accounts, transactions, budgets, savings goals and three settings pages.

<!-- DEMO VIDEO: drag whisper-money-format-locale-selector-qa.mp4 here -->

https://github.com/user-attachments/assets/b891b35d-839f-4272-ab57-6968c6e8c2cd


