### PR TITLE
fix(currency): keep serving rates when the exchange-rate cache write deadlocks

### DIFF
--- a/app/Services/CurrencyConversionService.php
+++ b/app/Services/CurrencyConversionService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use Illuminate\Database\QueryException;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
@@ -84,12 +85,41 @@ class CurrencyConversionService
 
         if ($rates === null) {
             $rates = $this->fetchRates($currency, $date);
-            Cache::put($persistentKey, $rates, $this->cacheTtlFor($date, $rates));
+            $this->cacheRates($persistentKey, $rates, $date);
         }
 
         $this->rateCache[$cacheKey] = $rates;
 
         return $rates;
+    }
+
+    /**
+     * Persist a fetched rate map, best-effort.
+     *
+     * The database cache store turns a write into an `insert ignore into
+     * cache`, so concurrent requests missing the same hot rate key race for
+     * the same row and InnoDB deadlocks one of them. The rates are already in
+     * hand by then, so losing that race is no reason to fail the request: the
+     * request that won it populated the row, and the next miss re-attempts the
+     * write anyway.
+     *
+     * Any write failure is swallowed, not only the deadlock: each one costs a
+     * value the next miss re-fetches, so none of them is worth a 500. Only the
+     * write is guarded — a structurally broken cache backend still surfaces,
+     * because the read a few lines above is not.
+     *
+     * @param  array<string, float>  $rates
+     */
+    private function cacheRates(string $persistentKey, array $rates, string $date): void
+    {
+        try {
+            Cache::put($persistentKey, $rates, $this->cacheTtlFor($date, $rates));
+        } catch (QueryException $e) {
+            Log::warning('Currency rate cache write failed', [
+                'key' => $persistentKey,
+                'error' => $e->getMessage(),
+            ]);
+        }
     }
 
     /**

--- a/tests/Feature/CurrencyConversionServiceTest.php
+++ b/tests/Feature/CurrencyConversionServiceTest.php
@@ -1,13 +1,29 @@
 <?php
 
 use App\Services\CurrencyConversionService;
+use Illuminate\Database\QueryException;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 
 beforeEach(function () {
     Cache::flush();
 });
+
+/**
+ * The deadlock the database cache store raises when concurrent requests race
+ * to `insert ignore` the same rate row.
+ */
+function deadlockOnCacheInsert(): QueryException
+{
+    return new QueryException(
+        'mysql',
+        'insert ignore into `cache` (`key`, `value`, `expiration`) values (?, ?, ?)',
+        ['currency-rates:eur:2026-01-15', 'serialized-rates', 1767225600],
+        new PDOException('SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction'),
+    );
+}
 
 test('converts crypto to fiat using CDN rates', function () {
     Http::fake([
@@ -189,4 +205,52 @@ test('converts new latam fiat currency using CDN rates', function () {
     $result = $service->convert('ARS', 'USD', 2800.0, '2026-01-15');
 
     expect($result)->toBe(2.0);
+});
+
+test('returns the fetched rates when the cache write deadlocks (regression for PHP-LARAVEL-J)', function () {
+    Http::fake([
+        'cdn.jsdelivr.net/*currencies/eur*' => Http::response([
+            'eur' => ['btc' => 0.000015],
+        ]),
+    ]);
+
+    Log::spy();
+
+    Cache::shouldReceive('get')->andReturnNull();
+    Cache::shouldReceive('put')->once()->andThrow(deadlockOnCacheInsert());
+
+    $rates = (new CurrencyConversionService)->getRatesForCurrency('EUR', '2026-01-15');
+
+    expect($rates)->toBe(['btc' => 0.000015]);
+
+    Log::shouldHaveReceived('warning')
+        ->once()
+        ->withArgs(fn (string $message, array $context) => $message === 'Currency rate cache write failed'
+            && $context['key'] === 'currency-rates:eur:2026-01-15');
+});
+
+test('memoizes rates in-request when the cache write deadlocks', function () {
+    Http::fake([
+        'cdn.jsdelivr.net/*currencies/eur*' => Http::response([
+            'eur' => ['btc' => 0.000015],
+        ]),
+    ]);
+
+    Cache::shouldReceive('get')->andReturnNull();
+    Cache::shouldReceive('put')->andThrow(deadlockOnCacheInsert());
+
+    $service = new CurrencyConversionService;
+    $service->getRatesForCurrency('EUR', '2026-01-15');
+    $service->getRatesForCurrency('EUR', '2026-01-15');
+
+    Http::assertSentCount(1);
+});
+
+test('the cache write guard does not swallow a broken cache read', function () {
+    Http::fake();
+
+    Cache::shouldReceive('get')->andThrow(deadlockOnCacheInsert());
+
+    expect(fn () => (new CurrencyConversionService)->getRatesForCurrency('EUR', '2026-01-15'))
+        ->toThrow(QueryException::class);
 });


### PR DESCRIPTION
Filling the exchange-rate cache could deadlock on the `cache` table and turn a
perfectly serviceable analytics request into a 500.

`CACHE_STORE` defaults to `database`, so every `Cache::put` is an `insert ignore
into cache`. Every chart endpoint converts currencies, so concurrent requests
miss the *same* hot rate key, all call `fetchRates()`, and all race to insert the
same row. InnoDB deadlocks one of them, the `QueryException` propagates out of
the controller, and the user gets a broken chart.

The detail that makes this a one-line class of bug: **at the moment of the throw
the rates are already in hand.** `fetchRates()` succeeded; only *persisting*
them failed. The very next line would have memoized them and served the request.
A lost cache-fill race is not a reason to fail a request.

## The fix

The persistent write becomes best-effort. If `Cache::put` throws a
`QueryException`, log it at `warning`, keep the rates, memoize them, return
them. The next miss re-attempts the write — and whichever request won the race
already populated the row, so in practice the value is there anyway.

The suppression is deliberately not narrowed to SQLSTATE `40001`: every
write-only failure is the same situation (rates fetched, write lost, next miss
re-attempts), so none of them is worth a 500, and a SQLSTATE branch would just
add a path no test can reach. What is *not* guarded is the `Cache::get` a few
lines above — so a structurally broken cache backend still surfaces loudly
instead of degrading in silence. There's a test pinning that invariant.

`warning`, not `error`, because this is now a handled condition and must not
come back as a Sentry error.

## Considered and rejected

- **`Cache::lock()` / `Cache::add()` as a mutex** — serialises every cold-key
  fill behind a database lock, on the same table that is deadlocking. Trades a
  rare deadlock for contention in the common case.
- **Switching the cache store to Redis** — an infrastructure decision with a far
  wider blast radius than this issue. `config/cache.php` already has a redis
  store configured for whoever wants to make that call; not this PR's.
- **Retrying the insert** — the value it would write is the value another
  request just wrote.

## Why this is a draft

**The Sentry issue is currently marked `ignored`**, so it does not show up in an
`is:unresolved` search — it was found by reading the raw event stream. It was
almost certainly ignored while its visible culprit was `/mcp/oauth`, an internal
endpoint where nobody cares (Seer rates it "super_low actionability"). It has
since been 500ing **`/api/cashflow/trend`**: 35+ events over ~29 days, most
recently 2026-09-10 13:36 UTC, still firing. `Users impacted: 0` is an artefact
of these being API requests, not a measure of the damage.

That is new information the ignore decision did not have. Deciding whether it
justifies overriding that decision is a human's call, not an auto-merge's —
hence a draft. The mechanism is reachable from every chart endpoint, so the fix
holds whatever the per-endpoint split turns out to be; I did not measure that
split and am not claiming one.

Fixes PHP-LARAVEL-J

## Tests

Both new deadlock tests fail on `main` with exactly the Sentry error and pass
with the fix:

- a `Cache::put` deadlock still returns the fetched rates, and logs one
  `warning`;
- the in-request memo is populated, so a second call makes no second HTTP
  request;
- a broken cache *read* still throws — the guard covers the write only.

The existing cross-instance caching test still proves a successful put persists
as before.
