### PR TITLE
fix(analytics): keep a throwing PostHog SDK from breaking the page

### DIFF
--- a/resources/js/lib/posthog.test.ts
+++ b/resources/js/lib/posthog.test.ts
@@ -1,8 +1,78 @@
-import { describe, expect, it } from 'vitest';
-import { isPostHogSessionRecordingEnabled } from './posthog';
+import posthog from 'posthog-js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    captureEvent,
+    identifyUser,
+    initializePostHog,
+    isPostHogSessionRecordingEnabled,
+    resetPostHog,
+} from './posthog';
+
+// An SDK behaving the way it behaves on the browsers that reported
+// PHP-LARAVEL-5J (crypto.getRandomValues throwing OperationError inside init)
+// and PHP-LARAVEL-5V (reading window.localStorage throwing SecurityError inside
+// reset): every entry point throws synchronously.
+vi.mock('posthog-js', () => {
+    const explode = () => {
+        throw new DOMException(
+            'The operation failed for an operation-specific reason',
+        );
+    };
+
+    return {
+        default: {
+            init: vi.fn(explode),
+            identify: vi.fn(explode),
+            reset: vi.fn(explode),
+            capture: vi.fn(explode),
+        },
+    };
+});
 
 describe('isPostHogSessionRecordingEnabled', () => {
     it('keeps session recording disabled by default', () => {
         expect(isPostHogSessionRecordingEnabled()).toBe(false);
+    });
+});
+
+describe('PostHog wrappers', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        // Pinned rather than inherited: the local .env disables PostHog and CI
+        // has no .env at all, so without this the wrappers would no-op on one
+        // machine and run on the other.
+        vi.stubEnv('VITE_POSTHOG_ENABLED', 'true');
+        // Without a key initializePostHog bails before reaching the SDK, so the
+        // throw it has to survive would never happen.
+        vi.stubEnv('VITE_POSTHOG_API_KEY', 'phc_test');
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it.each([
+        ['init', () => initializePostHog()],
+        ['identify', () => identifyUser('user-1', { email: 'reader@a.test' })],
+        ['reset', () => resetPostHog()],
+        ['capture', () => captureEvent('upgrade_checkout_started')],
+    ] as const)(
+        'keeps the app alive when posthog.%s throws',
+        (method, call) => {
+            expect(call).not.toThrow();
+            // The call still has to reach the SDK: a guard that skipped it
+            // altogether would pass the assertion above and collect nothing.
+            expect(posthog[method]).toHaveBeenCalled();
+        },
+    );
+
+    it('leaves the SDK alone when PostHog is disabled', () => {
+        vi.stubEnv('VITE_POSTHOG_ENABLED', 'false');
+
+        initializePostHog();
+        captureEvent('upgrade_checkout_started');
+
+        expect(posthog.init).not.toHaveBeenCalled();
+        expect(posthog.capture).not.toHaveBeenCalled();
     });
 });

--- a/resources/js/lib/posthog.test.ts
+++ b/resources/js/lib/posthog.test.ts
@@ -36,8 +36,11 @@ describe('isPostHogSessionRecordingEnabled', () => {
 });
 
 describe('PostHog wrappers', () => {
+    let warn: ReturnType<typeof vi.spyOn>;
+
     beforeEach(() => {
         vi.clearAllMocks();
+        warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
         // Pinned rather than inherited: the local .env disables PostHog and CI
         // has no .env at all, so without this the wrappers would no-op on one
         // machine and run on the other.
@@ -49,6 +52,7 @@ describe('PostHog wrappers', () => {
 
     afterEach(() => {
         vi.unstubAllEnvs();
+        vi.restoreAllMocks();
     });
 
     it.each([
@@ -63,6 +67,9 @@ describe('PostHog wrappers', () => {
             // The call still has to reach the SDK: a guard that skipped it
             // altogether would pass the assertion above and collect nothing.
             expect(posthog[method]).toHaveBeenCalled();
+            // Swallowed, but not in silence while someone is developing —
+            // a broken integration lands in the same catch.
+            expect(warn).toHaveBeenCalled();
         },
     );
 

--- a/resources/js/lib/posthog.ts
+++ b/resources/js/lib/posthog.ts
@@ -56,9 +56,17 @@ function withPostHog(call: () => void): void {
 
     try {
         call();
-    } catch {
+    } catch (error) {
         // A browser that will not let the SDK run is a browser we collect no
         // analytics from. The page carries on.
+        //
+        // Loud in development only: the two conditions above are nothing a
+        // developer can fix, but a genuinely broken integration — a bad key, a
+        // blocked host, a misused SDK method — lands in the same catch and
+        // would otherwise be invisible while working on it.
+        if (import.meta.env.DEV) {
+            console.warn('[PostHog] Call failed and was ignored.', error);
+        }
     }
 }
 

--- a/resources/js/lib/posthog.ts
+++ b/resources/js/lib/posthog.ts
@@ -25,35 +25,64 @@ export const isPostHogSessionRecordingEnabled = (): boolean => {
     return enabled === 'true' || enabled === '1';
 };
 
+/**
+ * Every call into the PostHog SDK, wrapped so it cannot take the page with it.
+ *
+ * The SDK reaches for browser APIs that are not always there to be reached.
+ * A hardened Firefox profile makes `crypto.getRandomValues` throw
+ * `OperationError`, which kills `posthog.init` mid-flight (PHP-LARAVEL-5J); a
+ * browser blocking site data throws `SecurityError` on the *read* of
+ * `window.localStorage`, which kills `posthog.reset` (PHP-LARAVEL-5V). Neither
+ * lands somewhere harmless: `initializePostHog` runs at module scope in
+ * app.tsx, so a throw there happens before React mounts and white-screens the
+ * app, and the other three run inside handlers that were doing real work — the
+ * upgrade dialog captures an event on its way to checkout.
+ *
+ * The failure is swallowed rather than reported. These are browser-environment
+ * conditions we cannot act on, and they have already cost us two Sentry issues
+ * of pure noise; analytics is never worth a broken page. Guarding here is the
+ * only lever we have, since the storage and crypto access that throws is the
+ * SDK's own, inside the bundle.
+ *
+ * The try/catch is doing the real work and there is nothing to "simplify" away:
+ * the SDK throws synchronously from inside these calls, so no guard around them
+ * can see it coming. Same spirit as ./safe-storage.ts and ./media-query.ts,
+ * which exist for the same class of crash.
+ */
+function withPostHog(call: () => void): void {
+    if (typeof window === 'undefined' || !isPostHogEnabled()) {
+        return;
+    }
+
+    try {
+        call();
+    } catch {
+        // A browser that will not let the SDK run is a browser we collect no
+        // analytics from. The page carries on.
+    }
+}
+
 export function initializePostHog(): void {
-    if (typeof window === 'undefined') {
-        return;
-    }
+    withPostHog(() => {
+        const apiKey = getPostHogApiKey();
+        if (!apiKey) {
+            console.warn(
+                '[PostHog] API key not provided. PostHog will not be initialized.',
+            );
+            return;
+        }
 
-    if (!isPostHogEnabled()) {
-        return;
-    }
-
-    const apiKey = getPostHogApiKey();
-    if (!apiKey) {
-        console.warn(
-            '[PostHog] API key not provided. PostHog will not be initialized.',
-        );
-        return;
-    }
-
-    const host = getPostHogHost();
-
-    posthog.init(apiKey, {
-        api_host: host,
-        ui_host: getPostHogUiHost(),
-        person_profiles: 'always',
-        disable_session_recording: !isPostHogSessionRecordingEnabled(),
-        loaded: () => {
-            if (import.meta.env.DEV) {
-                console.log('[PostHog] Initialized successfully');
-            }
-        },
+        posthog.init(apiKey, {
+            api_host: getPostHogHost(),
+            ui_host: getPostHogUiHost(),
+            person_profiles: 'always',
+            disable_session_recording: !isPostHogSessionRecordingEnabled(),
+            loaded: () => {
+                if (import.meta.env.DEV) {
+                    console.log('[PostHog] Initialized successfully');
+                }
+            },
+        });
     });
 }
 
@@ -61,28 +90,16 @@ export function identifyUser(
     userId: string,
     properties?: Record<string, unknown>,
 ): void {
-    if (typeof window === 'undefined' || !isPostHogEnabled()) {
-        return;
-    }
-
-    posthog.identify(userId, properties);
+    withPostHog(() => posthog.identify(userId, properties));
 }
 
 export function resetPostHog(): void {
-    if (typeof window === 'undefined' || !isPostHogEnabled()) {
-        return;
-    }
-
-    posthog.reset();
+    withPostHog(() => posthog.reset());
 }
 
 export function captureEvent(
     eventName: string,
     properties?: Record<string, unknown>,
 ): void {
-    if (typeof window === 'undefined' || !isPostHogEnabled()) {
-        return;
-    }
-
-    posthog.capture(eventName, properties);
+    withPostHog(() => posthog.capture(eventName, properties));
 }


### PR DESCRIPTION
## What

The PostHog SDK can throw straight into the app, and on one path it does so before React ever mounts.

`initializePostHog()` is called at module scope in `resources/js/app.tsx:82`. On a hardened Firefox profile `crypto.getRandomValues` throws `OperationError` from inside PostHog's uuidv7 generator during `posthog.init(...)` — so the throw lands in the app bootstrap, before the React tree exists, and the user gets a white screen instead of Whisper Money. That is `PHP-LARAVEL-5J` (10 events, Firefox 153 on Linux, on `/transactions`).

The same class of failure hits the other wrappers. A browser blocking site data throws `SecurityError` on the *read* of `window.localStorage`, which kills `posthog.reset()` — `PHP-LARAVEL-5V`. And `captureEvent()` runs inside click handlers that were doing real work: `components/subscription/upgrade-dialog.tsx:74` captures `upgrade_checkout_started` *before* sending the user to checkout, so a throw there took the checkout click with it.

Analytics is never worth a broken page.

Fixes PHP-LARAVEL-5J
Fixes PHP-LARAVEL-5V

## How

All four wrappers in `resources/js/lib/posthog.ts` now go through one `withPostHog()` helper that holds the `window` / enabled guard they each repeated *and* a try/catch around the SDK call. The guard lives in one place rather than at the ~10 call sites, so it cannot drift.

This follows the two existing precedents for the same class of boot-time crash, `resources/js/lib/safe-storage.ts` (PHP-LARAVEL-57, PHP-LARAVEL-4Y) and `resources/js/lib/media-query.ts`, down to the docblock explaining why the try/catch is load-bearing and must not be "simplified" away: the SDK throws synchronously from inside these calls, so no guard *around* them can see it coming.

### Swallowed, not reported to Sentry

The catch drops the error rather than forwarding it. These are browser-environment conditions we cannot act on — a hardened profile, blocked site data — and they have already cost us two issues of pure noise. It is the same stance `.ai/rules/lib.md` records for `HttpNetworkError`: when the only remaining lever is Sentry-side, do not add code that keeps re-reporting it.

The one exception is development. An empty catch also hides a *genuinely* broken integration — a bad key, a blocked host, a misused SDK method — from whoever is working on it, so the catch warns behind `import.meta.env.DEV`. Production stays silent.

Nothing else changes: PostHog is not disabled, not gated behind a new flag, no dependency added, and the disabled-flag path behaves exactly as before.

## Testing

`resources/js/lib/posthog.test.ts` mocks `posthog-js` so every entry point throws, mirroring `resources/js/lib/safe-storage.test.ts`. For each of the four wrappers it asserts three things: the call does not throw, it still *reached* the SDK (a guard that simply skipped the call would pass the first assertion and collect nothing), and the dev warning fired. A fifth test pins the disabled-flag path. Verified red without the guard — all four fail with the raw `DOMException`.

Browser QA on the running app reproduced the real condition rather than the mock — `crypto.getRandomValues` overridden to throw `OperationError` before navigation, run against the pre-fix file and then the fixed one, on `/login`:

| | pre-fix | fixed |
| --- | --- | --- |
| uncaught error | `OperationError: The operation failed for an operation-specific reason` | none |
| page body | empty, nothing mounted | login form rendered |

On a healthy browser the page renders and PostHog still initializes and reaches its host, so the guard has not quietly disabled analytics. The `SecurityError` case is swallowed the same way.

### Unrelated finding, not fixed here

Injecting the `SecurityError` on `window.localStorage` also crashes `<Login>` into the error boundary, from a source that is not PostHog — there are three direct `localStorage` accesses guarded only by `typeof window`: `lib/debug.ts:4`, `lib/key-storage.ts:11,22,30` and `hooks/use-admin.tsx:3`. It reproduces identically on `main`, so it is pre-existing and out of scope for this PR. `key-storage.ts` holds the encryption key, so it needs more than a swap to `safe-storage.ts` — losing it silently is a data problem, which that file's own docblock warns about.

## Demo

https://github.com/user-attachments/assets/621b343c-e749-4062-8789-b6955230a511



