### PR TITLE
fix(throttle): keep serving throttled requests when the rate-limiter cache write deadlocks

### DIFF
--- a/app/Listeners/LogCacheFailover.php
+++ b/app/Listeners/LogCacheFailover.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Cache\Events\CacheFailedOver;
+use Illuminate\Support\Facades\Log;
+
+class LogCacheFailover
+{
+    /**
+     * Record a cache store that failed and was failed over.
+     *
+     * The failover store swallows the underlying exception so the request can
+     * be served from the next store, which would otherwise make the failure
+     * invisible — the deadlock this exists for used to arrive as a Sentry 500.
+     * Warning matches the level the currency cache-write guard logs at: the
+     * request survived, but a store that keeps failing is worth looking at.
+     *
+     * The event fires once per failing store per request, not once per cache
+     * operation, so a broken store does not flood the log.
+     */
+    public function handle(CacheFailedOver $event): void
+    {
+        Log::warning('Cache store failed over', [
+            'store' => $event->storeName,
+            'error' => $event->exception->getMessage(),
+        ]);
+    }
+}

--- a/config/cache.php
+++ b/config/cache.php
@@ -19,6 +19,32 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Cache Store Used By The Rate Limiter
+    |--------------------------------------------------------------------------
+    |
+    | The rate limiter counts a hit by writing to the cache, which on the
+    | "database" store is an `insert ignore into cache`. Every concurrent
+    | request in the same bucket races for the same `...:timer` row, so InnoDB
+    | deadlocks one of them and `throttle` turned that into a 500 (the
+    | dashboard fires several API requests at once, so it hit real users).
+    |
+    | Pointing only the limiter at the "failover" store degrades that losing
+    | request to the in-process "array" store instead: its hit goes uncounted,
+    | but the request is served. "database" is still the first store, so a
+    | healthy cache counts every hit exactly as it did before.
+    |
+    | The trade is that a deadlocked hit is dropped rather than deferred, and
+    | this covers every limiter sharing the singleton — the "login" and
+    | "two-factor" ones included. A burst concurrent enough to deadlock buys a
+    | few uncounted attempts, which still beats answering them with a 500, but
+    | it is why the failover is logged instead of passing in silence.
+    |
+    */
+
+    'limiter' => 'failover',
+
+    /*
+    |--------------------------------------------------------------------------
     | Cache Stores
     |--------------------------------------------------------------------------
     |

--- a/tests/Feature/ThrottleCacheFailoverTest.php
+++ b/tests/Feature/ThrottleCacheFailoverTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\RateLimiter;
+use Illuminate\Cache\Repository;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * The deadlock InnoDB raises when concurrent requests in the same throttle
+ * bucket race to `insert ignore` the same rate-limiter row.
+ */
+function deadlockOnRateLimiterInsert(): QueryException
+{
+    return new QueryException(
+        'mysql',
+        'insert ignore into `cache` (`key`, `value`, `expiration`) values (?, ?, ?)',
+        ['whisper-money-cache-c651a105:timer', 'i:1789047427;', 1789047427],
+        new PDOException('SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction'),
+    );
+}
+
+/**
+ * Make every write to the "database" cache store deadlock, the way MySQL does
+ * to whichever request it picks as the victim.
+ *
+ * Only the writes throw — reads keep answering, which is the real shape of the
+ * failure: the row is fine, the insert is what loses the race.
+ */
+function deadlockDatabaseCacheWrites(): void
+{
+    Cache::extend('database', fn () => new Repository(new class extends ArrayStore
+    {
+        public function add($key, $value, $seconds)
+        {
+            throw deadlockOnRateLimiterInsert();
+        }
+
+        public function put($key, $value, $seconds)
+        {
+            throw deadlockOnRateLimiterInsert();
+        }
+
+        public function increment($key, $value = 1)
+        {
+            throw deadlockOnRateLimiterInsert();
+        }
+    }));
+
+    // The manager memoizes resolved stores, and the failover store asks it for
+    // "database" on every operation.
+    Cache::forgetDriver(['database', 'failover']);
+
+    // Production runs CACHE_STORE=database, so a limiter with no store of its
+    // own sits straight on the deadlocking one. This suite runs "array", which
+    // never reaches the insert and would pass no matter what we configured —
+    // so stand the default back up while the limiter resolves its store.
+    config(['cache.default' => 'database']);
+
+    app()->forgetInstance(RateLimiter::class);
+    app(RateLimiter::class);
+
+    // The limiter holds its repository from here on, so hand the rest of the
+    // app back the array store instead of a cache that throws on every write.
+    config(['cache.default' => 'array']);
+}
+
+test('a throttled request survives a rate-limiter cache deadlock (regression for PHP-LARAVEL-J)', function () {
+    deadlockDatabaseCacheWrites();
+
+    $this->actingAs(User::factory()->onboarded()->create())
+        ->getJson('api/import/data')
+        ->assertOk();
+});
+
+test('the deadlock is logged rather than degrading in silence', function () {
+    deadlockDatabaseCacheWrites();
+    Log::spy();
+
+    $this->actingAs(User::factory()->onboarded()->create())->getJson('api/import/data');
+
+    Log::shouldHaveReceived('warning')
+        ->withArgs(fn (string $message, array $context) => $message === 'Cache store failed over'
+            && $context['store'] === 'database'
+            && str_contains($context['error'], 'Deadlock found when trying to get lock'));
+});
+
+test('throttling still rejects once the limit is reached', function () {
+    $user = User::factory()->create();
+
+    // settings/password is throttle:6,1. The 7th attempt must still be turned
+    // away, so routing the limiter through the failover store cannot have
+    // quietly stopped it counting hits.
+    foreach (range(1, 6) as $ignored) {
+        $this->actingAs($user)->put('settings/password', [])->assertStatus(302);
+    }
+
+    $this->actingAs($user)->put('settings/password', [])->assertStatus(429);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -15,6 +15,7 @@ use App\Services\Banking\BalanceSyncService;
 use App\Services\Banking\EnableBankingProvider;
 use App\Services\Banking\Sync\BankingConnectionSyncerFactory;
 use App\Services\Banking\TransactionSyncService;
+use Illuminate\Cache\RateLimiter;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Client\ConnectionException;
@@ -97,6 +98,26 @@ pest()->beforeEach(function () {
 pest()->beforeEach(function () {
     Http::preventStrayRequests();
 })->in('Feature');
+
+/*
+|--------------------------------------------------------------------------
+| Keep throttle bookkeeping out of the query counts
+|--------------------------------------------------------------------------
+|
+| The rate limiter runs on the "failover" store, whose first store is
+| "database", so counting a hit costs a few queries against the cache table.
+| Production has always paid those — it runs CACHE_STORE=database, and the
+| limiter reached the same table long before the failover store did — so they
+| are not a cost this suite exists to watch. It runs CACHE_STORE=array, where
+| the limiter would otherwise spend nothing, and the ceilings below are there
+| to catch an endpoint loading its own data badly.
+|
+*/
+pest()->beforeEach(function () {
+    config(['cache.limiter' => 'array']);
+
+    app()->forgetInstance(RateLimiter::class);
+})->in('Performance');
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
## Not a duplicate of #973

Both PRs close call sites of the **same Sentry issue** ([PHP-LARAVEL-J](https://whisper-money.sentry.io/issues/PHP-LARAVEL-J)). Sentry groups that issue by the SQL prefix `insert ignore into cache`, so every deadlocking cache write in the app lands in one group:

- **#973** (merged) fixed `CurrencyConversionService::cacheRates()`. It is correct and is untouched here.
- **This PR** fixes the **rate limiter**, which is where the newest events come from — including the most recent one, whose stack trace is entirely framework code:

```
Illuminate\Routing\Middleware\ThrottleRequests::handleRequest()
    $this->limiter->hit($limit->key, $limit->decaySeconds);
Illuminate\Cache\RateLimiter::increment()
    $this->cache->add(...)
Illuminate\Cache\DatabaseStore::add()
```

The `:timer` key suffix in the Sentry payload is `RateLimiter::increment()`'s own key, not an app key.

## Why it happens

`CACHE_STORE` defaults to `database`, so counting a throttle hit is an `insert ignore into cache`. `routes/api.php:18` puts `throttle:300,1` on the whole authenticated API group and the dashboard fires several of those requests at once, so they race for the same `...:timer` row. InnoDB picks one as the deadlock victim and the `QueryException` escaped as a **500** — `handled: no`, 340 events, real users in DE/Frankfurt, 5 in the last three days. `/api/cashflow/trend` is the transaction that shows up.

## The fix

Laravel already builds the `RateLimiter` singleton from a `cache.limiter` config key:

```php
// Illuminate\Cache\CacheServiceProvider::register()
$this->app->singleton(RateLimiter::class, fn ($app) => new RateLimiter(
    $app->make('cache')->driver($app['config']->get('cache.limiter'))
));
```

…and `config/cache.php` already defined a `failover` store of `['database', 'array']` that nothing used. So the fix is one line naming that store as the limiter's. `FailoverStore` routes every operation through `attemptOnAllStores()`, which tries `database` first and only falls through on a `Throwable`.

A healthy cache counts every hit exactly as before. The deadlocked request degrades to the in-process `array` store instead of failing.

> The task brief suggested rebinding the `RateLimiter` singleton in `AppServiceProvider::register()` instead. I used the config key because it is the framework's own extension point for exactly this, is one line instead of four, and cannot drift out of sync with `CacheServiceProvider` on a Laravel upgrade.

## Two things to look at before merging — this is why it's a draft

**1. It covers every limiter, including the auth ones.** There is a single `RateLimiter` singleton, so this changes `throttle:300,1` (api), `throttle:mcp`, `throttle:6,1` (password update), the `web.php` throttles, **and Fortify's `login` (5/min by email+IP) and `two-factor` limiters**. That is the point of a config-level fix, but it does mean brute-force protection is in scope.

The trade: a deadlocked hit is **dropped**, not deferred. A burst concurrent enough to deadlock therefore buys a few uncounted attempts. It is bounded (one hit per deadlock, and InnoDB's victim choice is not attacker-steerable) and it replaces a hard 500, but it is a real if narrow loosening under contention.

**2. The failover store fails over reads too.** `tooManyAttempts()` calls `$this->cache->has($key.':timer')` through the same wrapper. So if the database cache store were *structurally* broken — table missing, connection refused, not merely deadlocking — the limiter's reads would also fall through to `array` and throttling would effectively stop counting, where it previously surfaced as errors.

This narrows the "leave the read path unguarded" principle from #973, for the limiter only. `cache.default` is untouched, so a structurally broken cache table still surfaces loudly everywhere else in the app. The signal that throttling itself has gone dark is the warning log below — there is no alert wired to it, and putting `sentry_logs` in `LOG_STACK` is deployment config I deliberately did not touch.

## Keeping it visible

`FailoverStore` swallows the exception, which would otherwise turn a loud 500 into silence. It fires `CacheFailedOver` once per failing store per request, and the new `LogCacheFailover` listener records it at `warning` — the level #973's cache-write guard uses.

## Tests

`tests/Feature/ThrottleCacheFailoverTest.php`, modelled on #973's:

- a throttled request survives a rate-limiter cache deadlock
- the deadlock is logged rather than degrading in silence
- throttling still rejects once the limit is reached (6 × 302 then 429 on `settings/password`)

The first test is a real regression test: with the `'limiter' => 'failover'` line removed it fails with a **500** carrying the exact production stack trace (`ThrottleRequests::handle` → `RateLimiter::hit` → `Repository::add`), and passes with it. The suite runs `CACHE_STORE=array`, which would never reach the deadlocking insert, so the helper stands the `database` default back up while the limiter resolves its store.

## One test-harness change worth explaining

`tests/Pest.php` pins the limiter back to the `array` store for the **Performance** suite. That suite runs `CACHE_STORE=array`, where the limiter spent *no* queries; the database-first chain otherwise adds ~4–6 throttle queries to every throttled endpoint and broke 5 `ApiQueryCountTest` ceilings.

**No production query count changes** — production already ran the limiter on `database`, and `attemptOnAllStores()` adds nothing when the first store succeeds. Raising those thresholds would have recorded a test-environment artefact as though an endpoint had got more expensive, so the harness is fixed instead of the numbers.

## Verification

- `./vendor/bin/pest --exclude-testsuite=Browser`, `pint --test`, `bun run dry` (3.64% vs 5.4%), `php artisan crap --base=origin/main --no-coverage`, `bun run format`, `bun run lint`
- Manual QA against the running app: `RateLimiter` resolves to `FailoverStore`; `X-RateLimit-Remaining` decrements 299 → 298 → 297 (hits still counted on `database`); with the `cache` table renamed away, `api/import/data` returned **200** and logged `Cache store failed over {"store":"database", ...}` where it previously 500'd; throttling still returned 429 on the 7th password attempt with the table restored.

Refs PHP-LARAVEL-J
