### PR TITLE
fix(storage): survive a browser that blocks site data

### DIFF
--- a/resources/js/hooks/use-admin.tsx
+++ b/resources/js/hooks/use-admin.tsx
@@ -1,8 +1,3 @@
-export const isAdmin = (): boolean => {
-    if (typeof window !== 'undefined') {
-        const isAdminFlag = localStorage.getItem('admin');
-        return isAdminFlag === 'true';
-    }
+import { readStoredValue } from '@/lib/safe-storage';
 
-    return false;
-};
+export const isAdmin = (): boolean => readStoredValue('admin') === 'true';

--- a/resources/js/lib/debug.ts
+++ b/resources/js/lib/debug.ts
@@ -1,7 +1,11 @@
+import { readStoredValue } from './safe-storage';
+
 export function consoleDebug(...args: unknown[]): void {
     if (typeof window === 'undefined') return;
 
-    const isDebugEnabled = localStorage.getItem('debug') === 'true';
+    // Through safe-storage because a logging helper must never be the thing
+    // that throws: blocked site data makes a bare read raise SecurityError.
+    const isDebugEnabled = readStoredValue('debug') === 'true';
     const isLocalhost = window.location.hostname === 'localhost';
     const isTestDomain = window.location.hostname.includes('.test');
 

--- a/resources/js/lib/key-storage.test.ts
+++ b/resources/js/lib/key-storage.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { clearKey, getStoredKey, storeKey } from './key-storage';
+
+type StorageArea = 'localStorage' | 'sessionStorage';
+
+const AREAS: StorageArea[] = ['localStorage', 'sessionStorage'];
+
+const realStorages = AREAS.map(
+    (area) =>
+        [
+            area,
+            Object.getOwnPropertyDescriptor(window, area) as PropertyDescriptor,
+        ] as const,
+);
+
+const replaceStorage = (area: StorageArea, value: unknown) => {
+    Object.defineProperty(window, area, {
+        configurable: true,
+        get: () => value,
+    });
+};
+
+const workingStorage = () => {
+    const stored = new Map<string, string>();
+
+    return {
+        getItem: (key: string) => stored.get(key) ?? null,
+        setItem: (key: string, value: string) => stored.set(key, value),
+        removeItem: (key: string) => stored.delete(key),
+    };
+};
+
+const throwOnAccess = (area: StorageArea) => {
+    Object.defineProperty(window, area, {
+        configurable: true,
+        get: () => {
+            throw new DOMException(
+                `Failed to read the '${area}' property from 'Window': Access is denied for this document.`,
+            );
+        },
+    });
+};
+
+const breakBothStorages = {
+    'storages that are null': () =>
+        AREAS.forEach((area) => replaceStorage(area, null)),
+    'storages that throw on access': () => AREAS.forEach(throwOnAccess),
+};
+
+afterEach(() => {
+    realStorages.forEach(([area, descriptor]) =>
+        Object.defineProperty(window, area, descriptor),
+    );
+});
+
+describe('key storage with working storage', () => {
+    const useWorkingStorages = () =>
+        AREAS.forEach((area) => replaceStorage(area, workingStorage()));
+
+    it('keeps a persistent key in localStorage and a session key in sessionStorage', () => {
+        useWorkingStorages();
+
+        storeKey('persistent-key', true);
+
+        expect(window.localStorage.getItem('encryption_key')).toBe(
+            'persistent-key',
+        );
+        expect(window.sessionStorage.getItem('encryption_key')).toBeNull();
+
+        clearKey();
+
+        storeKey('session-key', false);
+
+        expect(window.sessionStorage.getItem('encryption_key')).toBe(
+            'session-key',
+        );
+        expect(window.localStorage.getItem('encryption_key')).toBeNull();
+    });
+
+    it('prefers the session key over the persistent one', () => {
+        useWorkingStorages();
+        window.localStorage.setItem('encryption_key', 'persistent-key');
+        window.sessionStorage.setItem('encryption_key', 'session-key');
+
+        expect(getStoredKey()).toBe('session-key');
+    });
+
+    it('clears the key from both areas', () => {
+        useWorkingStorages();
+        window.localStorage.setItem('encryption_key', 'persistent-key');
+        window.sessionStorage.setItem('encryption_key', 'session-key');
+
+        clearKey();
+
+        expect(getStoredKey()).toBeNull();
+    });
+});
+
+// PHP-LARAVEL-5V: a browser blocking site data throws SecurityError on the
+// property read itself, and clearKey() runs in <Login>'s mount effect — the
+// unguarded version took down the page a locked-out user needs.
+describe('key storage the browser refuses to serve', () => {
+    it.each(Object.entries(breakBothStorages))(
+        'reads nothing and clears nothing with %s, instead of throwing',
+        (_name, breakStorage) => {
+            breakStorage();
+
+            expect(getStoredKey()).toBeNull();
+            expect(() => clearKey()).not.toThrow();
+        },
+    );
+
+    it.each(Object.entries(breakBothStorages))(
+        'drops a write with %s instead of throwing',
+        (_name, breakStorage) => {
+            breakStorage();
+
+            expect(() => storeKey('key', true)).not.toThrow();
+            expect(() => storeKey('key', false)).not.toThrow();
+        },
+    );
+
+    it('drops a write when setItem throws, e.g. an exhausted quota', () => {
+        replaceStorage('localStorage', {
+            getItem: () => null,
+            setItem: () => {
+                throw new DOMException('QuotaExceededError');
+            },
+        });
+
+        expect(() => storeKey('key', true)).not.toThrow();
+    });
+
+    // Losing the session copy must not leave the persistent one behind on a
+    // shared browser, so clearKey keeps going past a throw.
+    it('still clears the persistent key when the session area throws', () => {
+        throwOnAccess('sessionStorage');
+        replaceStorage('localStorage', workingStorage());
+        window.localStorage.setItem('encryption_key', 'persistent-key');
+
+        clearKey();
+
+        expect(window.localStorage.getItem('encryption_key')).toBeNull();
+    });
+});

--- a/resources/js/lib/key-storage.ts
+++ b/resources/js/lib/key-storage.ts
@@ -1,31 +1,66 @@
+/**
+ * Where the encryption key lives between unlocks.
+ *
+ * A browser configured to block site data throws `SecurityError` on the
+ * property read itself, so `typeof window` guards nothing (PHP-LARAVEL-5V,
+ * same failure class as PHP-LARAVEL-57 / PHP-LARAVEL-4Y). `clearKey()` runs in
+ * the login page's mount effect, so the unguarded version white-screened the
+ * one page a locked-out user needs.
+ *
+ * Everything here fails quietly, degrading to the normal unlock prompt.
+ * ./safe-storage's docblock asks that an encryption key not be given a silent
+ * write without telling the user, and this is a deliberate exception: the key
+ * now only decrypts a legacy user's data on the way in, so a lost write costs
+ * one more password prompt on a flow that is being retired. That flow is
+ * components/unlock-message-dialog.tsx, the one caller of storeKey: it reads
+ * as live code because it still has to work for those users, not because the
+ * feature is. If keys are ever stored for real again, storeKey has to report
+ * the failure and its caller has to surface it.
+ *
+ * Its read/write helpers are still not reused, for the duller reason that they
+ * only reach localStorage while the key also lives in sessionStorage.
+ *
+ * The catches are layered because the failures are: `getStorage` absorbs the
+ * throwing property read, the try around it absorbs `getItem`/`setItem`
+ * themselves, which still throw on an exhausted quota or in private mode.
+ */
+
+import { getStorage } from './safe-storage';
+
 const ENCRYPTION_KEY_NAME = 'encryption_key';
 
-function isBrowser(): boolean {
-    return typeof window !== 'undefined';
-}
-
 export function storeKey(key: string, persistent: boolean): void {
-    if (!isBrowser()) return;
-
-    if (persistent) {
-        localStorage.setItem(ENCRYPTION_KEY_NAME, key);
-    } else {
-        sessionStorage.setItem(ENCRYPTION_KEY_NAME, key);
+    try {
+        getStorage(persistent ? 'local' : 'session')?.setItem(
+            ENCRYPTION_KEY_NAME,
+            key,
+        );
+    } catch {
+        // Blocked storage or an exhausted quota: the key does not survive, and
+        // the next visit asks for the password again.
     }
 }
 
 export function getStoredKey(): string | null {
-    if (!isBrowser()) return null;
-
-    return (
-        sessionStorage.getItem(ENCRYPTION_KEY_NAME) ||
-        localStorage.getItem(ENCRYPTION_KEY_NAME)
-    );
+    try {
+        return (
+            getStorage('session')?.getItem(ENCRYPTION_KEY_NAME) ||
+            getStorage('local')?.getItem(ENCRYPTION_KEY_NAME) ||
+            null
+        );
+    } catch {
+        return null;
+    }
 }
 
 export function clearKey(): void {
-    if (!isBrowser()) return;
-
-    sessionStorage.removeItem(ENCRYPTION_KEY_NAME);
-    localStorage.removeItem(ENCRYPTION_KEY_NAME);
+    // One try per area on purpose: a throw while clearing the session copy
+    // must not leave the persistent one behind on a shared browser.
+    for (const area of ['session', 'local'] as const) {
+        try {
+            getStorage(area)?.removeItem(ENCRYPTION_KEY_NAME);
+        } catch {
+            // Storage that cannot be reached is storage holding nothing.
+        }
+    }
 }

--- a/resources/js/lib/safe-storage.test.ts
+++ b/resources/js/lib/safe-storage.test.ts
@@ -1,5 +1,7 @@
+import { isAdmin } from '@/hooks/use-admin';
 import { initializeTheme } from '@/hooks/use-appearance';
 import { initializeChartColorScheme } from '@/hooks/use-chart-color-scheme';
+import { consoleDebug } from '@/lib/debug';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
     readOwnedValue,
@@ -109,6 +111,20 @@ describe('boot initializers', () => {
         initializeTheme();
 
         expect(document.documentElement.classList.contains('dark')).toBe(true);
+    });
+});
+
+// Same invariant, off the boot path: a logging helper and an admin-flag check
+// have no business being the thing that throws (PHP-LARAVEL-5V).
+describe('flag readers', () => {
+    it.each([
+        ['a null localStorage', () => replaceStorage(null)],
+        ['a localStorage that throws on access', throwOnStorageAccess],
+    ])('read a flag through %s without throwing', (_name, breakStorage) => {
+        breakStorage();
+
+        expect(() => consoleDebug('anything')).not.toThrow();
+        expect(isAdmin()).toBe(false);
     });
 });
 


### PR DESCRIPTION
## The bug

Three modules read `localStorage` / `sessionStorage` behind a `typeof window` guard.
That guards the wrong thing. In a browser configured to block cookies and site data,
the **property read itself** throws `SecurityError`, before any check of the value can
run:

```
SecurityError: Failed to read the 'localStorage' property from 'Window':
Access is denied for this document.
```

`clearKey()` sits in `<Login>`'s mount effect, so the throw took down the login page —
the one page a locked-out user needs to get back in. The error boundary caught it and
rendered "Something went wrong." This hits every user on such a browser, whether or not
they ever had encryption.

Sentry: [PHP-LARAVEL-5V](https://whisper-money.sentry.io/issues/PHP-LARAVEL-5V) — same
failure class as PHP-LARAVEL-57 and PHP-LARAVEL-4Y, the two boot-time storage crashes
already named in `resources/js/lib/safe-storage.ts`'s docblock.

**Not a duplicate of #975.** That one guards the PostHog SDK's own storage use; this one
guards our storage calls. With the `SecurityError` injected the login page still dies
with PostHog ruled out.

## The fix

`resources/js/lib/safe-storage.ts` already exists for exactly this and already guards
the boot path, so all three modules go through it. No new abstraction, no new
dependency, and nothing about what is stored, where, or the session-vs-local preference
changes.

- `lib/debug.ts` and `hooks/use-admin.tsx` → `readStoredValue`.
- `lib/key-storage.ts` → `getStorage`, because `safe-storage`'s own read/write helpers
  only reach `localStorage` while the key also lives in `sessionStorage`.

Every failure here is quiet, degrading to the normal unlock prompt.

### One noted exception to a written rule

`safe-storage.ts`'s docblock asks that nothing whose loss is a data problem — "an
encryption key, say" — be given a silent write without telling the user. This change
does exactly that, so the reason is recorded in `key-storage.ts`'s own docblock rather
than left for a reviewer to spot: the key is now only used to decrypt a legacy user's
data on the way in, the flow is being retired, and a lost write costs one extra password
prompt. If keys are ever stored for real again, `storeKey` has to report the failure and
its caller has to surface it.

`clearKey` catches per storage area rather than once around both, so a throw while
clearing the session copy cannot leave the persistent copy behind on a shared browser.

## Tests

`resources/js/lib/key-storage.test.ts`, following `safe-storage.test.ts`: storage
swapped for `null` (Android WebViews with DOM storage disabled) and for one that throws
on access (blocked site data), asserting the caller survives and that `clearKey` still
clears the persistent copy when the session area throws. The regression block in
`safe-storage.test.ts` grows to cover the two flag readers, so neither can slide back to
a bare `localStorage` call.

Verified the tests fail against this branch's parent: 9 of 22 red on the old code, all
22 green on the new.

## QA

Reproduced and verified in Chrome with `SecurityError` injected on both storage globals,
the way it was found:

- **Before** (`main`'s modules): `/login` falls to the error boundary — "Something went
  wrong." Console shows the `SecurityError` thrown from `<Login>`.
- **After**: `/login` renders and logs in normally, with both globals confirmed to still
  throw on access in the same page — so the guards are doing the work, not a failed
  injection.

CI list from CLAUDE.md run locally: `bun run build`, `bun run format`, `bun run lint`,
`bun run dry` all pass, plus the full `bun run test` suite (125 files, 805 tests).
`bun run types` is red on ~70 files on `main` and is not a CI check; this branch adds no
new type errors (477 before, 477 after).

## Demo
https://github.com/user-attachments/assets/a7ca72a9-1998-4d1d-ab8e-82d77c7471fe

## Out of scope, noted while QA'ing

With site data blocked, `privacy-mode-context.tsx` also logs
`Failed to store privacy mode setting: SecurityError`. It already catches its own error
so it does not take the page down, and it is outside this PR's three modules. Other
direct `localStorage` reads remain in `transaction-list.tsx`,
`use-categorize-transactions.ts` and a few more — worth a follow-up sweep, not this
change.
