### PR TITLE
docs(rules): point banking clients at the shared transport-failure trait

### DIFF
--- a/.ai/rules/banking.md
+++ b/.ai/rules/banking.md
@@ -1,0 +1,17 @@
+---
+paths:
+  - 'app/Services/Banking/*Client.php'
+---
+
+# Banking
+
+## Route a banking client's HTTP calls through TranslatesTransportFailures
+A banking client must not let a transport failure escape raw. `SyncBankingConnectionJob::handleTemporaryError()` charges `consecutive_sync_failures` for anything that is not a `TransientBankingProviderException`, and running that budget out drops the connection out of every future scheduled sync silently, with no way back but reconnecting. A raw `ConnectionException` therefore turns a provider blip into a dead connection, and gets the user "an unexpected error occurred" instead of "temporarily unavailable".
+
+Use `app/Services/Banking/Concerns/TranslatesTransportFailures.php`: implement `provider()`, build the request with `transportClient()` (it sets the read and connect timeouts), and wrap the call in `translateTransportFailures()`. A timeout and a 5xx become transient; 401/403/429 stay `RequestException` because the job acts on those.
+
+Two traps:
+- Put the translation **outside** any `retry(..., when: 429)`, never inside the callback — the `when` closure would receive the translated exception and the 429 retry would stop working.
+- Cover every path. `BinanceClient::getTickerPrices()` used a separate public client and bypassed the signed-request helper.
+
+`WiseClient` and `InteractiveBrokersClient` still carry their own inline copies of this logic (written before the trait existed, in #968/#970). Folding them in is an open follow-up — do not add a third hand-rolled copy.

--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -5,6 +5,7 @@ Before planning or editing, find the row whose globs match the file's path and r
 | Applies to | Rule file |
 | --- | --- |
 | app/Console/Commands/AgentDatabaseCommand.php | .ai/rules/agent-db.md |
+| app/Services/Banking/*Client.php | .ai/rules/banking.md |
 | app/Jobs/** | .ai/rules/jobs.md |
 | resources/js/lib/{sentry,failed-navigation-toast,unattended-requests,leave-page}.ts | .ai/rules/lib.md |
 | app/Mcp/** | .ai/rules/mcp.md |


### PR DESCRIPTION
`#968` and `#970` closed the same gap in six banking clients, and `#970`
left `app/Services/Banking/Concerns/TranslatesTransportFailures.php` behind for
it. This records the rule so the next agent reuses the trait instead of
hand-rolling a seventh copy.

What the note carries:

- **Why it matters.** `SyncBankingConnectionJob::handleTemporaryError()` charges
  `consecutive_sync_failures` for anything that is not a
  `TransientBankingProviderException`, and exhausting that budget drops the
  connection out of every future scheduled sync silently, with no way back but
  reconnecting.
- **How to use the trait.** Implement `provider()`, build with
  `transportClient()`, wrap in `translateTransportFailures()`. Timeout and 5xx
  become transient; 401/403/429 stay `RequestException` because the job acts on
  them.
- **The two traps** that cost real time while fixing this: the translation must sit
  **outside** any `retry(..., when: 429)` or the `when` closure receives the
  translated exception and the retry stops working; and every request path needs
  covering — `BinanceClient::getTickerPrices()` bypassed the signed-request helper
  through a separate public client.
- **The open follow-up**: `WiseClient` and `InteractiveBrokersClient` still carry
  their own inline copies, written before the trait existed.

No code changes.